### PR TITLE
property for component's "install path"

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,10 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ## unreleased
 
+* Added
+  * Components' install path/location will be visible in the SBOM result ([#305] via [#308])
+
+[#305]: https://github.com/CycloneDX/cyclonedx-node-npm/issues/305
+[#308]: https://github.com/CycloneDX/cyclonedx-node-npm/pull/308
+
 ## 1.4.1 - 2022-11-06
 
 * Fixed
-  * Components' "sha512" hash is properly detected and populated in the SBOM result. ([#302] via [#303]) 
+  * Components' "sha512" hash is properly detected and populated in the SBOM result ([#302] via [#303]) 
 
 [#302]: https://github.com/CycloneDX/cyclonedx-node-npm/issues/302
 [#303]: https://github.com/CycloneDX/cyclonedx-node-npm/pull/303
@@ -15,7 +21,7 @@ All notable changes to this project will be documented in this file.
 ## 1.4.0 - 2022-11-05
 
 * Added
-  * Enabled support for NPM v9. ([#245] via [#246])
+  * Enabled support for NPM v9 ([#245] via [#246])
 
 [#245]: https://github.com/CycloneDX/cyclonedx-node-npm/issues/245
 [#246]: https://github.com/CycloneDX/cyclonedx-node-npm/pull/246
@@ -23,10 +29,10 @@ All notable changes to this project will be documented in this file.
 ## 1.3.0 - 2022-10-30
 
 * Fixed
-  * Improved the NPM compatibility with `--omit` options. ([#254] via [#259])
+  * Improved the NPM compatibility with `--omit` options ([#254] via [#259])
   * In case of an error, the exit code is guaranteed to be non-zero (via [#260])
 * Misc
-  * Added more debug output regarding NPM version detection. (via [#259])
+  * Added more debug output regarding NPM version detection (via [#259])
 
 [#254]: https://github.com/CycloneDX/cyclonedx-node-npm/issues/254
 [#259]: https://github.com/CycloneDX/cyclonedx-node-npm/pull/259

--- a/demo/bundled-dependencies/example-results/bom.1.2.json
+++ b/demo/bundled-dependencies/example-results/bom.1.2.json
@@ -8,7 +8,7 @@
       {
         "vendor": "@cyclonedx",
         "name": "cyclonedx-npm",
-        "version": "1.4.0"
+        "version": "1.4.1"
       }
     ],
     "component": {

--- a/demo/bundled-dependencies/example-results/bom.1.2.xml
+++ b/demo/bundled-dependencies/example-results/bom.1.2.xml
@@ -5,7 +5,7 @@
       <tool>
         <vendor>@cyclonedx</vendor>
         <name>cyclonedx-npm</name>
-        <version>1.4.0</version>
+        <version>1.4.1</version>
       </tool>
     </tools>
     <component type="application" bom-ref="demo-bundled-deps@0.0.0">

--- a/demo/bundled-dependencies/example-results/bom.1.3.json
+++ b/demo/bundled-dependencies/example-results/bom.1.3.json
@@ -27,7 +27,7 @@
       "purl": "pkg:npm/demo-bundled-deps@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -73,7 +73,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bundle-dependencies"
         }
       ],
@@ -121,7 +121,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/ansi-regex"
             }
           ]
@@ -169,7 +169,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/builtin-modules"
             }
           ]
@@ -217,7 +217,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/camelcase"
             }
           ]
@@ -265,7 +265,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/cliui"
             }
           ]
@@ -313,7 +313,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/code-point-at"
             }
           ]
@@ -361,7 +361,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/decamelize"
             }
           ]
@@ -408,7 +408,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/error-ex"
             }
           ]
@@ -456,7 +456,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/escape-string-regexp"
             }
           ]
@@ -504,7 +504,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/find-up"
             }
           ]
@@ -551,7 +551,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/graceful-fs"
             }
           ]
@@ -599,7 +599,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/hosted-git-info"
             }
           ]
@@ -647,7 +647,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/invert-kv"
             }
           ]
@@ -695,7 +695,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-arrayish"
             }
           ]
@@ -743,7 +743,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-builtin-module"
             }
           ]
@@ -791,7 +791,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -839,7 +839,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-utf8"
             }
           ]
@@ -887,7 +887,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lcid"
             }
           ]
@@ -935,7 +935,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/load-json-file"
             }
           ]
@@ -983,7 +983,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lodash.assign"
             }
           ]
@@ -1031,7 +1031,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lodash.keys"
             }
           ]
@@ -1079,7 +1079,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lodash.rest"
             }
           ]
@@ -1127,7 +1127,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/normalize-package-data"
             }
           ]
@@ -1175,7 +1175,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/number-is-nan"
             }
           ]
@@ -1223,7 +1223,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/object-assign"
             }
           ]
@@ -1271,7 +1271,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/os-locale"
             }
           ]
@@ -1319,7 +1319,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/parse-json"
             }
           ]
@@ -1367,7 +1367,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/path-exists"
             }
           ]
@@ -1415,7 +1415,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/path-type"
             }
           ]
@@ -1463,7 +1463,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pify"
             }
           ]
@@ -1511,7 +1511,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pinkie-promise"
             }
           ]
@@ -1559,7 +1559,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pinkie"
             }
           ]
@@ -1607,7 +1607,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pkg-conf"
             }
           ]
@@ -1655,7 +1655,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/read-pkg-up"
             }
           ]
@@ -1703,7 +1703,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/read-pkg"
             }
           ]
@@ -1751,7 +1751,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/require-main-filename"
             }
           ]
@@ -1798,7 +1798,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/semver"
             }
           ]
@@ -1846,7 +1846,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-correct"
             }
           ]
@@ -1894,7 +1894,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-exceptions"
             }
           ]
@@ -1940,7 +1940,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-expression-parse"
             }
           ]
@@ -1988,7 +1988,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-license-ids"
             }
           ]
@@ -2036,7 +2036,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/string-width"
             }
           ]
@@ -2084,7 +2084,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/strip-ansi"
             }
           ]
@@ -2132,7 +2132,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/strip-bom"
             }
           ]
@@ -2180,7 +2180,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/symbol"
             }
           ]
@@ -2228,7 +2228,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/validate-npm-package-license"
             }
           ]
@@ -2276,7 +2276,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/window-size"
             }
           ]
@@ -2324,7 +2324,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/wrap-ansi"
             }
           ]
@@ -2372,7 +2372,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/y18n"
             }
           ]
@@ -2420,7 +2420,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/yargs-parser"
             }
           ]
@@ -2467,7 +2467,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/yargs"
             }
           ]

--- a/demo/bundled-dependencies/example-results/bom.1.3.json
+++ b/demo/bundled-dependencies/example-results/bom.1.3.json
@@ -8,7 +8,7 @@
       {
         "vendor": "@cyclonedx",
         "name": "cyclonedx-npm",
-        "version": "1.4.0"
+        "version": "1.4.1"
       }
     ],
     "component": {
@@ -26,6 +26,10 @@
       ],
       "purl": "pkg:npm/demo-bundled-deps@0.0.0",
       "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
         {
           "name": "cdx:npm:package:private",
           "value": "true"
@@ -65,6 +69,12 @@
           "url": "https://github.com/gajus/bundle-dependencies",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bundle-dependencies"
         }
       ],
       "components": [
@@ -109,6 +119,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/ansi-regex"
             }
           ]
         },
@@ -153,6 +167,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/builtin-modules"
             }
           ]
         },
@@ -197,6 +215,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/camelcase"
             }
           ]
         },
@@ -241,6 +263,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/cliui"
             }
           ]
         },
@@ -285,6 +311,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/code-point-at"
             }
           ]
         },
@@ -329,6 +359,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/decamelize"
             }
           ]
         },
@@ -372,6 +406,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/error-ex"
             }
           ]
         },
@@ -416,6 +454,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/escape-string-regexp"
             }
           ]
         },
@@ -460,6 +502,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/find-up"
             }
           ]
         },
@@ -503,6 +549,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/graceful-fs"
             }
           ]
         },
@@ -547,6 +597,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/hosted-git-info"
             }
           ]
         },
@@ -591,6 +645,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/invert-kv"
             }
           ]
         },
@@ -635,6 +693,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-arrayish"
             }
           ]
         },
@@ -679,6 +741,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-builtin-module"
             }
           ]
         },
@@ -723,6 +789,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-fullwidth-code-point"
             }
           ]
         },
@@ -767,6 +837,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-utf8"
             }
           ]
         },
@@ -811,6 +885,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lcid"
             }
           ]
         },
@@ -855,6 +933,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/load-json-file"
             }
           ]
         },
@@ -899,6 +981,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lodash.assign"
             }
           ]
         },
@@ -943,6 +1029,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lodash.keys"
             }
           ]
         },
@@ -987,6 +1077,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lodash.rest"
             }
           ]
         },
@@ -1031,6 +1125,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/normalize-package-data"
             }
           ]
         },
@@ -1075,6 +1173,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/number-is-nan"
             }
           ]
         },
@@ -1119,6 +1221,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/object-assign"
             }
           ]
         },
@@ -1163,6 +1269,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/os-locale"
             }
           ]
         },
@@ -1207,6 +1317,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/parse-json"
             }
           ]
         },
@@ -1251,6 +1365,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/path-exists"
             }
           ]
         },
@@ -1295,6 +1413,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/path-type"
             }
           ]
         },
@@ -1339,6 +1461,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pify"
             }
           ]
         },
@@ -1383,6 +1509,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pinkie-promise"
             }
           ]
         },
@@ -1427,6 +1557,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pinkie"
             }
           ]
         },
@@ -1471,6 +1605,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pkg-conf"
             }
           ]
         },
@@ -1515,6 +1653,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/read-pkg-up"
             }
           ]
         },
@@ -1559,6 +1701,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/read-pkg"
             }
           ]
         },
@@ -1603,6 +1749,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/require-main-filename"
             }
           ]
         },
@@ -1646,6 +1796,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/semver"
             }
           ]
         },
@@ -1690,6 +1844,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-correct"
             }
           ]
         },
@@ -1734,6 +1892,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-exceptions"
             }
           ]
         },
@@ -1776,6 +1938,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-expression-parse"
             }
           ]
         },
@@ -1820,6 +1986,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-license-ids"
             }
           ]
         },
@@ -1864,6 +2034,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/string-width"
             }
           ]
         },
@@ -1908,6 +2082,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/strip-ansi"
             }
           ]
         },
@@ -1952,6 +2130,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/strip-bom"
             }
           ]
         },
@@ -1996,6 +2178,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/symbol"
             }
           ]
         },
@@ -2040,6 +2226,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/validate-npm-package-license"
             }
           ]
         },
@@ -2084,6 +2274,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/window-size"
             }
           ]
         },
@@ -2128,6 +2322,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/wrap-ansi"
             }
           ]
         },
@@ -2172,6 +2370,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/y18n"
             }
           ]
         },
@@ -2216,6 +2418,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/yargs-parser"
             }
           ]
         },
@@ -2259,6 +2465,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/yargs"
             }
           ]
         }

--- a/demo/bundled-dependencies/example-results/bom.1.3.xml
+++ b/demo/bundled-dependencies/example-results/bom.1.3.xml
@@ -19,7 +19,7 @@
       </licenses>
       <purl>pkg:npm/demo-bundled-deps@0.0.0</purl>
       <properties>
-        <property name="cdx:npm:package:installPath"/>
+        <property name="cdx:npm:package:path"/>
         <property name="cdx:npm:package:private">true</property>
       </properties>
     </component>
@@ -50,7 +50,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies</property>
+        <property name="cdx:npm:package:path">node_modules/bundle-dependencies</property>
       </properties>
       <components>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|ansi-regex@2.0.0">
@@ -84,7 +84,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/ansi-regex</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/ansi-regex</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|builtin-modules@1.1.1">
@@ -118,7 +118,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/builtin-modules</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/builtin-modules</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|camelcase@2.1.0">
@@ -152,7 +152,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/camelcase</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/camelcase</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|cliui@3.1.0">
@@ -186,7 +186,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/cliui</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/cliui</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|code-point-at@1.0.0">
@@ -220,7 +220,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/code-point-at</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/code-point-at</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|decamelize@1.1.2">
@@ -254,7 +254,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/decamelize</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/decamelize</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|error-ex@1.3.0">
@@ -287,7 +287,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/error-ex</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/error-ex</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|escape-string-regexp@1.0.5">
@@ -321,7 +321,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/escape-string-regexp</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/escape-string-regexp</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|find-up@1.1.0">
@@ -355,7 +355,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/find-up</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/find-up</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|graceful-fs@4.1.3">
@@ -388,7 +388,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/graceful-fs</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/graceful-fs</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|hosted-git-info@2.1.4">
@@ -422,7 +422,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/hosted-git-info</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/hosted-git-info</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|invert-kv@1.0.0">
@@ -456,7 +456,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/invert-kv</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/invert-kv</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|is-arrayish@0.2.1">
@@ -490,7 +490,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/is-arrayish</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/is-arrayish</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|is-builtin-module@1.0.0">
@@ -524,7 +524,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/is-builtin-module</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/is-builtin-module</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|is-fullwidth-code-point@1.0.0">
@@ -558,7 +558,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/is-fullwidth-code-point</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/is-fullwidth-code-point</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|is-utf8@0.2.1">
@@ -592,7 +592,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/is-utf8</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/is-utf8</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|lcid@1.0.0">
@@ -626,7 +626,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/lcid</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/lcid</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|load-json-file@1.1.0">
@@ -660,7 +660,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/load-json-file</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/load-json-file</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|lodash.assign@4.0.3">
@@ -694,7 +694,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/lodash.assign</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/lodash.assign</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|lodash.keys@4.0.3">
@@ -728,7 +728,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/lodash.keys</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/lodash.keys</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|lodash.rest@4.0.1">
@@ -762,7 +762,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/lodash.rest</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/lodash.rest</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|normalize-package-data@2.3.5">
@@ -796,7 +796,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/normalize-package-data</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/normalize-package-data</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|number-is-nan@1.0.0">
@@ -830,7 +830,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/number-is-nan</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/number-is-nan</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|object-assign@4.0.1">
@@ -864,7 +864,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/object-assign</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/object-assign</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|os-locale@1.4.0">
@@ -898,7 +898,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/os-locale</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/os-locale</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|parse-json@2.2.0">
@@ -932,7 +932,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/parse-json</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/parse-json</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|path-exists@2.1.0">
@@ -966,7 +966,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/path-exists</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/path-exists</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|path-type@1.1.0">
@@ -1000,7 +1000,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/path-type</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/path-type</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|pify@2.3.0">
@@ -1034,7 +1034,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/pify</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/pify</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|pinkie-promise@2.0.0">
@@ -1068,7 +1068,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/pinkie-promise</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/pinkie-promise</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|pinkie@2.0.4">
@@ -1102,7 +1102,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/pinkie</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/pinkie</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|pkg-conf@1.1.1">
@@ -1136,7 +1136,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/pkg-conf</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/pkg-conf</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|read-pkg-up@1.0.1">
@@ -1170,7 +1170,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/read-pkg-up</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/read-pkg-up</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|read-pkg@1.1.0">
@@ -1204,7 +1204,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/read-pkg</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/read-pkg</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|require-main-filename@1.0.1">
@@ -1238,7 +1238,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/require-main-filename</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/require-main-filename</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|semver@5.1.0">
@@ -1271,7 +1271,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/semver</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/semver</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|spdx-correct@1.0.2">
@@ -1305,7 +1305,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/spdx-correct</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/spdx-correct</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|spdx-exceptions@1.0.4">
@@ -1339,7 +1339,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/spdx-exceptions</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/spdx-exceptions</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|spdx-expression-parse@1.0.2">
@@ -1371,7 +1371,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/spdx-expression-parse</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/spdx-expression-parse</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|spdx-license-ids@1.2.0">
@@ -1405,7 +1405,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/spdx-license-ids</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/spdx-license-ids</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|string-width@1.0.1">
@@ -1439,7 +1439,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/string-width</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/string-width</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|strip-ansi@3.0.1">
@@ -1473,7 +1473,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/strip-ansi</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/strip-ansi</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|strip-bom@2.0.0">
@@ -1507,7 +1507,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/strip-bom</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/strip-bom</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|symbol@0.2.1">
@@ -1541,7 +1541,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/symbol</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/symbol</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|validate-npm-package-license@3.0.1">
@@ -1575,7 +1575,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/validate-npm-package-license</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/validate-npm-package-license</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|window-size@0.2.0">
@@ -1609,7 +1609,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/window-size</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/window-size</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|wrap-ansi@1.0.0">
@@ -1643,7 +1643,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/wrap-ansi</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/wrap-ansi</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|y18n@3.2.0">
@@ -1677,7 +1677,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/y18n</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/y18n</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|yargs-parser@2.1.0">
@@ -1711,7 +1711,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/yargs-parser</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/yargs-parser</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|yargs@4.1.0">
@@ -1744,7 +1744,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/yargs</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/yargs</property>
           </properties>
         </component>
       </components>

--- a/demo/bundled-dependencies/example-results/bom.1.3.xml
+++ b/demo/bundled-dependencies/example-results/bom.1.3.xml
@@ -5,7 +5,7 @@
       <tool>
         <vendor>@cyclonedx</vendor>
         <name>cyclonedx-npm</name>
-        <version>1.4.0</version>
+        <version>1.4.1</version>
       </tool>
     </tools>
     <component type="application" bom-ref="demo-bundled-deps@0.0.0">
@@ -19,6 +19,7 @@
       </licenses>
       <purl>pkg:npm/demo-bundled-deps@0.0.0</purl>
       <properties>
+        <property name="cdx:npm:package:installPath"/>
         <property name="cdx:npm:package:private">true</property>
       </properties>
     </component>
@@ -48,6 +49,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies</property>
+      </properties>
       <components>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|ansi-regex@2.0.0">
           <author>Sindre Sorhus</author>
@@ -80,6 +84,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/ansi-regex</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|builtin-modules@1.1.1">
@@ -113,6 +118,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/builtin-modules</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|camelcase@2.1.0">
@@ -146,6 +152,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/camelcase</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|cliui@3.1.0">
@@ -179,6 +186,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/cliui</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|code-point-at@1.0.0">
@@ -212,6 +220,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/code-point-at</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|decamelize@1.1.2">
@@ -245,6 +254,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/decamelize</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|error-ex@1.3.0">
@@ -277,6 +287,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/error-ex</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|escape-string-regexp@1.0.5">
@@ -310,6 +321,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/escape-string-regexp</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|find-up@1.1.0">
@@ -343,6 +355,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/find-up</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|graceful-fs@4.1.3">
@@ -375,6 +388,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/graceful-fs</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|hosted-git-info@2.1.4">
@@ -408,6 +422,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/hosted-git-info</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|invert-kv@1.0.0">
@@ -441,6 +456,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/invert-kv</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|is-arrayish@0.2.1">
@@ -474,6 +490,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/is-arrayish</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|is-builtin-module@1.0.0">
@@ -507,6 +524,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/is-builtin-module</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|is-fullwidth-code-point@1.0.0">
@@ -540,6 +558,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/is-fullwidth-code-point</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|is-utf8@0.2.1">
@@ -573,6 +592,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/is-utf8</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|lcid@1.0.0">
@@ -606,6 +626,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/lcid</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|load-json-file@1.1.0">
@@ -639,6 +660,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/load-json-file</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|lodash.assign@4.0.3">
@@ -672,6 +694,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/lodash.assign</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|lodash.keys@4.0.3">
@@ -705,6 +728,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/lodash.keys</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|lodash.rest@4.0.1">
@@ -738,6 +762,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/lodash.rest</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|normalize-package-data@2.3.5">
@@ -771,6 +796,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/normalize-package-data</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|number-is-nan@1.0.0">
@@ -804,6 +830,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/number-is-nan</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|object-assign@4.0.1">
@@ -837,6 +864,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/object-assign</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|os-locale@1.4.0">
@@ -870,6 +898,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/os-locale</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|parse-json@2.2.0">
@@ -903,6 +932,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/parse-json</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|path-exists@2.1.0">
@@ -936,6 +966,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/path-exists</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|path-type@1.1.0">
@@ -969,6 +1000,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/path-type</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|pify@2.3.0">
@@ -1002,6 +1034,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/pify</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|pinkie-promise@2.0.0">
@@ -1035,6 +1068,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/pinkie-promise</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|pinkie@2.0.4">
@@ -1068,6 +1102,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/pinkie</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|pkg-conf@1.1.1">
@@ -1101,6 +1136,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/pkg-conf</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|read-pkg-up@1.0.1">
@@ -1134,6 +1170,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/read-pkg-up</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|read-pkg@1.1.0">
@@ -1167,6 +1204,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/read-pkg</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|require-main-filename@1.0.1">
@@ -1200,6 +1238,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/require-main-filename</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|semver@5.1.0">
@@ -1232,6 +1271,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/semver</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|spdx-correct@1.0.2">
@@ -1265,6 +1305,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/spdx-correct</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|spdx-exceptions@1.0.4">
@@ -1298,6 +1339,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/spdx-exceptions</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|spdx-expression-parse@1.0.2">
@@ -1329,6 +1371,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/spdx-expression-parse</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|spdx-license-ids@1.2.0">
@@ -1362,6 +1405,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/spdx-license-ids</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|string-width@1.0.1">
@@ -1395,6 +1439,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/string-width</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|strip-ansi@3.0.1">
@@ -1428,6 +1473,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/strip-ansi</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|strip-bom@2.0.0">
@@ -1461,6 +1507,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/strip-bom</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|symbol@0.2.1">
@@ -1494,6 +1541,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/symbol</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|validate-npm-package-license@3.0.1">
@@ -1527,6 +1575,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/validate-npm-package-license</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|window-size@0.2.0">
@@ -1560,6 +1609,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/window-size</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|wrap-ansi@1.0.0">
@@ -1593,6 +1643,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/wrap-ansi</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|y18n@3.2.0">
@@ -1626,6 +1677,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/y18n</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|yargs-parser@2.1.0">
@@ -1659,6 +1711,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/yargs-parser</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|yargs@4.1.0">
@@ -1691,6 +1744,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/yargs</property>
           </properties>
         </component>
       </components>

--- a/demo/bundled-dependencies/example-results/bom.1.4.json
+++ b/demo/bundled-dependencies/example-results/bom.1.4.json
@@ -8,7 +8,7 @@
       {
         "vendor": "@cyclonedx",
         "name": "cyclonedx-npm",
-        "version": "1.4.0",
+        "version": "1.4.1",
         "externalReferences": [
           {
             "url": "https://github.com/CycloneDX/cyclonedx-node-npm/issues",
@@ -43,6 +43,10 @@
       ],
       "purl": "pkg:npm/demo-bundled-deps@0.0.0",
       "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
         {
           "name": "cdx:npm:package:private",
           "value": "true"
@@ -82,6 +86,12 @@
           "url": "https://github.com/gajus/bundle-dependencies",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bundle-dependencies"
         }
       ],
       "components": [
@@ -126,6 +136,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/ansi-regex"
             }
           ]
         },
@@ -170,6 +184,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/builtin-modules"
             }
           ]
         },
@@ -214,6 +232,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/camelcase"
             }
           ]
         },
@@ -258,6 +280,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/cliui"
             }
           ]
         },
@@ -302,6 +328,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/code-point-at"
             }
           ]
         },
@@ -346,6 +376,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/decamelize"
             }
           ]
         },
@@ -389,6 +423,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/error-ex"
             }
           ]
         },
@@ -433,6 +471,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/escape-string-regexp"
             }
           ]
         },
@@ -477,6 +519,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/find-up"
             }
           ]
         },
@@ -520,6 +566,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/graceful-fs"
             }
           ]
         },
@@ -564,6 +614,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/hosted-git-info"
             }
           ]
         },
@@ -608,6 +662,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/invert-kv"
             }
           ]
         },
@@ -652,6 +710,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-arrayish"
             }
           ]
         },
@@ -696,6 +758,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-builtin-module"
             }
           ]
         },
@@ -740,6 +806,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-fullwidth-code-point"
             }
           ]
         },
@@ -784,6 +854,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-utf8"
             }
           ]
         },
@@ -828,6 +902,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lcid"
             }
           ]
         },
@@ -872,6 +950,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/load-json-file"
             }
           ]
         },
@@ -916,6 +998,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lodash.assign"
             }
           ]
         },
@@ -960,6 +1046,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lodash.keys"
             }
           ]
         },
@@ -1004,6 +1094,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lodash.rest"
             }
           ]
         },
@@ -1048,6 +1142,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/normalize-package-data"
             }
           ]
         },
@@ -1092,6 +1190,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/number-is-nan"
             }
           ]
         },
@@ -1136,6 +1238,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/object-assign"
             }
           ]
         },
@@ -1180,6 +1286,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/os-locale"
             }
           ]
         },
@@ -1224,6 +1334,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/parse-json"
             }
           ]
         },
@@ -1268,6 +1382,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/path-exists"
             }
           ]
         },
@@ -1312,6 +1430,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/path-type"
             }
           ]
         },
@@ -1356,6 +1478,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pify"
             }
           ]
         },
@@ -1400,6 +1526,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pinkie-promise"
             }
           ]
         },
@@ -1444,6 +1574,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pinkie"
             }
           ]
         },
@@ -1488,6 +1622,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pkg-conf"
             }
           ]
         },
@@ -1532,6 +1670,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/read-pkg-up"
             }
           ]
         },
@@ -1576,6 +1718,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/read-pkg"
             }
           ]
         },
@@ -1620,6 +1766,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/require-main-filename"
             }
           ]
         },
@@ -1663,6 +1813,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/semver"
             }
           ]
         },
@@ -1707,6 +1861,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-correct"
             }
           ]
         },
@@ -1751,6 +1909,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-exceptions"
             }
           ]
         },
@@ -1793,6 +1955,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-expression-parse"
             }
           ]
         },
@@ -1837,6 +2003,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-license-ids"
             }
           ]
         },
@@ -1881,6 +2051,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/string-width"
             }
           ]
         },
@@ -1925,6 +2099,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/strip-ansi"
             }
           ]
         },
@@ -1969,6 +2147,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/strip-bom"
             }
           ]
         },
@@ -2013,6 +2195,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/symbol"
             }
           ]
         },
@@ -2057,6 +2243,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/validate-npm-package-license"
             }
           ]
         },
@@ -2101,6 +2291,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/window-size"
             }
           ]
         },
@@ -2145,6 +2339,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/wrap-ansi"
             }
           ]
         },
@@ -2189,6 +2387,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/y18n"
             }
           ]
         },
@@ -2233,6 +2435,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/yargs-parser"
             }
           ]
         },
@@ -2276,6 +2482,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/yargs"
             }
           ]
         }

--- a/demo/bundled-dependencies/example-results/bom.1.4.json
+++ b/demo/bundled-dependencies/example-results/bom.1.4.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-bundled-deps@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -90,7 +90,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bundle-dependencies"
         }
       ],
@@ -138,7 +138,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/ansi-regex"
             }
           ]
@@ -186,7 +186,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/builtin-modules"
             }
           ]
@@ -234,7 +234,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/camelcase"
             }
           ]
@@ -282,7 +282,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/cliui"
             }
           ]
@@ -330,7 +330,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/code-point-at"
             }
           ]
@@ -378,7 +378,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/decamelize"
             }
           ]
@@ -425,7 +425,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/error-ex"
             }
           ]
@@ -473,7 +473,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/escape-string-regexp"
             }
           ]
@@ -521,7 +521,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/find-up"
             }
           ]
@@ -568,7 +568,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/graceful-fs"
             }
           ]
@@ -616,7 +616,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/hosted-git-info"
             }
           ]
@@ -664,7 +664,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/invert-kv"
             }
           ]
@@ -712,7 +712,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-arrayish"
             }
           ]
@@ -760,7 +760,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-builtin-module"
             }
           ]
@@ -808,7 +808,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -856,7 +856,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-utf8"
             }
           ]
@@ -904,7 +904,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lcid"
             }
           ]
@@ -952,7 +952,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/load-json-file"
             }
           ]
@@ -1000,7 +1000,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lodash.assign"
             }
           ]
@@ -1048,7 +1048,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lodash.keys"
             }
           ]
@@ -1096,7 +1096,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lodash.rest"
             }
           ]
@@ -1144,7 +1144,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/normalize-package-data"
             }
           ]
@@ -1192,7 +1192,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/number-is-nan"
             }
           ]
@@ -1240,7 +1240,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/object-assign"
             }
           ]
@@ -1288,7 +1288,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/os-locale"
             }
           ]
@@ -1336,7 +1336,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/parse-json"
             }
           ]
@@ -1384,7 +1384,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/path-exists"
             }
           ]
@@ -1432,7 +1432,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/path-type"
             }
           ]
@@ -1480,7 +1480,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pify"
             }
           ]
@@ -1528,7 +1528,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pinkie-promise"
             }
           ]
@@ -1576,7 +1576,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pinkie"
             }
           ]
@@ -1624,7 +1624,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pkg-conf"
             }
           ]
@@ -1672,7 +1672,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/read-pkg-up"
             }
           ]
@@ -1720,7 +1720,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/read-pkg"
             }
           ]
@@ -1768,7 +1768,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/require-main-filename"
             }
           ]
@@ -1815,7 +1815,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/semver"
             }
           ]
@@ -1863,7 +1863,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-correct"
             }
           ]
@@ -1911,7 +1911,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-exceptions"
             }
           ]
@@ -1957,7 +1957,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-expression-parse"
             }
           ]
@@ -2005,7 +2005,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-license-ids"
             }
           ]
@@ -2053,7 +2053,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/string-width"
             }
           ]
@@ -2101,7 +2101,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/strip-ansi"
             }
           ]
@@ -2149,7 +2149,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/strip-bom"
             }
           ]
@@ -2197,7 +2197,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/symbol"
             }
           ]
@@ -2245,7 +2245,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/validate-npm-package-license"
             }
           ]
@@ -2293,7 +2293,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/window-size"
             }
           ]
@@ -2341,7 +2341,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/wrap-ansi"
             }
           ]
@@ -2389,7 +2389,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/y18n"
             }
           ]
@@ -2437,7 +2437,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/yargs-parser"
             }
           ]
@@ -2484,7 +2484,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/yargs"
             }
           ]

--- a/demo/bundled-dependencies/example-results/bom.1.4.xml
+++ b/demo/bundled-dependencies/example-results/bom.1.4.xml
@@ -5,7 +5,7 @@
       <tool>
         <vendor>@cyclonedx</vendor>
         <name>cyclonedx-npm</name>
-        <version>1.4.0</version>
+        <version>1.4.1</version>
         <externalReferences>
           <reference type="issue-tracker">
             <url>https://github.com/CycloneDX/cyclonedx-node-npm/issues</url>
@@ -33,6 +33,7 @@
       </licenses>
       <purl>pkg:npm/demo-bundled-deps@0.0.0</purl>
       <properties>
+        <property name="cdx:npm:package:installPath"/>
         <property name="cdx:npm:package:private">true</property>
       </properties>
     </component>
@@ -62,6 +63,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies</property>
+      </properties>
       <components>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|ansi-regex@2.0.0">
           <author>Sindre Sorhus</author>
@@ -94,6 +98,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/ansi-regex</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|builtin-modules@1.1.1">
@@ -127,6 +132,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/builtin-modules</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|camelcase@2.1.0">
@@ -160,6 +166,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/camelcase</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|cliui@3.1.0">
@@ -193,6 +200,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/cliui</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|code-point-at@1.0.0">
@@ -226,6 +234,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/code-point-at</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|decamelize@1.1.2">
@@ -259,6 +268,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/decamelize</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|error-ex@1.3.0">
@@ -291,6 +301,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/error-ex</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|escape-string-regexp@1.0.5">
@@ -324,6 +335,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/escape-string-regexp</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|find-up@1.1.0">
@@ -357,6 +369,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/find-up</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|graceful-fs@4.1.3">
@@ -389,6 +402,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/graceful-fs</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|hosted-git-info@2.1.4">
@@ -422,6 +436,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/hosted-git-info</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|invert-kv@1.0.0">
@@ -455,6 +470,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/invert-kv</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|is-arrayish@0.2.1">
@@ -488,6 +504,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/is-arrayish</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|is-builtin-module@1.0.0">
@@ -521,6 +538,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/is-builtin-module</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|is-fullwidth-code-point@1.0.0">
@@ -554,6 +572,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/is-fullwidth-code-point</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|is-utf8@0.2.1">
@@ -587,6 +606,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/is-utf8</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|lcid@1.0.0">
@@ -620,6 +640,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/lcid</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|load-json-file@1.1.0">
@@ -653,6 +674,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/load-json-file</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|lodash.assign@4.0.3">
@@ -686,6 +708,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/lodash.assign</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|lodash.keys@4.0.3">
@@ -719,6 +742,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/lodash.keys</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|lodash.rest@4.0.1">
@@ -752,6 +776,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/lodash.rest</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|normalize-package-data@2.3.5">
@@ -785,6 +810,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/normalize-package-data</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|number-is-nan@1.0.0">
@@ -818,6 +844,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/number-is-nan</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|object-assign@4.0.1">
@@ -851,6 +878,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/object-assign</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|os-locale@1.4.0">
@@ -884,6 +912,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/os-locale</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|parse-json@2.2.0">
@@ -917,6 +946,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/parse-json</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|path-exists@2.1.0">
@@ -950,6 +980,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/path-exists</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|path-type@1.1.0">
@@ -983,6 +1014,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/path-type</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|pify@2.3.0">
@@ -1016,6 +1048,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/pify</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|pinkie-promise@2.0.0">
@@ -1049,6 +1082,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/pinkie-promise</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|pinkie@2.0.4">
@@ -1082,6 +1116,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/pinkie</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|pkg-conf@1.1.1">
@@ -1115,6 +1150,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/pkg-conf</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|read-pkg-up@1.0.1">
@@ -1148,6 +1184,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/read-pkg-up</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|read-pkg@1.1.0">
@@ -1181,6 +1218,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/read-pkg</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|require-main-filename@1.0.1">
@@ -1214,6 +1252,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/require-main-filename</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|semver@5.1.0">
@@ -1246,6 +1285,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/semver</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|spdx-correct@1.0.2">
@@ -1279,6 +1319,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/spdx-correct</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|spdx-exceptions@1.0.4">
@@ -1312,6 +1353,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/spdx-exceptions</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|spdx-expression-parse@1.0.2">
@@ -1343,6 +1385,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/spdx-expression-parse</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|spdx-license-ids@1.2.0">
@@ -1376,6 +1419,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/spdx-license-ids</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|string-width@1.0.1">
@@ -1409,6 +1453,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/string-width</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|strip-ansi@3.0.1">
@@ -1442,6 +1487,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/strip-ansi</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|strip-bom@2.0.0">
@@ -1475,6 +1521,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/strip-bom</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|symbol@0.2.1">
@@ -1508,6 +1555,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/symbol</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|validate-npm-package-license@3.0.1">
@@ -1541,6 +1589,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/validate-npm-package-license</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|window-size@0.2.0">
@@ -1574,6 +1623,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/window-size</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|wrap-ansi@1.0.0">
@@ -1607,6 +1657,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/wrap-ansi</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|y18n@3.2.0">
@@ -1640,6 +1691,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/y18n</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|yargs-parser@2.1.0">
@@ -1673,6 +1725,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/yargs-parser</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|yargs@4.1.0">
@@ -1705,6 +1758,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
+            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/yargs</property>
           </properties>
         </component>
       </components>

--- a/demo/bundled-dependencies/example-results/bom.1.4.xml
+++ b/demo/bundled-dependencies/example-results/bom.1.4.xml
@@ -33,7 +33,7 @@
       </licenses>
       <purl>pkg:npm/demo-bundled-deps@0.0.0</purl>
       <properties>
-        <property name="cdx:npm:package:installPath"/>
+        <property name="cdx:npm:package:path"/>
         <property name="cdx:npm:package:private">true</property>
       </properties>
     </component>
@@ -64,7 +64,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies</property>
+        <property name="cdx:npm:package:path">node_modules/bundle-dependencies</property>
       </properties>
       <components>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|ansi-regex@2.0.0">
@@ -98,7 +98,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/ansi-regex</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/ansi-regex</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|builtin-modules@1.1.1">
@@ -132,7 +132,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/builtin-modules</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/builtin-modules</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|camelcase@2.1.0">
@@ -166,7 +166,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/camelcase</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/camelcase</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|cliui@3.1.0">
@@ -200,7 +200,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/cliui</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/cliui</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|code-point-at@1.0.0">
@@ -234,7 +234,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/code-point-at</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/code-point-at</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|decamelize@1.1.2">
@@ -268,7 +268,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/decamelize</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/decamelize</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|error-ex@1.3.0">
@@ -301,7 +301,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/error-ex</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/error-ex</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|escape-string-regexp@1.0.5">
@@ -335,7 +335,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/escape-string-regexp</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/escape-string-regexp</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|find-up@1.1.0">
@@ -369,7 +369,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/find-up</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/find-up</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|graceful-fs@4.1.3">
@@ -402,7 +402,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/graceful-fs</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/graceful-fs</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|hosted-git-info@2.1.4">
@@ -436,7 +436,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/hosted-git-info</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/hosted-git-info</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|invert-kv@1.0.0">
@@ -470,7 +470,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/invert-kv</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/invert-kv</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|is-arrayish@0.2.1">
@@ -504,7 +504,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/is-arrayish</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/is-arrayish</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|is-builtin-module@1.0.0">
@@ -538,7 +538,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/is-builtin-module</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/is-builtin-module</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|is-fullwidth-code-point@1.0.0">
@@ -572,7 +572,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/is-fullwidth-code-point</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/is-fullwidth-code-point</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|is-utf8@0.2.1">
@@ -606,7 +606,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/is-utf8</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/is-utf8</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|lcid@1.0.0">
@@ -640,7 +640,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/lcid</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/lcid</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|load-json-file@1.1.0">
@@ -674,7 +674,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/load-json-file</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/load-json-file</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|lodash.assign@4.0.3">
@@ -708,7 +708,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/lodash.assign</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/lodash.assign</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|lodash.keys@4.0.3">
@@ -742,7 +742,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/lodash.keys</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/lodash.keys</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|lodash.rest@4.0.1">
@@ -776,7 +776,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/lodash.rest</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/lodash.rest</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|normalize-package-data@2.3.5">
@@ -810,7 +810,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/normalize-package-data</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/normalize-package-data</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|number-is-nan@1.0.0">
@@ -844,7 +844,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/number-is-nan</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/number-is-nan</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|object-assign@4.0.1">
@@ -878,7 +878,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/object-assign</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/object-assign</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|os-locale@1.4.0">
@@ -912,7 +912,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/os-locale</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/os-locale</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|parse-json@2.2.0">
@@ -946,7 +946,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/parse-json</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/parse-json</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|path-exists@2.1.0">
@@ -980,7 +980,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/path-exists</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/path-exists</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|path-type@1.1.0">
@@ -1014,7 +1014,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/path-type</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/path-type</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|pify@2.3.0">
@@ -1048,7 +1048,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/pify</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/pify</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|pinkie-promise@2.0.0">
@@ -1082,7 +1082,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/pinkie-promise</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/pinkie-promise</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|pinkie@2.0.4">
@@ -1116,7 +1116,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/pinkie</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/pinkie</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|pkg-conf@1.1.1">
@@ -1150,7 +1150,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/pkg-conf</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/pkg-conf</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|read-pkg-up@1.0.1">
@@ -1184,7 +1184,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/read-pkg-up</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/read-pkg-up</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|read-pkg@1.1.0">
@@ -1218,7 +1218,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/read-pkg</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/read-pkg</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|require-main-filename@1.0.1">
@@ -1252,7 +1252,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/require-main-filename</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/require-main-filename</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|semver@5.1.0">
@@ -1285,7 +1285,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/semver</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/semver</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|spdx-correct@1.0.2">
@@ -1319,7 +1319,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/spdx-correct</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/spdx-correct</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|spdx-exceptions@1.0.4">
@@ -1353,7 +1353,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/spdx-exceptions</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/spdx-exceptions</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|spdx-expression-parse@1.0.2">
@@ -1385,7 +1385,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/spdx-expression-parse</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/spdx-expression-parse</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|spdx-license-ids@1.2.0">
@@ -1419,7 +1419,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/spdx-license-ids</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/spdx-license-ids</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|string-width@1.0.1">
@@ -1453,7 +1453,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/string-width</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/string-width</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|strip-ansi@3.0.1">
@@ -1487,7 +1487,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/strip-ansi</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/strip-ansi</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|strip-bom@2.0.0">
@@ -1521,7 +1521,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/strip-bom</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/strip-bom</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|symbol@0.2.1">
@@ -1555,7 +1555,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/symbol</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/symbol</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|validate-npm-package-license@3.0.1">
@@ -1589,7 +1589,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/validate-npm-package-license</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/validate-npm-package-license</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|window-size@0.2.0">
@@ -1623,7 +1623,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/window-size</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/window-size</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|wrap-ansi@1.0.0">
@@ -1657,7 +1657,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/wrap-ansi</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/wrap-ansi</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|y18n@3.2.0">
@@ -1691,7 +1691,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/y18n</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/y18n</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|yargs-parser@2.1.0">
@@ -1725,7 +1725,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/yargs-parser</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/yargs-parser</property>
           </properties>
         </component>
         <component type="library" bom-ref="bundle-dependencies@1.0.2|yargs@4.1.0">
@@ -1758,7 +1758,7 @@
           </externalReferences>
           <properties>
             <property name="cdx:npm:package:bundled">true</property>
-            <property name="cdx:npm:package:installPath">node_modules/bundle-dependencies/node_modules/yargs</property>
+            <property name="cdx:npm:package:path">node_modules/bundle-dependencies/node_modules/yargs</property>
           </properties>
         </component>
       </components>

--- a/demo/dev-dependencies/example-results/bom.1.2.json
+++ b/demo/dev-dependencies/example-results/bom.1.2.json
@@ -8,7 +8,7 @@
       {
         "vendor": "@cyclonedx",
         "name": "cyclonedx-npm",
-        "version": "1.4.0"
+        "version": "1.4.1"
       }
     ],
     "component": {

--- a/demo/dev-dependencies/example-results/bom.1.2.xml
+++ b/demo/dev-dependencies/example-results/bom.1.2.xml
@@ -5,7 +5,7 @@
       <tool>
         <vendor>@cyclonedx</vendor>
         <name>cyclonedx-npm</name>
-        <version>1.4.0</version>
+        <version>1.4.1</version>
       </tool>
     </tools>
     <component type="application" bom-ref="demo-dev-dependencies@0.0.0">

--- a/demo/dev-dependencies/example-results/bom.1.3.json
+++ b/demo/dev-dependencies/example-results/bom.1.3.json
@@ -8,7 +8,7 @@
       {
         "vendor": "@cyclonedx",
         "name": "cyclonedx-npm",
-        "version": "1.4.0"
+        "version": "1.4.1"
       }
     ],
     "component": {
@@ -26,6 +26,10 @@
       ],
       "purl": "pkg:npm/demo-dev-dependencies@0.0.0",
       "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
         {
           "name": "cdx:npm:package:private",
           "value": "true"
@@ -76,6 +80,10 @@
         {
           "name": "cdx:npm:package:development",
           "value": "true"
+        },
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/node"
         }
       ]
     }

--- a/demo/dev-dependencies/example-results/bom.1.3.json
+++ b/demo/dev-dependencies/example-results/bom.1.3.json
@@ -27,7 +27,7 @@
       "purl": "pkg:npm/demo-dev-dependencies@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -82,7 +82,7 @@
           "value": "true"
         },
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/node"
         }
       ]

--- a/demo/dev-dependencies/example-results/bom.1.3.xml
+++ b/demo/dev-dependencies/example-results/bom.1.3.xml
@@ -5,7 +5,7 @@
       <tool>
         <vendor>@cyclonedx</vendor>
         <name>cyclonedx-npm</name>
-        <version>1.4.0</version>
+        <version>1.4.1</version>
       </tool>
     </tools>
     <component type="application" bom-ref="demo-dev-dependencies@0.0.0">
@@ -19,6 +19,7 @@
       </licenses>
       <purl>pkg:npm/demo-dev-dependencies@0.0.0</purl>
       <properties>
+        <property name="cdx:npm:package:installPath"/>
         <property name="cdx:npm:package:private">true</property>
       </properties>
     </component>
@@ -54,6 +55,7 @@
       </externalReferences>
       <properties>
         <property name="cdx:npm:package:development">true</property>
+        <property name="cdx:npm:package:installPath">node_modules/@types/node</property>
       </properties>
     </component>
   </components>

--- a/demo/dev-dependencies/example-results/bom.1.3.xml
+++ b/demo/dev-dependencies/example-results/bom.1.3.xml
@@ -19,7 +19,7 @@
       </licenses>
       <purl>pkg:npm/demo-dev-dependencies@0.0.0</purl>
       <properties>
-        <property name="cdx:npm:package:installPath"/>
+        <property name="cdx:npm:package:path"/>
         <property name="cdx:npm:package:private">true</property>
       </properties>
     </component>
@@ -55,7 +55,7 @@
       </externalReferences>
       <properties>
         <property name="cdx:npm:package:development">true</property>
-        <property name="cdx:npm:package:installPath">node_modules/@types/node</property>
+        <property name="cdx:npm:package:path">node_modules/@types/node</property>
       </properties>
     </component>
   </components>

--- a/demo/dev-dependencies/example-results/bom.1.4.json
+++ b/demo/dev-dependencies/example-results/bom.1.4.json
@@ -8,7 +8,7 @@
       {
         "vendor": "@cyclonedx",
         "name": "cyclonedx-npm",
-        "version": "1.4.0",
+        "version": "1.4.1",
         "externalReferences": [
           {
             "url": "https://github.com/CycloneDX/cyclonedx-node-npm/issues",
@@ -43,6 +43,10 @@
       ],
       "purl": "pkg:npm/demo-dev-dependencies@0.0.0",
       "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
         {
           "name": "cdx:npm:package:private",
           "value": "true"
@@ -93,6 +97,10 @@
         {
           "name": "cdx:npm:package:development",
           "value": "true"
+        },
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/node"
         }
       ]
     }

--- a/demo/dev-dependencies/example-results/bom.1.4.json
+++ b/demo/dev-dependencies/example-results/bom.1.4.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-dev-dependencies@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -99,7 +99,7 @@
           "value": "true"
         },
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/node"
         }
       ]

--- a/demo/dev-dependencies/example-results/bom.1.4.xml
+++ b/demo/dev-dependencies/example-results/bom.1.4.xml
@@ -33,7 +33,7 @@
       </licenses>
       <purl>pkg:npm/demo-dev-dependencies@0.0.0</purl>
       <properties>
-        <property name="cdx:npm:package:installPath"/>
+        <property name="cdx:npm:package:path"/>
         <property name="cdx:npm:package:private">true</property>
       </properties>
     </component>
@@ -69,7 +69,7 @@
       </externalReferences>
       <properties>
         <property name="cdx:npm:package:development">true</property>
-        <property name="cdx:npm:package:installPath">node_modules/@types/node</property>
+        <property name="cdx:npm:package:path">node_modules/@types/node</property>
       </properties>
     </component>
   </components>

--- a/demo/dev-dependencies/example-results/bom.1.4.xml
+++ b/demo/dev-dependencies/example-results/bom.1.4.xml
@@ -5,7 +5,7 @@
       <tool>
         <vendor>@cyclonedx</vendor>
         <name>cyclonedx-npm</name>
-        <version>1.4.0</version>
+        <version>1.4.1</version>
         <externalReferences>
           <reference type="issue-tracker">
             <url>https://github.com/CycloneDX/cyclonedx-node-npm/issues</url>
@@ -33,6 +33,7 @@
       </licenses>
       <purl>pkg:npm/demo-dev-dependencies@0.0.0</purl>
       <properties>
+        <property name="cdx:npm:package:installPath"/>
         <property name="cdx:npm:package:private">true</property>
       </properties>
     </component>
@@ -68,6 +69,7 @@
       </externalReferences>
       <properties>
         <property name="cdx:npm:package:development">true</property>
+        <property name="cdx:npm:package:installPath">node_modules/@types/node</property>
       </properties>
     </component>
   </components>

--- a/demo/juice-shop/example-results/bom.1.2.json
+++ b/demo/juice-shop/example-results/bom.1.2.json
@@ -8,7 +8,7 @@
       {
         "vendor": "@cyclonedx",
         "name": "cyclonedx-npm",
-        "version": "1.4.0"
+        "version": "1.4.1"
       }
     ],
     "component": {
@@ -5752,6 +5752,14 @@
           "content": "6b5788162e11f724ab6e232ec931b1e5ef76b911f9b5063a900acd70568a05495e2282e3763060ed9c66dccaa6dca9a47f6ec72d1ff57e7c57f6af0643b21abe"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://github.com/niklasvh/base64-arraybuffer/blob/master/LICENSE-MIT"
+          }
+        }
+      ],
       "purl": "pkg:npm/base64-arraybuffer@0.1.4",
       "externalReferences": [
         {
@@ -6662,6 +6670,12 @@
           "license": {
             "id": "MIT"
           }
+        },
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://github.com/brianloveswords/buffer-crc32/raw/master/LICENSE"
+          }
         }
       ],
       "purl": "pkg:npm/buffer-crc32@0.2.13",
@@ -6873,6 +6887,14 @@
         {
           "alg": "SHA-512",
           "content": "2275850e89af964123fb158b05f53702f9db558a9e4d6990a29896d2d596132e727a1626d9890611ce7db149b0ff8b72e598ff6f45871acd4b81e72e052046ae"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "http://github.com/mscdex/busboy/raw/master/LICENSE"
+          }
         }
       ],
       "purl": "pkg:npm/busboy@0.2.14",
@@ -10845,6 +10867,12 @@
           "license": {
             "id": "MIT"
           }
+        },
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://raw.githubusercontent.com/unclechu/node-deep-extend/master/LICENSE"
+          }
         }
       ],
       "purl": "pkg:npm/deep-extend@0.6.0",
@@ -11256,6 +11284,14 @@
         {
           "alg": "SHA-512",
           "content": "143bdbb67abb77394fcf4c32625384c627c311972ef21fab12b11781fc6a98b7d17c2fe4262744161e3e79f7c944edcfd3199fab23db48c1b42ef78d45f4ca56"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "http://github.com/mscdex/dicer/raw/master/LICENSE"
+          }
         }
       ],
       "purl": "pkg:npm/dicer@0.2.5",
@@ -12891,6 +12927,14 @@
           "content": "664fde34a576cdb8e92b3aec43e9f51baa6855b12b4312742c13895da299d445622f31fe86b2eef5c757238cf0f5d05026c970044a5b4363f5a12ee70f1b3a8d"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://github.com/cowboy/node-exit/blob/master/LICENSE-MIT"
+          }
+        }
+      ],
       "purl": "pkg:npm/exit@0.1.2",
       "externalReferences": [
         {
@@ -13489,6 +13533,14 @@
           "content": "086481d1bddb3555c8e93d021797ffe7964a62b220fdbd3ad7b10f99728af44e32d6ad96d70f494e08cf7e1b16c2e3e20ad939b280609b966482ac6086c7da1e"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "http://www.opensource.org/licenses/MIT"
+          }
+        }
+      ],
       "purl": "pkg:npm/express-jwt@0.1.3",
       "externalReferences": [
         {
@@ -13558,6 +13610,13 @@
             {
               "alg": "SHA-512",
               "content": "9778c28c225f0baa48b9c6b5dc6329094e2588462f624d7b5e9160a494b22e9f115fe770760ad906fb646a87e622282995ecdb1b55591548106c315149ddfb60"
+            }
+          ],
+          "licenses": [
+            {
+              "license": {
+                "id": "MIT"
+              }
             }
           ],
           "purl": "pkg:npm/moment@2.0.0",
@@ -15299,6 +15358,12 @@
           "license": {
             "id": "MIT"
           }
+        },
+        {
+          "license": {
+            "id": "MIT",
+            "url": "http://github.com/Raynos/for-each/raw/master/LICENSE"
+          }
         }
       ],
       "purl": "pkg:npm/for-each@0.3.3",
@@ -16353,6 +16418,14 @@
         {
           "alg": "SHA-512",
           "content": "db36e50c168571bdeb078ac5efb5d59ee20d384da1da4fce9ea5c08b2d08ad3c547d5d62169de56b7de8010558f690a9594dbaf1615856ddadef586532e2ec3a"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://github.com/cowboy/node-getobject/blob/master/LICENSE-MIT"
+          }
         }
       ],
       "purl": "pkg:npm/getobject@1.0.2",
@@ -17643,6 +17716,14 @@
           "content": "60b88341ab38e198a5fdb3648561423fade923291348ce1368dcd73e257b9e23241d179f9a9c857b96968919f80ace6e24c2e15da77ca63ac08b604e9a44e465"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://github.com/exo-dev/grunt-replace-json/blob/master/LICENCE.md"
+          }
+        }
+      ],
       "purl": "pkg:npm/grunt-replace-json@0.1.0",
       "externalReferences": [
         {
@@ -17756,6 +17837,14 @@
             {
               "alg": "SHA-512",
               "content": "cfc36bc218bac33c4d3086f196b4f3b945ba296b8a928819ffb39d0d5abed3e9319fbeca507d678a9c7c894eacbaa907a9ce32ea7edaf40f08a66c58fe94e35a"
+            }
+          ],
+          "licenses": [
+            {
+              "license": {
+                "id": "MIT",
+                "url": "https://github.com/cowboy/node-findup-sync/blob/master/LICENSE-MIT"
+              }
             }
           ],
           "purl": "pkg:npm/findup-sync@0.3.0",
@@ -18579,6 +18668,12 @@
           "license": {
             "id": "MIT"
           }
+        },
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://github.com/tarruda/has/blob/master/LICENSE-MIT"
+          }
         }
       ],
       "purl": "pkg:npm/has@1.0.3",
@@ -18694,6 +18789,14 @@
         {
           "alg": "SHA-512",
           "content": "c059f526572c81b71611ac10e80d46ced80d45197a53212d6804480e901e1f7737e53ffd89dfd040abdaa75340cfa624da82ab2b05d0659144452d2d97d13426"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "http://mths.be/mit"
+          }
         }
       ],
       "purl": "pkg:npm/he@0.4.1",
@@ -18899,6 +19002,14 @@
           "content": "b7e51eac2b10be24b29802270f4d4fc3e0e7feeb26cf5b113bedd9935fa5c7c7a0f962a90f6ba57305aa1c72f4f9ab1e441afedfebc88621b52b5253c1a21c4c"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://github.com/cowboy/javascript-hooker/blob/master/LICENSE-MIT"
+          }
+        }
+      ],
       "purl": "pkg:npm/hooker@0.2.3",
       "externalReferences": [
         {
@@ -19012,6 +19123,14 @@
         {
           "alg": "SHA-512",
           "content": "67c8bade7eec7ae3ef45ed4f432ae39a8552b6fedb8cc6b4b24ace97f93ab674ffe56a4f36bcd62c1d4783f749c415c7fcce8a66f9b6e494065428901b15112d"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "http://github.com/fb55/htmlparser2/raw/master/LICENSE"
+          }
         }
       ],
       "purl": "pkg:npm/htmlparser2@3.3.0",
@@ -21403,6 +21522,12 @@
         {
           "license": {
             "id": "MIT"
+          }
+        },
+        {
+          "license": {
+            "id": "MIT",
+            "url": "http://github.com/inspect-js/is-object/raw/master/LICENSE"
           }
         }
       ],
@@ -27451,6 +27576,14 @@
               "content": "ae9e5d30a37ccc4b3d75f8bd8345f50a52e657ffd647293f475e66a6914d202205446e4ff7654fed9d38a7ca64fbe800068f56dad63e907caee8fd661078264c"
             }
           ],
+          "licenses": [
+            {
+              "license": {
+                "name": "BSD",
+                "url": "http://github.com/ariya/esprima/raw/master/LICENSE.BSD"
+              }
+            }
+          ],
           "purl": "pkg:npm/esprima@1.0.4",
           "externalReferences": [
             {
@@ -30019,6 +30152,14 @@
         {
           "alg": "SHA-512",
           "content": "112176dd5e12286ea55521998183696ec89a02475a6fa6603b17b9da9efe2a27775b7bb76f147855f77fa36d5d98dee34add08c20678bf9314776e8512d5c4f7"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://raw.github.com/gkz/prelude-ls/master/LICENSE"
+          }
         }
       ],
       "purl": "pkg:npm/prelude-ls@1.1.2",
@@ -36692,6 +36833,14 @@
           "content": "8e8b3cbbef892a6d0045c4944c06573950b4992a31ec1867eac060b72ef73f57f72467fbc86d9c9536c134751d75efe476f3f614449a9bebccea5f2306b3711c"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "http://github.com/mscdex/streamsearch/raw/master/LICENSE"
+          }
+        }
+      ],
       "purl": "pkg:npm/streamsearch@0.1.2",
       "externalReferences": [
         {
@@ -36823,6 +36972,14 @@
         {
           "alg": "SHA-512",
           "content": "9faf47df53a7c5219267265b80196f6085e5acc849434750017d63b354038696941face6537418963d3b6c2c023653cebb7a115c8b9b18f9768031a71ec882aa"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "http://mths.be/mit"
+          }
         }
       ],
       "purl": "pkg:npm/string.fromcodepoint@0.2.1",
@@ -40161,6 +40318,12 @@
         {
           "license": {
             "id": "MIT"
+          }
+        },
+        {
+          "license": {
+            "id": "MIT",
+            "url": "http://opensource.org/licenses/MIT"
           }
         }
       ],

--- a/demo/juice-shop/example-results/bom.1.2.xml
+++ b/demo/juice-shop/example-results/bom.1.2.xml
@@ -5,7 +5,7 @@
       <tool>
         <vendor>@cyclonedx</vendor>
         <name>cyclonedx-npm</name>
-        <version>1.4.0</version>
+        <version>1.4.1</version>
       </tool>
     </tools>
     <component type="application" bom-ref="juice-shop@14.1.1">
@@ -4293,6 +4293,12 @@
       <hashes>
         <hash alg="SHA-512">6b5788162e11f724ab6e232ec931b1e5ef76b911f9b5063a900acd70568a05495e2282e3763060ed9c66dccaa6dca9a47f6ec72d1ff57e7c57f6af0643b21abe</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <url>https://github.com/niklasvh/base64-arraybuffer/blob/master/LICENSE-MIT</url>
+        </license>
+      </licenses>
       <purl>pkg:npm/base64-arraybuffer@0.1.4</purl>
       <externalReferences>
         <reference type="distribution">
@@ -4964,6 +4970,10 @@
         <license>
           <id>MIT</id>
         </license>
+        <license>
+          <id>MIT</id>
+          <url>https://github.com/brianloveswords/buffer-crc32/raw/master/LICENSE</url>
+        </license>
       </licenses>
       <purl>pkg:npm/buffer-crc32@0.2.13</purl>
       <externalReferences>
@@ -5121,6 +5131,12 @@
       <hashes>
         <hash alg="SHA-512">2275850e89af964123fb158b05f53702f9db558a9e4d6990a29896d2d596132e727a1626d9890611ce7db149b0ff8b72e598ff6f45871acd4b81e72e052046ae</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <url>http://github.com/mscdex/busboy/raw/master/LICENSE</url>
+        </license>
+      </licenses>
       <purl>pkg:npm/busboy@0.2.14</purl>
       <externalReferences>
         <reference type="distribution">
@@ -8067,6 +8083,10 @@
         <license>
           <id>MIT</id>
         </license>
+        <license>
+          <id>MIT</id>
+          <url>https://raw.githubusercontent.com/unclechu/node-deep-extend/master/LICENSE</url>
+        </license>
       </licenses>
       <purl>pkg:npm/deep-extend@0.6.0</purl>
       <externalReferences>
@@ -8373,6 +8393,12 @@
       <hashes>
         <hash alg="SHA-512">143bdbb67abb77394fcf4c32625384c627c311972ef21fab12b11781fc6a98b7d17c2fe4262744161e3e79f7c944edcfd3199fab23db48c1b42ef78d45f4ca56</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <url>http://github.com/mscdex/dicer/raw/master/LICENSE</url>
+        </license>
+      </licenses>
       <purl>pkg:npm/dicer@0.2.5</purl>
       <externalReferences>
         <reference type="distribution">
@@ -9574,6 +9600,12 @@
       <hashes>
         <hash alg="SHA-512">664fde34a576cdb8e92b3aec43e9f51baa6855b12b4312742c13895da299d445622f31fe86b2eef5c757238cf0f5d05026c970044a5b4363f5a12ee70f1b3a8d</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <url>https://github.com/cowboy/node-exit/blob/master/LICENSE-MIT</url>
+        </license>
+      </licenses>
       <purl>pkg:npm/exit@0.1.2</purl>
       <externalReferences>
         <reference type="distribution">
@@ -10023,6 +10055,12 @@
       <hashes>
         <hash alg="SHA-512">086481d1bddb3555c8e93d021797ffe7964a62b220fdbd3ad7b10f99728af44e32d6ad96d70f494e08cf7e1b16c2e3e20ad939b280609b966482ac6086c7da1e</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <url>http://www.opensource.org/licenses/MIT</url>
+        </license>
+      </licenses>
       <purl>pkg:npm/express-jwt@0.1.3</purl>
       <externalReferences>
         <reference type="distribution">
@@ -10076,6 +10114,11 @@
           <hashes>
             <hash alg="SHA-512">9778c28c225f0baa48b9c6b5dc6329094e2588462f624d7b5e9160a494b22e9f115fe770760ad906fb646a87e622282995ecdb1b55591548106c315149ddfb60</hash>
           </hashes>
+          <licenses>
+            <license>
+              <id>MIT</id>
+            </license>
+          </licenses>
           <purl>pkg:npm/moment@2.0.0</purl>
           <externalReferences>
             <reference type="distribution">
@@ -11372,6 +11415,10 @@
         <license>
           <id>MIT</id>
         </license>
+        <license>
+          <id>MIT</id>
+          <url>http://github.com/Raynos/for-each/raw/master/LICENSE</url>
+        </license>
       </licenses>
       <purl>pkg:npm/for-each@0.3.3</purl>
       <externalReferences>
@@ -12158,6 +12205,12 @@
       <hashes>
         <hash alg="SHA-512">db36e50c168571bdeb078ac5efb5d59ee20d384da1da4fce9ea5c08b2d08ad3c547d5d62169de56b7de8010558f690a9594dbaf1615856ddadef586532e2ec3a</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <url>https://github.com/cowboy/node-getobject/blob/master/LICENSE-MIT</url>
+        </license>
+      </licenses>
       <purl>pkg:npm/getobject@1.0.2</purl>
       <externalReferences>
         <reference type="distribution">
@@ -13113,6 +13166,12 @@
       <hashes>
         <hash alg="SHA-512">60b88341ab38e198a5fdb3648561423fade923291348ce1368dcd73e257b9e23241d179f9a9c857b96968919f80ace6e24c2e15da77ca63ac08b604e9a44e465</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <url>https://github.com/exo-dev/grunt-replace-json/blob/master/LICENCE.md</url>
+        </license>
+      </licenses>
       <purl>pkg:npm/grunt-replace-json@0.1.0</purl>
       <externalReferences>
         <reference type="distribution">
@@ -13199,6 +13258,12 @@
           <hashes>
             <hash alg="SHA-512">cfc36bc218bac33c4d3086f196b4f3b945ba296b8a928819ffb39d0d5abed3e9319fbeca507d678a9c7c894eacbaa907a9ce32ea7edaf40f08a66c58fe94e35a</hash>
           </hashes>
+          <licenses>
+            <license>
+              <id>MIT</id>
+              <url>https://github.com/cowboy/node-findup-sync/blob/master/LICENSE-MIT</url>
+            </license>
+          </licenses>
           <purl>pkg:npm/findup-sync@0.3.0</purl>
           <externalReferences>
             <reference type="distribution">
@@ -13814,6 +13879,10 @@
         <license>
           <id>MIT</id>
         </license>
+        <license>
+          <id>MIT</id>
+          <url>https://github.com/tarruda/has/blob/master/LICENSE-MIT</url>
+        </license>
       </licenses>
       <purl>pkg:npm/has@1.0.3</purl>
       <externalReferences>
@@ -13901,6 +13970,12 @@
       <hashes>
         <hash alg="SHA-512">c059f526572c81b71611ac10e80d46ced80d45197a53212d6804480e901e1f7737e53ffd89dfd040abdaa75340cfa624da82ab2b05d0659144452d2d97d13426</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <url>http://mths.be/mit</url>
+        </license>
+      </licenses>
       <purl>pkg:npm/he@0.4.1</purl>
       <externalReferences>
         <reference type="distribution">
@@ -14053,6 +14128,12 @@
       <hashes>
         <hash alg="SHA-512">b7e51eac2b10be24b29802270f4d4fc3e0e7feeb26cf5b113bedd9935fa5c7c7a0f962a90f6ba57305aa1c72f4f9ab1e441afedfebc88621b52b5253c1a21c4c</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <url>https://github.com/cowboy/javascript-hooker/blob/master/LICENSE-MIT</url>
+        </license>
+      </licenses>
       <purl>pkg:npm/hooker@0.2.3</purl>
       <externalReferences>
         <reference type="distribution">
@@ -14139,6 +14220,12 @@
       <hashes>
         <hash alg="SHA-512">67c8bade7eec7ae3ef45ed4f432ae39a8552b6fedb8cc6b4b24ace97f93ab674ffe56a4f36bcd62c1d4783f749c415c7fcce8a66f9b6e494065428901b15112d</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <url>http://github.com/fb55/htmlparser2/raw/master/LICENSE</url>
+        </license>
+      </licenses>
       <purl>pkg:npm/htmlparser2@3.3.0</purl>
       <externalReferences>
         <reference type="distribution">
@@ -15915,6 +16002,10 @@
       <licenses>
         <license>
           <id>MIT</id>
+        </license>
+        <license>
+          <id>MIT</id>
+          <url>http://github.com/inspect-js/is-object/raw/master/LICENSE</url>
         </license>
       </licenses>
       <purl>pkg:npm/is-object@1.0.2</purl>
@@ -20388,6 +20479,12 @@
           <hashes>
             <hash alg="SHA-512">ae9e5d30a37ccc4b3d75f8bd8345f50a52e657ffd647293f475e66a6914d202205446e4ff7654fed9d38a7ca64fbe800068f56dad63e907caee8fd661078264c</hash>
           </hashes>
+          <licenses>
+            <license>
+              <name>BSD</name>
+              <url>http://github.com/ariya/esprima/raw/master/LICENSE.BSD</url>
+            </license>
+          </licenses>
           <purl>pkg:npm/esprima@1.0.4</purl>
           <externalReferences>
             <reference type="distribution">
@@ -22298,6 +22395,12 @@
       <hashes>
         <hash alg="SHA-512">112176dd5e12286ea55521998183696ec89a02475a6fa6603b17b9da9efe2a27775b7bb76f147855f77fa36d5d98dee34add08c20678bf9314776e8512d5c4f7</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <url>https://raw.github.com/gkz/prelude-ls/master/LICENSE</url>
+        </license>
+      </licenses>
       <purl>pkg:npm/prelude-ls@1.1.2</purl>
       <externalReferences>
         <reference type="distribution">
@@ -27241,6 +27344,12 @@
       <hashes>
         <hash alg="SHA-512">8e8b3cbbef892a6d0045c4944c06573950b4992a31ec1867eac060b72ef73f57f72467fbc86d9c9536c134751d75efe476f3f614449a9bebccea5f2306b3711c</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <url>http://github.com/mscdex/streamsearch/raw/master/LICENSE</url>
+        </license>
+      </licenses>
       <purl>pkg:npm/streamsearch@0.1.2</purl>
       <externalReferences>
         <reference type="distribution">
@@ -27339,6 +27448,12 @@
       <hashes>
         <hash alg="SHA-512">9faf47df53a7c5219267265b80196f6085e5acc849434750017d63b354038696941face6537418963d3b6c2c023653cebb7a115c8b9b18f9768031a71ec882aa</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <url>http://mths.be/mit</url>
+        </license>
+      </licenses>
       <purl>pkg:npm/string.fromcodepoint@0.2.1</purl>
       <externalReferences>
         <reference type="distribution">
@@ -29817,6 +29932,10 @@
       <licenses>
         <license>
           <id>MIT</id>
+        </license>
+        <license>
+          <id>MIT</id>
+          <url>http://opensource.org/licenses/MIT</url>
         </license>
       </licenses>
       <purl>pkg:npm/utils-merge@1.0.1</purl>

--- a/demo/juice-shop/example-results/bom.1.3.json
+++ b/demo/juice-shop/example-results/bom.1.3.json
@@ -45,7 +45,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -97,7 +97,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@babel/helper-string-parser"
         }
       ]
@@ -138,7 +138,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@babel/helper-validator-identifier"
         }
       ]
@@ -189,7 +189,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@babel/parser"
         }
       ]
@@ -240,7 +240,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@babel/types"
         }
       ]
@@ -291,7 +291,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@colors/colors"
         }
       ]
@@ -342,7 +342,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@dabh/diagnostics"
         }
       ]
@@ -383,7 +383,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@gar/promisify"
         }
       ]
@@ -424,7 +424,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@mapbox/node-pre-gyp"
         }
       ],
@@ -464,7 +464,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/ansi-regex"
             }
           ]
@@ -514,7 +514,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/are-we-there-yet"
             }
           ]
@@ -554,7 +554,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/detect-libc"
             }
           ]
@@ -604,7 +604,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/gauge"
             }
           ]
@@ -644,7 +644,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -684,7 +684,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/make-dir"
             }
           ],
@@ -723,7 +723,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/@mapbox/node-pre-gyp/node_modules/make-dir/node_modules/semver"
                 }
               ]
@@ -765,7 +765,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/nopt"
             }
           ]
@@ -805,7 +805,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/npmlog"
             }
           ]
@@ -844,7 +844,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/readable-stream"
             }
           ]
@@ -884,7 +884,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/string-width"
             }
           ]
@@ -924,7 +924,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/strip-ansi"
             }
           ]
@@ -972,7 +972,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/core-loader"
         }
       ]
@@ -1018,7 +1018,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/core"
         }
       ]
@@ -1064,7 +1064,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/evaluator"
         }
       ]
@@ -1110,7 +1110,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-all"
         }
       ]
@@ -1156,7 +1156,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ar"
         }
       ]
@@ -1202,7 +1202,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-bn"
         }
       ]
@@ -1248,7 +1248,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ca"
         }
       ]
@@ -1294,7 +1294,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-cs"
         }
       ]
@@ -1340,7 +1340,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-da"
         }
       ]
@@ -1386,7 +1386,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-de"
         }
       ]
@@ -1432,7 +1432,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-el"
         }
       ]
@@ -1478,7 +1478,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-en-min"
         }
       ]
@@ -1524,7 +1524,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-en"
         }
       ]
@@ -1570,7 +1570,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-es"
         }
       ]
@@ -1616,7 +1616,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-eu"
         }
       ]
@@ -1662,7 +1662,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-fa"
         }
       ]
@@ -1708,7 +1708,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-fi"
         }
       ]
@@ -1754,7 +1754,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-fr"
         }
       ]
@@ -1800,7 +1800,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ga"
         }
       ]
@@ -1846,7 +1846,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-gl"
         }
       ]
@@ -1892,7 +1892,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-hi"
         }
       ]
@@ -1938,7 +1938,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-hu"
         }
       ]
@@ -1984,7 +1984,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-hy"
         }
       ]
@@ -2030,7 +2030,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-id"
         }
       ]
@@ -2076,7 +2076,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-it"
         }
       ]
@@ -2122,7 +2122,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ja"
         }
       ]
@@ -2168,7 +2168,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ko"
         }
       ]
@@ -2214,7 +2214,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-lt"
         }
       ]
@@ -2260,7 +2260,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ms"
         }
       ]
@@ -2306,7 +2306,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ne"
         }
       ]
@@ -2352,7 +2352,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-nl"
         }
       ]
@@ -2398,7 +2398,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-no"
         }
       ]
@@ -2444,7 +2444,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-pl"
         }
       ]
@@ -2490,7 +2490,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-pt"
         }
       ]
@@ -2536,7 +2536,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ro"
         }
       ]
@@ -2582,7 +2582,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ru"
         }
       ]
@@ -2628,7 +2628,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-sl"
         }
       ]
@@ -2674,7 +2674,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-sr"
         }
       ]
@@ -2720,7 +2720,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-sv"
         }
       ]
@@ -2766,7 +2766,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ta"
         }
       ]
@@ -2812,7 +2812,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-th"
         }
       ]
@@ -2858,7 +2858,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-tl"
         }
       ]
@@ -2904,7 +2904,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-tr"
         }
       ]
@@ -2950,7 +2950,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-uk"
         }
       ]
@@ -2996,7 +2996,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-zh"
         }
       ]
@@ -3042,7 +3042,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/language-min"
         }
       ]
@@ -3088,7 +3088,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/language"
         }
       ]
@@ -3134,7 +3134,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/ner"
         }
       ]
@@ -3180,7 +3180,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/neural"
         }
       ]
@@ -3226,7 +3226,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/nlg"
         }
       ]
@@ -3272,7 +3272,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/nlp"
         }
       ]
@@ -3318,7 +3318,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/nlu"
         }
       ]
@@ -3364,7 +3364,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/request"
         }
       ]
@@ -3410,7 +3410,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/sentiment"
         }
       ]
@@ -3456,7 +3456,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/similarity"
         }
       ]
@@ -3502,7 +3502,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/slot"
         }
       ]
@@ -3538,7 +3538,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@npmcli/fs"
         }
       ]
@@ -3578,7 +3578,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@npmcli/move-file"
         }
       ]
@@ -3624,7 +3624,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib/core"
         }
       ]
@@ -3670,7 +3670,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib/plugin-crypto"
         }
       ]
@@ -3716,7 +3716,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib/plugin-thirty-two"
         }
       ]
@@ -3762,7 +3762,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib/preset-default"
         }
       ]
@@ -3808,7 +3808,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib/preset-v11"
         }
       ]
@@ -3849,7 +3849,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@sindresorhus/is"
         }
       ]
@@ -3900,7 +3900,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@swc/helpers"
         }
       ]
@@ -3946,7 +3946,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@tokenizer/token"
         }
       ]
@@ -3992,7 +3992,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@tootallnate/once"
         }
       ]
@@ -4037,7 +4037,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/component-emitter"
         }
       ]
@@ -4082,7 +4082,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/cookie"
         }
       ]
@@ -4127,7 +4127,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/cors"
         }
       ]
@@ -4172,7 +4172,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/debug"
         }
       ]
@@ -4212,7 +4212,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/ms"
         }
       ]
@@ -4257,7 +4257,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/node"
         }
       ]
@@ -4298,7 +4298,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/strip-bom"
         }
       ]
@@ -4338,7 +4338,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/strip-json-comments"
         }
       ]
@@ -4383,7 +4383,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/validator"
         }
       ]
@@ -4423,7 +4423,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/abbrev"
         }
       ]
@@ -4462,7 +4462,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/accepts"
         }
       ]
@@ -4506,7 +4506,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/acorn-walk"
         }
       ]
@@ -4550,7 +4550,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/acorn"
         }
       ]
@@ -4595,7 +4595,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/agent-base"
         }
       ],
@@ -4635,7 +4635,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agent-base/node_modules/debug"
             }
           ]
@@ -4674,7 +4674,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agent-base/node_modules/ms"
             }
           ]
@@ -4721,7 +4721,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/agentkeepalive"
         }
       ],
@@ -4761,7 +4761,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agentkeepalive/node_modules/debug"
             }
           ]
@@ -4801,7 +4801,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agentkeepalive/node_modules/depd"
             }
           ]
@@ -4840,7 +4840,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agentkeepalive/node_modules/ms"
             }
           ]
@@ -4882,7 +4882,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/aggregate-error"
         }
       ]
@@ -4932,7 +4932,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ajv"
         }
       ]
@@ -4972,7 +4972,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ansi-regex"
         }
       ]
@@ -5012,7 +5012,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ansi-styles"
         }
       ]
@@ -5057,7 +5057,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/anymatch"
         }
       ],
@@ -5107,7 +5107,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/anymatch/node_modules/normalize-path"
             }
           ]
@@ -5148,7 +5148,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/append-field"
         }
       ]
@@ -5198,7 +5198,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/aproba"
         }
       ]
@@ -5238,7 +5238,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/archive-type"
         }
       ],
@@ -5278,7 +5278,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/archive-type/node_modules/file-type"
             }
           ]
@@ -5330,7 +5330,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/archiver-utils"
         }
       ]
@@ -5380,7 +5380,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/archiver"
         }
       ]
@@ -5430,7 +5430,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/are-we-there-yet"
         }
       ]
@@ -5470,7 +5470,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/arg"
         }
       ]
@@ -5509,7 +5509,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/argparse"
         }
       ],
@@ -5549,7 +5549,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/argparse/node_modules/sprintf-js"
             }
           ]
@@ -5601,7 +5601,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/arr-diff"
         }
       ]
@@ -5651,7 +5651,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/arr-flatten"
         }
       ]
@@ -5701,7 +5701,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/arr-union"
         }
       ]
@@ -5751,7 +5751,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/array-each"
         }
       ]
@@ -5801,7 +5801,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/array-flatten"
         }
       ]
@@ -5851,7 +5851,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/array-slice"
         }
       ]
@@ -5901,7 +5901,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/array-unique"
         }
       ]
@@ -5940,7 +5940,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/asap"
         }
       ]
@@ -5980,7 +5980,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/asn1"
         }
       ]
@@ -6020,7 +6020,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/assert-never"
         }
       ]
@@ -6060,7 +6060,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/assert-plus"
         }
       ]
@@ -6110,7 +6110,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/assign-symbols"
         }
       ]
@@ -6160,7 +6160,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/async"
         }
       ]
@@ -6210,7 +6210,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/asynckit"
         }
       ]
@@ -6260,7 +6260,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/at-least-node"
         }
       ]
@@ -6303,7 +6303,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/atob"
         }
       ]
@@ -6353,7 +6353,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/available-typed-arrays"
         }
       ]
@@ -6393,7 +6393,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/aws-sign2"
         }
       ]
@@ -6433,7 +6433,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/aws4"
         }
       ]
@@ -6473,7 +6473,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/babel-walk"
         }
       ]
@@ -6518,7 +6518,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/balanced-match"
         }
       ]
@@ -6568,7 +6568,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base"
         }
       ],
@@ -6618,7 +6618,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/base/node_modules/define-property"
             }
           ]
@@ -6671,7 +6671,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base64-arraybuffer"
         }
       ]
@@ -6721,7 +6721,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base64-js"
         }
       ]
@@ -6761,7 +6761,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base64id"
         }
       ]
@@ -6801,7 +6801,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base64url"
         }
       ]
@@ -6840,7 +6840,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/basic-auth"
         }
       ]
@@ -6880,7 +6880,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/batch"
         }
       ]
@@ -6919,7 +6919,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bcrypt-pbkdf"
         }
       ]
@@ -6959,7 +6959,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/big-integer"
         }
       ]
@@ -6999,7 +6999,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/binary-extensions"
         }
       ]
@@ -7039,7 +7039,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/binary"
         }
       ]
@@ -7089,7 +7089,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bindings"
         }
       ]
@@ -7129,7 +7129,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bintrees"
         }
       ]
@@ -7173,7 +7173,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bl"
         }
       ]
@@ -7223,7 +7223,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bluebird"
         }
       ]
@@ -7262,7 +7262,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/body-parser"
         }
       ]
@@ -7307,7 +7307,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bower-config"
         }
       ],
@@ -7352,7 +7352,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bower-config/node_modules/minimist"
             }
           ]
@@ -7399,7 +7399,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/brace-expansion"
         }
       ]
@@ -7449,7 +7449,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/braces"
         }
       ],
@@ -7499,7 +7499,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/braces/node_modules/extend-shallow"
             }
           ]
@@ -7549,7 +7549,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/braces/node_modules/is-extendable"
             }
           ]
@@ -7601,7 +7601,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/brotli"
         }
       ]
@@ -7639,7 +7639,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-alloc-unsafe"
         }
       ]
@@ -7677,7 +7677,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-alloc"
         }
       ]
@@ -7728,7 +7728,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-crc32"
         }
       ]
@@ -7766,7 +7766,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-fill"
         }
       ]
@@ -7804,7 +7804,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-from"
         }
       ]
@@ -7854,7 +7854,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-indexof-polyfill"
         }
       ]
@@ -7904,7 +7904,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer"
         }
       ]
@@ -7937,7 +7937,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffers"
         }
       ]
@@ -7978,7 +7978,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/busboy"
         }
       ],
@@ -8023,7 +8023,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/busboy/node_modules/isarray"
             }
           ]
@@ -8063,7 +8063,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/busboy/node_modules/readable-stream"
             }
           ]
@@ -8107,7 +8107,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/busboy/node_modules/string_decoder"
             }
           ]
@@ -8159,7 +8159,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/byline"
         }
       ]
@@ -8199,7 +8199,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bytes"
         }
       ]
@@ -8238,7 +8238,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cacache"
         }
       ]
@@ -8288,7 +8288,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cache-base"
         }
       ]
@@ -8338,7 +8338,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cacheable-request"
         }
       ],
@@ -8378,7 +8378,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cacheable-request/node_modules/get-stream"
             }
           ]
@@ -8418,7 +8418,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cacheable-request/node_modules/lowercase-keys"
             }
           ]
@@ -8470,7 +8470,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/call-bind"
         }
       ]
@@ -8510,7 +8510,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/camelcase"
         }
       ]
@@ -8555,7 +8555,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/caseless"
         }
       ]
@@ -8595,7 +8595,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/chainsaw"
         }
       ]
@@ -8634,7 +8634,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/chalk"
         }
       ]
@@ -8674,7 +8674,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/character-parser"
         }
       ]
@@ -8724,7 +8724,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/check-dependencies"
         }
       ],
@@ -8763,7 +8763,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/check-dependencies/node_modules/semver"
             }
           ]
@@ -8815,7 +8815,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/check-types"
         }
       ]
@@ -8865,7 +8865,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/chokidar"
         }
       ],
@@ -8915,7 +8915,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar/node_modules/braces"
             }
           ]
@@ -8965,7 +8965,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar/node_modules/fill-range"
             }
           ]
@@ -9015,7 +9015,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar/node_modules/is-glob"
             }
           ]
@@ -9065,7 +9065,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar/node_modules/is-number"
             }
           ]
@@ -9115,7 +9115,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar/node_modules/normalize-path"
             }
           ]
@@ -9165,7 +9165,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar/node_modules/to-regex-range"
             }
           ]
@@ -9207,7 +9207,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/chownr"
         }
       ]
@@ -9257,7 +9257,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/clarinet"
         }
       ]
@@ -9307,7 +9307,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/class-utils"
         }
       ],
@@ -9357,7 +9357,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils/node_modules/define-property"
             }
           ]
@@ -9407,7 +9407,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils/node_modules/is-accessor-descriptor"
             }
           ],
@@ -9457,7 +9457,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/class-utils/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
@@ -9509,7 +9509,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils/node_modules/is-data-descriptor"
             }
           ],
@@ -9559,7 +9559,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/class-utils/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
@@ -9611,7 +9611,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils/node_modules/is-descriptor"
             }
           ]
@@ -9661,7 +9661,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils/node_modules/kind-of"
             }
           ]
@@ -9703,7 +9703,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/clean-stack"
         }
       ]
@@ -9743,7 +9743,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cliui"
         }
       ],
@@ -9783,7 +9783,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui/node_modules/ansi-regex"
             }
           ]
@@ -9833,7 +9833,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui/node_modules/emoji-regex"
             }
           ]
@@ -9873,7 +9873,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -9913,7 +9913,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui/node_modules/string-width"
             }
           ]
@@ -9953,7 +9953,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui/node_modules/strip-ansi"
             }
           ]
@@ -10005,7 +10005,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/clone-response"
         }
       ]
@@ -10050,7 +10050,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/clone"
         }
       ]
@@ -10090,7 +10090,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/code-point-at"
         }
       ]
@@ -10140,7 +10140,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/collection-visit"
         }
       ]
@@ -10180,7 +10180,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color-convert"
         }
       ]
@@ -10230,7 +10230,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color-name"
         }
       ]
@@ -10270,7 +10270,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color-string"
         }
       ]
@@ -10310,7 +10310,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color-support"
         }
       ]
@@ -10349,7 +10349,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color"
         }
       ]
@@ -10399,7 +10399,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/colors"
         }
       ]
@@ -10449,7 +10449,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/colorspace"
         }
       ]
@@ -10494,7 +10494,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/combined-stream"
         }
       ]
@@ -10534,7 +10534,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/commander"
         }
       ]
@@ -10573,7 +10573,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/component-emitter"
         }
       ]
@@ -10612,7 +10612,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/component-type"
         }
       ]
@@ -10662,7 +10662,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/compress-commons"
         }
       ]
@@ -10701,7 +10701,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/compressible"
         }
       ]
@@ -10740,7 +10740,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/compression"
         }
       ],
@@ -10780,7 +10780,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/compression/node_modules/bytes"
             }
           ]
@@ -10822,7 +10822,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/concat-map"
         }
       ]
@@ -10867,7 +10867,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/concat-stream"
         }
       ]
@@ -10907,7 +10907,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/concurrently"
         }
       ],
@@ -10947,7 +10947,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/concurrently/node_modules/supports-color"
             }
           ]
@@ -10994,7 +10994,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/config"
         }
       ]
@@ -11034,7 +11034,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/console-control-strings"
         }
       ]
@@ -11074,7 +11074,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/constantinople"
         }
       ]
@@ -11114,7 +11114,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/content-disposition"
         }
       ],
@@ -11164,7 +11164,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/content-disposition/node_modules/safe-buffer"
             }
           ]
@@ -11206,7 +11206,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/content-type"
         }
       ]
@@ -11246,7 +11246,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cookie-parser"
         }
       ]
@@ -11286,7 +11286,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cookie-signature"
         }
       ]
@@ -11326,7 +11326,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cookie"
         }
       ]
@@ -11376,7 +11376,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/copy-descriptor"
         }
       ]
@@ -11421,7 +11421,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/core-util-is"
         }
       ]
@@ -11461,7 +11461,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cors"
         }
       ]
@@ -11511,7 +11511,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/crc"
         }
       ]
@@ -11561,7 +11561,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/crc32-stream"
         }
       ]
@@ -11600,7 +11600,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/create-require"
         }
       ]
@@ -11645,7 +11645,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/crypto-js"
         }
       ]
@@ -11685,7 +11685,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dashdash"
         }
       ]
@@ -11724,7 +11724,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/date-fns"
         }
       ]
@@ -11769,7 +11769,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dateformat"
         }
       ]
@@ -11809,7 +11809,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/debug"
         }
       ]
@@ -11849,7 +11849,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decamelize"
         }
       ]
@@ -11889,7 +11889,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decode-uri-component"
         }
       ]
@@ -11928,7 +11928,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-response"
         }
       ]
@@ -11968,7 +11968,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-tar"
         }
       ],
@@ -12008,7 +12008,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-tar/node_modules/file-type"
             }
           ]
@@ -12050,7 +12050,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-tarbz2"
         }
       ],
@@ -12090,7 +12090,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-tarbz2/node_modules/file-type"
             }
           ]
@@ -12132,7 +12132,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-targz"
         }
       ],
@@ -12172,7 +12172,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-targz/node_modules/file-type"
             }
           ]
@@ -12214,7 +12214,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-unzip"
         }
       ],
@@ -12254,7 +12254,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-unzip/node_modules/file-type"
             }
           ]
@@ -12294,7 +12294,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-unzip/node_modules/get-stream"
             }
           ]
@@ -12334,7 +12334,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-unzip/node_modules/pify"
             }
           ]
@@ -12376,7 +12376,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress"
         }
       ],
@@ -12416,7 +12416,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress/node_modules/make-dir"
             }
           ],
@@ -12456,7 +12456,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/decompress/node_modules/make-dir/node_modules/pify"
                 }
               ]
@@ -12498,7 +12498,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress/node_modules/pify"
             }
           ]
@@ -12540,7 +12540,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/deep-equal"
         }
       ]
@@ -12596,7 +12596,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/deep-extend"
         }
       ]
@@ -12636,7 +12636,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/deep-is"
         }
       ]
@@ -12676,7 +12676,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/define-properties"
         }
       ]
@@ -12726,7 +12726,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/define-property"
         }
       ]
@@ -12771,7 +12771,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/delayed-stream"
         }
       ]
@@ -12810,7 +12810,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/delegates"
         }
       ]
@@ -12850,7 +12850,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/depd"
         }
       ]
@@ -12890,7 +12890,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/destroy"
         }
       ]
@@ -12940,7 +12940,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/detect-file"
         }
       ]
@@ -12980,7 +12980,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/detect-libc"
         }
       ]
@@ -13030,7 +13030,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dfa"
         }
       ]
@@ -13071,7 +13071,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dicer"
         }
       ],
@@ -13116,7 +13116,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/dicer/node_modules/isarray"
             }
           ]
@@ -13156,7 +13156,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/dicer/node_modules/readable-stream"
             }
           ]
@@ -13200,7 +13200,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/dicer/node_modules/string_decoder"
             }
           ]
@@ -13246,7 +13246,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/diff"
         }
       ]
@@ -13286,7 +13286,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/doctypes"
         }
       ]
@@ -13326,7 +13326,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/domelementtype"
         }
       ]
@@ -13359,7 +13359,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/domhandler"
         }
       ]
@@ -13392,7 +13392,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/domutils"
         }
       ]
@@ -13432,7 +13432,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dottie"
         }
       ]
@@ -13482,7 +13482,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/double-ended-queue"
         }
       ]
@@ -13532,7 +13532,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/doublearray"
         }
       ]
@@ -13572,7 +13572,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/download"
         }
       ],
@@ -13612,7 +13612,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/download/node_modules/file-type"
             }
           ]
@@ -13654,7 +13654,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/duplexer2"
         }
       ]
@@ -13693,7 +13693,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/duplexer3"
         }
       ]
@@ -13731,7 +13731,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dynamic-dedupe"
         }
       ]
@@ -13781,7 +13781,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ecc-jsbn"
         }
       ]
@@ -13821,7 +13821,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ee-first"
         }
       ]
@@ -13870,7 +13870,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/eivindfjeldstad-dot"
         }
       ]
@@ -13920,7 +13920,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/emoji-regex"
         }
       ]
@@ -13960,7 +13960,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/enabled"
         }
       ]
@@ -13999,7 +13999,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/encodeurl"
         }
       ]
@@ -14039,7 +14039,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/encoding"
         }
       ],
@@ -14089,7 +14089,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/encoding/node_modules/iconv-lite"
             }
           ]
@@ -14141,7 +14141,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/end-of-stream"
         }
       ]
@@ -14185,7 +14185,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/engine.io-parser"
         }
       ]
@@ -14230,7 +14230,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/engine.io"
         }
       ],
@@ -14270,7 +14270,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/engine.io/node_modules/debug"
             }
           ]
@@ -14309,7 +14309,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/engine.io/node_modules/ms"
             }
           ]
@@ -14351,7 +14351,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/env-paths"
         }
       ]
@@ -14396,7 +14396,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/err-code"
         }
       ]
@@ -14435,7 +14435,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/error-ex"
         }
       ]
@@ -14474,7 +14474,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/errorhandler"
         }
       ]
@@ -14524,7 +14524,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/es-get-iterator"
         }
       ]
@@ -14563,7 +14563,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/escape-html"
         }
       ]
@@ -14603,7 +14603,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/escape-string-regexp"
         }
       ]
@@ -14647,7 +14647,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/escodegen"
         }
       ]
@@ -14697,7 +14697,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/esprima"
         }
       ]
@@ -14741,7 +14741,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/estraverse"
         }
       ]
@@ -14785,7 +14785,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/esutils"
         }
       ]
@@ -14824,7 +14824,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/etag"
         }
       ]
@@ -14864,7 +14864,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/eventemitter2"
         }
       ]
@@ -14909,7 +14909,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/eventemitter3"
         }
       ]
@@ -14941,7 +14941,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/exif"
         }
       ]
@@ -14992,7 +14992,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/exit"
         }
       ]
@@ -15042,7 +15042,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/expand-brackets"
         }
       ],
@@ -15092,7 +15092,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/define-property"
             }
           ]
@@ -15142,7 +15142,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/extend-shallow"
             }
           ]
@@ -15192,7 +15192,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/is-accessor-descriptor"
             }
           ],
@@ -15242,7 +15242,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/expand-brackets/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
@@ -15294,7 +15294,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/is-data-descriptor"
             }
           ],
@@ -15344,7 +15344,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/expand-brackets/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
@@ -15396,7 +15396,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/is-descriptor"
             }
           ]
@@ -15446,7 +15446,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/is-extendable"
             }
           ]
@@ -15496,7 +15496,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/kind-of"
             }
           ]
@@ -15541,7 +15541,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/expand-template"
         }
       ]
@@ -15591,7 +15591,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/expand-tilde"
         }
       ]
@@ -15631,7 +15631,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-ipfilter"
         }
       ]
@@ -15677,7 +15677,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-jwt"
         }
       ],
@@ -15722,7 +15722,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/express-jwt/node_modules/jsonwebtoken"
             }
           ]
@@ -15772,7 +15772,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/express-jwt/node_modules/moment"
             }
           ]
@@ -15819,7 +15819,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-rate-limit"
         }
       ]
@@ -15869,7 +15869,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-robots-txt"
         }
       ]
@@ -15917,7 +15917,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-security.txt"
         }
       ]
@@ -15962,7 +15962,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express"
         }
       ],
@@ -16002,7 +16002,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/express/node_modules/cookie"
             }
           ]
@@ -16052,7 +16052,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/express/node_modules/safe-buffer"
             }
           ]
@@ -16094,7 +16094,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ext-list"
         }
       ]
@@ -16134,7 +16134,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ext-name"
         }
       ]
@@ -16184,7 +16184,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/extend-shallow"
         }
       ]
@@ -16224,7 +16224,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/extend"
         }
       ]
@@ -16274,7 +16274,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/extglob"
         }
       ],
@@ -16324,7 +16324,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/extglob/node_modules/define-property"
             }
           ]
@@ -16374,7 +16374,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/extglob/node_modules/extend-shallow"
             }
           ]
@@ -16424,7 +16424,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/extglob/node_modules/is-extendable"
             }
           ]
@@ -16465,7 +16465,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/extsprintf"
         }
       ]
@@ -16515,7 +16515,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fast-deep-equal"
         }
       ]
@@ -16560,7 +16560,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fast-json-stable-stringify"
         }
       ]
@@ -16600,7 +16600,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fast-levenshtein"
         }
       ]
@@ -16650,7 +16650,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fast.js"
         }
       ]
@@ -16695,7 +16695,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fd-slicer"
         }
       ]
@@ -16745,7 +16745,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/feature-policy"
         }
       ]
@@ -16795,7 +16795,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fecha"
         }
       ]
@@ -16845,7 +16845,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/file-js"
         }
       ],
@@ -16890,7 +16890,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/file-js/node_modules/brace-expansion"
             }
           ]
@@ -16930,7 +16930,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/file-js/node_modules/minimatch"
             }
           ]
@@ -16972,7 +16972,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/file-stream-rotator"
         }
       ]
@@ -17012,7 +17012,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/file-type"
         }
       ]
@@ -17062,7 +17062,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/file-uri-to-path"
         }
       ]
@@ -17111,7 +17111,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/filehound"
         }
       ]
@@ -17151,7 +17151,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/filename-reserved-regex"
         }
       ]
@@ -17191,7 +17191,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/filenamify"
         }
       ]
@@ -17240,7 +17240,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/filesniffer"
         }
       ]
@@ -17290,7 +17290,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fill-range"
         }
       ],
@@ -17340,7 +17340,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/fill-range/node_modules/extend-shallow"
             }
           ]
@@ -17390,7 +17390,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/fill-range/node_modules/is-extendable"
             }
           ]
@@ -17437,7 +17437,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/finale-rest"
         }
       ]
@@ -17477,7 +17477,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/finalhandler"
         }
       ]
@@ -17517,7 +17517,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/find-up"
         }
       ]
@@ -17557,7 +17557,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/findup-sync"
         }
       ]
@@ -17597,7 +17597,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fined"
         }
       ]
@@ -17637,7 +17637,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/flagged-respawn"
         }
       ]
@@ -17687,7 +17687,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fn.name"
         }
       ]
@@ -17727,7 +17727,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fontkit"
         }
       ]
@@ -17783,7 +17783,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/for-each"
         }
       ]
@@ -17833,7 +17833,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/for-in"
         }
       ]
@@ -17883,7 +17883,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/for-own"
         }
       ]
@@ -17933,7 +17933,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/foreachasync"
         }
       ]
@@ -17973,7 +17973,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/forever-agent"
         }
       ]
@@ -18013,7 +18013,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/form-data"
         }
       ]
@@ -18051,7 +18051,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/formatio"
         }
       ]
@@ -18090,7 +18090,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/forwarded"
         }
       ]
@@ -18140,7 +18140,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fragment-cache"
         }
       ]
@@ -18180,7 +18180,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fresh"
         }
       ]
@@ -18230,7 +18230,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/from2"
         }
       ]
@@ -18280,7 +18280,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fs-constants"
         }
       ]
@@ -18325,7 +18325,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fs-extra"
         }
       ]
@@ -18375,7 +18375,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fs-minipass"
         }
       ]
@@ -18415,7 +18415,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fs.realpath"
         }
       ]
@@ -18455,7 +18455,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fstream"
         }
       ],
@@ -18495,7 +18495,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/fstream/node_modules/mkdirp"
             }
           ]
@@ -18535,7 +18535,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/fstream/node_modules/rimraf"
             }
           ]
@@ -18587,7 +18587,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/function-bind"
         }
       ]
@@ -18637,7 +18637,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/functions-have-names"
         }
       ]
@@ -18677,7 +18677,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fuzzball"
         }
       ]
@@ -18727,7 +18727,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/gauge"
         }
       ]
@@ -18767,7 +18767,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/geojson-utils"
         }
       ]
@@ -18816,7 +18816,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-caller-file"
         }
       ]
@@ -18866,7 +18866,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-intrinsic"
         }
       ]
@@ -18906,7 +18906,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-stream"
         }
       ]
@@ -18956,7 +18956,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-value"
         }
       ]
@@ -19007,7 +19007,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/getobject"
         }
       ]
@@ -19047,7 +19047,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/getpass"
         }
       ]
@@ -19092,7 +19092,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/github-from-package"
         }
       ]
@@ -19132,7 +19132,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/glob-parent"
         }
       ],
@@ -19182,7 +19182,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/glob-parent/node_modules/is-glob"
             }
           ]
@@ -19224,7 +19224,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/glob"
         }
       ],
@@ -19269,7 +19269,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/glob/node_modules/brace-expansion"
             }
           ]
@@ -19309,7 +19309,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/glob/node_modules/minimatch"
             }
           ]
@@ -19361,7 +19361,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/global-modules"
         }
       ]
@@ -19411,7 +19411,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/global-prefix"
         }
       ],
@@ -19451,7 +19451,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/global-prefix/node_modules/which"
             }
           ]
@@ -19503,7 +19503,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/gopd"
         }
       ]
@@ -19542,7 +19542,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/got"
         }
       ],
@@ -19582,7 +19582,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/got/node_modules/get-stream"
             }
           ]
@@ -19622,7 +19622,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/got/node_modules/pify"
             }
           ]
@@ -19663,7 +19663,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/graceful-fs"
         }
       ]
@@ -19703,7 +19703,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-cli"
         }
       ],
@@ -19743,7 +19743,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-cli/node_modules/nopt"
             }
           ]
@@ -19785,7 +19785,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-contrib-compress"
         }
       ],
@@ -19825,7 +19825,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-contrib-compress/node_modules/ansi-styles"
             }
           ]
@@ -19864,7 +19864,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-contrib-compress/node_modules/chalk"
             }
           ]
@@ -19904,7 +19904,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-contrib-compress/node_modules/supports-color"
             }
           ]
@@ -19951,7 +19951,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-known-options"
         }
       ]
@@ -20001,7 +20001,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-legacy-log-utils"
         }
       ],
@@ -20041,7 +20041,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils/node_modules/ansi-styles"
             }
           ]
@@ -20080,7 +20080,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils/node_modules/chalk"
             }
           ]
@@ -20120,7 +20120,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils/node_modules/color-convert"
             }
           ]
@@ -20170,7 +20170,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils/node_modules/color-name"
             }
           ]
@@ -20210,7 +20210,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils/node_modules/has-flag"
             }
           ]
@@ -20250,7 +20250,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils/node_modules/supports-color"
             }
           ]
@@ -20302,7 +20302,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-legacy-log"
         }
       ],
@@ -20352,7 +20352,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log/node_modules/colors"
             }
           ]
@@ -20404,7 +20404,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-legacy-util"
         }
       ],
@@ -20454,7 +20454,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-util/node_modules/async"
             }
           ]
@@ -20507,7 +20507,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-replace-json"
         }
       ]
@@ -20552,7 +20552,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt"
         }
       ],
@@ -20597,7 +20597,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt/node_modules/brace-expansion"
             }
           ]
@@ -20648,7 +20648,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt/node_modules/findup-sync"
             }
           ],
@@ -20688,7 +20688,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/grunt/node_modules/findup-sync/node_modules/glob"
                 }
               ]
@@ -20730,7 +20730,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt/node_modules/glob"
             }
           ]
@@ -20770,7 +20770,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt/node_modules/minimatch"
             }
           ]
@@ -20817,7 +20817,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/handlebars"
         }
       ],
@@ -20857,7 +20857,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/handlebars/node_modules/wordwrap"
             }
           ]
@@ -20909,7 +20909,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/har-schema"
         }
       ]
@@ -20959,7 +20959,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/har-validator"
         }
       ]
@@ -20999,7 +20999,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-ansi"
         }
       ]
@@ -21049,7 +21049,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-bigints"
         }
       ]
@@ -21089,7 +21089,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-flag"
         }
       ]
@@ -21139,7 +21139,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-property-descriptors"
         }
       ]
@@ -21189,7 +21189,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-symbol-support-x"
         }
       ]
@@ -21239,7 +21239,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-symbols"
         }
       ]
@@ -21289,7 +21289,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-to-string-tag-x"
         }
       ]
@@ -21339,7 +21339,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-tostringtag"
         }
       ]
@@ -21389,7 +21389,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-unicode"
         }
       ]
@@ -21439,7 +21439,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-value"
         }
       ]
@@ -21489,7 +21489,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-values"
         }
       ],
@@ -21539,7 +21539,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/has-values/node_modules/kind-of"
             }
           ]
@@ -21597,7 +21597,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has"
         }
       ]
@@ -21647,7 +21647,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hashids"
         }
       ]
@@ -21687,7 +21687,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hbs"
         }
       ]
@@ -21738,7 +21738,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/he"
         }
       ]
@@ -21783,7 +21783,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/heap"
         }
       ]
@@ -21833,7 +21833,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/helmet"
         }
       ]
@@ -21878,7 +21878,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hoister"
         }
       ]
@@ -21928,7 +21928,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/homedir-polyfill"
         }
       ]
@@ -21979,7 +21979,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hooker"
         }
       ]
@@ -22029,7 +22029,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hosted-git-info"
         }
       ]
@@ -22069,7 +22069,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/html-entities"
         }
       ]
@@ -22115,7 +22115,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/htmlparser2"
         }
       ],
@@ -22160,7 +22160,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/htmlparser2/node_modules/isarray"
             }
           ]
@@ -22200,7 +22200,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/htmlparser2/node_modules/readable-stream"
             }
           ]
@@ -22244,7 +22244,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/htmlparser2/node_modules/string_decoder"
             }
           ]
@@ -22286,7 +22286,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/http-cache-semantics"
         }
       ]
@@ -22326,7 +22326,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/http-errors"
         }
       ]
@@ -22371,7 +22371,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/http-proxy-agent"
         }
       ],
@@ -22411,7 +22411,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/http-proxy-agent/node_modules/debug"
             }
           ]
@@ -22450,7 +22450,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/http-proxy-agent/node_modules/ms"
             }
           ]
@@ -22502,7 +22502,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/http-signature"
         }
       ]
@@ -22547,7 +22547,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/https-proxy-agent"
         }
       ],
@@ -22587,7 +22587,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/https-proxy-agent/node_modules/debug"
             }
           ]
@@ -22626,7 +22626,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/https-proxy-agent/node_modules/ms"
             }
           ]
@@ -22668,7 +22668,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/humanize-ms"
         }
       ]
@@ -22713,7 +22713,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/i18n"
         }
       ]
@@ -22763,7 +22763,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/iconv-lite"
         }
       ]
@@ -22803,7 +22803,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ieee754"
         }
       ]
@@ -22843,7 +22843,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ignore-walk"
         }
       ],
@@ -22888,7 +22888,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/ignore-walk/node_modules/brace-expansion"
             }
           ]
@@ -22928,7 +22928,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/ignore-walk/node_modules/minimatch"
             }
           ]
@@ -22979,7 +22979,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/iltorb"
         }
       ]
@@ -23029,7 +23029,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/imurmurhash"
         }
       ]
@@ -23069,7 +23069,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/indent-string"
         }
       ]
@@ -23109,7 +23109,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/infer-owner"
         }
       ]
@@ -23149,7 +23149,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/inflection"
         }
       ]
@@ -23199,7 +23199,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/inflight"
         }
       ]
@@ -23238,7 +23238,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/inherits"
         }
       ]
@@ -23278,7 +23278,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ini"
         }
       ]
@@ -23328,7 +23328,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/interpret"
         }
       ]
@@ -23368,7 +23368,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/into-stream"
         }
       ]
@@ -23408,7 +23408,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/invariant"
         }
       ]
@@ -23452,7 +23452,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ip"
         }
       ]
@@ -23502,7 +23502,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ip6"
         }
       ]
@@ -23542,7 +23542,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ipaddr.js"
         }
       ]
@@ -23592,7 +23592,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-absolute"
         }
       ]
@@ -23642,7 +23642,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-accessor-descriptor"
         }
       ]
@@ -23692,7 +23692,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-arguments"
         }
       ]
@@ -23732,7 +23732,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-arrayish"
         }
       ]
@@ -23782,7 +23782,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-bigint"
         }
       ]
@@ -23822,7 +23822,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-binary-path"
         }
       ]
@@ -23862,7 +23862,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-boolean-object"
         }
       ]
@@ -23907,7 +23907,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-buffer"
         }
       ]
@@ -23947,7 +23947,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-callable"
         }
       ]
@@ -23997,7 +23997,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-core-module"
         }
       ]
@@ -24047,7 +24047,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-data-descriptor"
         }
       ]
@@ -24087,7 +24087,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-date-object"
         }
       ]
@@ -24137,7 +24137,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-descriptor"
         }
       ]
@@ -24177,7 +24177,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-docker"
         }
       ]
@@ -24217,7 +24217,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-expression"
         }
       ]
@@ -24267,7 +24267,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-extendable"
         }
       ]
@@ -24317,7 +24317,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-extglob"
         }
       ]
@@ -24357,7 +24357,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-fullwidth-code-point"
         }
       ]
@@ -24402,7 +24402,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-generator-function"
         }
       ]
@@ -24452,7 +24452,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-glob"
         }
       ]
@@ -24492,7 +24492,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-heroku"
         }
       ]
@@ -24542,7 +24542,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-lambda"
         }
       ]
@@ -24592,7 +24592,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-map"
         }
       ]
@@ -24632,7 +24632,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-natural-number"
         }
       ]
@@ -24682,7 +24682,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-number-like"
         }
       ]
@@ -24732,7 +24732,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-number-object"
         }
       ]
@@ -24782,7 +24782,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-number"
         }
       ],
@@ -24832,7 +24832,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/is-number/node_modules/kind-of"
             }
           ]
@@ -24890,7 +24890,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-object"
         }
       ]
@@ -24930,7 +24930,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-plain-obj"
         }
       ]
@@ -24980,7 +24980,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-plain-object"
         }
       ]
@@ -25020,7 +25020,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-promise"
         }
       ]
@@ -25070,7 +25070,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-regex"
         }
       ]
@@ -25120,7 +25120,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-relative"
         }
       ]
@@ -25160,7 +25160,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-retry-allowed"
         }
       ]
@@ -25210,7 +25210,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-set"
         }
       ]
@@ -25250,7 +25250,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-stream"
         }
       ]
@@ -25290,7 +25290,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-string"
         }
       ]
@@ -25335,7 +25335,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-symbol"
         }
       ]
@@ -25375,7 +25375,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-typed-array"
         }
       ]
@@ -25425,7 +25425,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-typedarray"
         }
       ]
@@ -25475,7 +25475,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-unc-path"
         }
       ]
@@ -25525,7 +25525,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-weakmap"
         }
       ]
@@ -25575,7 +25575,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-weakset"
         }
       ]
@@ -25625,7 +25625,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-windows"
         }
       ]
@@ -25670,7 +25670,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isarray"
         }
       ]
@@ -25720,7 +25720,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isexe"
         }
       ]
@@ -25770,7 +25770,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isobject"
         }
       ]
@@ -25820,7 +25820,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isstream"
         }
       ]
@@ -25860,7 +25860,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isurl"
         }
       ]
@@ -25900,7 +25900,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/js-stringify"
         }
       ]
@@ -25940,7 +25940,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/js-tokens"
         }
       ]
@@ -25985,7 +25985,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/js-yaml"
         }
       ]
@@ -26025,7 +26025,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jsbn"
         }
       ]
@@ -26070,7 +26070,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-buffer"
         }
       ]
@@ -26110,7 +26110,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-parse-better-errors"
         }
       ]
@@ -26160,7 +26160,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-schema-traverse"
         }
       ]
@@ -26198,7 +26198,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-schema"
         }
       ]
@@ -26248,7 +26248,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-stringify-safe"
         }
       ]
@@ -26298,7 +26298,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json5"
         }
       ]
@@ -26338,7 +26338,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jsonfile"
         }
       ]
@@ -26383,7 +26383,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jsonwebtoken"
         }
       ]
@@ -26422,7 +26422,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jsprim"
         }
       ]
@@ -26472,7 +26472,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jssha"
         }
       ]
@@ -26512,7 +26512,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jstransformer"
         }
       ]
@@ -26562,7 +26562,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/juicy-chat-bot"
         }
       ]
@@ -26602,7 +26602,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jwa"
         }
       ]
@@ -26642,7 +26642,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jws"
         }
       ]
@@ -26692,7 +26692,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/keyv"
         }
       ]
@@ -26742,7 +26742,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/kind-of"
         }
       ]
@@ -26792,7 +26792,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/kuler"
         }
       ]
@@ -26842,7 +26842,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/kuromoji"
         }
       ]
@@ -26892,7 +26892,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lazystream"
         }
       ]
@@ -26942,7 +26942,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/levn"
         }
       ]
@@ -26987,7 +26987,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/libxmljs2"
         }
       ],
@@ -27026,7 +27026,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/libxmljs2/node_modules/nan"
             }
           ]
@@ -27068,7 +27068,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/liftup"
         }
       ],
@@ -27118,7 +27118,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/braces"
             }
           ]
@@ -27168,7 +27168,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/fill-range"
             }
           ]
@@ -27208,7 +27208,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/findup-sync"
             }
           ]
@@ -27258,7 +27258,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/is-glob"
             }
           ]
@@ -27308,7 +27308,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/is-number"
             }
           ]
@@ -27358,7 +27358,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/micromatch"
             }
           ]
@@ -27408,7 +27408,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/to-regex-range"
             }
           ]
@@ -27460,7 +27460,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/linebreak"
         }
       ],
@@ -27500,7 +27500,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/linebreak/node_modules/base64-js"
             }
           ]
@@ -27542,7 +27542,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/listenercount"
         }
       ]
@@ -27582,7 +27582,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/locate-path"
         }
       ]
@@ -27627,7 +27627,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lodash.camelcase"
         }
       ]
@@ -27672,7 +27672,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lodash.isfinite"
         }
       ]
@@ -27717,7 +27717,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lodash.set"
         }
       ]
@@ -27762,7 +27762,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lodash"
         }
       ]
@@ -27812,7 +27812,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/logform"
         }
       ],
@@ -27851,7 +27851,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/logform/node_modules/ms"
             }
           ]
@@ -27903,7 +27903,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lolex"
         }
       ]
@@ -27948,7 +27948,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/loose-envify"
         }
       ]
@@ -27988,7 +27988,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lowercase-keys"
         }
       ]
@@ -28028,7 +28028,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lru-cache"
         }
       ]
@@ -28068,7 +28068,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-dir"
         }
       ],
@@ -28107,7 +28107,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-dir/node_modules/semver"
             }
           ]
@@ -28159,7 +28159,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-error"
         }
       ]
@@ -28199,7 +28199,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-fetch-happen"
         }
       ],
@@ -28245,7 +28245,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen/node_modules/@tootallnate/once"
             }
           ]
@@ -28285,7 +28285,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen/node_modules/debug"
             }
           ]
@@ -28325,7 +28325,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen/node_modules/http-cache-semantics"
             }
           ]
@@ -28370,7 +28370,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen/node_modules/http-proxy-agent"
             }
           ]
@@ -28409,7 +28409,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen/node_modules/ms"
             }
           ]
@@ -28461,7 +28461,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-iterator"
         }
       ]
@@ -28511,7 +28511,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-plural"
         }
       ]
@@ -28561,7 +28561,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/map-cache"
         }
       ]
@@ -28611,7 +28611,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/map-visit"
         }
       ]
@@ -28656,7 +28656,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/marsdb"
         }
       ]
@@ -28696,7 +28696,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/math-interval-parser"
         }
       ]
@@ -28736,7 +28736,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/media-typer"
         }
       ]
@@ -28776,7 +28776,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/merge-descriptors"
         }
       ]
@@ -28821,7 +28821,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/messageformat-formatters"
         }
       ]
@@ -28865,7 +28865,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/messageformat-parser"
         }
       ]
@@ -28910,7 +28910,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/messageformat"
         }
       ],
@@ -28960,7 +28960,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/messageformat/node_modules/make-plural"
             }
           ]
@@ -29001,7 +29001,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/methods"
         }
       ]
@@ -29051,7 +29051,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/micromatch"
         }
       ]
@@ -29090,7 +29090,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mime-db"
         }
       ]
@@ -29129,7 +29129,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mime-types"
         }
       ]
@@ -29169,7 +29169,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mime"
         }
       ]
@@ -29209,7 +29209,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mimic-response"
         }
       ]
@@ -29249,7 +29249,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minimatch"
         }
       ]
@@ -29294,7 +29294,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minimist"
         }
       ]
@@ -29329,7 +29329,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-collect"
         }
       ]
@@ -29368,7 +29368,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-fetch"
         }
       ]
@@ -29408,7 +29408,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-flush"
         }
       ]
@@ -29443,7 +29443,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-pipeline"
         }
       ]
@@ -29483,7 +29483,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-sized"
         }
       ]
@@ -29523,7 +29523,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass"
         }
       ]
@@ -29563,7 +29563,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minizlib"
         }
       ]
@@ -29613,7 +29613,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mixin-deep"
         }
       ]
@@ -29663,7 +29663,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mkdirp-classic"
         }
       ]
@@ -29702,7 +29702,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mkdirp"
         }
       ]
@@ -29752,7 +29752,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/moment-timezone"
         }
       ]
@@ -29802,7 +29802,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/moment"
         }
       ]
@@ -29841,7 +29841,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/morgan"
         }
       ],
@@ -29880,7 +29880,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/morgan/node_modules/on-finished"
             }
           ]
@@ -29932,7 +29932,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mout"
         }
       ]
@@ -29971,7 +29971,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ms"
         }
       ]
@@ -30010,7 +30010,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/multer"
         }
       ],
@@ -30050,7 +30050,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/multer/node_modules/mkdirp"
             }
           ]
@@ -30097,7 +30097,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mustache"
         }
       ]
@@ -30136,7 +30136,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/nan"
         }
       ]
@@ -30186,7 +30186,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/nanomatch"
         }
       ]
@@ -30236,7 +30236,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/napi-build-utils"
         }
       ]
@@ -30276,7 +30276,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/needle"
         }
       ],
@@ -30316,7 +30316,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/needle/node_modules/debug"
             }
           ]
@@ -30355,7 +30355,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/needle/node_modules/ms"
             }
           ]
@@ -30396,7 +30396,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/negotiator"
         }
       ]
@@ -30440,7 +30440,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/neo-async"
         }
       ]
@@ -30490,7 +30490,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-abi"
         }
       ],
@@ -30529,7 +30529,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-abi/node_modules/semver"
             }
           ]
@@ -30580,7 +30580,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-addon-api"
         }
       ]
@@ -30630,7 +30630,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-fetch"
         }
       ]
@@ -30670,7 +30670,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-gyp"
         }
       ],
@@ -30710,7 +30710,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/ansi-regex"
             }
           ]
@@ -30760,7 +30760,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/are-we-there-yet"
             }
           ]
@@ -30810,7 +30810,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/gauge"
             }
           ]
@@ -30850,7 +30850,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -30890,7 +30890,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/nopt"
             }
           ]
@@ -30930,7 +30930,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/npmlog"
             }
           ]
@@ -30969,7 +30969,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/readable-stream"
             }
           ]
@@ -31009,7 +31009,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/string-width"
             }
           ]
@@ -31049,7 +31049,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/strip-ansi"
             }
           ]
@@ -31091,7 +31091,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-pre-gyp"
         }
       ],
@@ -31131,7 +31131,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/chownr"
             }
           ]
@@ -31181,7 +31181,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/fs-minipass"
             }
           ]
@@ -31221,7 +31221,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/minipass"
             }
           ]
@@ -31261,7 +31261,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/minizlib"
             }
           ]
@@ -31301,7 +31301,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/mkdirp"
             }
           ]
@@ -31341,7 +31341,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/nopt"
             }
           ]
@@ -31381,7 +31381,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/rimraf"
             }
           ]
@@ -31431,7 +31431,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/safe-buffer"
             }
           ]
@@ -31470,7 +31470,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/semver"
             }
           ]
@@ -31510,7 +31510,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/tar"
             }
           ]
@@ -31550,7 +31550,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/yallist"
             }
           ]
@@ -31591,7 +31591,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/noop-logger"
         }
       ]
@@ -31631,7 +31631,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/nopt"
         }
       ]
@@ -31671,7 +31671,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/normalize-package-data"
         }
       ],
@@ -31710,7 +31710,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/normalize-package-data/node_modules/semver"
             }
           ]
@@ -31762,7 +31762,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/normalize-path"
         }
       ]
@@ -31802,7 +31802,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/normalize-url"
         }
       ]
@@ -31847,7 +31847,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/notevil"
         }
       ],
@@ -31892,7 +31892,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/notevil/node_modules/esprima"
             }
           ]
@@ -31934,7 +31934,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/npm-bundled"
         }
       ]
@@ -31974,7 +31974,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/npm-normalize-package-bin"
         }
       ]
@@ -32024,7 +32024,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/npm-packlist"
         }
       ]
@@ -32064,7 +32064,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/npmlog"
         }
       ]
@@ -32104,7 +32104,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/number-is-nan"
         }
       ]
@@ -32144,7 +32144,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/oauth-sign"
         }
       ]
@@ -32184,7 +32184,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-assign"
         }
       ]
@@ -32234,7 +32234,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-copy"
         }
       ],
@@ -32284,7 +32284,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy/node_modules/define-property"
             }
           ]
@@ -32334,7 +32334,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy/node_modules/is-accessor-descriptor"
             }
           ]
@@ -32384,7 +32384,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy/node_modules/is-data-descriptor"
             }
           ]
@@ -32434,7 +32434,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy/node_modules/is-descriptor"
             }
           ],
@@ -32484,7 +32484,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/object-copy/node_modules/is-descriptor/node_modules/kind-of"
                 }
               ]
@@ -32536,7 +32536,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy/node_modules/kind-of"
             }
           ]
@@ -32583,7 +32583,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-inspect"
         }
       ]
@@ -32633,7 +32633,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-is"
         }
       ]
@@ -32673,7 +32673,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-keys"
         }
       ]
@@ -32723,7 +32723,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-visit"
         }
       ]
@@ -32763,7 +32763,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object.assign"
         }
       ]
@@ -32813,7 +32813,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object.defaults"
         }
       ]
@@ -32863,7 +32863,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object.map"
         }
       ]
@@ -32913,7 +32913,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object.pick"
         }
       ]
@@ -32952,7 +32952,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/on-finished"
         }
       ]
@@ -32992,7 +32992,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/on-headers"
         }
       ]
@@ -33032,7 +33032,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/once"
         }
       ]
@@ -33072,7 +33072,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/one-time"
         }
       ]
@@ -33112,7 +33112,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/opentype.js"
         }
       ]
@@ -33162,7 +33162,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/optionator"
         }
       ]
@@ -33202,7 +33202,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/os-homedir"
         }
       ]
@@ -33242,7 +33242,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/os-tmpdir"
         }
       ]
@@ -33282,7 +33282,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/osenv"
         }
       ]
@@ -33327,7 +33327,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/otplib"
         }
       ]
@@ -33367,7 +33367,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-cancelable"
         }
       ]
@@ -33407,7 +33407,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-event"
         }
       ]
@@ -33447,7 +33447,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-finally"
         }
       ]
@@ -33487,7 +33487,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-is-promise"
         }
       ]
@@ -33527,7 +33527,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-limit"
         }
       ]
@@ -33567,7 +33567,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-locate"
         }
       ]
@@ -33607,7 +33607,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-map"
         }
       ]
@@ -33647,7 +33647,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-timeout"
         }
       ]
@@ -33687,7 +33687,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-try"
         }
       ]
@@ -33731,7 +33731,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pako"
         }
       ]
@@ -33781,7 +33781,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/parse-filepath"
         }
       ]
@@ -33821,7 +33821,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/parse-json"
         }
       ]
@@ -33871,7 +33871,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/parse-passwd"
         }
       ]
@@ -33910,7 +33910,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/parseurl"
         }
       ]
@@ -33960,7 +33960,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pascalcase"
         }
       ]
@@ -34000,7 +34000,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-exists"
         }
       ]
@@ -34040,7 +34040,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-is-absolute"
         }
       ]
@@ -34090,7 +34090,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-parse"
         }
       ]
@@ -34140,7 +34140,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-root-regex"
         }
       ]
@@ -34190,7 +34190,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-root"
         }
       ]
@@ -34229,7 +34229,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-to-regexp"
         }
       ]
@@ -34279,7 +34279,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pdfkit"
         }
       ]
@@ -34324,7 +34324,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/peek-readable"
         }
       ]
@@ -34369,7 +34369,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pend"
         }
       ]
@@ -34419,7 +34419,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/performance-now"
         }
       ]
@@ -34469,7 +34469,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pg-connection-string"
         }
       ]
@@ -34519,7 +34519,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/picomatch"
         }
       ]
@@ -34559,7 +34559,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pify"
         }
       ]
@@ -34599,7 +34599,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pinkie-promise"
         }
       ]
@@ -34639,7 +34639,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pinkie"
         }
       ]
@@ -34677,7 +34677,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/png-js"
         }
       ]
@@ -34726,7 +34726,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/portscanner"
         }
       ]
@@ -34776,7 +34776,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/posix-character-classes"
         }
       ]
@@ -34826,7 +34826,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/prebuild-install"
         }
       ]
@@ -34877,7 +34877,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/prelude-ls"
         }
       ]
@@ -34917,7 +34917,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/prepend-http"
         }
       ]
@@ -34957,7 +34957,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pretty-bytes"
         }
       ]
@@ -35006,7 +35006,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/process-nextick-args"
         }
       ]
@@ -35051,7 +35051,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/prom-client"
         }
       ]
@@ -35101,7 +35101,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/promise-inflight"
         }
       ]
@@ -35146,7 +35146,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/promise-retry"
         }
       ],
@@ -35191,7 +35191,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/promise-retry/node_modules/err-code"
             }
           ]
@@ -35236,7 +35236,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/promise-retry/node_modules/retry"
             }
           ]
@@ -35278,7 +35278,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/promise"
         }
       ]
@@ -35323,7 +35323,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/proper-lockfile"
         }
       ]
@@ -35363,7 +35363,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/proxy-addr"
         }
       ]
@@ -35403,7 +35403,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/psl"
         }
       ]
@@ -35443,7 +35443,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-attrs"
         }
       ]
@@ -35483,7 +35483,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-code-gen"
         }
       ]
@@ -35523,7 +35523,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-error"
         }
       ]
@@ -35563,7 +35563,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-filters"
         }
       ]
@@ -35603,7 +35603,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-lexer"
         }
       ]
@@ -35643,7 +35643,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-linker"
         }
       ]
@@ -35683,7 +35683,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-load"
         }
       ]
@@ -35723,7 +35723,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-parser"
         }
       ]
@@ -35763,7 +35763,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-runtime"
         }
       ]
@@ -35803,7 +35803,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-strip-comments"
         }
       ]
@@ -35843,7 +35843,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-walk"
         }
       ]
@@ -35888,7 +35888,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug"
         }
       ]
@@ -35928,7 +35928,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pump"
         }
       ]
@@ -35978,7 +35978,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/punycode"
         }
       ]
@@ -36022,7 +36022,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/qs"
         }
       ]
@@ -36062,7 +36062,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/query-string"
         }
       ]
@@ -36102,7 +36102,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/range_check"
         }
       ]
@@ -36142,7 +36142,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/range-parser"
         }
       ]
@@ -36182,7 +36182,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/raw-body"
         }
       ]
@@ -36220,7 +36220,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/rc"
         }
       ]
@@ -36260,7 +36260,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/read-pkg"
         }
       ],
@@ -36300,7 +36300,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/read-pkg/node_modules/pify"
             }
           ]
@@ -36341,7 +36341,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/readable-stream"
         }
       ],
@@ -36386,7 +36386,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/readable-stream/node_modules/isarray"
             }
           ]
@@ -36433,7 +36433,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/readable-web-to-node-stream"
         }
       ],
@@ -36472,7 +36472,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/readable-web-to-node-stream/node_modules/readable-stream"
             }
           ]
@@ -36524,7 +36524,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/readdirp"
         }
       ]
@@ -36564,7 +36564,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/rechoir"
         }
       ]
@@ -36614,7 +36614,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/regex-not"
         }
       ]
@@ -36654,7 +36654,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/regexp.prototype.flags"
         }
       ]
@@ -36704,7 +36704,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/remove-trailing-separator"
         }
       ]
@@ -36754,7 +36754,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/repeat-element"
         }
       ]
@@ -36804,7 +36804,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/repeat-string"
         }
       ]
@@ -36844,7 +36844,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/replace"
         }
       ],
@@ -36884,7 +36884,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/ansi-regex"
             }
           ]
@@ -36924,7 +36924,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/ansi-styles"
             }
           ]
@@ -36969,7 +36969,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/brace-expansion"
             }
           ]
@@ -37009,7 +37009,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/cliui"
             }
           ]
@@ -37049,7 +37049,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/color-convert"
             }
           ]
@@ -37099,7 +37099,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/color-name"
             }
           ]
@@ -37139,7 +37139,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/find-up"
             }
           ]
@@ -37179,7 +37179,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -37219,7 +37219,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/locate-path"
             }
           ]
@@ -37259,7 +37259,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/minimatch"
             }
           ]
@@ -37299,7 +37299,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/p-locate"
             }
           ]
@@ -37339,7 +37339,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/path-exists"
             }
           ]
@@ -37379,7 +37379,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/string-width"
             }
           ]
@@ -37419,7 +37419,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/strip-ansi"
             }
           ]
@@ -37459,7 +37459,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/wrap-ansi"
             }
           ]
@@ -37499,7 +37499,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/yargs-parser"
             }
           ]
@@ -37543,7 +37543,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/yargs"
             }
           ]
@@ -37590,7 +37590,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/request"
         }
       ],
@@ -37634,7 +37634,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/request/node_modules/qs"
             }
           ]
@@ -37686,7 +37686,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/require-directory"
         }
       ]
@@ -37736,7 +37736,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/require-main-filename"
         }
       ]
@@ -37786,7 +37786,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/resolve-dir"
         }
       ]
@@ -37826,7 +37826,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/resolve-url"
         }
       ]
@@ -37866,7 +37866,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/resolve"
         }
       ]
@@ -37906,7 +37906,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/responselike"
         }
       ]
@@ -37956,7 +37956,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/restructure"
         }
       ]
@@ -37996,7 +37996,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ret"
         }
       ]
@@ -38046,7 +38046,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/retry-as-promised"
         }
       ]
@@ -38091,7 +38091,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/retry"
         }
       ]
@@ -38131,7 +38131,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/rimraf"
         }
       ]
@@ -38181,7 +38181,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/rxjs"
         }
       ],
@@ -38231,7 +38231,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/rxjs/node_modules/tslib"
             }
           ]
@@ -38283,7 +38283,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safe-buffer"
         }
       ]
@@ -38328,7 +38328,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safe-regex"
         }
       ]
@@ -38378,7 +38378,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safe-stable-stringify"
         }
       ]
@@ -38423,7 +38423,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safer-buffer"
         }
       ]
@@ -38461,7 +38461,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/samsam"
         }
       ]
@@ -38501,7 +38501,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sanitize-filename"
         }
       ]
@@ -38541,7 +38541,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sanitize-html"
         }
       ],
@@ -38591,7 +38591,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sanitize-html/node_modules/lodash"
             }
           ]
@@ -38633,7 +38633,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sax"
         }
       ]
@@ -38672,7 +38672,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/seek-bzip"
         }
       ]
@@ -38712,7 +38712,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/semver"
         }
       ]
@@ -38752,7 +38752,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/send"
         }
       ],
@@ -38791,7 +38791,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/send/node_modules/ms"
             }
           ]
@@ -38833,7 +38833,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sequelize-pool"
         }
       ]
@@ -38882,7 +38882,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sequelize"
         }
       ],
@@ -38922,7 +38922,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sequelize/node_modules/debug"
             }
           ]
@@ -38961,7 +38961,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sequelize/node_modules/ms"
             }
           ]
@@ -39000,7 +39000,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sequelize/node_modules/uuid"
             }
           ]
@@ -39042,7 +39042,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/serve-index"
         }
       ],
@@ -39082,7 +39082,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index/node_modules/depd"
             }
           ]
@@ -39122,7 +39122,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index/node_modules/http-errors"
             }
           ]
@@ -39161,7 +39161,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index/node_modules/inherits"
             }
           ]
@@ -39211,7 +39211,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index/node_modules/setprototypeof"
             }
           ]
@@ -39250,7 +39250,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index/node_modules/statuses"
             }
           ]
@@ -39292,7 +39292,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/serve-static"
         }
       ]
@@ -39342,7 +39342,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/set-blocking"
         }
       ]
@@ -39392,7 +39392,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/set-value"
         }
       ],
@@ -39442,7 +39442,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/set-value/node_modules/extend-shallow"
             }
           ]
@@ -39492,7 +39492,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/set-value/node_modules/is-extendable"
             }
           ]
@@ -39534,7 +39534,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/setimmediate"
         }
       ]
@@ -39584,7 +39584,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/setprototypeof"
         }
       ]
@@ -39634,7 +39634,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/side-channel"
         }
       ]
@@ -39684,7 +39684,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/signal-exit"
         }
       ]
@@ -39734,7 +39734,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/simple-concat"
         }
       ]
@@ -39784,7 +39784,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/simple-get"
         }
       ],
@@ -39824,7 +39824,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/simple-get/node_modules/decompress-response"
             }
           ]
@@ -39864,7 +39864,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/simple-get/node_modules/mimic-response"
             }
           ]
@@ -39906,7 +39906,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/simple-swizzle"
         }
       ],
@@ -39946,7 +39946,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/simple-swizzle/node_modules/is-arrayish"
             }
           ]
@@ -39998,7 +39998,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sinon"
         }
       ]
@@ -40048,7 +40048,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/smart-buffer"
         }
       ]
@@ -40098,7 +40098,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/snapdragon-node"
         }
       ],
@@ -40148,7 +40148,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon-node/node_modules/define-property"
             }
           ]
@@ -40200,7 +40200,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/snapdragon-util"
         }
       ],
@@ -40250,7 +40250,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon-util/node_modules/kind-of"
             }
           ]
@@ -40302,7 +40302,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/snapdragon"
         }
       ],
@@ -40352,7 +40352,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/define-property"
             }
           ]
@@ -40402,7 +40402,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/extend-shallow"
             }
           ]
@@ -40452,7 +40452,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/is-accessor-descriptor"
             }
           ],
@@ -40502,7 +40502,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/snapdragon/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
@@ -40554,7 +40554,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/is-data-descriptor"
             }
           ],
@@ -40604,7 +40604,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/snapdragon/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
@@ -40656,7 +40656,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/is-descriptor"
             }
           ]
@@ -40706,7 +40706,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/is-extendable"
             }
           ]
@@ -40756,7 +40756,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/kind-of"
             }
           ]
@@ -40801,7 +40801,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/source-map"
             }
           ]
@@ -40842,7 +40842,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socket.io-adapter"
         }
       ]
@@ -40881,7 +40881,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socket.io-parser"
         }
       ],
@@ -40921,7 +40921,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socket.io-parser/node_modules/debug"
             }
           ]
@@ -40960,7 +40960,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socket.io-parser/node_modules/ms"
             }
           ]
@@ -41001,7 +41001,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socket.io"
         }
       ],
@@ -41041,7 +41041,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socket.io/node_modules/debug"
             }
           ]
@@ -41080,7 +41080,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socket.io/node_modules/ms"
             }
           ]
@@ -41132,7 +41132,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socks-proxy-agent"
         }
       ],
@@ -41172,7 +41172,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socks-proxy-agent/node_modules/debug"
             }
           ]
@@ -41211,7 +41211,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socks-proxy-agent/node_modules/ms"
             }
           ]
@@ -41263,7 +41263,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socks"
         }
       ],
@@ -41307,7 +41307,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socks/node_modules/ip"
             }
           ]
@@ -41349,7 +41349,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sort-keys-length"
         }
       ],
@@ -41389,7 +41389,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sort-keys-length/node_modules/sort-keys"
             }
           ]
@@ -41431,7 +41431,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sort-keys"
         }
       ]
@@ -41471,7 +41471,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/source-map-resolve"
         }
       ]
@@ -41515,7 +41515,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/source-map-support"
         }
       ]
@@ -41555,7 +41555,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/source-map-url"
         }
       ]
@@ -41600,7 +41600,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/source-map"
         }
       ]
@@ -41640,7 +41640,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spawn-command"
         }
       ]
@@ -41680,7 +41680,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spdx-correct"
         }
       ]
@@ -41720,7 +41720,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spdx-exceptions"
         }
       ]
@@ -41760,7 +41760,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spdx-expression-parse"
         }
       ]
@@ -41800,7 +41800,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spdx-license-ids"
         }
       ]
@@ -41850,7 +41850,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/split-string"
         }
       ]
@@ -41890,7 +41890,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sprintf-js"
         }
       ]
@@ -41935,7 +41935,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sqlite3"
         }
       ]
@@ -41985,7 +41985,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sshpk"
         }
       ]
@@ -42025,7 +42025,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ssri"
         }
       ]
@@ -42070,7 +42070,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/stack-trace"
         }
       ]
@@ -42120,7 +42120,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/static-extend"
         }
       ],
@@ -42170,7 +42170,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend/node_modules/define-property"
             }
           ]
@@ -42220,7 +42220,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend/node_modules/is-accessor-descriptor"
             }
           ],
@@ -42270,7 +42270,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/static-extend/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
@@ -42322,7 +42322,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend/node_modules/is-data-descriptor"
             }
           ],
@@ -42372,7 +42372,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/static-extend/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
@@ -42424,7 +42424,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend/node_modules/is-descriptor"
             }
           ]
@@ -42474,7 +42474,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend/node_modules/kind-of"
             }
           ]
@@ -42515,7 +42515,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/statuses"
         }
       ]
@@ -42555,7 +42555,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/stream-buffers"
         }
       ]
@@ -42596,7 +42596,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/streamsearch"
         }
       ]
@@ -42636,7 +42636,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strict-uri-encode"
         }
       ]
@@ -42680,7 +42680,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string_decoder"
         }
       ]
@@ -42720,7 +42720,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string-width"
         }
       ]
@@ -42771,7 +42771,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string.fromcodepoint"
         }
       ]
@@ -42821,7 +42821,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string.prototype.codepointat"
         }
       ]
@@ -42861,7 +42861,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-ansi"
         }
       ]
@@ -42901,7 +42901,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-bom"
         }
       ]
@@ -42941,7 +42941,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-dirs"
         }
       ]
@@ -42981,7 +42981,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-json-comments"
         }
       ]
@@ -43021,7 +43021,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-outer"
         }
       ]
@@ -43066,7 +43066,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strtok3"
         }
       ]
@@ -43106,7 +43106,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/supports-color"
         }
       ]
@@ -43156,7 +43156,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/supports-preserve-symlinks-flag"
         }
       ]
@@ -43206,7 +43206,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/svg-captcha"
         }
       ]
@@ -43244,7 +43244,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/swagger-ui-dist"
         }
       ]
@@ -43294,7 +43294,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/swagger-ui-express"
         }
       ]
@@ -43344,7 +43344,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tar-fs"
         }
       ],
@@ -43388,7 +43388,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/tar-fs/node_modules/bl"
             }
           ]
@@ -43428,7 +43428,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/tar-fs/node_modules/chownr"
             }
           ]
@@ -43467,7 +43467,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/tar-fs/node_modules/readable-stream"
             }
           ]
@@ -43517,7 +43517,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/tar-fs/node_modules/tar-stream"
             }
           ]
@@ -43569,7 +43569,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tar-stream"
         }
       ]
@@ -43609,7 +43609,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tar"
         }
       ]
@@ -43659,7 +43659,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tdigest"
         }
       ]
@@ -43709,7 +43709,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/text-hex"
         }
       ]
@@ -43742,7 +43742,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/thirty-two"
         }
       ]
@@ -43787,7 +43787,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/through"
         }
       ]
@@ -43827,7 +43827,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/timed-out"
         }
       ]
@@ -43877,7 +43877,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tiny-inflate"
         }
       ]
@@ -43927,7 +43927,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-buffer"
         }
       ]
@@ -43967,7 +43967,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-fast-properties"
         }
       ]
@@ -44017,7 +44017,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-object-path"
         }
       ],
@@ -44067,7 +44067,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/to-object-path/node_modules/kind-of"
             }
           ]
@@ -44119,7 +44119,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-regex-range"
         }
       ]
@@ -44169,7 +44169,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-regex"
         }
       ]
@@ -44209,7 +44209,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/toidentifier"
         }
       ]
@@ -44249,7 +44249,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/token-stream"
         }
       ]
@@ -44294,7 +44294,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/token-types"
         }
       ]
@@ -44333,7 +44333,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/toposort-class"
         }
       ]
@@ -44383,7 +44383,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tough-cookie"
         }
       ]
@@ -44433,7 +44433,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tr46"
         }
       ]
@@ -44473,7 +44473,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/traverse"
         }
       ]
@@ -44518,7 +44518,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tree-kill"
         }
       ]
@@ -44558,7 +44558,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/trim-repeated"
         }
       ]
@@ -44608,7 +44608,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/triple-beam"
         }
       ]
@@ -44658,7 +44658,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/truncate-utf8-bytes"
         }
       ]
@@ -44697,7 +44697,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ts-node-dev"
         }
       ],
@@ -44737,7 +44737,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/ts-node-dev/node_modules/rimraf"
             }
           ]
@@ -44789,7 +44789,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ts-node"
         }
       ]
@@ -44839,7 +44839,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tsconfig"
         }
       ]
@@ -44889,7 +44889,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tslib"
         }
       ]
@@ -44929,7 +44929,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tunnel-agent"
         }
       ]
@@ -44979,7 +44979,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tweetnacl"
         }
       ]
@@ -45029,7 +45029,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/type-check"
         }
       ]
@@ -45068,7 +45068,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/type-is"
         }
       ]
@@ -45107,7 +45107,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/typecast"
         }
       ]
@@ -45152,7 +45152,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/typedarray"
         }
       ]
@@ -45202,7 +45202,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/typescript"
         }
       ]
@@ -45242,7 +45242,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/uglify-js"
         }
       ]
@@ -45287,7 +45287,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unbzip2-stream"
         }
       ]
@@ -45337,7 +45337,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unc-path-regex"
         }
       ]
@@ -45386,7 +45386,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/underscore.string"
         }
       ]
@@ -45436,7 +45436,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unicode-properties"
         }
       ]
@@ -45486,7 +45486,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unicode-trie"
         }
       ]
@@ -45536,7 +45536,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/union-value"
         }
       ],
@@ -45586,7 +45586,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/union-value/node_modules/is-extendable"
             }
           ]
@@ -45638,7 +45638,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unique-filename"
         }
       ]
@@ -45678,7 +45678,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unique-slug"
         }
       ]
@@ -45728,7 +45728,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unit-compare"
         }
       ]
@@ -45778,7 +45778,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/universalify"
         }
       ]
@@ -45818,7 +45818,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unpipe"
         }
       ]
@@ -45868,7 +45868,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unset-value"
         }
       ],
@@ -45918,7 +45918,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/unset-value/node_modules/has-value"
             }
           ],
@@ -45968,7 +45968,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/unset-value/node_modules/has-value/node_modules/isobject"
                 }
               ]
@@ -46020,7 +46020,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/unset-value/node_modules/has-values"
             }
           ]
@@ -46065,7 +46065,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/unset-value/node_modules/isarray"
             }
           ]
@@ -46107,7 +46107,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/untildify"
         }
       ]
@@ -46147,7 +46147,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unzipper"
         }
       ],
@@ -46197,7 +46197,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/unzipper/node_modules/bluebird"
             }
           ]
@@ -46249,7 +46249,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/uri-js"
         }
       ]
@@ -46289,7 +46289,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/urix"
         }
       ]
@@ -46329,7 +46329,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/url-parse-lax"
         }
       ]
@@ -46369,7 +46369,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/url-to-options"
         }
       ]
@@ -46419,7 +46419,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/use"
         }
       ]
@@ -46469,7 +46469,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/utf8-byte-length"
         }
       ]
@@ -46519,7 +46519,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/util-deprecate"
         }
       ]
@@ -46564,7 +46564,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/util"
         }
       ]
@@ -46615,7 +46615,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/utils-merge"
         }
       ]
@@ -46654,7 +46654,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/uuid"
         }
       ]
@@ -46694,7 +46694,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/v8flags"
         }
       ]
@@ -46734,7 +46734,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/validate-npm-package-license"
         }
       ]
@@ -46774,7 +46774,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/validate"
         }
       ]
@@ -46824,7 +46824,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/validator"
         }
       ]
@@ -46864,7 +46864,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/vary"
         }
       ]
@@ -46903,7 +46903,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/verror"
         }
       ],
@@ -46948,7 +46948,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/verror/node_modules/core-util-is"
             }
           ]
@@ -46990,7 +46990,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/vm2"
         }
       ],
@@ -47034,7 +47034,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/vm2/node_modules/acorn"
             }
           ]
@@ -47086,7 +47086,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/void-elements"
         }
       ]
@@ -47134,7 +47134,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/walk"
         }
       ]
@@ -47179,7 +47179,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/walkdir"
         }
       ]
@@ -47219,7 +47219,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/webidl-conversions"
         }
       ]
@@ -47259,7 +47259,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/whatwg-url"
         }
       ]
@@ -47309,7 +47309,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-boxed-primitive"
         }
       ]
@@ -47359,7 +47359,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-collection"
         }
       ]
@@ -47409,7 +47409,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-module"
         }
       ]
@@ -47459,7 +47459,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-pm-runs"
         }
       ]
@@ -47499,7 +47499,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-typed-array"
         }
       ]
@@ -47539,7 +47539,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which"
         }
       ]
@@ -47579,7 +47579,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wide-align"
         }
       ]
@@ -47629,7 +47629,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/winston-transport"
         }
       ],
@@ -47668,7 +47668,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/winston-transport/node_modules/readable-stream"
             }
           ]
@@ -47710,7 +47710,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/winston"
         }
       ],
@@ -47760,7 +47760,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/winston/node_modules/async"
             }
           ]
@@ -47800,7 +47800,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/winston/node_modules/is-stream"
             }
           ]
@@ -47839,7 +47839,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/winston/node_modules/readable-stream"
             }
           ]
@@ -47881,7 +47881,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/with"
         }
       ]
@@ -47921,7 +47921,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wkx"
         }
       ]
@@ -47971,7 +47971,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/word-wrap"
         }
       ]
@@ -48011,7 +48011,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wordwrap"
         }
       ]
@@ -48051,7 +48051,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wrap-ansi"
         }
       ],
@@ -48091,7 +48091,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi/node_modules/ansi-regex"
             }
           ]
@@ -48141,7 +48141,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi/node_modules/emoji-regex"
             }
           ]
@@ -48181,7 +48181,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -48221,7 +48221,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi/node_modules/string-width"
             }
           ]
@@ -48261,7 +48261,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi/node_modules/strip-ansi"
             }
           ]
@@ -48313,7 +48313,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wrappy"
         }
       ]
@@ -48363,7 +48363,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ws"
         }
       ]
@@ -48413,7 +48413,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/xtend"
         }
       ]
@@ -48463,7 +48463,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/y18n"
         }
       ]
@@ -48503,7 +48503,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yallist"
         }
       ]
@@ -48543,7 +48543,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yaml-schema-validator"
         }
       ]
@@ -48583,7 +48583,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yargs-parser"
         }
       ]
@@ -48627,7 +48627,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yargs"
         }
       ],
@@ -48667,7 +48667,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs/node_modules/ansi-regex"
             }
           ]
@@ -48717,7 +48717,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs/node_modules/emoji-regex"
             }
           ]
@@ -48757,7 +48757,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -48797,7 +48797,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs/node_modules/string-width"
             }
           ]
@@ -48837,7 +48837,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs/node_modules/strip-ansi"
             }
           ]
@@ -48889,7 +48889,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yauzl"
         }
       ]
@@ -48929,7 +48929,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yn"
         }
       ]
@@ -48979,7 +48979,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/z85"
         }
       ]
@@ -49029,7 +49029,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/zip-stream"
         }
       ]
@@ -49074,7 +49074,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/zlibjs"
         }
       ]

--- a/demo/juice-shop/example-results/bom.1.3.json
+++ b/demo/juice-shop/example-results/bom.1.3.json
@@ -8,7 +8,7 @@
       {
         "vendor": "@cyclonedx",
         "name": "cyclonedx-npm",
-        "version": "1.4.0"
+        "version": "1.4.1"
       }
     ],
     "component": {
@@ -44,6 +44,10 @@
         }
       ],
       "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
         {
           "name": "cdx:npm:package:private",
           "value": "true"
@@ -90,6 +94,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@babel/helper-string-parser"
+        }
       ]
     },
     {
@@ -124,6 +134,12 @@
           "url": "https://github.com/babel/babel.git#packages/babel-helper-validator-identifier",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\" and \"repository.directory\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@babel/helper-validator-identifier"
         }
       ]
     },
@@ -170,6 +186,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@babel/parser"
+        }
       ]
     },
     {
@@ -214,6 +236,12 @@
           "url": "https://babel.dev/docs/en/next/babel-types",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@babel/types"
         }
       ]
     },
@@ -260,6 +288,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@colors/colors"
+        }
       ]
     },
     {
@@ -305,6 +339,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@dabh/diagnostics"
+        }
       ]
     },
     {
@@ -339,6 +379,12 @@
           "url": "https://github.com/wraithgar/gar-promisify.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@gar/promisify"
         }
       ]
     },
@@ -376,6 +422,12 @@
           "comment": "as detected from PackageJson property \"repository.url\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@mapbox/node-pre-gyp"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -408,6 +460,12 @@
               "url": "chalk/ansi-regex",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/ansi-regex"
             }
           ]
         },
@@ -453,6 +511,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/are-we-there-yet"
+            }
           ]
         },
         {
@@ -486,6 +550,12 @@
               "url": "git://github.com/lovell/detect-libc",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/detect-libc"
             }
           ]
         },
@@ -531,6 +601,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/gauge"
+            }
           ]
         },
         {
@@ -564,6 +640,12 @@
               "url": "sindresorhus/is-fullwidth-code-point",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/is-fullwidth-code-point"
             }
           ]
         },
@@ -600,6 +682,12 @@
               "comment": "as detected from PackageJson property \"repository\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/make-dir"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -631,6 +719,12 @@
                   "url": "https://github.com/npm/node-semver",
                   "type": "vcs",
                   "comment": "as detected from PackageJson property \"repository\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/@mapbox/node-pre-gyp/node_modules/make-dir/node_modules/semver"
                 }
               ]
             }
@@ -668,6 +762,12 @@
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/nopt"
+            }
           ]
         },
         {
@@ -702,6 +802,12 @@
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/npmlog"
+            }
           ]
         },
         {
@@ -734,6 +840,12 @@
               "url": "git://github.com/nodejs/readable-stream",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/readable-stream"
             }
           ]
         },
@@ -769,6 +881,12 @@
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/string-width"
+            }
           ]
         },
         {
@@ -802,6 +920,12 @@
               "url": "chalk/strip-ansi",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/strip-ansi"
             }
           ]
         }
@@ -845,6 +969,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/core-loader"
+        }
       ]
     },
     {
@@ -884,6 +1014,12 @@
           "url": "git+https://github.com/axa-group/nlp.js.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/core"
         }
       ]
     },
@@ -925,6 +1061,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/evaluator"
+        }
       ]
     },
     {
@@ -964,6 +1106,12 @@
           "url": "git+https://github.com/axa-group/nlp.js.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-all"
         }
       ]
     },
@@ -1005,6 +1153,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ar"
+        }
       ]
     },
     {
@@ -1044,6 +1198,12 @@
           "url": "git+https://github.com/axa-group/nlp.js.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-bn"
         }
       ]
     },
@@ -1085,6 +1245,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ca"
+        }
       ]
     },
     {
@@ -1124,6 +1290,12 @@
           "url": "git+https://github.com/axa-group/nlp.js.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-cs"
         }
       ]
     },
@@ -1165,6 +1337,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-da"
+        }
       ]
     },
     {
@@ -1204,6 +1382,12 @@
           "url": "git+https://github.com/axa-group/nlp.js.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-de"
         }
       ]
     },
@@ -1245,6 +1429,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-el"
+        }
       ]
     },
     {
@@ -1284,6 +1474,12 @@
           "url": "git+https://github.com/axa-group/nlp.js.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-en-min"
         }
       ]
     },
@@ -1325,6 +1521,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-en"
+        }
       ]
     },
     {
@@ -1364,6 +1566,12 @@
           "url": "git+https://github.com/axa-group/nlp.js.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-es"
         }
       ]
     },
@@ -1405,6 +1613,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-eu"
+        }
       ]
     },
     {
@@ -1444,6 +1658,12 @@
           "url": "git+https://github.com/axa-group/nlp.js.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-fa"
         }
       ]
     },
@@ -1485,6 +1705,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-fi"
+        }
       ]
     },
     {
@@ -1524,6 +1750,12 @@
           "url": "git+https://github.com/axa-group/nlp.js.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-fr"
         }
       ]
     },
@@ -1565,6 +1797,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ga"
+        }
       ]
     },
     {
@@ -1604,6 +1842,12 @@
           "url": "git+https://github.com/axa-group/nlp.js.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-gl"
         }
       ]
     },
@@ -1645,6 +1889,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-hi"
+        }
       ]
     },
     {
@@ -1684,6 +1934,12 @@
           "url": "git+https://github.com/axa-group/nlp.js.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-hu"
         }
       ]
     },
@@ -1725,6 +1981,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-hy"
+        }
       ]
     },
     {
@@ -1764,6 +2026,12 @@
           "url": "git+https://github.com/axa-group/nlp.js.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-id"
         }
       ]
     },
@@ -1805,6 +2073,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-it"
+        }
       ]
     },
     {
@@ -1844,6 +2118,12 @@
           "url": "git+https://github.com/axa-group/nlp.js.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ja"
         }
       ]
     },
@@ -1885,6 +2165,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ko"
+        }
       ]
     },
     {
@@ -1924,6 +2210,12 @@
           "url": "git+https://github.com/axa-group/nlp.js.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-lt"
         }
       ]
     },
@@ -1965,6 +2257,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ms"
+        }
       ]
     },
     {
@@ -2004,6 +2302,12 @@
           "url": "git+https://github.com/axa-group/nlp.js.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ne"
         }
       ]
     },
@@ -2045,6 +2349,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-nl"
+        }
       ]
     },
     {
@@ -2084,6 +2394,12 @@
           "url": "git+https://github.com/axa-group/nlp.js.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-no"
         }
       ]
     },
@@ -2125,6 +2441,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-pl"
+        }
       ]
     },
     {
@@ -2164,6 +2486,12 @@
           "url": "git+https://github.com/axa-group/nlp.js.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-pt"
         }
       ]
     },
@@ -2205,6 +2533,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ro"
+        }
       ]
     },
     {
@@ -2244,6 +2578,12 @@
           "url": "git+https://github.com/axa-group/nlp.js.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ru"
         }
       ]
     },
@@ -2285,6 +2625,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-sl"
+        }
       ]
     },
     {
@@ -2324,6 +2670,12 @@
           "url": "git+https://github.com/axa-group/nlp.js.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-sr"
         }
       ]
     },
@@ -2365,6 +2717,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-sv"
+        }
       ]
     },
     {
@@ -2404,6 +2762,12 @@
           "url": "git+https://github.com/axa-group/nlp.js.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ta"
         }
       ]
     },
@@ -2445,6 +2809,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-th"
+        }
       ]
     },
     {
@@ -2484,6 +2854,12 @@
           "url": "git+https://github.com/axa-group/nlp.js.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-tl"
         }
       ]
     },
@@ -2525,6 +2901,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-tr"
+        }
       ]
     },
     {
@@ -2564,6 +2946,12 @@
           "url": "git+https://github.com/axa-group/nlp.js.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-uk"
         }
       ]
     },
@@ -2605,6 +2993,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-zh"
+        }
       ]
     },
     {
@@ -2644,6 +3038,12 @@
           "url": "git+https://github.com/axa-group/nlp.js.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/language-min"
         }
       ]
     },
@@ -2685,6 +3085,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/language"
+        }
       ]
     },
     {
@@ -2724,6 +3130,12 @@
           "url": "git+https://github.com/axa-group/nlp.js.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/ner"
         }
       ]
     },
@@ -2765,6 +3177,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/neural"
+        }
       ]
     },
     {
@@ -2804,6 +3222,12 @@
           "url": "git+https://github.com/axa-group/nlp.js.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/nlg"
         }
       ]
     },
@@ -2845,6 +3269,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/nlp"
+        }
       ]
     },
     {
@@ -2884,6 +3314,12 @@
           "url": "git+https://github.com/axa-group/nlp.js.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/nlu"
         }
       ]
     },
@@ -2925,6 +3361,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/request"
+        }
       ]
     },
     {
@@ -2964,6 +3406,12 @@
           "url": "git+https://github.com/axa-group/nlp.js.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/sentiment"
         }
       ]
     },
@@ -3005,6 +3453,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/similarity"
+        }
       ]
     },
     {
@@ -3045,6 +3499,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/slot"
+        }
       ]
     },
     {
@@ -3074,6 +3534,12 @@
           "url": "https://registry.npmjs.org/@npmcli/fs/-/fs-1.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@npmcli/fs"
         }
       ]
     },
@@ -3108,6 +3574,12 @@
           "url": "git+https://github.com/npm/move-file",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@npmcli/move-file"
         }
       ]
     },
@@ -3149,6 +3621,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib/core"
+        }
       ]
     },
     {
@@ -3188,6 +3666,12 @@
           "url": "https://yeojz.otplib.dev",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib/plugin-crypto"
         }
       ]
     },
@@ -3229,6 +3713,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib/plugin-thirty-two"
+        }
       ]
     },
     {
@@ -3268,6 +3758,12 @@
           "url": "https://yeojz.otplib.dev",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib/preset-default"
         }
       ]
     },
@@ -3309,6 +3805,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib/preset-v11"
+        }
       ]
     },
     {
@@ -3343,6 +3845,12 @@
           "url": "sindresorhus/is",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@sindresorhus/is"
         }
       ]
     },
@@ -3389,6 +3897,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@swc/helpers"
+        }
       ]
     },
     {
@@ -3428,6 +3942,12 @@
           "url": "https://github.com/Borewit/tokenizer-token.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@tokenizer/token"
         }
       ]
     },
@@ -3469,6 +3989,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@tootallnate/once"
+        }
       ]
     },
     {
@@ -3507,6 +4033,12 @@
           "url": "https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/component-emitter",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/component-emitter"
         }
       ]
     },
@@ -3547,6 +4079,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/cookie"
+        }
       ]
     },
     {
@@ -3585,6 +4123,12 @@
           "url": "https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/cors",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/cors"
         }
       ]
     },
@@ -3625,6 +4169,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/debug"
+        }
       ]
     },
     {
@@ -3658,6 +4208,12 @@
           "url": "https://github.com/DefinitelyTyped/DefinitelyTyped.git#types/ms",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\" and \"repository.directory\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/ms"
         }
       ]
     },
@@ -3698,6 +4254,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/node"
+        }
       ]
     },
     {
@@ -3733,6 +4295,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/strip-bom"
+        }
       ]
     },
     {
@@ -3766,6 +4334,12 @@
           "url": "https://www.github.com/DefinitelyTyped/DefinitelyTyped.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/strip-json-comments"
         }
       ]
     },
@@ -3806,6 +4380,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/validator"
+        }
       ]
     },
     {
@@ -3840,6 +4420,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/abbrev"
+        }
       ]
     },
     {
@@ -3872,6 +4458,12 @@
           "url": "jshttp/accepts",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/accepts"
         }
       ]
     },
@@ -3911,6 +4503,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/acorn-walk"
+        }
       ]
     },
     {
@@ -3948,6 +4546,12 @@
           "url": "https://github.com/acornjs/acorn",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/acorn"
         }
       ]
     },
@@ -3989,6 +4593,12 @@
           "comment": "as detected from PackageJson property \"repository.url\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/agent-base"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4022,6 +4632,12 @@
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agent-base/node_modules/debug"
+            }
           ]
         },
         {
@@ -4054,6 +4670,12 @@
               "url": "zeit/ms",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agent-base/node_modules/ms"
             }
           ]
         }
@@ -4097,6 +4719,12 @@
           "comment": "as detected from PackageJson property \"repository.url\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/agentkeepalive"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4129,6 +4757,12 @@
               "url": "git://github.com/debug-js/debug.git",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agentkeepalive/node_modules/debug"
             }
           ]
         },
@@ -4164,6 +4798,12 @@
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agentkeepalive/node_modules/depd"
+            }
           ]
         },
         {
@@ -4196,6 +4836,12 @@
               "url": "zeit/ms",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agentkeepalive/node_modules/ms"
             }
           ]
         }
@@ -4232,6 +4878,12 @@
           "url": "sindresorhus/aggregate-error",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/aggregate-error"
         }
       ]
     },
@@ -4277,6 +4929,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ajv"
+        }
       ]
     },
     {
@@ -4311,6 +4969,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ansi-regex"
+        }
       ]
     },
     {
@@ -4344,6 +5008,12 @@
           "url": "chalk/ansi-styles",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ansi-styles"
         }
       ]
     },
@@ -4383,6 +5053,12 @@
           "url": "https://github.com/micromatch/anymatch",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/anymatch"
         }
       ],
       "components": [
@@ -4428,6 +5104,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/anymatch/node_modules/normalize-path"
+            }
           ]
         }
       ]
@@ -4462,6 +5144,12 @@
           "url": "http://github.com/LinusU/node-append-field.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/append-field"
         }
       ]
     },
@@ -4507,6 +5195,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/aproba"
+        }
       ]
     },
     {
@@ -4542,6 +5236,12 @@
           "comment": "as detected from PackageJson property \"repository\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/archive-type"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4574,6 +5274,12 @@
               "url": "sindresorhus/file-type",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/archive-type/node_modules/file-type"
             }
           ]
         }
@@ -4621,6 +5327,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/archiver-utils"
+        }
       ]
     },
     {
@@ -4664,6 +5376,12 @@
           "url": "https://github.com/archiverjs/node-archiver",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/archiver"
         }
       ]
     },
@@ -4709,6 +5427,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/are-we-there-yet"
+        }
       ]
     },
     {
@@ -4742,6 +5466,12 @@
           "url": "zeit/arg",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/arg"
         }
       ]
     },
@@ -4777,6 +5507,12 @@
           "comment": "as detected from PackageJson property \"repository\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/argparse"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4809,6 +5545,12 @@
               "url": "https://github.com/alexei/sprintf.js.git",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/argparse/node_modules/sprintf-js"
             }
           ]
         }
@@ -4856,6 +5598,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/arr-diff"
+        }
       ]
     },
     {
@@ -4899,6 +5647,12 @@
           "url": "https://github.com/jonschlinkert/arr-flatten",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/arr-flatten"
         }
       ]
     },
@@ -4944,6 +5698,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/arr-union"
+        }
       ]
     },
     {
@@ -4987,6 +5747,12 @@
           "url": "https://github.com/jonschlinkert/array-each",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/array-each"
         }
       ]
     },
@@ -5032,6 +5798,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/array-flatten"
+        }
       ]
     },
     {
@@ -5075,6 +5847,12 @@
           "url": "https://github.com/jonschlinkert/array-slice",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/array-slice"
         }
       ]
     },
@@ -5120,6 +5898,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/array-unique"
+        }
       ]
     },
     {
@@ -5152,6 +5936,12 @@
           "url": "https://github.com/kriskowal/asap.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/asap"
         }
       ]
     },
@@ -5187,6 +5977,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/asn1"
+        }
       ]
     },
     {
@@ -5221,6 +6017,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/assert-never"
+        }
       ]
     },
     {
@@ -5254,6 +6056,12 @@
           "url": "https://github.com/mcavage/node-assert-plus.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/assert-plus"
         }
       ]
     },
@@ -5299,6 +6107,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/assign-symbols"
+        }
       ]
     },
     {
@@ -5342,6 +6156,12 @@
           "url": "https://caolan.github.io/async/",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/async"
         }
       ]
     },
@@ -5387,6 +6207,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/asynckit"
+        }
       ]
     },
     {
@@ -5431,6 +6257,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/at-least-node"
+        }
       ]
     },
     {
@@ -5467,6 +6299,12 @@
           "url": "https://git.coolaj86.com/coolaj86/atob.js.git",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/atob"
         }
       ]
     },
@@ -5512,6 +6350,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/available-typed-arrays"
+        }
       ]
     },
     {
@@ -5545,6 +6389,12 @@
           "url": "https://github.com/mikeal/aws-sign",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/aws-sign2"
         }
       ]
     },
@@ -5580,6 +6430,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/aws4"
+        }
       ]
     },
     {
@@ -5613,6 +6469,12 @@
           "url": "https://github.com/pugjs/babel-walk.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/babel-walk"
         }
       ]
     },
@@ -5652,6 +6514,12 @@
           "url": "https://github.com/juliangruber/balanced-match",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/balanced-match"
         }
       ]
     },
@@ -5698,6 +6566,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5741,6 +6615,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/base/node_modules/define-property"
+            }
           ]
         }
       ]
@@ -5756,6 +6636,14 @@
         {
           "alg": "SHA-512",
           "content": "6b5788162e11f724ab6e232ec931b1e5ef76b911f9b5063a900acd70568a05495e2282e3763060ed9c66dccaa6dca9a47f6ec72d1ff57e7c57f6af0643b21abe"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://github.com/niklasvh/base64-arraybuffer/blob/master/LICENSE-MIT"
+          }
         }
       ],
       "purl": "pkg:npm/base64-arraybuffer@0.1.4",
@@ -5779,6 +6667,12 @@
           "url": "https://github.com/niklasvh/base64-arraybuffer",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base64-arraybuffer"
         }
       ]
     },
@@ -5824,6 +6718,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base64-js"
+        }
       ]
     },
     {
@@ -5857,6 +6757,12 @@
           "url": "https://github.com/faeldt/base64id.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base64id"
         }
       ]
     },
@@ -5892,6 +6798,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base64url"
+        }
       ]
     },
     {
@@ -5924,6 +6836,12 @@
           "url": "jshttp/basic-auth",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/basic-auth"
         }
       ]
     },
@@ -5959,6 +6877,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/batch"
+        }
       ]
     },
     {
@@ -5991,6 +6915,12 @@
           "url": "git://github.com/joyent/node-bcrypt-pbkdf.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bcrypt-pbkdf"
         }
       ]
     },
@@ -6026,6 +6956,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/big-integer"
+        }
       ]
     },
     {
@@ -6060,6 +6996,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/binary-extensions"
+        }
       ]
     },
     {
@@ -6093,6 +7035,12 @@
           "url": "http://github.com/substack/node-binary.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/binary"
         }
       ]
     },
@@ -6138,6 +7086,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bindings"
+        }
       ]
     },
     {
@@ -6171,6 +7125,12 @@
           "url": "git://github.com/vadimg/js_bintrees.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bintrees"
         }
       ]
     },
@@ -6209,6 +7169,12 @@
           "url": "https://github.com/rvagg/bl",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bl"
         }
       ]
     },
@@ -6254,6 +7220,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bluebird"
+        }
       ]
     },
     {
@@ -6286,6 +7258,12 @@
           "url": "expressjs/body-parser",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/body-parser"
         }
       ]
     },
@@ -6327,6 +7305,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bower-config"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -6364,6 +7348,12 @@
               "url": "https://github.com/minimistjs/minimist",
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bower-config/node_modules/minimist"
             }
           ]
         }
@@ -6405,6 +7395,12 @@
           "url": "https://github.com/juliangruber/brace-expansion",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/brace-expansion"
         }
       ]
     },
@@ -6451,6 +7447,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/braces"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -6493,6 +7495,12 @@
               "url": "https://github.com/jonschlinkert/extend-shallow",
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/braces/node_modules/extend-shallow"
             }
           ]
         },
@@ -6537,6 +7545,12 @@
               "url": "https://github.com/jonschlinkert/is-extendable",
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/braces/node_modules/is-extendable"
             }
           ]
         }
@@ -6584,6 +7598,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/brotli"
+        }
       ]
     },
     {
@@ -6615,6 +7635,12 @@
           "url": "LinusU/buffer-alloc-unsafe",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-alloc-unsafe"
         }
       ]
     },
@@ -6648,6 +7674,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-alloc"
+        }
       ]
     },
     {
@@ -6668,6 +7700,12 @@
           "license": {
             "id": "MIT"
           }
+        },
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://github.com/brianloveswords/buffer-crc32/raw/master/LICENSE"
+          }
         }
       ],
       "purl": "pkg:npm/buffer-crc32@0.2.13",
@@ -6686,6 +7724,12 @@
           "url": "https://github.com/brianloveswords/buffer-crc32",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-crc32"
         }
       ]
     },
@@ -6719,6 +7763,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-fill"
+        }
       ]
     },
     {
@@ -6750,6 +7800,12 @@
           "url": "LinusU/buffer-from",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-from"
         }
       ]
     },
@@ -6795,6 +7851,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-indexof-polyfill"
+        }
       ]
     },
     {
@@ -6839,6 +7901,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer"
+        }
       ]
     },
     {
@@ -6866,6 +7934,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffers"
+        }
       ]
     },
     {
@@ -6881,6 +7955,14 @@
           "content": "2275850e89af964123fb158b05f53702f9db558a9e4d6990a29896d2d596132e727a1626d9890611ce7db149b0ff8b72e598ff6f45871acd4b81e72e052046ae"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "http://github.com/mscdex/busboy/raw/master/LICENSE"
+          }
+        }
+      ],
       "purl": "pkg:npm/busboy@0.2.14",
       "externalReferences": [
         {
@@ -6892,6 +7974,12 @@
           "url": "http://github.com/mscdex/busboy.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/busboy"
         }
       ],
       "components": [
@@ -6932,6 +8020,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/busboy/node_modules/isarray"
+            }
           ]
         },
         {
@@ -6965,6 +8059,12 @@
               "url": "git://github.com/isaacs/readable-stream",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/busboy/node_modules/readable-stream"
             }
           ]
         },
@@ -7003,6 +8103,12 @@
               "url": "https://github.com/rvagg/string_decoder",
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/busboy/node_modules/string_decoder"
             }
           ]
         }
@@ -7050,6 +8156,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/byline"
+        }
       ]
     },
     {
@@ -7084,6 +8196,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bytes"
+        }
       ]
     },
     {
@@ -7116,6 +8234,12 @@
           "url": "https://github.com/npm/cacache",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cacache"
         }
       ]
     },
@@ -7160,6 +8284,12 @@
           "url": "https://github.com/jonschlinkert/cache-base",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cache-base"
         }
       ]
     },
@@ -7206,6 +8336,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cacheable-request"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7238,6 +8374,12 @@
               "url": "sindresorhus/get-stream",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cacheable-request/node_modules/get-stream"
             }
           ]
         },
@@ -7272,6 +8414,12 @@
               "url": "sindresorhus/lowercase-keys",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cacheable-request/node_modules/lowercase-keys"
             }
           ]
         }
@@ -7319,6 +8467,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/call-bind"
+        }
       ]
     },
     {
@@ -7352,6 +8506,12 @@
           "url": "sindresorhus/camelcase",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/camelcase"
         }
       ]
     },
@@ -7392,6 +8552,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/caseless"
+        }
       ]
     },
     {
@@ -7426,6 +8592,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/chainsaw"
+        }
       ]
     },
     {
@@ -7458,6 +8630,12 @@
           "url": "chalk/chalk",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/chalk"
         }
       ]
     },
@@ -7492,6 +8670,12 @@
           "url": "https://github.com/ForbesLindesay/character-parser.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/character-parser"
         }
       ]
     },
@@ -7538,6 +8722,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/check-dependencies"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7569,6 +8759,12 @@
               "url": "https://github.com/npm/node-semver",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/check-dependencies/node_modules/semver"
             }
           ]
         }
@@ -7616,6 +8812,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/check-types"
+        }
       ]
     },
     {
@@ -7661,6 +8863,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/chokidar"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7703,6 +8911,12 @@
               "url": "https://github.com/micromatch/braces",
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar/node_modules/braces"
             }
           ]
         },
@@ -7748,6 +8962,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar/node_modules/fill-range"
+            }
           ]
         },
         {
@@ -7791,6 +9011,12 @@
               "url": "https://github.com/micromatch/is-glob",
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar/node_modules/is-glob"
             }
           ]
         },
@@ -7836,6 +9062,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar/node_modules/is-number"
+            }
           ]
         },
         {
@@ -7879,6 +9111,12 @@
               "url": "https://github.com/jonschlinkert/normalize-path",
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar/node_modules/normalize-path"
             }
           ]
         },
@@ -7924,6 +9162,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar/node_modules/to-regex-range"
+            }
           ]
         }
       ]
@@ -7959,6 +9203,12 @@
           "url": "git://github.com/isaacs/chownr.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/chownr"
         }
       ]
     },
@@ -8003,6 +9253,12 @@
           "url": "https://github.com/dscape/clarinet",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/clarinet"
         }
       ]
     },
@@ -8049,6 +9305,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/class-utils"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -8091,6 +9353,12 @@
               "url": "https://github.com/jonschlinkert/define-property",
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils/node_modules/define-property"
             }
           ]
         },
@@ -8137,6 +9405,12 @@
               "comment": "as detected from PackageJson property \"homepage\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils/node_modules/is-accessor-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -8179,6 +9453,12 @@
                   "url": "https://github.com/jonschlinkert/kind-of",
                   "type": "website",
                   "comment": "as detected from PackageJson property \"homepage\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/class-utils/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -8227,6 +9507,12 @@
               "comment": "as detected from PackageJson property \"homepage\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils/node_modules/is-data-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -8269,6 +9555,12 @@
                   "url": "https://github.com/jonschlinkert/kind-of",
                   "type": "website",
                   "comment": "as detected from PackageJson property \"homepage\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/class-utils/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -8316,6 +9608,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils/node_modules/is-descriptor"
+            }
           ]
         },
         {
@@ -8360,6 +9658,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils/node_modules/kind-of"
+            }
           ]
         }
       ]
@@ -8396,6 +9700,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/clean-stack"
+        }
       ]
     },
     {
@@ -8431,6 +9741,12 @@
           "comment": "as detected from PackageJson property \"repository.url\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cliui"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -8463,6 +9779,12 @@
               "url": "chalk/ansi-regex",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui/node_modules/ansi-regex"
             }
           ]
         },
@@ -8508,6 +9830,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui/node_modules/emoji-regex"
+            }
           ]
         },
         {
@@ -8541,6 +9869,12 @@
               "url": "sindresorhus/is-fullwidth-code-point",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui/node_modules/is-fullwidth-code-point"
             }
           ]
         },
@@ -8576,6 +9910,12 @@
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui/node_modules/string-width"
+            }
           ]
         },
         {
@@ -8609,6 +9949,12 @@
               "url": "chalk/strip-ansi",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui/node_modules/strip-ansi"
             }
           ]
         }
@@ -8656,6 +10002,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/clone-response"
+        }
       ]
     },
     {
@@ -8695,6 +10047,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/clone"
+        }
       ]
     },
     {
@@ -8728,6 +10086,12 @@
           "url": "sindresorhus/code-point-at",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/code-point-at"
         }
       ]
     },
@@ -8773,6 +10137,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/collection-visit"
+        }
       ]
     },
     {
@@ -8806,6 +10176,12 @@
           "url": "Qix-/color-convert",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color-convert"
         }
       ]
     },
@@ -8851,6 +10227,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color-name"
+        }
       ]
     },
     {
@@ -8884,6 +10266,12 @@
           "url": "Qix-/color-string",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color-string"
         }
       ]
     },
@@ -8919,6 +10307,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color-support"
+        }
       ]
     },
     {
@@ -8951,6 +10345,12 @@
           "url": "Qix-/color",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color"
         }
       ]
     },
@@ -8996,6 +10396,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/colors"
+        }
       ]
     },
     {
@@ -9040,6 +10446,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/colorspace"
+        }
       ]
     },
     {
@@ -9079,6 +10491,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/combined-stream"
+        }
       ]
     },
     {
@@ -9113,6 +10531,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/commander"
+        }
       ]
     },
     {
@@ -9146,6 +10570,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/component-emitter"
+        }
       ]
     },
     {
@@ -9178,6 +10608,12 @@
           "url": "https://github.com/component/type.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/component-type"
         }
       ]
     },
@@ -9223,6 +10659,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/compress-commons"
+        }
       ]
     },
     {
@@ -9255,6 +10697,12 @@
           "url": "jshttp/compressible",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/compressible"
         }
       ]
     },
@@ -9290,6 +10738,12 @@
           "comment": "as detected from PackageJson property \"repository\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/compression"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9322,6 +10776,12 @@
               "url": "visionmedia/bytes.js",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/compression/node_modules/bytes"
             }
           ]
         }
@@ -9358,6 +10818,12 @@
           "url": "git://github.com/substack/node-concat-map.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/concat-map"
         }
       ]
     },
@@ -9398,6 +10864,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/concat-stream"
+        }
       ]
     },
     {
@@ -9433,6 +10905,12 @@
           "comment": "as detected from PackageJson property \"repository.url\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/concurrently"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9465,6 +10943,12 @@
               "url": "chalk/supports-color",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/concurrently/node_modules/supports-color"
             }
           ]
         }
@@ -9507,6 +10991,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/config"
+        }
       ]
     },
     {
@@ -9540,6 +11030,12 @@
           "url": "https://github.com/iarna/console-control-strings",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/console-control-strings"
         }
       ]
     },
@@ -9575,6 +11071,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/constantinople"
+        }
       ]
     },
     {
@@ -9608,6 +11110,12 @@
           "url": "jshttp/content-disposition",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/content-disposition"
         }
       ],
       "components": [
@@ -9653,6 +11161,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/content-disposition/node_modules/safe-buffer"
+            }
           ]
         }
       ]
@@ -9689,6 +11203,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/content-type"
+        }
       ]
     },
     {
@@ -9722,6 +11242,12 @@
           "url": "expressjs/cookie-parser",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cookie-parser"
         }
       ]
     },
@@ -9757,6 +11283,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cookie-signature"
+        }
       ]
     },
     {
@@ -9790,6 +11322,12 @@
           "url": "jshttp/cookie",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cookie"
         }
       ]
     },
@@ -9835,6 +11373,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/copy-descriptor"
+        }
       ]
     },
     {
@@ -9874,6 +11418,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/core-util-is"
+        }
       ]
     },
     {
@@ -9907,6 +11457,12 @@
           "url": "expressjs/cors",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cors"
         }
       ]
     },
@@ -9952,6 +11508,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/crc"
+        }
       ]
     },
     {
@@ -9996,6 +11558,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/crc32-stream"
+        }
       ]
     },
     {
@@ -10028,6 +11596,12 @@
           "url": "nuxt-contrib/create-require",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/create-require"
         }
       ]
     },
@@ -10068,6 +11642,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/crypto-js"
+        }
       ]
     },
     {
@@ -10102,6 +11682,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dashdash"
+        }
       ]
     },
     {
@@ -10134,6 +11720,12 @@
           "url": "https://github.com/date-fns/date-fns",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/date-fns"
         }
       ]
     },
@@ -10174,6 +11766,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dateformat"
+        }
       ]
     },
     {
@@ -10207,6 +11805,12 @@
           "url": "git://github.com/visionmedia/debug.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/debug"
         }
       ]
     },
@@ -10242,6 +11846,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decamelize"
+        }
       ]
     },
     {
@@ -10276,6 +11886,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decode-uri-component"
+        }
       ]
     },
     {
@@ -10308,6 +11924,12 @@
           "url": "sindresorhus/decompress-response",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-response"
         }
       ]
     },
@@ -10344,6 +11966,12 @@
           "comment": "as detected from PackageJson property \"repository\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-tar"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -10376,6 +12004,12 @@
               "url": "sindresorhus/file-type",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-tar/node_modules/file-type"
             }
           ]
         }
@@ -10414,6 +12048,12 @@
           "comment": "as detected from PackageJson property \"repository\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-tarbz2"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -10446,6 +12086,12 @@
               "url": "sindresorhus/file-type",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-tarbz2/node_modules/file-type"
             }
           ]
         }
@@ -10484,6 +12130,12 @@
           "comment": "as detected from PackageJson property \"repository\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-targz"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -10516,6 +12168,12 @@
               "url": "sindresorhus/file-type",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-targz/node_modules/file-type"
             }
           ]
         }
@@ -10554,6 +12212,12 @@
           "comment": "as detected from PackageJson property \"repository\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-unzip"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -10586,6 +12250,12 @@
               "url": "sindresorhus/file-type",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-unzip/node_modules/file-type"
             }
           ]
         },
@@ -10621,6 +12291,12 @@
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-unzip/node_modules/get-stream"
+            }
           ]
         },
         {
@@ -10654,6 +12330,12 @@
               "url": "sindresorhus/pify",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-unzip/node_modules/pify"
             }
           ]
         }
@@ -10692,6 +12374,12 @@
           "comment": "as detected from PackageJson property \"repository\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -10726,6 +12414,12 @@
               "comment": "as detected from PackageJson property \"repository\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress/node_modules/make-dir"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -10758,6 +12452,12 @@
                   "url": "sindresorhus/pify",
                   "type": "vcs",
                   "comment": "as detected from PackageJson property \"repository\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/decompress/node_modules/make-dir/node_modules/pify"
                 }
               ]
             }
@@ -10795,6 +12495,12 @@
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress/node_modules/pify"
+            }
           ]
         }
       ]
@@ -10831,6 +12537,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/deep-equal"
+        }
       ]
     },
     {
@@ -10850,6 +12562,12 @@
         {
           "license": {
             "id": "MIT"
+          }
+        },
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://raw.githubusercontent.com/unclechu/node-deep-extend/master/LICENSE"
           }
         }
       ],
@@ -10874,6 +12592,12 @@
           "url": "https://github.com/unclechu/node-deep-extend",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/deep-extend"
         }
       ]
     },
@@ -10909,6 +12633,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/deep-is"
+        }
       ]
     },
     {
@@ -10942,6 +12672,12 @@
           "url": "git://github.com/ljharb/define-properties.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/define-properties"
         }
       ]
     },
@@ -10987,6 +12723,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/define-property"
+        }
       ]
     },
     {
@@ -11026,6 +12768,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/delayed-stream"
+        }
       ]
     },
     {
@@ -11058,6 +12806,12 @@
           "url": "visionmedia/node-delegates",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/delegates"
         }
       ]
     },
@@ -11093,6 +12847,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/depd"
+        }
       ]
     },
     {
@@ -11126,6 +12886,12 @@
           "url": "stream-utils/destroy",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/destroy"
         }
       ]
     },
@@ -11171,6 +12937,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/detect-file"
+        }
       ]
     },
     {
@@ -11204,6 +12976,12 @@
           "url": "git://github.com/lovell/detect-libc",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/detect-libc"
         }
       ]
     },
@@ -11249,6 +13027,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dfa"
+        }
       ]
     },
     {
@@ -11264,6 +13048,14 @@
           "content": "143bdbb67abb77394fcf4c32625384c627c311972ef21fab12b11781fc6a98b7d17c2fe4262744161e3e79f7c944edcfd3199fab23db48c1b42ef78d45f4ca56"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "http://github.com/mscdex/dicer/raw/master/LICENSE"
+          }
+        }
+      ],
       "purl": "pkg:npm/dicer@0.2.5",
       "externalReferences": [
         {
@@ -11275,6 +13067,12 @@
           "url": "http://github.com/mscdex/dicer.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dicer"
         }
       ],
       "components": [
@@ -11315,6 +13113,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/dicer/node_modules/isarray"
+            }
           ]
         },
         {
@@ -11348,6 +13152,12 @@
               "url": "git://github.com/isaacs/readable-stream",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/dicer/node_modules/readable-stream"
             }
           ]
         },
@@ -11386,6 +13196,12 @@
               "url": "https://github.com/rvagg/string_decoder",
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/dicer/node_modules/string_decoder"
             }
           ]
         }
@@ -11427,6 +13243,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/diff"
+        }
       ]
     },
     {
@@ -11460,6 +13282,12 @@
           "url": "https://github.com/pugjs/doctypes.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/doctypes"
         }
       ]
     },
@@ -11495,6 +13323,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/domelementtype"
+        }
       ]
     },
     {
@@ -11522,6 +13356,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/domhandler"
+        }
       ]
     },
     {
@@ -11548,6 +13388,12 @@
           "url": "git://github.com/FB55/domutils.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/domutils"
         }
       ]
     },
@@ -11582,6 +13428,12 @@
           "url": "git://github.com/mickhansen/dottie.js.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dottie"
         }
       ]
     },
@@ -11627,6 +13479,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/double-ended-queue"
+        }
       ]
     },
     {
@@ -11671,6 +13529,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/doublearray"
+        }
       ]
     },
     {
@@ -11706,6 +13570,12 @@
           "comment": "as detected from PackageJson property \"repository\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/download"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -11738,6 +13608,12 @@
               "url": "sindresorhus/file-type",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/download/node_modules/file-type"
             }
           ]
         }
@@ -11775,6 +13651,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/duplexer2"
+        }
       ]
     },
     {
@@ -11808,6 +13690,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/duplexer3"
+        }
       ]
     },
     {
@@ -11839,6 +13727,12 @@
           "url": "https://github.com/thlorenz/dynamic-dedupe",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dynamic-dedupe"
         }
       ]
     },
@@ -11884,6 +13778,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ecc-jsbn"
+        }
       ]
     },
     {
@@ -11917,6 +13817,12 @@
           "url": "jonathanong/ee-first",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ee-first"
         }
       ]
     },
@@ -11960,6 +13866,12 @@
           "url": "https://github.com/eivindfjeldstad/dot",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/eivindfjeldstad-dot"
         }
       ]
     },
@@ -12005,6 +13917,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/emoji-regex"
+        }
       ]
     },
     {
@@ -12039,6 +13957,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/enabled"
+        }
       ]
     },
     {
@@ -12071,6 +13995,12 @@
           "url": "pillarjs/encodeurl",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/encodeurl"
         }
       ]
     },
@@ -12105,6 +14035,12 @@
           "url": "https://github.com/andris9/encoding.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/encoding"
         }
       ],
       "components": [
@@ -12149,6 +14085,12 @@
               "url": "https://github.com/ashtuchkin/iconv-lite",
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/encoding/node_modules/iconv-lite"
             }
           ]
         }
@@ -12196,6 +14138,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/end-of-stream"
+        }
       ]
     },
     {
@@ -12233,6 +14181,12 @@
           "url": "https://github.com/socketio/engine.io-parser",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/engine.io-parser"
         }
       ]
     },
@@ -12274,6 +14228,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/engine.io"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12307,6 +14267,12 @@
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/engine.io/node_modules/debug"
+            }
           ]
         },
         {
@@ -12339,6 +14305,12 @@
               "url": "zeit/ms",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/engine.io/node_modules/ms"
             }
           ]
         }
@@ -12375,6 +14347,12 @@
           "url": "sindresorhus/env-paths",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/env-paths"
         }
       ]
     },
@@ -12415,6 +14393,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/err-code"
+        }
       ]
     },
     {
@@ -12448,6 +14432,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/error-ex"
+        }
       ]
     },
     {
@@ -12480,6 +14470,12 @@
           "url": "expressjs/errorhandler",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/errorhandler"
         }
       ]
     },
@@ -12525,6 +14521,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/es-get-iterator"
+        }
       ]
     },
     {
@@ -12557,6 +14559,12 @@
           "url": "component/escape-html",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/escape-html"
         }
       ]
     },
@@ -12591,6 +14599,12 @@
           "url": "sindresorhus/escape-string-regexp",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/escape-string-regexp"
         }
       ]
     },
@@ -12629,6 +14643,12 @@
           "url": "http://github.com/estools/escodegen",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/escodegen"
         }
       ]
     },
@@ -12674,6 +14694,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/esprima"
+        }
       ]
     },
     {
@@ -12711,6 +14737,12 @@
           "url": "https://github.com/estools/estraverse",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/estraverse"
         }
       ]
     },
@@ -12750,6 +14782,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/esutils"
+        }
       ]
     },
     {
@@ -12782,6 +14820,12 @@
           "url": "jshttp/etag",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/etag"
         }
       ]
     },
@@ -12816,6 +14860,12 @@
           "url": "git://github.com/hij1nx/EventEmitter2.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/eventemitter2"
         }
       ]
     },
@@ -12856,6 +14906,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/eventemitter3"
+        }
       ]
     },
     {
@@ -12882,6 +14938,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/exif"
+        }
       ]
     },
     {
@@ -12895,6 +14957,14 @@
         {
           "alg": "SHA-512",
           "content": "664fde34a576cdb8e92b3aec43e9f51baa6855b12b4312742c13895da299d445622f31fe86b2eef5c757238cf0f5d05026c970044a5b4363f5a12ee70f1b3a8d"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://github.com/cowboy/node-exit/blob/master/LICENSE-MIT"
+          }
         }
       ],
       "purl": "pkg:npm/exit@0.1.2",
@@ -12918,6 +14988,12 @@
           "url": "https://github.com/cowboy/node-exit",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/exit"
         }
       ]
     },
@@ -12964,6 +15040,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/expand-brackets"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -13006,6 +15088,12 @@
               "url": "https://github.com/jonschlinkert/define-property",
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/define-property"
             }
           ]
         },
@@ -13050,6 +15138,12 @@
               "url": "https://github.com/jonschlinkert/extend-shallow",
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/extend-shallow"
             }
           ]
         },
@@ -13096,6 +15190,12 @@
               "comment": "as detected from PackageJson property \"homepage\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/is-accessor-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -13138,6 +15238,12 @@
                   "url": "https://github.com/jonschlinkert/kind-of",
                   "type": "website",
                   "comment": "as detected from PackageJson property \"homepage\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/expand-brackets/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -13186,6 +15292,12 @@
               "comment": "as detected from PackageJson property \"homepage\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/is-data-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -13228,6 +15340,12 @@
                   "url": "https://github.com/jonschlinkert/kind-of",
                   "type": "website",
                   "comment": "as detected from PackageJson property \"homepage\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/expand-brackets/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -13275,6 +15393,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/is-descriptor"
+            }
           ]
         },
         {
@@ -13318,6 +15442,12 @@
               "url": "https://github.com/jonschlinkert/is-extendable",
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/is-extendable"
             }
           ]
         },
@@ -13363,6 +15493,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/kind-of"
+            }
           ]
         }
       ]
@@ -13401,6 +15537,12 @@
           "url": "https://github.com/ralphtheninja/expand-template",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/expand-template"
         }
       ]
     },
@@ -13446,6 +15588,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/expand-tilde"
+        }
       ]
     },
     {
@@ -13480,6 +15628,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-ipfilter"
+        }
       ]
     },
     {
@@ -13493,6 +15647,14 @@
         {
           "alg": "SHA-512",
           "content": "086481d1bddb3555c8e93d021797ffe7964a62b220fdbd3ad7b10f99728af44e32d6ad96d70f494e08cf7e1b16c2e3e20ad939b280609b966482ac6086c7da1e"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "http://www.opensource.org/licenses/MIT"
+          }
         }
       ],
       "purl": "pkg:npm/express-jwt@0.1.3",
@@ -13511,6 +15673,12 @@
           "url": "git://github.com/auth0/express-jwt.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-jwt"
         }
       ],
       "components": [
@@ -13551,6 +15719,12 @@
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/express-jwt/node_modules/jsonwebtoken"
+            }
           ]
         },
         {
@@ -13564,6 +15738,13 @@
             {
               "alg": "SHA-512",
               "content": "9778c28c225f0baa48b9c6b5dc6329094e2588462f624d7b5e9160a494b22e9f115fe770760ad906fb646a87e622282995ecdb1b55591548106c315149ddfb60"
+            }
+          ],
+          "licenses": [
+            {
+              "license": {
+                "id": "MIT"
+              }
             }
           ],
           "purl": "pkg:npm/moment@2.0.0",
@@ -13587,6 +15768,12 @@
               "url": "http://momentjs.com",
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/express-jwt/node_modules/moment"
             }
           ]
         }
@@ -13628,6 +15815,12 @@
           "url": "https://github.com/nfriedly/express-rate-limit",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-rate-limit"
         }
       ]
     },
@@ -13673,6 +15866,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-robots-txt"
+        }
       ]
     },
     {
@@ -13715,6 +15914,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-security.txt"
+        }
       ]
     },
     {
@@ -13755,6 +15960,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -13787,6 +15998,12 @@
               "url": "jshttp/cookie",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/express/node_modules/cookie"
             }
           ]
         },
@@ -13832,6 +16049,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/express/node_modules/safe-buffer"
+            }
           ]
         }
       ]
@@ -13868,6 +16091,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ext-list"
+        }
       ]
     },
     {
@@ -13901,6 +16130,12 @@
           "url": "kevva/ext-name",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ext-name"
         }
       ]
     },
@@ -13946,6 +16181,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/extend-shallow"
+        }
       ]
     },
     {
@@ -13979,6 +16220,12 @@
           "url": "https://github.com/justmoon/node-extend.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/extend"
         }
       ]
     },
@@ -14025,6 +16272,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/extglob"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14067,6 +16320,12 @@
               "url": "https://github.com/jonschlinkert/define-property",
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/extglob/node_modules/define-property"
             }
           ]
         },
@@ -14112,6 +16371,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/extglob/node_modules/extend-shallow"
+            }
           ]
         },
         {
@@ -14156,6 +16421,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/extglob/node_modules/is-extendable"
+            }
           ]
         }
       ]
@@ -14190,6 +16461,12 @@
           "url": "git://github.com/davepacheco/node-extsprintf.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/extsprintf"
         }
       ]
     },
@@ -14235,6 +16512,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fast-deep-equal"
+        }
       ]
     },
     {
@@ -14274,6 +16557,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fast-json-stable-stringify"
+        }
       ]
     },
     {
@@ -14307,6 +16596,12 @@
           "url": "https://github.com/hiddentao/fast-levenshtein.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fast-levenshtein"
         }
       ]
     },
@@ -14352,6 +16647,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fast.js"
+        }
       ]
     },
     {
@@ -14390,6 +16691,12 @@
           "url": "git://github.com/andrewrk/node-fd-slicer.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fd-slicer"
         }
       ]
     },
@@ -14435,6 +16742,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/feature-policy"
+        }
       ]
     },
     {
@@ -14478,6 +16791,12 @@
           "url": "https://github.com/taylorhakes/fecha",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fecha"
         }
       ]
     },
@@ -14524,6 +16843,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/file-js"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14562,6 +16887,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/file-js/node_modules/brace-expansion"
+            }
           ]
         },
         {
@@ -14595,6 +16926,12 @@
               "url": "git://github.com/isaacs/minimatch.git",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/file-js/node_modules/minimatch"
             }
           ]
         }
@@ -14632,6 +16969,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/file-stream-rotator"
+        }
       ]
     },
     {
@@ -14665,6 +17008,12 @@
           "url": "sindresorhus/file-type",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/file-type"
         }
       ]
     },
@@ -14710,6 +17059,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/file-uri-to-path"
+        }
       ]
     },
     {
@@ -14753,6 +17108,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/filehound"
+        }
       ]
     },
     {
@@ -14787,6 +17148,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/filename-reserved-regex"
+        }
       ]
     },
     {
@@ -14820,6 +17187,12 @@
           "url": "sindresorhus/filenamify",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/filenamify"
         }
       ]
     },
@@ -14863,6 +17236,12 @@
           "url": "https://github.com/nspragg/filesniffer",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/filesniffer"
         }
       ]
     },
@@ -14909,6 +17288,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fill-range"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14951,6 +17336,12 @@
               "url": "https://github.com/jonschlinkert/extend-shallow",
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/fill-range/node_modules/extend-shallow"
             }
           ]
         },
@@ -14996,6 +17387,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/fill-range/node_modules/is-extendable"
+            }
           ]
         }
       ]
@@ -15037,6 +17434,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/finale-rest"
+        }
       ]
     },
     {
@@ -15070,6 +17473,12 @@
           "url": "pillarjs/finalhandler",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/finalhandler"
         }
       ]
     },
@@ -15105,6 +17514,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/find-up"
+        }
       ]
     },
     {
@@ -15138,6 +17553,12 @@
           "url": "js-cli/node-findup-sync",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/findup-sync"
         }
       ]
     },
@@ -15173,6 +17594,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fined"
+        }
       ]
     },
     {
@@ -15206,6 +17633,12 @@
           "url": "gulpjs/flagged-respawn",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/flagged-respawn"
         }
       ]
     },
@@ -15251,6 +17684,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fn.name"
+        }
       ]
     },
     {
@@ -15285,6 +17724,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fontkit"
+        }
       ]
     },
     {
@@ -15304,6 +17749,12 @@
         {
           "license": {
             "id": "MIT"
+          }
+        },
+        {
+          "license": {
+            "id": "MIT",
+            "url": "http://github.com/Raynos/for-each/raw/master/LICENSE"
           }
         }
       ],
@@ -15328,6 +17779,12 @@
           "url": "https://github.com/Raynos/for-each",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/for-each"
         }
       ]
     },
@@ -15373,6 +17830,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/for-in"
+        }
       ]
     },
     {
@@ -15416,6 +17879,12 @@
           "url": "https://github.com/jonschlinkert/for-own",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/for-own"
         }
       ]
     },
@@ -15461,6 +17930,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/foreachasync"
+        }
       ]
     },
     {
@@ -15494,6 +17969,12 @@
           "url": "https://github.com/mikeal/forever-agent",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/forever-agent"
         }
       ]
     },
@@ -15529,6 +18010,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/form-data"
+        }
       ]
     },
     {
@@ -15560,6 +18047,12 @@
           "url": "http://busterjs.org/docs/formatio/",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/formatio"
         }
       ]
     },
@@ -15593,6 +18086,12 @@
           "url": "jshttp/forwarded",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/forwarded"
         }
       ]
     },
@@ -15638,6 +18137,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fragment-cache"
+        }
       ]
     },
     {
@@ -15671,6 +18176,12 @@
           "url": "jshttp/fresh",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fresh"
         }
       ]
     },
@@ -15716,6 +18227,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/from2"
+        }
       ]
     },
     {
@@ -15760,6 +18277,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fs-constants"
+        }
       ]
     },
     {
@@ -15798,6 +18321,12 @@
           "url": "https://github.com/jprichardson/node-fs-extra",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fs-extra"
         }
       ]
     },
@@ -15843,6 +18372,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fs-minipass"
+        }
       ]
     },
     {
@@ -15876,6 +18411,12 @@
           "url": "git+https://github.com/isaacs/fs.realpath.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fs.realpath"
         }
       ]
     },
@@ -15912,6 +18453,12 @@
           "comment": "as detected from PackageJson property \"repository.url\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fstream"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -15944,6 +18491,12 @@
               "url": "https://github.com/substack/node-mkdirp.git",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/fstream/node_modules/mkdirp"
             }
           ]
         },
@@ -15978,6 +18531,12 @@
               "url": "git://github.com/isaacs/rimraf.git",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/fstream/node_modules/rimraf"
             }
           ]
         }
@@ -16025,6 +18584,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/function-bind"
+        }
       ]
     },
     {
@@ -16069,6 +18634,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/functions-have-names"
+        }
       ]
     },
     {
@@ -16102,6 +18673,12 @@
           "url": "https://github.com/nol13/fuzzball.js.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fuzzball"
         }
       ]
     },
@@ -16147,6 +18724,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/gauge"
+        }
       ]
     },
     {
@@ -16180,6 +18763,12 @@
           "url": "git://github.com/maxogden/geojson-js-utils.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/geojson-utils"
         }
       ]
     },
@@ -16223,6 +18812,12 @@
           "url": "https://github.com/stefanpenner/get-caller-file#readme",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-caller-file"
         }
       ]
     },
@@ -16268,6 +18863,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-intrinsic"
+        }
       ]
     },
     {
@@ -16301,6 +18902,12 @@
           "url": "sindresorhus/get-stream",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-stream"
         }
       ]
     },
@@ -16346,6 +18953,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-value"
+        }
       ]
     },
     {
@@ -16359,6 +18972,14 @@
         {
           "alg": "SHA-512",
           "content": "db36e50c168571bdeb078ac5efb5d59ee20d384da1da4fce9ea5c08b2d08ad3c547d5d62169de56b7de8010558f690a9594dbaf1615856ddadef586532e2ec3a"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://github.com/cowboy/node-getobject/blob/master/LICENSE-MIT"
+          }
         }
       ],
       "purl": "pkg:npm/getobject@1.0.2",
@@ -16382,6 +19003,12 @@
           "url": "https://github.com/cowboy/node-getobject",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/getobject"
         }
       ]
     },
@@ -16416,6 +19043,12 @@
           "url": "https://github.com/arekinath/node-getpass.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/getpass"
         }
       ]
     },
@@ -16456,6 +19089,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/github-from-package"
+        }
       ]
     },
     {
@@ -16489,6 +19128,12 @@
           "url": "gulpjs/glob-parent",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/glob-parent"
         }
       ],
       "components": [
@@ -16534,6 +19179,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/glob-parent/node_modules/is-glob"
+            }
           ]
         }
       ]
@@ -16569,6 +19220,12 @@
           "url": "git://github.com/isaacs/node-glob.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/glob"
         }
       ],
       "components": [
@@ -16609,6 +19266,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/glob/node_modules/brace-expansion"
+            }
           ]
         },
         {
@@ -16642,6 +19305,12 @@
               "url": "git://github.com/isaacs/minimatch.git",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/glob/node_modules/minimatch"
             }
           ]
         }
@@ -16689,6 +19358,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/global-modules"
+        }
       ]
     },
     {
@@ -16734,6 +19409,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/global-prefix"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -16766,6 +19447,12 @@
               "url": "git://github.com/isaacs/node-which.git",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/global-prefix/node_modules/which"
             }
           ]
         }
@@ -16813,6 +19500,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/gopd"
+        }
       ]
     },
     {
@@ -16845,6 +19538,12 @@
           "url": "sindresorhus/got",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/got"
         }
       ],
       "components": [
@@ -16880,6 +19579,12 @@
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/got/node_modules/get-stream"
+            }
           ]
         },
         {
@@ -16913,6 +19618,12 @@
               "url": "sindresorhus/pify",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/got/node_modules/pify"
             }
           ]
         }
@@ -16949,6 +19660,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/graceful-fs"
+        }
       ]
     },
     {
@@ -16984,6 +19701,12 @@
           "comment": "as detected from PackageJson property \"repository\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-cli"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17016,6 +19739,12 @@
               "url": "https://github.com/npm/nopt.git",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-cli/node_modules/nopt"
             }
           ]
         }
@@ -17054,6 +19783,12 @@
           "comment": "as detected from PackageJson property \"repository\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-contrib-compress"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17086,6 +19821,12 @@
               "url": "chalk/ansi-styles",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-contrib-compress/node_modules/ansi-styles"
             }
           ]
         },
@@ -17120,6 +19861,12 @@
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-contrib-compress/node_modules/chalk"
+            }
           ]
         },
         {
@@ -17153,6 +19900,12 @@
               "url": "chalk/supports-color",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-contrib-compress/node_modules/supports-color"
             }
           ]
         }
@@ -17194,6 +19947,12 @@
           "url": "http://gruntjs.com/",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-known-options"
         }
       ]
     },
@@ -17240,6 +19999,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-legacy-log-utils"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17272,6 +20037,12 @@
               "url": "chalk/ansi-styles",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils/node_modules/ansi-styles"
             }
           ]
         },
@@ -17306,6 +20077,12 @@
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils/node_modules/chalk"
+            }
           ]
         },
         {
@@ -17339,6 +20116,12 @@
               "url": "Qix-/color-convert",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils/node_modules/color-convert"
             }
           ]
         },
@@ -17384,6 +20167,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils/node_modules/color-name"
+            }
           ]
         },
         {
@@ -17418,6 +20207,12 @@
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils/node_modules/has-flag"
+            }
           ]
         },
         {
@@ -17451,6 +20246,12 @@
               "url": "chalk/supports-color",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils/node_modules/supports-color"
             }
           ]
         }
@@ -17499,6 +20300,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-legacy-log"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17541,6 +20348,12 @@
               "url": "https://github.com/Marak/colors.js",
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log/node_modules/colors"
             }
           ]
         }
@@ -17589,6 +20402,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-legacy-util"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17632,6 +20451,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-util/node_modules/async"
+            }
           ]
         }
       ]
@@ -17647,6 +20472,14 @@
         {
           "alg": "SHA-512",
           "content": "60b88341ab38e198a5fdb3648561423fade923291348ce1368dcd73e257b9e23241d179f9a9c857b96968919f80ace6e24c2e15da77ca63ac08b604e9a44e465"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://github.com/exo-dev/grunt-replace-json/blob/master/LICENCE.md"
+          }
         }
       ],
       "purl": "pkg:npm/grunt-replace-json@0.1.0",
@@ -17670,6 +20503,12 @@
           "url": "https://github.com/exo-dev/grunt-replace-json",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-replace-json"
         }
       ]
     },
@@ -17711,6 +20550,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17749,6 +20594,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt/node_modules/brace-expansion"
+            }
           ]
         },
         {
@@ -17762,6 +20613,14 @@
             {
               "alg": "SHA-512",
               "content": "cfc36bc218bac33c4d3086f196b4f3b945ba296b8a928819ffb39d0d5abed3e9319fbeca507d678a9c7c894eacbaa907a9ce32ea7edaf40f08a66c58fe94e35a"
+            }
+          ],
+          "licenses": [
+            {
+              "license": {
+                "id": "MIT",
+                "url": "https://github.com/cowboy/node-findup-sync/blob/master/LICENSE-MIT"
+              }
             }
           ],
           "purl": "pkg:npm/findup-sync@0.3.0",
@@ -17785,6 +20644,12 @@
               "url": "https://github.com/cowboy/node-findup-sync",
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt/node_modules/findup-sync"
             }
           ],
           "components": [
@@ -17819,6 +20684,12 @@
                   "url": "git://github.com/isaacs/node-glob.git",
                   "type": "vcs",
                   "comment": "as detected from PackageJson property \"repository.url\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/grunt/node_modules/findup-sync/node_modules/glob"
                 }
               ]
             }
@@ -17856,6 +20727,12 @@
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt/node_modules/glob"
+            }
           ]
         },
         {
@@ -17889,6 +20766,12 @@
               "url": "git://github.com/isaacs/minimatch.git",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt/node_modules/minimatch"
             }
           ]
         }
@@ -17932,6 +20815,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/handlebars"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17964,6 +20853,12 @@
               "url": "git://github.com/substack/node-wordwrap.git",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/handlebars/node_modules/wordwrap"
             }
           ]
         }
@@ -18011,6 +20906,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/har-schema"
+        }
       ]
     },
     {
@@ -18055,6 +20956,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/har-validator"
+        }
       ]
     },
     {
@@ -18088,6 +20995,12 @@
           "url": "sindresorhus/has-ansi",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-ansi"
         }
       ]
     },
@@ -18133,6 +21046,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-bigints"
+        }
       ]
     },
     {
@@ -18166,6 +21085,12 @@
           "url": "sindresorhus/has-flag",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-flag"
         }
       ]
     },
@@ -18211,6 +21136,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-property-descriptors"
+        }
       ]
     },
     {
@@ -18254,6 +21185,12 @@
           "url": "https://github.com/Xotic750/has-symbol-support-x",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-symbol-support-x"
         }
       ]
     },
@@ -18299,6 +21236,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-symbols"
+        }
       ]
     },
     {
@@ -18342,6 +21285,12 @@
           "url": "https://github.com/Xotic750/has-to-string-tag-x",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-to-string-tag-x"
         }
       ]
     },
@@ -18387,6 +21336,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-tostringtag"
+        }
       ]
     },
     {
@@ -18431,6 +21386,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-unicode"
+        }
       ]
     },
     {
@@ -18474,6 +21435,12 @@
           "url": "https://github.com/jonschlinkert/has-value",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-value"
         }
       ]
     },
@@ -18520,6 +21487,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-values"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18563,6 +21536,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/has-values/node_modules/kind-of"
+            }
           ]
         }
       ]
@@ -18584,6 +21563,12 @@
         {
           "license": {
             "id": "MIT"
+          }
+        },
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://github.com/tarruda/has/blob/master/LICENSE-MIT"
           }
         }
       ],
@@ -18608,6 +21593,12 @@
           "url": "https://github.com/tarruda/has",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has"
         }
       ]
     },
@@ -18653,6 +21644,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hashids"
+        }
       ]
     },
     {
@@ -18687,6 +21684,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hbs"
+        }
       ]
     },
     {
@@ -18700,6 +21703,14 @@
         {
           "alg": "SHA-512",
           "content": "c059f526572c81b71611ac10e80d46ced80d45197a53212d6804480e901e1f7737e53ffd89dfd040abdaa75340cfa624da82ab2b05d0659144452d2d97d13426"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "http://mths.be/mit"
+          }
         }
       ],
       "purl": "pkg:npm/he@0.4.1",
@@ -18723,6 +21734,12 @@
           "url": "http://mths.be/he",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/he"
         }
       ]
     },
@@ -18762,6 +21779,12 @@
           "url": "https://github.com/qiao/heap.js",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/heap"
         }
       ]
     },
@@ -18807,6 +21830,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/helmet"
+        }
       ]
     },
     {
@@ -18845,6 +21874,12 @@
           "url": "https://github.com/mmckegg/hoister.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hoister"
         }
       ]
     },
@@ -18890,6 +21925,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/homedir-polyfill"
+        }
       ]
     },
     {
@@ -18903,6 +21944,14 @@
         {
           "alg": "SHA-512",
           "content": "b7e51eac2b10be24b29802270f4d4fc3e0e7feeb26cf5b113bedd9935fa5c7c7a0f962a90f6ba57305aa1c72f4f9ab1e441afedfebc88621b52b5253c1a21c4c"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://github.com/cowboy/javascript-hooker/blob/master/LICENSE-MIT"
+          }
         }
       ],
       "purl": "pkg:npm/hooker@0.2.3",
@@ -18926,6 +21975,12 @@
           "url": "http://github.com/cowboy/javascript-hooker",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hooker"
         }
       ]
     },
@@ -18971,6 +22026,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hosted-git-info"
+        }
       ]
     },
     {
@@ -19005,6 +22066,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/html-entities"
+        }
       ]
     },
     {
@@ -19018,6 +22085,14 @@
         {
           "alg": "SHA-512",
           "content": "67c8bade7eec7ae3ef45ed4f432ae39a8552b6fedb8cc6b4b24ace97f93ab674ffe56a4f36bcd62c1d4783f749c415c7fcce8a66f9b6e494065428901b15112d"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "http://github.com/fb55/htmlparser2/raw/master/LICENSE"
+          }
         }
       ],
       "purl": "pkg:npm/htmlparser2@3.3.0",
@@ -19036,6 +22111,12 @@
           "url": "git://github.com/fb55/htmlparser2.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/htmlparser2"
         }
       ],
       "components": [
@@ -19076,6 +22157,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/htmlparser2/node_modules/isarray"
+            }
           ]
         },
         {
@@ -19109,6 +22196,12 @@
               "url": "git://github.com/isaacs/readable-stream",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/htmlparser2/node_modules/readable-stream"
             }
           ]
         },
@@ -19148,6 +22241,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/htmlparser2/node_modules/string_decoder"
+            }
           ]
         }
       ]
@@ -19184,6 +22283,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/http-cache-semantics"
+        }
       ]
     },
     {
@@ -19217,6 +22322,12 @@
           "url": "jshttp/http-errors",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/http-errors"
         }
       ]
     },
@@ -19258,6 +22369,12 @@
           "comment": "as detected from PackageJson property \"repository.url\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/http-proxy-agent"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -19291,6 +22408,12 @@
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/http-proxy-agent/node_modules/debug"
+            }
           ]
         },
         {
@@ -19323,6 +22446,12 @@
               "url": "zeit/ms",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/http-proxy-agent/node_modules/ms"
             }
           ]
         }
@@ -19370,6 +22499,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/http-signature"
+        }
       ]
     },
     {
@@ -19410,6 +22545,12 @@
           "comment": "as detected from PackageJson property \"repository.url\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/https-proxy-agent"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -19443,6 +22584,12 @@
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/https-proxy-agent/node_modules/debug"
+            }
           ]
         },
         {
@@ -19475,6 +22622,12 @@
               "url": "zeit/ms",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/https-proxy-agent/node_modules/ms"
             }
           ]
         }
@@ -19511,6 +22664,12 @@
           "url": "https://github.com/node-modules/humanize-ms",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/humanize-ms"
         }
       ]
     },
@@ -19550,6 +22709,12 @@
           "url": "http://github.com/mashpie/i18n-node",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/i18n"
         }
       ]
     },
@@ -19595,6 +22760,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/iconv-lite"
+        }
       ]
     },
     {
@@ -19629,6 +22800,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ieee754"
+        }
       ]
     },
     {
@@ -19662,6 +22839,12 @@
           "url": "git+https://github.com/isaacs/ignore-walk.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ignore-walk"
         }
       ],
       "components": [
@@ -19702,6 +22885,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/ignore-walk/node_modules/brace-expansion"
+            }
           ]
         },
         {
@@ -19735,6 +22924,12 @@
               "url": "git://github.com/isaacs/minimatch.git",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/ignore-walk/node_modules/minimatch"
             }
           ]
         }
@@ -19781,6 +22976,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/iltorb"
+        }
       ]
     },
     {
@@ -19825,6 +23026,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/imurmurhash"
+        }
       ]
     },
     {
@@ -19858,6 +23065,12 @@
           "url": "sindresorhus/indent-string",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/indent-string"
         }
       ]
     },
@@ -19893,6 +23106,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/infer-owner"
+        }
       ]
     },
     {
@@ -19926,6 +23145,12 @@
           "url": "https://github.com/dreamerslab/node.inflection.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/inflection"
         }
       ]
     },
@@ -19971,6 +23196,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/inflight"
+        }
       ]
     },
     {
@@ -20003,6 +23234,12 @@
           "url": "git://github.com/isaacs/inherits",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/inherits"
         }
       ]
     },
@@ -20037,6 +23274,12 @@
           "url": "git://github.com/isaacs/ini.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ini"
         }
       ]
     },
@@ -20082,6 +23325,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/interpret"
+        }
       ]
     },
     {
@@ -20116,6 +23365,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/into-stream"
+        }
       ]
     },
     {
@@ -20149,6 +23404,12 @@
           "url": "https://github.com/zertosh/invariant",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/invariant"
         }
       ]
     },
@@ -20187,6 +23448,12 @@
           "url": "https://github.com/indutny/node-ip",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ip"
         }
       ]
     },
@@ -20232,6 +23499,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ip6"
+        }
       ]
     },
     {
@@ -20265,6 +23538,12 @@
           "url": "git://github.com/whitequark/ipaddr.js",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ipaddr.js"
         }
       ]
     },
@@ -20310,6 +23589,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-absolute"
+        }
       ]
     },
     {
@@ -20353,6 +23638,12 @@
           "url": "https://github.com/jonschlinkert/is-accessor-descriptor",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-accessor-descriptor"
         }
       ]
     },
@@ -20398,6 +23689,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-arguments"
+        }
       ]
     },
     {
@@ -20431,6 +23728,12 @@
           "url": "https://github.com/qix-/node-is-arrayish.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-arrayish"
         }
       ]
     },
@@ -20476,6 +23779,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-bigint"
+        }
       ]
     },
     {
@@ -20510,6 +23819,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-binary-path"
+        }
       ]
     },
     {
@@ -20543,6 +23858,12 @@
           "url": "git://github.com/inspect-js/is-boolean-object.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-boolean-object"
         }
       ]
     },
@@ -20583,6 +23904,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-buffer"
+        }
       ]
     },
     {
@@ -20616,6 +23943,12 @@
           "url": "git://github.com/inspect-js/is-callable.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-callable"
         }
       ]
     },
@@ -20661,6 +23994,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-core-module"
+        }
       ]
     },
     {
@@ -20705,6 +24044,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-data-descriptor"
+        }
       ]
     },
     {
@@ -20738,6 +24083,12 @@
           "url": "git://github.com/inspect-js/is-date-object.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-date-object"
         }
       ]
     },
@@ -20783,6 +24134,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-descriptor"
+        }
       ]
     },
     {
@@ -20817,6 +24174,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-docker"
+        }
       ]
     },
     {
@@ -20850,6 +24213,12 @@
           "url": "https://github.com/pugjs/is-expression.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-expression"
         }
       ]
     },
@@ -20895,6 +24264,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-extendable"
+        }
       ]
     },
     {
@@ -20939,6 +24314,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-extglob"
+        }
       ]
     },
     {
@@ -20972,6 +24353,12 @@
           "url": "sindresorhus/is-fullwidth-code-point",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-fullwidth-code-point"
         }
       ]
     },
@@ -21011,6 +24398,12 @@
           "url": "git://github.com/inspect-js/is-generator-function.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-generator-function"
         }
       ]
     },
@@ -21056,6 +24449,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-glob"
+        }
       ]
     },
     {
@@ -21089,6 +24488,12 @@
           "url": "sindresorhus/is-heroku",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-heroku"
         }
       ]
     },
@@ -21134,6 +24539,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-lambda"
+        }
       ]
     },
     {
@@ -21178,6 +24589,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-map"
+        }
       ]
     },
     {
@@ -21211,6 +24628,12 @@
           "url": "shinnn/is-natural-number.js",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-natural-number"
         }
       ]
     },
@@ -21256,6 +24679,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-number-like"
+        }
       ]
     },
     {
@@ -21299,6 +24728,12 @@
           "url": "https://github.com/inspect-js/is-number-object#readme",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-number-object"
         }
       ]
     },
@@ -21345,6 +24780,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-number"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21388,6 +24829,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/is-number/node_modules/kind-of"
+            }
           ]
         }
       ]
@@ -21409,6 +24856,12 @@
         {
           "license": {
             "id": "MIT"
+          }
+        },
+        {
+          "license": {
+            "id": "MIT",
+            "url": "http://github.com/inspect-js/is-object/raw/master/LICENSE"
           }
         }
       ],
@@ -21433,6 +24886,12 @@
           "url": "https://github.com/inspect-js/is-object",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-object"
         }
       ]
     },
@@ -21467,6 +24926,12 @@
           "url": "sindresorhus/is-plain-obj",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-plain-obj"
         }
       ]
     },
@@ -21512,6 +24977,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-plain-object"
+        }
       ]
     },
     {
@@ -21545,6 +25016,12 @@
           "url": "https://github.com/then/is-promise.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-promise"
         }
       ]
     },
@@ -21590,6 +25067,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-regex"
+        }
       ]
     },
     {
@@ -21634,6 +25117,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-relative"
+        }
       ]
     },
     {
@@ -21667,6 +25156,12 @@
           "url": "floatdrop/is-retry-allowed",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-retry-allowed"
         }
       ]
     },
@@ -21712,6 +25207,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-set"
+        }
       ]
     },
     {
@@ -21746,6 +25247,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-stream"
+        }
       ]
     },
     {
@@ -21779,6 +25286,12 @@
           "url": "git://github.com/ljharb/is-string.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-string"
         }
       ]
     },
@@ -21819,6 +25332,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-symbol"
+        }
       ]
     },
     {
@@ -21852,6 +25371,12 @@
           "url": "git://github.com/inspect-js/is-typed-array.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-typed-array"
         }
       ]
     },
@@ -21897,6 +25422,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-typedarray"
+        }
       ]
     },
     {
@@ -21940,6 +25471,12 @@
           "url": "https://github.com/jonschlinkert/is-unc-path",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-unc-path"
         }
       ]
     },
@@ -21985,6 +25522,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-weakmap"
+        }
       ]
     },
     {
@@ -22028,6 +25571,12 @@
           "url": "https://github.com/inspect-js/is-weakset#readme",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-weakset"
         }
       ]
     },
@@ -22073,6 +25622,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-windows"
+        }
       ]
     },
     {
@@ -22111,6 +25666,12 @@
           "url": "https://github.com/juliangruber/isarray",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isarray"
         }
       ]
     },
@@ -22156,6 +25717,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isexe"
+        }
       ]
     },
     {
@@ -22199,6 +25766,12 @@
           "url": "https://github.com/jonschlinkert/isobject",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isobject"
         }
       ]
     },
@@ -22244,6 +25817,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isstream"
+        }
       ]
     },
     {
@@ -22277,6 +25856,12 @@
           "url": "stevenvachon/isurl",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isurl"
         }
       ]
     },
@@ -22312,6 +25897,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/js-stringify"
+        }
       ]
     },
     {
@@ -22345,6 +25936,12 @@
           "url": "lydell/js-tokens",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/js-tokens"
         }
       ]
     },
@@ -22385,6 +25982,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/js-yaml"
+        }
       ]
     },
     {
@@ -22418,6 +26021,12 @@
           "url": "https://github.com/andyperlitch/jsbn.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jsbn"
         }
       ]
     },
@@ -22458,6 +26067,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-buffer"
+        }
       ]
     },
     {
@@ -22491,6 +26106,12 @@
           "url": "https://github.com/zkat/json-parse-better-errors",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-parse-better-errors"
         }
       ]
     },
@@ -22536,6 +26157,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-schema-traverse"
+        }
       ]
     },
     {
@@ -22567,6 +26194,12 @@
           "url": "http://github.com/kriszyp/json-schema",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-schema"
         }
       ]
     },
@@ -22612,6 +26245,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-stringify-safe"
+        }
       ]
     },
     {
@@ -22656,6 +26295,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json5"
+        }
       ]
     },
     {
@@ -22689,6 +26334,12 @@
           "url": "git@github.com:jprichardson/node-jsonfile.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jsonfile"
         }
       ]
     },
@@ -22729,6 +26380,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jsonwebtoken"
+        }
       ]
     },
     {
@@ -22761,6 +26418,12 @@
           "url": "git://github.com/joyent/node-jsprim.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jsprim"
         }
       ]
     },
@@ -22806,6 +26469,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jssha"
+        }
       ]
     },
     {
@@ -22839,6 +26508,12 @@
           "url": "https://github.com/jstransformers/jstransformer.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jstransformer"
         }
       ]
     },
@@ -22884,6 +26559,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/juicy-chat-bot"
+        }
       ]
     },
     {
@@ -22918,6 +26599,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jwa"
+        }
       ]
     },
     {
@@ -22951,6 +26638,12 @@
           "url": "git://github.com/brianloveswords/node-jws.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jws"
         }
       ]
     },
@@ -22996,6 +26689,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/keyv"
+        }
       ]
     },
     {
@@ -23039,6 +26738,12 @@
           "url": "https://github.com/jonschlinkert/kind-of",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/kind-of"
         }
       ]
     },
@@ -23084,6 +26789,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/kuler"
+        }
       ]
     },
     {
@@ -23127,6 +26838,12 @@
           "url": "https://github.com/takuyaa/kuromoji.js",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/kuromoji"
         }
       ]
     },
@@ -23172,6 +26889,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lazystream"
+        }
       ]
     },
     {
@@ -23216,6 +26939,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/levn"
+        }
       ]
     },
     {
@@ -23256,6 +26985,12 @@
           "comment": "as detected from PackageJson property \"repository.url\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/libxmljs2"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -23287,6 +27022,12 @@
               "url": "git://github.com/nodejs/nan.git",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/libxmljs2/node_modules/nan"
             }
           ]
         }
@@ -23323,6 +27064,12 @@
           "url": "gruntjs/js-liftup",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/liftup"
         }
       ],
       "components": [
@@ -23368,6 +27115,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/braces"
+            }
           ]
         },
         {
@@ -23412,6 +27165,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/fill-range"
+            }
           ]
         },
         {
@@ -23445,6 +27204,12 @@
               "url": "gulpjs/findup-sync",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/findup-sync"
             }
           ]
         },
@@ -23490,6 +27255,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/is-glob"
+            }
           ]
         },
         {
@@ -23533,6 +27304,12 @@
               "url": "https://github.com/jonschlinkert/is-number",
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/is-number"
             }
           ]
         },
@@ -23578,6 +27355,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/micromatch"
+            }
           ]
         },
         {
@@ -23621,6 +27404,12 @@
               "url": "https://github.com/micromatch/to-regex-range",
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/to-regex-range"
             }
           ]
         }
@@ -23669,6 +27458,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/linebreak"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -23701,6 +27496,12 @@
               "url": "git://github.com/beatgammit/base64-js.git",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/linebreak/node_modules/base64-js"
             }
           ]
         }
@@ -23738,6 +27539,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/listenercount"
+        }
       ]
     },
     {
@@ -23771,6 +27578,12 @@
           "url": "sindresorhus/locate-path",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/locate-path"
         }
       ]
     },
@@ -23811,6 +27624,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lodash.camelcase"
+        }
       ]
     },
     {
@@ -23849,6 +27668,12 @@
           "url": "https://lodash.com/",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lodash.isfinite"
         }
       ]
     },
@@ -23889,6 +27714,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lodash.set"
+        }
       ]
     },
     {
@@ -23927,6 +27758,12 @@
           "url": "https://lodash.com/",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lodash"
         }
       ]
     },
@@ -23973,6 +27810,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/logform"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -24004,6 +27847,12 @@
               "url": "vercel/ms",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/logform/node_modules/ms"
             }
           ]
         }
@@ -24051,6 +27900,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lolex"
+        }
       ]
     },
     {
@@ -24090,6 +27945,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/loose-envify"
+        }
       ]
     },
     {
@@ -24124,6 +27985,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lowercase-keys"
+        }
       ]
     },
     {
@@ -24157,6 +28024,12 @@
           "url": "git://github.com/isaacs/node-lru-cache.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lru-cache"
         }
       ]
     },
@@ -24193,6 +28066,12 @@
           "comment": "as detected from PackageJson property \"repository\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-dir"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -24224,6 +28103,12 @@
               "url": "https://github.com/npm/node-semver",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-dir/node_modules/semver"
             }
           ]
         }
@@ -24271,6 +28156,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-error"
+        }
       ]
     },
     {
@@ -24304,6 +28195,12 @@
           "url": "https://github.com/npm/make-fetch-happen",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-fetch-happen"
         }
       ],
       "components": [
@@ -24345,6 +28242,12 @@
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen/node_modules/@tootallnate/once"
+            }
           ]
         },
         {
@@ -24379,6 +28282,12 @@
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen/node_modules/debug"
+            }
           ]
         },
         {
@@ -24412,6 +28321,12 @@
               "url": "https://github.com/kornelski/http-cache-semantics.git",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen/node_modules/http-cache-semantics"
             }
           ]
         },
@@ -24452,6 +28367,12 @@
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen/node_modules/http-proxy-agent"
+            }
           ]
         },
         {
@@ -24484,6 +28405,12 @@
               "url": "zeit/ms",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen/node_modules/ms"
             }
           ]
         }
@@ -24531,6 +28458,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-iterator"
+        }
       ]
     },
     {
@@ -24574,6 +28507,12 @@
           "url": "https://github.com/eemeli/make-plural#readme",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-plural"
         }
       ]
     },
@@ -24619,6 +28558,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/map-cache"
+        }
       ]
     },
     {
@@ -24663,6 +28608,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/map-visit"
+        }
       ]
     },
     {
@@ -24702,6 +28653,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/marsdb"
+        }
       ]
     },
     {
@@ -24735,6 +28692,12 @@
           "url": "Semigradsky/math-interval-parser",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/math-interval-parser"
         }
       ]
     },
@@ -24770,6 +28733,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/media-typer"
+        }
       ]
     },
     {
@@ -24803,6 +28772,12 @@
           "url": "component/merge-descriptors",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/merge-descriptors"
         }
       ]
     },
@@ -24843,6 +28818,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/messageformat-formatters"
+        }
       ]
     },
     {
@@ -24880,6 +28861,12 @@
           "url": "https://messageformat.github.io/",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/messageformat-parser"
         }
       ]
     },
@@ -24919,6 +28906,12 @@
           "url": "https://messageformat.github.io/messageformat/",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/messageformat"
         }
       ],
       "components": [
@@ -24964,6 +28957,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/messageformat/node_modules/make-plural"
+            }
           ]
         }
       ]
@@ -24998,6 +28997,12 @@
           "url": "jshttp/methods",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/methods"
         }
       ]
     },
@@ -25043,6 +29048,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/micromatch"
+        }
       ]
     },
     {
@@ -25076,6 +29087,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mime-db"
+        }
       ]
     },
     {
@@ -25108,6 +29125,12 @@
           "url": "jshttp/mime-types",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mime-types"
         }
       ]
     },
@@ -25143,6 +29166,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mime"
+        }
       ]
     },
     {
@@ -25177,6 +29206,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mimic-response"
+        }
       ]
     },
     {
@@ -25210,6 +29245,12 @@
           "url": "git://github.com/isaacs/minimatch.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minimatch"
         }
       ]
     },
@@ -25250,6 +29291,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minimist"
+        }
       ]
     },
     {
@@ -25278,6 +29325,12 @@
           "url": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-collect"
         }
       ]
     },
@@ -25311,6 +29364,12 @@
           "url": "git+https://github.com/npm/minipass-fetch.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-fetch"
         }
       ]
     },
@@ -25346,6 +29405,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-flush"
+        }
       ]
     },
     {
@@ -25374,6 +29439,12 @@
           "url": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-pipeline"
         }
       ]
     },
@@ -25409,6 +29480,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-sized"
+        }
       ]
     },
     {
@@ -25443,6 +29520,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass"
+        }
       ]
     },
     {
@@ -25476,6 +29559,12 @@
           "url": "git+https://github.com/isaacs/minizlib.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minizlib"
         }
       ]
     },
@@ -25521,6 +29610,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mixin-deep"
+        }
       ]
     },
     {
@@ -25565,6 +29660,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mkdirp-classic"
+        }
       ]
     },
     {
@@ -25597,6 +29698,12 @@
           "url": "https://github.com/isaacs/node-mkdirp.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mkdirp"
         }
       ]
     },
@@ -25642,6 +29749,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/moment-timezone"
+        }
       ]
     },
     {
@@ -25686,6 +29799,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/moment"
+        }
       ]
     },
     {
@@ -25720,6 +29839,12 @@
           "comment": "as detected from PackageJson property \"repository\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/morgan"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -25751,6 +29876,12 @@
               "url": "jshttp/on-finished",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/morgan/node_modules/on-finished"
             }
           ]
         }
@@ -25798,6 +29929,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mout"
+        }
       ]
     },
     {
@@ -25830,6 +29967,12 @@
           "url": "zeit/ms",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ms"
         }
       ]
     },
@@ -25865,6 +30008,12 @@
           "comment": "as detected from PackageJson property \"repository\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/multer"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -25897,6 +30046,12 @@
               "url": "https://github.com/substack/node-mkdirp.git",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/multer/node_modules/mkdirp"
             }
           ]
         }
@@ -25939,6 +30094,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mustache"
+        }
       ]
     },
     {
@@ -25971,6 +30132,12 @@
           "url": "git://github.com/nodejs/nan.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/nan"
         }
       ]
     },
@@ -26016,6 +30183,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/nanomatch"
+        }
       ]
     },
     {
@@ -26060,6 +30233,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/napi-build-utils"
+        }
       ]
     },
     {
@@ -26095,6 +30274,12 @@
           "comment": "as detected from PackageJson property \"repository.url\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/needle"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -26128,6 +30313,12 @@
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/needle/node_modules/debug"
+            }
           ]
         },
         {
@@ -26160,6 +30351,12 @@
               "url": "vercel/ms",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/needle/node_modules/ms"
             }
           ]
         }
@@ -26195,6 +30392,12 @@
           "url": "jshttp/negotiator",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/negotiator"
         }
       ]
     },
@@ -26233,6 +30436,12 @@
           "url": "https://github.com/suguru03/neo-async",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/neo-async"
         }
       ]
     },
@@ -26279,6 +30488,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-abi"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -26310,6 +30525,12 @@
               "url": "https://github.com/npm/node-semver",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-abi/node_modules/semver"
             }
           ]
         }
@@ -26356,6 +30577,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-addon-api"
+        }
       ]
     },
     {
@@ -26400,6 +30627,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-fetch"
+        }
       ]
     },
     {
@@ -26435,6 +30668,12 @@
           "comment": "as detected from PackageJson property \"repository.url\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-gyp"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -26467,6 +30706,12 @@
               "url": "chalk/ansi-regex",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/ansi-regex"
             }
           ]
         },
@@ -26512,6 +30757,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/are-we-there-yet"
+            }
           ]
         },
         {
@@ -26556,6 +30807,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/gauge"
+            }
           ]
         },
         {
@@ -26589,6 +30846,12 @@
               "url": "sindresorhus/is-fullwidth-code-point",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/is-fullwidth-code-point"
             }
           ]
         },
@@ -26624,6 +30887,12 @@
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/nopt"
+            }
           ]
         },
         {
@@ -26658,6 +30927,12 @@
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/npmlog"
+            }
           ]
         },
         {
@@ -26690,6 +30965,12 @@
               "url": "git://github.com/nodejs/readable-stream",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/readable-stream"
             }
           ]
         },
@@ -26725,6 +31006,12 @@
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/string-width"
+            }
           ]
         },
         {
@@ -26758,6 +31045,12 @@
               "url": "chalk/strip-ansi",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/strip-ansi"
             }
           ]
         }
@@ -26796,6 +31089,12 @@
           "comment": "as detected from PackageJson property \"repository.url\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-pre-gyp"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -26828,6 +31127,12 @@
               "url": "git://github.com/isaacs/chownr.git",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/chownr"
             }
           ]
         },
@@ -26873,6 +31178,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/fs-minipass"
+            }
           ]
         },
         {
@@ -26906,6 +31217,12 @@
               "url": "git+https://github.com/isaacs/minipass.git",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/minipass"
             }
           ]
         },
@@ -26941,6 +31258,12 @@
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/minizlib"
+            }
           ]
         },
         {
@@ -26974,6 +31297,12 @@
               "url": "https://github.com/substack/node-mkdirp.git",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/mkdirp"
             }
           ]
         },
@@ -27009,6 +31338,12 @@
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/nopt"
+            }
           ]
         },
         {
@@ -27042,6 +31377,12 @@
               "url": "git://github.com/isaacs/rimraf.git",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/rimraf"
             }
           ]
         },
@@ -27087,6 +31428,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/safe-buffer"
+            }
           ]
         },
         {
@@ -27119,6 +31466,12 @@
               "url": "https://github.com/npm/node-semver",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/semver"
             }
           ]
         },
@@ -27154,6 +31507,12 @@
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/tar"
+            }
           ]
         },
         {
@@ -27187,6 +31546,12 @@
               "url": "git+https://github.com/isaacs/yallist.git",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/yallist"
             }
           ]
         }
@@ -27223,6 +31588,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/noop-logger"
+        }
       ]
     },
     {
@@ -27256,6 +31627,12 @@
           "url": "https://github.com/npm/nopt.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/nopt"
         }
       ]
     },
@@ -27292,6 +31669,12 @@
           "comment": "as detected from PackageJson property \"repository.url\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/normalize-package-data"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -27323,6 +31706,12 @@
               "url": "https://github.com/npm/node-semver",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/normalize-package-data/node_modules/semver"
             }
           ]
         }
@@ -27370,6 +31759,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/normalize-path"
+        }
       ]
     },
     {
@@ -27403,6 +31798,12 @@
           "url": "sindresorhus/normalize-url",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/normalize-url"
         }
       ]
     },
@@ -27444,6 +31845,12 @@
           "comment": "as detected from PackageJson property \"repository.url\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/notevil"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -27455,6 +31862,14 @@
             {
               "alg": "SHA-512",
               "content": "ae9e5d30a37ccc4b3d75f8bd8345f50a52e657ffd647293f475e66a6914d202205446e4ff7654fed9d38a7ca64fbe800068f56dad63e907caee8fd661078264c"
+            }
+          ],
+          "licenses": [
+            {
+              "license": {
+                "name": "BSD",
+                "url": "http://github.com/ariya/esprima/raw/master/LICENSE.BSD"
+              }
             }
           ],
           "purl": "pkg:npm/esprima@1.0.4",
@@ -27473,6 +31888,12 @@
               "url": "http://esprima.org",
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/notevil/node_modules/esprima"
             }
           ]
         }
@@ -27510,6 +31931,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/npm-bundled"
+        }
       ]
     },
     {
@@ -27543,6 +31970,12 @@
           "url": "git+https://github.com/npm/npm-normalize-package-bin",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/npm-normalize-package-bin"
         }
       ]
     },
@@ -27588,6 +32021,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/npm-packlist"
+        }
       ]
     },
     {
@@ -27621,6 +32060,12 @@
           "url": "https://github.com/npm/npmlog.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/npmlog"
         }
       ]
     },
@@ -27656,6 +32101,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/number-is-nan"
+        }
       ]
     },
     {
@@ -27690,6 +32141,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/oauth-sign"
+        }
       ]
     },
     {
@@ -27723,6 +32180,12 @@
           "url": "sindresorhus/object-assign",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-assign"
         }
       ]
     },
@@ -27769,6 +32232,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-copy"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -27811,6 +32280,12 @@
               "url": "https://github.com/jonschlinkert/define-property",
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy/node_modules/define-property"
             }
           ]
         },
@@ -27856,6 +32331,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy/node_modules/is-accessor-descriptor"
+            }
           ]
         },
         {
@@ -27899,6 +32380,12 @@
               "url": "https://github.com/jonschlinkert/is-data-descriptor",
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy/node_modules/is-data-descriptor"
             }
           ]
         },
@@ -27945,6 +32432,12 @@
               "comment": "as detected from PackageJson property \"homepage\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy/node_modules/is-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -27987,6 +32480,12 @@
                   "url": "https://github.com/jonschlinkert/kind-of",
                   "type": "website",
                   "comment": "as detected from PackageJson property \"homepage\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/object-copy/node_modules/is-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -28034,6 +32533,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy/node_modules/kind-of"
+            }
           ]
         }
       ]
@@ -28074,6 +32579,12 @@
           "url": "https://github.com/inspect-js/object-inspect",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-inspect"
         }
       ]
     },
@@ -28119,6 +32630,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-is"
+        }
       ]
     },
     {
@@ -28152,6 +32669,12 @@
           "url": "git://github.com/ljharb/object-keys.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-keys"
         }
       ]
     },
@@ -28197,6 +32720,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-visit"
+        }
       ]
     },
     {
@@ -28230,6 +32759,12 @@
           "url": "git://github.com/ljharb/object.assign.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object.assign"
         }
       ]
     },
@@ -28275,6 +32810,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object.defaults"
+        }
       ]
     },
     {
@@ -28318,6 +32859,12 @@
           "url": "https://github.com/jonschlinkert/object.map",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object.map"
         }
       ]
     },
@@ -28363,6 +32910,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object.pick"
+        }
       ]
     },
     {
@@ -28395,6 +32948,12 @@
           "url": "jshttp/on-finished",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/on-finished"
         }
       ]
     },
@@ -28430,6 +32989,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/on-headers"
+        }
       ]
     },
     {
@@ -28463,6 +33028,12 @@
           "url": "git://github.com/isaacs/once",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/once"
         }
       ]
     },
@@ -28498,6 +33069,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/one-time"
+        }
       ]
     },
     {
@@ -28531,6 +33108,12 @@
           "url": "git://github.com/nodebox/opentype.js.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/opentype.js"
         }
       ]
     },
@@ -28576,6 +33159,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/optionator"
+        }
       ]
     },
     {
@@ -28609,6 +33198,12 @@
           "url": "sindresorhus/os-homedir",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/os-homedir"
         }
       ]
     },
@@ -28644,6 +33239,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/os-tmpdir"
+        }
       ]
     },
     {
@@ -28677,6 +33278,12 @@
           "url": "https://github.com/npm/osenv",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/osenv"
         }
       ]
     },
@@ -28717,6 +33324,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/otplib"
+        }
       ]
     },
     {
@@ -28750,6 +33363,12 @@
           "url": "sindresorhus/p-cancelable",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-cancelable"
         }
       ]
     },
@@ -28785,6 +33404,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-event"
+        }
       ]
     },
     {
@@ -28818,6 +33443,12 @@
           "url": "sindresorhus/p-finally",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-finally"
         }
       ]
     },
@@ -28853,6 +33484,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-is-promise"
+        }
       ]
     },
     {
@@ -28886,6 +33523,12 @@
           "url": "sindresorhus/p-limit",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-limit"
         }
       ]
     },
@@ -28921,6 +33564,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-locate"
+        }
       ]
     },
     {
@@ -28954,6 +33603,12 @@
           "url": "sindresorhus/p-map",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-map"
         }
       ]
     },
@@ -28989,6 +33644,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-timeout"
+        }
       ]
     },
     {
@@ -29022,6 +33683,12 @@
           "url": "sindresorhus/p-try",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-try"
         }
       ]
     },
@@ -29060,6 +33727,12 @@
           "url": "https://github.com/nodeca/pako",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pako"
         }
       ]
     },
@@ -29105,6 +33778,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/parse-filepath"
+        }
       ]
     },
     {
@@ -29138,6 +33817,12 @@
           "url": "sindresorhus/parse-json",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/parse-json"
         }
       ]
     },
@@ -29183,6 +33868,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/parse-passwd"
+        }
       ]
     },
     {
@@ -29215,6 +33906,12 @@
           "url": "pillarjs/parseurl",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/parseurl"
         }
       ]
     },
@@ -29260,6 +33957,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pascalcase"
+        }
       ]
     },
     {
@@ -29294,6 +33997,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-exists"
+        }
       ]
     },
     {
@@ -29327,6 +34036,12 @@
           "url": "sindresorhus/path-is-absolute",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-is-absolute"
         }
       ]
     },
@@ -29372,6 +34087,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-parse"
+        }
       ]
     },
     {
@@ -29415,6 +34136,12 @@
           "url": "https://github.com/regexhq/path-root-regex",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-root-regex"
         }
       ]
     },
@@ -29460,6 +34187,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-root"
+        }
       ]
     },
     {
@@ -29492,6 +34225,12 @@
           "url": "https://github.com/component/path-to-regexp.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-to-regexp"
         }
       ]
     },
@@ -29537,6 +34276,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pdfkit"
+        }
       ]
     },
     {
@@ -29576,6 +34321,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/peek-readable"
+        }
       ]
     },
     {
@@ -29614,6 +34365,12 @@
           "url": "git://github.com/andrewrk/node-pend.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pend"
         }
       ]
     },
@@ -29659,6 +34416,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/performance-now"
+        }
       ]
     },
     {
@@ -29702,6 +34465,12 @@
           "url": "https://github.com/brianc/node-postgres/tree/master/packages/pg-connection-string",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pg-connection-string"
         }
       ]
     },
@@ -29747,6 +34516,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/picomatch"
+        }
       ]
     },
     {
@@ -29780,6 +34555,12 @@
           "url": "sindresorhus/pify",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pify"
         }
       ]
     },
@@ -29815,6 +34596,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pinkie-promise"
+        }
       ]
     },
     {
@@ -29849,6 +34636,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pinkie"
+        }
       ]
     },
     {
@@ -29880,6 +34673,12 @@
           "url": "https://github.com/devongovett/png.js.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/png-js"
         }
       ]
     },
@@ -29923,6 +34722,12 @@
           "url": "https://github.com/baalexander/node-portscanner",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/portscanner"
         }
       ]
     },
@@ -29968,6 +34773,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/posix-character-classes"
+        }
       ]
     },
     {
@@ -30012,6 +34823,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/prebuild-install"
+        }
       ]
     },
     {
@@ -30025,6 +34842,14 @@
         {
           "alg": "SHA-512",
           "content": "112176dd5e12286ea55521998183696ec89a02475a6fa6603b17b9da9efe2a27775b7bb76f147855f77fa36d5d98dee34add08c20678bf9314776e8512d5c4f7"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://raw.github.com/gkz/prelude-ls/master/LICENSE"
+          }
         }
       ],
       "purl": "pkg:npm/prelude-ls@1.1.2",
@@ -30048,6 +34873,12 @@
           "url": "http://preludels.com",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/prelude-ls"
         }
       ]
     },
@@ -30083,6 +34914,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/prepend-http"
+        }
       ]
     },
     {
@@ -30116,6 +34953,12 @@
           "url": "sindresorhus/pretty-bytes",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pretty-bytes"
         }
       ]
     },
@@ -30160,6 +35003,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/process-nextick-args"
+        }
       ]
     },
     {
@@ -30198,6 +35047,12 @@
           "url": "https://github.com/siimon/prom-client",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/prom-client"
         }
       ]
     },
@@ -30243,6 +35098,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/promise-inflight"
+        }
       ]
     },
     {
@@ -30283,6 +35144,12 @@
           "comment": "as detected from PackageJson property \"repository.url\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/promise-retry"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -30320,6 +35187,12 @@
               "url": "git://github.com/IndigoUnited/js-err-code.git",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/promise-retry/node_modules/err-code"
             }
           ]
         },
@@ -30360,6 +35233,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/promise-retry/node_modules/retry"
+            }
           ]
         }
       ]
@@ -30395,6 +35274,12 @@
           "url": "https://github.com/then/promise.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/promise"
         }
       ]
     },
@@ -30435,6 +35320,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/proper-lockfile"
+        }
       ]
     },
     {
@@ -30468,6 +35359,12 @@
           "url": "jshttp/proxy-addr",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/proxy-addr"
         }
       ]
     },
@@ -30503,6 +35400,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/psl"
+        }
       ]
     },
     {
@@ -30536,6 +35439,12 @@
           "url": "https://github.com/pugjs/pug/tree/master/packages/pug-attrs",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-attrs"
         }
       ]
     },
@@ -30571,6 +35480,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-code-gen"
+        }
       ]
     },
     {
@@ -30604,6 +35519,12 @@
           "url": "https://github.com/pugjs/pug/tree/master/packages/pug-error",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-error"
         }
       ]
     },
@@ -30639,6 +35560,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-filters"
+        }
       ]
     },
     {
@@ -30672,6 +35599,12 @@
           "url": "https://github.com/pugjs/pug/tree/master/packages/pug-lexer",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-lexer"
         }
       ]
     },
@@ -30707,6 +35640,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-linker"
+        }
       ]
     },
     {
@@ -30740,6 +35679,12 @@
           "url": "https://github.com/pugjs/pug/tree/master/packages/pug-load",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-load"
         }
       ]
     },
@@ -30775,6 +35720,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-parser"
+        }
       ]
     },
     {
@@ -30808,6 +35759,12 @@
           "url": "https://github.com/pugjs/pug/tree/master/packages/pug-runtime",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-runtime"
         }
       ]
     },
@@ -30843,6 +35800,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-strip-comments"
+        }
       ]
     },
     {
@@ -30876,6 +35839,12 @@
           "url": "https://github.com/pugjs/pug/tree/master/packages/pug-walk",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-walk"
         }
       ]
     },
@@ -30916,6 +35885,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug"
+        }
       ]
     },
     {
@@ -30949,6 +35924,12 @@
           "url": "git://github.com/mafintosh/pump.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pump"
         }
       ]
     },
@@ -30994,6 +35975,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/punycode"
+        }
       ]
     },
     {
@@ -31032,6 +36019,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/qs"
+        }
       ]
     },
     {
@@ -31065,6 +36058,12 @@
           "url": "sindresorhus/query-string",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/query-string"
         }
       ]
     },
@@ -31100,6 +36099,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/range_check"
+        }
       ]
     },
     {
@@ -31133,6 +36138,12 @@
           "url": "jshttp/range-parser",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/range-parser"
         }
       ]
     },
@@ -31168,6 +36179,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/raw-body"
+        }
       ]
     },
     {
@@ -31199,6 +36216,12 @@
           "url": "https://github.com/dominictarr/rc.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/rc"
         }
       ]
     },
@@ -31235,6 +36258,12 @@
           "comment": "as detected from PackageJson property \"repository\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/read-pkg"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -31267,6 +36296,12 @@
               "url": "sindresorhus/pify",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/read-pkg/node_modules/pify"
             }
           ]
         }
@@ -31302,6 +36337,12 @@
           "url": "git://github.com/nodejs/readable-stream",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/readable-stream"
         }
       ],
       "components": [
@@ -31341,6 +36382,12 @@
               "url": "https://github.com/juliangruber/isarray",
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/readable-stream/node_modules/isarray"
             }
           ]
         }
@@ -31384,6 +36431,12 @@
           "comment": "as detected from PackageJson property \"repository\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/readable-web-to-node-stream"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -31415,6 +36468,12 @@
               "url": "git://github.com/nodejs/readable-stream",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/readable-web-to-node-stream/node_modules/readable-stream"
             }
           ]
         }
@@ -31462,6 +36521,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/readdirp"
+        }
       ]
     },
     {
@@ -31495,6 +36560,12 @@
           "url": "gulpjs/rechoir",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/rechoir"
         }
       ]
     },
@@ -31540,6 +36611,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/regex-not"
+        }
       ]
     },
     {
@@ -31573,6 +36650,12 @@
           "url": "git://github.com/es-shims/RegExp.prototype.flags.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/regexp.prototype.flags"
         }
       ]
     },
@@ -31618,6 +36701,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/remove-trailing-separator"
+        }
       ]
     },
     {
@@ -31661,6 +36750,12 @@
           "url": "https://github.com/jonschlinkert/repeat-element",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/repeat-element"
         }
       ]
     },
@@ -31706,6 +36801,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/repeat-string"
+        }
       ]
     },
     {
@@ -31741,6 +36842,12 @@
           "comment": "as detected from PackageJson property \"repository.url\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/replace"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -31773,6 +36880,12 @@
               "url": "chalk/ansi-regex",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/ansi-regex"
             }
           ]
         },
@@ -31807,6 +36920,12 @@
               "url": "chalk/ansi-styles",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/ansi-styles"
             }
           ]
         },
@@ -31847,6 +36966,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/brace-expansion"
+            }
           ]
         },
         {
@@ -31881,6 +37006,12 @@
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/cliui"
+            }
           ]
         },
         {
@@ -31914,6 +37045,12 @@
               "url": "Qix-/color-convert",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/color-convert"
             }
           ]
         },
@@ -31959,6 +37096,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/color-name"
+            }
           ]
         },
         {
@@ -31992,6 +37135,12 @@
               "url": "sindresorhus/find-up",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/find-up"
             }
           ]
         },
@@ -32027,6 +37176,12 @@
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/is-fullwidth-code-point"
+            }
           ]
         },
         {
@@ -32060,6 +37215,12 @@
               "url": "sindresorhus/locate-path",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/locate-path"
             }
           ]
         },
@@ -32095,6 +37256,12 @@
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/minimatch"
+            }
           ]
         },
         {
@@ -32128,6 +37295,12 @@
               "url": "sindresorhus/p-locate",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/p-locate"
             }
           ]
         },
@@ -32163,6 +37336,12 @@
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/path-exists"
+            }
           ]
         },
         {
@@ -32196,6 +37375,12 @@
               "url": "sindresorhus/string-width",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/string-width"
             }
           ]
         },
@@ -32231,6 +37416,12 @@
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/strip-ansi"
+            }
           ]
         },
         {
@@ -32265,6 +37456,12 @@
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/wrap-ansi"
+            }
           ]
         },
         {
@@ -32298,6 +37495,12 @@
               "url": "https://github.com/yargs/yargs-parser.git",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/yargs-parser"
             }
           ]
         },
@@ -32336,6 +37539,12 @@
               "url": "https://yargs.js.org/",
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/yargs"
             }
           ]
         }
@@ -32379,6 +37588,12 @@
           "comment": "as detected from PackageJson property \"repository.url\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/request"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -32415,6 +37630,12 @@
               "url": "https://github.com/ljharb/qs",
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/request/node_modules/qs"
             }
           ]
         }
@@ -32462,6 +37683,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/require-directory"
+        }
       ]
     },
     {
@@ -32505,6 +37732,12 @@
           "url": "https://github.com/yargs/require-main-filename#readme",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/require-main-filename"
         }
       ]
     },
@@ -32550,6 +37783,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/resolve-dir"
+        }
       ]
     },
     {
@@ -32583,6 +37822,12 @@
           "url": "lydell/resolve-url",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/resolve-url"
         }
       ]
     },
@@ -32618,6 +37863,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/resolve"
+        }
       ]
     },
     {
@@ -32651,6 +37902,12 @@
           "url": "https://github.com/lukechilds/responselike.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/responselike"
         }
       ]
     },
@@ -32696,6 +37953,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/restructure"
+        }
       ]
     },
     {
@@ -32729,6 +37992,12 @@
           "url": "git://github.com/fent/ret.js.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ret"
         }
       ]
     },
@@ -32774,6 +38043,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/retry-as-promised"
+        }
       ]
     },
     {
@@ -32813,6 +38088,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/retry"
+        }
       ]
     },
     {
@@ -32846,6 +38127,12 @@
           "url": "git://github.com/isaacs/rimraf.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/rimraf"
         }
       ]
     },
@@ -32892,6 +38179,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/rxjs"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -32934,6 +38227,12 @@
               "url": "https://www.typescriptlang.org/",
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/rxjs/node_modules/tslib"
             }
           ]
         }
@@ -32981,6 +38280,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safe-buffer"
+        }
       ]
     },
     {
@@ -33019,6 +38324,12 @@
           "url": "https://github.com/substack/safe-regex",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safe-regex"
         }
       ]
     },
@@ -33064,6 +38375,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safe-stable-stringify"
+        }
       ]
     },
     {
@@ -33103,6 +38420,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safer-buffer"
+        }
       ]
     },
     {
@@ -33134,6 +38457,12 @@
           "url": "http://busterjs.org/docs/buster-assertions",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/samsam"
         }
       ]
     },
@@ -33169,6 +38498,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sanitize-filename"
+        }
       ]
     },
     {
@@ -33202,6 +38537,12 @@
           "url": "https://github.com/punkave/sanitize-html.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sanitize-html"
         }
       ],
       "components": [
@@ -33247,6 +38588,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sanitize-html/node_modules/lodash"
+            }
           ]
         }
       ]
@@ -33283,6 +38630,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sax"
+        }
       ]
     },
     {
@@ -33315,6 +38668,12 @@
           "url": "https://github.com/cscott/seek-bzip.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/seek-bzip"
         }
       ]
     },
@@ -33349,6 +38708,12 @@
           "url": "https://github.com/npm/node-semver.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/semver"
         }
       ]
     },
@@ -33385,6 +38750,12 @@
           "comment": "as detected from PackageJson property \"repository\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/send"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -33416,6 +38787,12 @@
               "url": "vercel/ms",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/send/node_modules/ms"
             }
           ]
         }
@@ -33452,6 +38829,12 @@
           "url": "http://github.com/sushantdhiman/sequelize-pool.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sequelize-pool"
         }
       ]
     },
@@ -33497,6 +38880,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sequelize"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -33529,6 +38918,12 @@
               "url": "git://github.com/debug-js/debug.git",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sequelize/node_modules/debug"
             }
           ]
         },
@@ -33563,6 +38958,12 @@
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sequelize/node_modules/ms"
+            }
           ]
         },
         {
@@ -33595,6 +38996,12 @@
               "url": "https://github.com/uuidjs/uuid.git",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sequelize/node_modules/uuid"
             }
           ]
         }
@@ -33633,6 +39040,12 @@
           "comment": "as detected from PackageJson property \"repository\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/serve-index"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -33665,6 +39078,12 @@
               "url": "dougwilson/nodejs-depd",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index/node_modules/depd"
             }
           ]
         },
@@ -33700,6 +39119,12 @@
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index/node_modules/http-errors"
+            }
           ]
         },
         {
@@ -33732,6 +39157,12 @@
               "url": "git://github.com/isaacs/inherits",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index/node_modules/inherits"
             }
           ]
         },
@@ -33777,6 +39208,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index/node_modules/setprototypeof"
+            }
           ]
         },
         {
@@ -33809,6 +39246,12 @@
               "url": "jshttp/statuses",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index/node_modules/statuses"
             }
           ]
         }
@@ -33845,6 +39288,12 @@
           "url": "expressjs/serve-static",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/serve-static"
         }
       ]
     },
@@ -33889,6 +39338,12 @@
           "url": "https://github.com/yargs/set-blocking#readme",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/set-blocking"
         }
       ]
     },
@@ -33935,6 +39390,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/set-value"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -33977,6 +39438,12 @@
               "url": "https://github.com/jonschlinkert/extend-shallow",
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/set-value/node_modules/extend-shallow"
             }
           ]
         },
@@ -34022,6 +39489,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/set-value/node_modules/is-extendable"
+            }
           ]
         }
       ]
@@ -34057,6 +39530,12 @@
           "url": "YuzuJS/setImmediate",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/setimmediate"
         }
       ]
     },
@@ -34102,6 +39581,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/setprototypeof"
+        }
       ]
     },
     {
@@ -34145,6 +39630,12 @@
           "url": "https://github.com/ljharb/side-channel#readme",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/side-channel"
         }
       ]
     },
@@ -34190,6 +39681,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/signal-exit"
+        }
       ]
     },
     {
@@ -34233,6 +39730,12 @@
           "url": "https://github.com/feross/simple-concat",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/simple-concat"
         }
       ]
     },
@@ -34279,6 +39782,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/simple-get"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -34311,6 +39820,12 @@
               "url": "sindresorhus/decompress-response",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/simple-get/node_modules/decompress-response"
             }
           ]
         },
@@ -34345,6 +39860,12 @@
               "url": "sindresorhus/mimic-response",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/simple-get/node_modules/mimic-response"
             }
           ]
         }
@@ -34383,6 +39904,12 @@
           "comment": "as detected from PackageJson property \"repository\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/simple-swizzle"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -34415,6 +39942,12 @@
               "url": "https://github.com/qix-/node-is-arrayish.git",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/simple-swizzle/node_modules/is-arrayish"
             }
           ]
         }
@@ -34462,6 +39995,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sinon"
+        }
       ]
     },
     {
@@ -34505,6 +40044,12 @@
           "url": "https://github.com/JoshGlazebrook/smart-buffer/",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/smart-buffer"
         }
       ]
     },
@@ -34551,6 +40096,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/snapdragon-node"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -34593,6 +40144,12 @@
               "url": "https://github.com/jonschlinkert/define-property",
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon-node/node_modules/define-property"
             }
           ]
         }
@@ -34641,6 +40198,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/snapdragon-util"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -34683,6 +40246,12 @@
               "url": "https://github.com/jonschlinkert/kind-of",
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon-util/node_modules/kind-of"
             }
           ]
         }
@@ -34731,6 +40300,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/snapdragon"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -34773,6 +40348,12 @@
               "url": "https://github.com/jonschlinkert/define-property",
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/define-property"
             }
           ]
         },
@@ -34817,6 +40398,12 @@
               "url": "https://github.com/jonschlinkert/extend-shallow",
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/extend-shallow"
             }
           ]
         },
@@ -34863,6 +40450,12 @@
               "comment": "as detected from PackageJson property \"homepage\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/is-accessor-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -34905,6 +40498,12 @@
                   "url": "https://github.com/jonschlinkert/kind-of",
                   "type": "website",
                   "comment": "as detected from PackageJson property \"homepage\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/snapdragon/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -34953,6 +40552,12 @@
               "comment": "as detected from PackageJson property \"homepage\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/is-data-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -34995,6 +40600,12 @@
                   "url": "https://github.com/jonschlinkert/kind-of",
                   "type": "website",
                   "comment": "as detected from PackageJson property \"homepage\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/snapdragon/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -35042,6 +40653,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/is-descriptor"
+            }
           ]
         },
         {
@@ -35085,6 +40702,12 @@
               "url": "https://github.com/jonschlinkert/is-extendable",
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/is-extendable"
             }
           ]
         },
@@ -35130,6 +40753,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/kind-of"
+            }
           ]
         },
         {
@@ -35169,6 +40798,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/source-map"
+            }
           ]
         }
       ]
@@ -35204,6 +40839,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socket.io-adapter"
+        }
       ]
     },
     {
@@ -35236,6 +40877,12 @@
           "url": "https://github.com/socketio/socket.io-parser.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socket.io-parser"
         }
       ],
       "components": [
@@ -35271,6 +40918,12 @@
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socket.io-parser/node_modules/debug"
+            }
           ]
         },
         {
@@ -35303,6 +40956,12 @@
               "url": "zeit/ms",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socket.io-parser/node_modules/ms"
             }
           ]
         }
@@ -35340,6 +40999,12 @@
           "comment": "as detected from PackageJson property \"repository.url\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socket.io"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -35373,6 +41038,12 @@
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socket.io/node_modules/debug"
+            }
           ]
         },
         {
@@ -35405,6 +41076,12 @@
               "url": "zeit/ms",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socket.io/node_modules/ms"
             }
           ]
         }
@@ -35453,6 +41130,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socks-proxy-agent"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -35486,6 +41169,12 @@
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socks-proxy-agent/node_modules/debug"
+            }
           ]
         },
         {
@@ -35518,6 +41207,12 @@
               "url": "zeit/ms",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socks-proxy-agent/node_modules/ms"
             }
           ]
         }
@@ -35566,6 +41261,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socks"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -35602,6 +41303,12 @@
               "url": "https://github.com/indutny/node-ip",
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socks/node_modules/ip"
             }
           ]
         }
@@ -35640,6 +41347,12 @@
           "comment": "as detected from PackageJson property \"repository\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sort-keys-length"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -35672,6 +41385,12 @@
               "url": "sindresorhus/sort-keys",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sort-keys-length/node_modules/sort-keys"
             }
           ]
         }
@@ -35709,6 +41428,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sort-keys"
+        }
       ]
     },
     {
@@ -35742,6 +41467,12 @@
           "url": "lydell/source-map-resolve",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/source-map-resolve"
         }
       ]
     },
@@ -35781,6 +41512,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/source-map-support"
+        }
       ]
     },
     {
@@ -35814,6 +41551,12 @@
           "url": "lydell/source-map-url",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/source-map-url"
         }
       ]
     },
@@ -35854,6 +41597,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/source-map"
+        }
       ]
     },
     {
@@ -35887,6 +41636,12 @@
           "url": "https://github.com/mmalecki/spawn-command",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spawn-command"
         }
       ]
     },
@@ -35922,6 +41677,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spdx-correct"
+        }
       ]
     },
     {
@@ -35955,6 +41716,12 @@
           "url": "kemitchell/spdx-exceptions.json",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spdx-exceptions"
         }
       ]
     },
@@ -35990,6 +41757,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spdx-expression-parse"
+        }
       ]
     },
     {
@@ -36023,6 +41796,12 @@
           "url": "jslicense/spdx-license-ids",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spdx-license-ids"
         }
       ]
     },
@@ -36068,6 +41847,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/split-string"
+        }
       ]
     },
     {
@@ -36101,6 +41886,12 @@
           "url": "https://github.com/alexei/sprintf.js.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sprintf-js"
         }
       ]
     },
@@ -36140,6 +41931,12 @@
           "url": "https://github.com/TryGhost/node-sqlite3",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sqlite3"
         }
       ]
     },
@@ -36185,6 +41982,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sshpk"
+        }
       ]
     },
     {
@@ -36218,6 +42021,12 @@
           "url": "https://github.com/npm/ssri",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ssri"
         }
       ]
     },
@@ -36257,6 +42066,12 @@
           "url": "https://github.com/felixge/node-stack-trace",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/stack-trace"
         }
       ]
     },
@@ -36303,6 +42118,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/static-extend"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -36345,6 +42166,12 @@
               "url": "https://github.com/jonschlinkert/define-property",
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend/node_modules/define-property"
             }
           ]
         },
@@ -36391,6 +42218,12 @@
               "comment": "as detected from PackageJson property \"homepage\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend/node_modules/is-accessor-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -36433,6 +42266,12 @@
                   "url": "https://github.com/jonschlinkert/kind-of",
                   "type": "website",
                   "comment": "as detected from PackageJson property \"homepage\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/static-extend/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -36481,6 +42320,12 @@
               "comment": "as detected from PackageJson property \"homepage\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend/node_modules/is-data-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -36523,6 +42368,12 @@
                   "url": "https://github.com/jonschlinkert/kind-of",
                   "type": "website",
                   "comment": "as detected from PackageJson property \"homepage\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/static-extend/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -36570,6 +42421,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend/node_modules/is-descriptor"
+            }
           ]
         },
         {
@@ -36614,6 +42471,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend/node_modules/kind-of"
+            }
           ]
         }
       ]
@@ -36649,6 +42512,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/statuses"
+        }
       ]
     },
     {
@@ -36683,6 +42552,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/stream-buffers"
+        }
       ]
     },
     {
@@ -36698,6 +42573,14 @@
           "content": "8e8b3cbbef892a6d0045c4944c06573950b4992a31ec1867eac060b72ef73f57f72467fbc86d9c9536c134751d75efe476f3f614449a9bebccea5f2306b3711c"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "http://github.com/mscdex/streamsearch/raw/master/LICENSE"
+          }
+        }
+      ],
       "purl": "pkg:npm/streamsearch@0.1.2",
       "externalReferences": [
         {
@@ -36709,6 +42592,12 @@
           "url": "http://github.com/mscdex/streamsearch.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/streamsearch"
         }
       ]
     },
@@ -36743,6 +42632,12 @@
           "url": "kevva/strict-uri-encode",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strict-uri-encode"
         }
       ]
     },
@@ -36782,6 +42677,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string_decoder"
+        }
       ]
     },
     {
@@ -36816,6 +42717,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string-width"
+        }
       ]
     },
     {
@@ -36829,6 +42736,14 @@
         {
           "alg": "SHA-512",
           "content": "9faf47df53a7c5219267265b80196f6085e5acc849434750017d63b354038696941face6537418963d3b6c2c023653cebb7a115c8b9b18f9768031a71ec882aa"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "http://mths.be/mit"
+          }
         }
       ],
       "purl": "pkg:npm/string.fromcodepoint@0.2.1",
@@ -36852,6 +42767,12 @@
           "url": "http://mths.be/fromcodepoint",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string.fromcodepoint"
         }
       ]
     },
@@ -36897,6 +42818,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string.prototype.codepointat"
+        }
       ]
     },
     {
@@ -36930,6 +42857,12 @@
           "url": "chalk/strip-ansi",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-ansi"
         }
       ]
     },
@@ -36965,6 +42898,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-bom"
+        }
       ]
     },
     {
@@ -36998,6 +42937,12 @@
           "url": "shinnn/node-strip-dirs",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-dirs"
         }
       ]
     },
@@ -37033,6 +42978,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-json-comments"
+        }
       ]
     },
     {
@@ -37066,6 +43017,12 @@
           "url": "sindresorhus/strip-outer",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-outer"
         }
       ]
     },
@@ -37106,6 +43063,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strtok3"
+        }
       ]
     },
     {
@@ -37139,6 +43102,12 @@
           "url": "chalk/supports-color",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/supports-color"
         }
       ]
     },
@@ -37184,6 +43153,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/supports-preserve-symlinks-flag"
+        }
       ]
     },
     {
@@ -37228,6 +43203,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/svg-captcha"
+        }
       ]
     },
     {
@@ -37259,6 +43240,12 @@
           "url": "git@github.com:swagger-api/swagger-ui.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/swagger-ui-dist"
         }
       ]
     },
@@ -37303,6 +43290,12 @@
           "url": "https://github.com/scottie1984/swagger-ui-express",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/swagger-ui-express"
         }
       ]
     },
@@ -37349,6 +43342,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tar-fs"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -37386,6 +43385,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/tar-fs/node_modules/bl"
+            }
           ]
         },
         {
@@ -37420,6 +43425,12 @@
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/tar-fs/node_modules/chownr"
+            }
           ]
         },
         {
@@ -37452,6 +43463,12 @@
               "url": "git://github.com/nodejs/readable-stream",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/tar-fs/node_modules/readable-stream"
             }
           ]
         },
@@ -37496,6 +43513,12 @@
               "url": "https://github.com/mafintosh/tar-stream",
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/tar-fs/node_modules/tar-stream"
             }
           ]
         }
@@ -37543,6 +43566,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tar-stream"
+        }
       ]
     },
     {
@@ -37576,6 +43605,12 @@
           "url": "https://github.com/npm/node-tar.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tar"
         }
       ]
     },
@@ -37621,6 +43656,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tdigest"
+        }
       ]
     },
     {
@@ -37665,6 +43706,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/text-hex"
+        }
       ]
     },
     {
@@ -37691,6 +43738,12 @@
           "url": "git://github.com/chrisumbel/thirty-two.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/thirty-two"
         }
       ]
     },
@@ -37731,6 +43784,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/through"
+        }
       ]
     },
     {
@@ -37764,6 +43823,12 @@
           "url": "floatdrop/timed-out",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/timed-out"
         }
       ]
     },
@@ -37809,6 +43874,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tiny-inflate"
+        }
       ]
     },
     {
@@ -37853,6 +43924,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-buffer"
+        }
       ]
     },
     {
@@ -37886,6 +43963,12 @@
           "url": "sindresorhus/to-fast-properties",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-fast-properties"
         }
       ]
     },
@@ -37932,6 +44015,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-object-path"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -37974,6 +44063,12 @@
               "url": "https://github.com/jonschlinkert/kind-of",
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/to-object-path/node_modules/kind-of"
             }
           ]
         }
@@ -38021,6 +44116,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-regex-range"
+        }
       ]
     },
     {
@@ -38065,6 +44166,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-regex"
+        }
       ]
     },
     {
@@ -38099,6 +44206,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/toidentifier"
+        }
       ]
     },
     {
@@ -38132,6 +44245,12 @@
           "url": "https://github.com/pugjs/token-stream.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/token-stream"
         }
       ]
     },
@@ -38172,6 +44291,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/token-types"
+        }
       ]
     },
     {
@@ -38204,6 +44329,12 @@
           "url": "https://github.com/gustavohenke/toposort.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/toposort-class"
         }
       ]
     },
@@ -38249,6 +44380,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tough-cookie"
+        }
       ]
     },
     {
@@ -38293,6 +44430,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tr46"
+        }
       ]
     },
     {
@@ -38326,6 +44469,12 @@
           "url": "http://github.com/substack/js-traverse.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/traverse"
         }
       ]
     },
@@ -38366,6 +44515,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tree-kill"
+        }
       ]
     },
     {
@@ -38399,6 +44554,12 @@
           "url": "sindresorhus/trim-repeated",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/trim-repeated"
         }
       ]
     },
@@ -38444,6 +44605,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/triple-beam"
+        }
       ]
     },
     {
@@ -38488,6 +44655,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/truncate-utf8-bytes"
+        }
       ]
     },
     {
@@ -38522,6 +44695,12 @@
           "comment": "as detected from PackageJson property \"repository.url\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ts-node-dev"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -38554,6 +44733,12 @@
               "url": "git://github.com/isaacs/rimraf.git",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/ts-node-dev/node_modules/rimraf"
             }
           ]
         }
@@ -38601,6 +44786,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ts-node"
+        }
       ]
     },
     {
@@ -38644,6 +44835,12 @@
           "url": "https://github.com/TypeStrong/tsconfig",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tsconfig"
         }
       ]
     },
@@ -38689,6 +44886,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tslib"
+        }
       ]
     },
     {
@@ -38722,6 +44925,12 @@
           "url": "https://github.com/mikeal/tunnel-agent",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tunnel-agent"
         }
       ]
     },
@@ -38767,6 +44976,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tweetnacl"
+        }
       ]
     },
     {
@@ -38811,6 +45026,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/type-check"
+        }
       ]
     },
     {
@@ -38844,6 +45065,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/type-is"
+        }
       ]
     },
     {
@@ -38876,6 +45103,12 @@
           "url": "https://github.com/eivindfjeldstad/typecast.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/typecast"
         }
       ]
     },
@@ -38915,6 +45148,12 @@
           "url": "https://github.com/substack/typedarray",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/typedarray"
         }
       ]
     },
@@ -38960,6 +45199,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/typescript"
+        }
       ]
     },
     {
@@ -38993,6 +45238,12 @@
           "url": "mishoo/UglifyJS",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/uglify-js"
         }
       ]
     },
@@ -39032,6 +45283,12 @@
           "url": "https://github.com/regular/unbzip2-stream.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unbzip2-stream"
         }
       ]
     },
@@ -39077,6 +45334,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unc-path-regex"
+        }
       ]
     },
     {
@@ -39119,6 +45382,12 @@
           "url": "http://epeli.github.com/underscore.string/",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/underscore.string"
         }
       ]
     },
@@ -39164,6 +45433,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unicode-properties"
+        }
       ]
     },
     {
@@ -39207,6 +45482,12 @@
           "url": "https://github.com/devongovett/unicode-trie",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unicode-trie"
         }
       ]
     },
@@ -39253,6 +45534,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/union-value"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -39295,6 +45582,12 @@
               "url": "https://github.com/jonschlinkert/is-extendable",
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/union-value/node_modules/is-extendable"
             }
           ]
         }
@@ -39342,6 +45635,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unique-filename"
+        }
       ]
     },
     {
@@ -39375,6 +45674,12 @@
           "url": "git://github.com/iarna/unique-slug.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unique-slug"
         }
       ]
     },
@@ -39420,6 +45725,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unit-compare"
+        }
       ]
     },
     {
@@ -39464,6 +45775,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/universalify"
+        }
       ]
     },
     {
@@ -39497,6 +45814,12 @@
           "url": "stream-utils/unpipe",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unpipe"
         }
       ]
     },
@@ -39543,6 +45866,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unset-value"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -39587,6 +45916,12 @@
               "comment": "as detected from PackageJson property \"homepage\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/unset-value/node_modules/has-value"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -39629,6 +45964,12 @@
                   "url": "https://github.com/jonschlinkert/isobject",
                   "type": "website",
                   "comment": "as detected from PackageJson property \"homepage\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/unset-value/node_modules/has-value/node_modules/isobject"
                 }
               ]
             }
@@ -39676,6 +46017,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/unset-value/node_modules/has-values"
+            }
           ]
         },
         {
@@ -39715,6 +46062,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/unset-value/node_modules/isarray"
+            }
           ]
         }
       ]
@@ -39751,6 +46104,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/untildify"
+        }
       ]
     },
     {
@@ -39784,6 +46143,12 @@
           "url": "https://github.com/ZJONSSON/node-unzipper.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unzipper"
         }
       ],
       "components": [
@@ -39828,6 +46193,12 @@
               "url": "https://github.com/petkaantonov/bluebird",
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/unzipper/node_modules/bluebird"
             }
           ]
         }
@@ -39875,6 +46246,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/uri-js"
+        }
       ]
     },
     {
@@ -39908,6 +46285,12 @@
           "url": "lydell/urix",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/urix"
         }
       ]
     },
@@ -39943,6 +46326,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/url-parse-lax"
+        }
       ]
     },
     {
@@ -39976,6 +46365,12 @@
           "url": "stevenvachon/url-to-options",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/url-to-options"
         }
       ]
     },
@@ -40021,6 +46416,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/use"
+        }
       ]
     },
     {
@@ -40064,6 +46465,12 @@
           "url": "https://github.com/parshap/utf8-byte-length#readme",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/utf8-byte-length"
         }
       ]
     },
@@ -40109,6 +46516,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/util-deprecate"
+        }
       ]
     },
     {
@@ -40148,6 +46561,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/util"
+        }
       ]
     },
     {
@@ -40168,6 +46587,12 @@
           "license": {
             "id": "MIT"
           }
+        },
+        {
+          "license": {
+            "id": "MIT",
+            "url": "http://opensource.org/licenses/MIT"
+          }
         }
       ],
       "purl": "pkg:npm/utils-merge@1.0.1",
@@ -40186,6 +46611,12 @@
           "url": "git://github.com/jaredhanson/utils-merge.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/utils-merge"
         }
       ]
     },
@@ -40219,6 +46650,12 @@
           "url": "https://github.com/uuidjs/uuid.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/uuid"
         }
       ]
     },
@@ -40254,6 +46691,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/v8flags"
+        }
       ]
     },
     {
@@ -40288,6 +46731,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/validate-npm-package-license"
+        }
       ]
     },
     {
@@ -40321,6 +46770,12 @@
           "url": "eivindfjeldstad/validate",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/validate"
         }
       ]
     },
@@ -40366,6 +46821,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/validator"
+        }
       ]
     },
     {
@@ -40400,6 +46861,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/vary"
+        }
       ]
     },
     {
@@ -40432,6 +46899,12 @@
           "url": "git://github.com/davepacheco/node-verror.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/verror"
         }
       ],
       "components": [
@@ -40472,6 +46945,12 @@
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/verror/node_modules/core-util-is"
+            }
           ]
         }
       ]
@@ -40507,6 +46986,12 @@
           "url": "github:patriksimek/vm2",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/vm2"
         }
       ],
       "components": [
@@ -40545,6 +47030,12 @@
               "url": "https://github.com/acornjs/acorn",
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/vm2/node_modules/acorn"
             }
           ]
         }
@@ -40592,6 +47083,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/void-elements"
+        }
       ]
     },
     {
@@ -40634,6 +47131,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/walk"
+        }
       ]
     },
     {
@@ -40673,6 +47176,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/walkdir"
+        }
       ]
     },
     {
@@ -40707,6 +47216,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/webidl-conversions"
+        }
       ]
     },
     {
@@ -40740,6 +47255,12 @@
           "url": "jsdom/whatwg-url",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/whatwg-url"
         }
       ]
     },
@@ -40785,6 +47306,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-boxed-primitive"
+        }
       ]
     },
     {
@@ -40828,6 +47355,12 @@
           "url": "https://github.com/inspect-js/which-collection#readme",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-collection"
         }
       ]
     },
@@ -40873,6 +47406,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-module"
+        }
       ]
     },
     {
@@ -40917,6 +47456,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-pm-runs"
+        }
       ]
     },
     {
@@ -40950,6 +47495,12 @@
           "url": "git://github.com/inspect-js/which-typed-array.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-typed-array"
         }
       ]
     },
@@ -40985,6 +47536,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which"
+        }
       ]
     },
     {
@@ -41018,6 +47575,12 @@
           "url": "https://github.com/iarna/wide-align",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wide-align"
         }
       ]
     },
@@ -41064,6 +47627,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/winston-transport"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -41095,6 +47664,12 @@
               "url": "git://github.com/nodejs/readable-stream",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/winston-transport/node_modules/readable-stream"
             }
           ]
         }
@@ -41131,6 +47706,12 @@
           "url": "https://github.com/winstonjs/winston.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/winston"
         }
       ],
       "components": [
@@ -41176,6 +47757,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/winston/node_modules/async"
+            }
           ]
         },
         {
@@ -41210,6 +47797,12 @@
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/winston/node_modules/is-stream"
+            }
           ]
         },
         {
@@ -41242,6 +47835,12 @@
               "url": "git://github.com/nodejs/readable-stream",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/winston/node_modules/readable-stream"
             }
           ]
         }
@@ -41279,6 +47878,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/with"
+        }
       ]
     },
     {
@@ -41312,6 +47917,12 @@
           "url": "http://github.com/cschwarz/wkx.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wkx"
         }
       ]
     },
@@ -41357,6 +47968,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/word-wrap"
+        }
       ]
     },
     {
@@ -41390,6 +48007,12 @@
           "url": "git://github.com/substack/node-wordwrap.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wordwrap"
         }
       ]
     },
@@ -41426,6 +48049,12 @@
           "comment": "as detected from PackageJson property \"repository\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wrap-ansi"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -41458,6 +48087,12 @@
               "url": "chalk/ansi-regex",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi/node_modules/ansi-regex"
             }
           ]
         },
@@ -41503,6 +48138,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi/node_modules/emoji-regex"
+            }
           ]
         },
         {
@@ -41536,6 +48177,12 @@
               "url": "sindresorhus/is-fullwidth-code-point",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi/node_modules/is-fullwidth-code-point"
             }
           ]
         },
@@ -41571,6 +48218,12 @@
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi/node_modules/string-width"
+            }
           ]
         },
         {
@@ -41604,6 +48257,12 @@
               "url": "chalk/strip-ansi",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi/node_modules/strip-ansi"
             }
           ]
         }
@@ -41651,6 +48310,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wrappy"
+        }
       ]
     },
     {
@@ -41694,6 +48359,12 @@
           "url": "https://github.com/websockets/ws",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ws"
         }
       ]
     },
@@ -41739,6 +48410,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/xtend"
+        }
       ]
     },
     {
@@ -41783,6 +48460,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/y18n"
+        }
       ]
     },
     {
@@ -41816,6 +48499,12 @@
           "url": "git+https://github.com/isaacs/yallist.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yallist"
         }
       ]
     },
@@ -41851,6 +48540,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yaml-schema-validator"
+        }
       ]
     },
     {
@@ -41884,6 +48579,12 @@
           "url": "git@github.com:yargs/yargs-parser.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yargs-parser"
         }
       ]
     },
@@ -41924,6 +48625,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yargs"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -41956,6 +48663,12 @@
               "url": "chalk/ansi-regex",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs/node_modules/ansi-regex"
             }
           ]
         },
@@ -42001,6 +48714,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs/node_modules/emoji-regex"
+            }
           ]
         },
         {
@@ -42034,6 +48753,12 @@
               "url": "sindresorhus/is-fullwidth-code-point",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs/node_modules/is-fullwidth-code-point"
             }
           ]
         },
@@ -42069,6 +48794,12 @@
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs/node_modules/string-width"
+            }
           ]
         },
         {
@@ -42102,6 +48833,12 @@
               "url": "chalk/strip-ansi",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs/node_modules/strip-ansi"
             }
           ]
         }
@@ -42149,6 +48886,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yauzl"
+        }
       ]
     },
     {
@@ -42182,6 +48925,12 @@
           "url": "sindresorhus/yn",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yn"
         }
       ]
     },
@@ -42227,6 +48976,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/z85"
+        }
       ]
     },
     {
@@ -42271,6 +49026,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/zip-stream"
+        }
       ]
     },
     {
@@ -42309,6 +49070,12 @@
           "url": "https://github.com/imaya/zlib.js",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/zlibjs"
         }
       ]
     }

--- a/demo/juice-shop/example-results/bom.1.3.xml
+++ b/demo/juice-shop/example-results/bom.1.3.xml
@@ -5,7 +5,7 @@
       <tool>
         <vendor>@cyclonedx</vendor>
         <name>cyclonedx-npm</name>
-        <version>1.4.0</version>
+        <version>1.4.1</version>
       </tool>
     </tools>
     <component type="application" bom-ref="juice-shop@14.1.1">
@@ -34,6 +34,7 @@
         </reference>
       </externalReferences>
       <properties>
+        <property name="cdx:npm:package:installPath"/>
         <property name="cdx:npm:package:private">true</property>
       </properties>
     </component>
@@ -68,6 +69,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@babel/helper-string-parser</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@babel/helper-validator-identifier@7.19.1">
       <author>The Babel Team (https://babel.dev/team)</author>
@@ -94,6 +98,9 @@
           <comment>as detected from PackageJson property "repository.url" and "repository.directory"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@babel/helper-validator-identifier</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@babel/parser@7.20.2">
       <author>The Babel Team (https://babel.dev/team)</author>
@@ -128,6 +135,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@babel/parser</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@babel/types@7.20.2">
       <author>The Babel Team (https://babel.dev/team)</author>
@@ -162,6 +172,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@babel/types</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@colors/colors@1.5.0">
       <author>DABH</author>
@@ -196,6 +209,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@colors/colors</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@dabh/diagnostics@2.0.3">
       <author>Arnout Kazemier</author>
@@ -230,6 +246,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@dabh/diagnostics</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@gar/promisify@1.1.3">
       <author>Gar &lt;gar+npm@danger.computer&gt;</author>
@@ -256,6 +275,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@gar/promisify</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@mapbox/node-pre-gyp@1.0.10">
       <author>Dane Springmeyer &lt;dane@mapbox.com&gt;</author>
@@ -282,6 +304,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@mapbox/node-pre-gyp</property>
+      </properties>
       <components>
         <component type="library" bom-ref="@mapbox/node-pre-gyp@1.0.10|ansi-regex@5.0.1">
           <author>Sindre Sorhus</author>
@@ -307,6 +332,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/@mapbox/node-pre-gyp/node_modules/ansi-regex</property>
+          </properties>
         </component>
         <component type="library" bom-ref="@mapbox/node-pre-gyp@1.0.10|are-we-there-yet@2.0.0">
           <author>GitHub Inc.</author>
@@ -340,6 +368,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/@mapbox/node-pre-gyp/node_modules/are-we-there-yet</property>
+          </properties>
         </component>
         <component type="library" bom-ref="@mapbox/node-pre-gyp@1.0.10|detect-libc@2.0.1">
           <author>Lovell Fuller &lt;npm@lovell.info&gt;</author>
@@ -365,6 +396,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/@mapbox/node-pre-gyp/node_modules/detect-libc</property>
+          </properties>
         </component>
         <component type="library" bom-ref="@mapbox/node-pre-gyp@1.0.10|gauge@3.0.2">
           <author>Rebecca Turner &lt;me@re-becca.org&gt;</author>
@@ -398,6 +432,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/@mapbox/node-pre-gyp/node_modules/gauge</property>
+          </properties>
         </component>
         <component type="library" bom-ref="@mapbox/node-pre-gyp@1.0.10|is-fullwidth-code-point@3.0.0">
           <author>Sindre Sorhus</author>
@@ -423,6 +460,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/@mapbox/node-pre-gyp/node_modules/is-fullwidth-code-point</property>
+          </properties>
         </component>
         <component type="library" bom-ref="@mapbox/node-pre-gyp@1.0.10|make-dir@3.1.0">
           <author>Sindre Sorhus</author>
@@ -448,6 +488,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/@mapbox/node-pre-gyp/node_modules/make-dir</property>
+          </properties>
           <components>
             <component type="library" bom-ref="@mapbox/node-pre-gyp@1.0.10|make-dir@3.1.0|semver@6.3.0">
               <name>semver</name>
@@ -472,6 +515,9 @@
                   <comment>as detected from PackageJson property "repository"</comment>
                 </reference>
               </externalReferences>
+              <properties>
+                <property name="cdx:npm:package:installPath">node_modules/@mapbox/node-pre-gyp/node_modules/make-dir/node_modules/semver</property>
+              </properties>
             </component>
           </components>
         </component>
@@ -499,6 +545,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/@mapbox/node-pre-gyp/node_modules/nopt</property>
+          </properties>
         </component>
         <component type="library" bom-ref="@mapbox/node-pre-gyp@1.0.10|npmlog@5.0.1">
           <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me/)</author>
@@ -524,6 +573,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/@mapbox/node-pre-gyp/node_modules/npmlog</property>
+          </properties>
         </component>
         <component type="library" bom-ref="@mapbox/node-pre-gyp@1.0.10|readable-stream@3.6.0">
           <name>readable-stream</name>
@@ -548,6 +600,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/@mapbox/node-pre-gyp/node_modules/readable-stream</property>
+          </properties>
         </component>
         <component type="library" bom-ref="@mapbox/node-pre-gyp@1.0.10|string-width@4.2.3">
           <author>Sindre Sorhus</author>
@@ -573,6 +628,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/@mapbox/node-pre-gyp/node_modules/string-width</property>
+          </properties>
         </component>
         <component type="library" bom-ref="@mapbox/node-pre-gyp@1.0.10|strip-ansi@6.0.1">
           <author>Sindre Sorhus</author>
@@ -598,6 +656,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/@mapbox/node-pre-gyp/node_modules/strip-ansi</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -630,6 +691,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/core-loader</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/core@4.23.4">
       <author>Jesus Seijas</author>
@@ -660,6 +724,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/core</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/evaluator@4.22.7">
       <author>Jesus Seijas</author>
@@ -690,6 +757,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/evaluator</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-all@4.24.0">
       <author>Jesus Seijas</author>
@@ -720,6 +790,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-all</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-ar@4.23.4">
       <author>Jesus Seijas</author>
@@ -750,6 +823,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-ar</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-bn@4.23.4">
       <author>Jesus Seijas</author>
@@ -780,6 +856,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-bn</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-ca@4.23.4">
       <author>Jesus Seijas</author>
@@ -810,6 +889,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-ca</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-cs@4.23.4">
       <author>Jesus Seijas</author>
@@ -840,6 +922,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-cs</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-da@4.23.4">
       <author>Jesus Seijas</author>
@@ -870,6 +955,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-da</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-de@4.23.4">
       <author>Jesus Seijas</author>
@@ -900,6 +988,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-de</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-el@4.23.4">
       <author>Jesus Seijas</author>
@@ -930,6 +1021,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-el</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-en-min@4.23.4">
       <author>Jesus Seijas</author>
@@ -960,6 +1054,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-en-min</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-en@4.23.4">
       <author>Jesus Seijas</author>
@@ -990,6 +1087,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-en</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-es@4.23.4">
       <author>Jesus Seijas</author>
@@ -1020,6 +1120,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-es</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-eu@4.23.4">
       <author>Jesus Seijas</author>
@@ -1050,6 +1153,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-eu</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-fa@4.23.4">
       <author>Jesus Seijas</author>
@@ -1080,6 +1186,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-fa</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-fi@4.23.4">
       <author>Jesus Seijas</author>
@@ -1110,6 +1219,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-fi</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-fr@4.23.4">
       <author>Jesus Seijas</author>
@@ -1140,6 +1252,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-fr</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-ga@4.23.4">
       <author>Jesus Seijas</author>
@@ -1170,6 +1285,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-ga</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-gl@4.23.4">
       <author>Jesus Seijas</author>
@@ -1200,6 +1318,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-gl</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-hi@4.23.4">
       <author>Jesus Seijas</author>
@@ -1230,6 +1351,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-hi</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-hu@4.23.4">
       <author>Jesus Seijas</author>
@@ -1260,6 +1384,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-hu</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-hy@4.23.4">
       <author>Jesus Seijas</author>
@@ -1290,6 +1417,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-hy</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-id@4.23.4">
       <author>Jesus Seijas</author>
@@ -1320,6 +1450,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-id</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-it@4.23.4">
       <author>Jesus Seijas</author>
@@ -1350,6 +1483,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-it</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-ja@4.24.0">
       <author>Jesus Seijas</author>
@@ -1380,6 +1516,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-ja</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-ko@4.23.4">
       <author>Jesus Seijas</author>
@@ -1410,6 +1549,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-ko</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-lt@4.23.4">
       <author>Jesus Seijas</author>
@@ -1440,6 +1582,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-lt</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-ms@4.23.4">
       <author>Jesus Seijas</author>
@@ -1470,6 +1615,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-ms</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-ne@4.23.4">
       <author>Jesus Seijas</author>
@@ -1500,6 +1648,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-ne</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-nl@4.23.4">
       <author>Jesus Seijas</author>
@@ -1530,6 +1681,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-nl</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-no@4.23.4">
       <author>Jesus Seijas</author>
@@ -1560,6 +1714,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-no</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-pl@4.23.4">
       <author>Jesus Seijas</author>
@@ -1590,6 +1747,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-pl</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-pt@4.23.4">
       <author>Jesus Seijas</author>
@@ -1620,6 +1780,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-pt</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-ro@4.23.4">
       <author>Jesus Seijas</author>
@@ -1650,6 +1813,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-ro</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-ru@4.23.4">
       <author>Jesus Seijas</author>
@@ -1680,6 +1846,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-ru</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-sl@4.23.4">
       <author>Jesus Seijas</author>
@@ -1710,6 +1879,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-sl</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-sr@4.23.4">
       <author>Jesus Seijas</author>
@@ -1740,6 +1912,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-sr</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-sv@4.23.4">
       <author>Jesus Seijas</author>
@@ -1770,6 +1945,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-sv</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-ta@4.23.4">
       <author>Jesus Seijas</author>
@@ -1800,6 +1978,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-ta</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-th@4.23.4">
       <author>Jesus Seijas</author>
@@ -1830,6 +2011,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-th</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-tl@4.23.4">
       <author>Jesus Seijas</author>
@@ -1860,6 +2044,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-tl</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-tr@4.23.4">
       <author>Jesus Seijas</author>
@@ -1890,6 +2077,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-tr</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-uk@4.23.4">
       <author>Jesus Seijas</author>
@@ -1920,6 +2110,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-uk</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-zh@4.23.4">
       <author>Jesus Seijas</author>
@@ -1950,6 +2143,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-zh</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/language-min@4.22.7">
       <author>Jesus Seijas</author>
@@ -1980,6 +2176,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/language-min</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/language@4.22.7">
       <author>Jesus Seijas</author>
@@ -2010,6 +2209,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/language</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/ner@4.23.4">
       <author>Jesus Seijas</author>
@@ -2040,6 +2242,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/ner</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/neural@4.22.7">
       <author>Jesus Seijas</author>
@@ -2070,6 +2275,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/neural</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/nlg@4.23.4">
       <author>Jesus Seijas</author>
@@ -2100,6 +2308,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/nlg</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/nlp@4.23.5">
       <author>Jesus Seijas</author>
@@ -2130,6 +2341,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/nlp</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/nlu@4.23.5">
       <author>Jesus Seijas</author>
@@ -2160,6 +2374,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/nlu</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/request@4.22.7">
       <author>Jesus Seijas</author>
@@ -2190,6 +2407,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/request</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/sentiment@4.23.4">
       <author>Jesus Seijas</author>
@@ -2220,6 +2440,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/sentiment</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/similarity@4.22.7">
       <author>Jesus Seijas</author>
@@ -2250,6 +2473,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/similarity</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/slot@4.22.17">
       <author>Jesus Seijas</author>
@@ -2280,6 +2506,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/slot</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@npmcli/fs@1.1.1">
       <author>GitHub Inc.</author>
@@ -2302,6 +2531,9 @@
           <comment>as detected from npm-ls property "resolved"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@npmcli/fs</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@npmcli/move-file@1.1.2">
       <group>@npmcli</group>
@@ -2327,6 +2559,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@npmcli/move-file</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@otplib/core@12.0.1">
       <author>Gerald Yeo &lt;contact@fusedthought.com&gt;</author>
@@ -2357,6 +2592,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@otplib/core</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@otplib/plugin-crypto@12.0.1">
       <author>Gerald Yeo &lt;contact@fusedthought.com&gt;</author>
@@ -2387,6 +2625,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@otplib/plugin-crypto</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@otplib/plugin-thirty-two@12.0.1">
       <author>Gerald Yeo &lt;contact@fusedthought.com&gt;</author>
@@ -2417,6 +2658,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@otplib/plugin-thirty-two</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@otplib/preset-default@12.0.1">
       <author>Gerald Yeo &lt;contact@fusedthought.com&gt;</author>
@@ -2447,6 +2691,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@otplib/preset-default</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@otplib/preset-v11@12.0.1">
       <author>Gerald Yeo &lt;contact@fusedthought.com&gt;</author>
@@ -2477,6 +2724,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@otplib/preset-v11</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@sindresorhus/is@0.7.0">
       <author>Sindre Sorhus</author>
@@ -2503,6 +2753,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@sindresorhus/is</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@swc/helpers@0.3.17">
       <author>강동윤 &lt;kdy1997.dev@gmail.com&gt;</author>
@@ -2537,6 +2790,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@swc/helpers</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@tokenizer/token@0.3.0">
       <author>Borewit</author>
@@ -2567,6 +2823,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@tokenizer/token</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@tootallnate/once@2.0.0">
       <author>Nathan Rajlich &lt;nathan@tootallnate.net&gt; (http://n8.io/)</author>
@@ -2597,6 +2856,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@tootallnate/once</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@types/component-emitter@1.2.11">
       <group>@types</group>
@@ -2626,6 +2888,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@types/component-emitter</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@types/cookie@0.4.1">
       <group>@types</group>
@@ -2655,6 +2920,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@types/cookie</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@types/cors@2.8.12">
       <group>@types</group>
@@ -2684,6 +2952,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@types/cors</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@types/debug@4.1.7">
       <group>@types</group>
@@ -2713,6 +2984,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@types/debug</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@types/ms@0.7.31">
       <group>@types</group>
@@ -2738,6 +3012,9 @@
           <comment>as detected from PackageJson property "repository.url" and "repository.directory"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@types/ms</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@types/node@18.11.9">
       <group>@types</group>
@@ -2767,6 +3044,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@types/node</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@types/strip-bom@3.0.0">
       <author>Mohamed Hegazy &lt;https://github.com/mhegazy&gt;</author>
@@ -2793,6 +3073,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@types/strip-bom</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@types/strip-json-comments@0.0.30">
       <group>@types</group>
@@ -2818,6 +3101,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@types/strip-json-comments</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@types/validator@13.7.10">
       <group>@types</group>
@@ -2847,6 +3133,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@types/validator</property>
+      </properties>
     </component>
     <component type="library" bom-ref="abbrev@1.1.1">
       <author>Isaac Z. Schlueter &lt;i@izs.me&gt;</author>
@@ -2872,6 +3161,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/abbrev</property>
+      </properties>
     </component>
     <component type="library" bom-ref="accepts@1.3.8">
       <name>accepts</name>
@@ -2896,6 +3188,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/accepts</property>
+      </properties>
     </component>
     <component type="library" bom-ref="acorn-walk@8.2.0">
       <name>acorn-walk</name>
@@ -2924,6 +3219,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/acorn-walk</property>
+      </properties>
     </component>
     <component type="library" bom-ref="acorn@7.4.1">
       <name>acorn</name>
@@ -2952,6 +3250,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/acorn</property>
+      </properties>
     </component>
     <component type="library" bom-ref="agent-base@6.0.2">
       <author>Nathan Rajlich &lt;nathan@tootallnate.net&gt; (http://n8.io/)</author>
@@ -2981,6 +3282,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/agent-base</property>
+      </properties>
       <components>
         <component type="library" bom-ref="agent-base@6.0.2|debug@4.3.4">
           <author>Josh Junon &lt;josh.junon@protonmail.com&gt;</author>
@@ -3006,6 +3310,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/agent-base/node_modules/debug</property>
+          </properties>
         </component>
         <component type="library" bom-ref="agent-base@6.0.2|ms@2.1.2">
           <name>ms</name>
@@ -3030,6 +3337,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/agent-base/node_modules/ms</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -3061,6 +3371,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/agentkeepalive</property>
+      </properties>
       <components>
         <component type="library" bom-ref="agentkeepalive@4.2.1|debug@4.3.4">
           <author>Josh Junon &lt;josh.junon@protonmail.com&gt;</author>
@@ -3086,6 +3399,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/agentkeepalive/node_modules/debug</property>
+          </properties>
         </component>
         <component type="library" bom-ref="agentkeepalive@4.2.1|depd@1.1.2">
           <author>Douglas Christopher Wilson &lt;doug@somethingdoug.com&gt;</author>
@@ -3111,6 +3427,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/agentkeepalive/node_modules/depd</property>
+          </properties>
         </component>
         <component type="library" bom-ref="agentkeepalive@4.2.1|ms@2.1.2">
           <name>ms</name>
@@ -3135,6 +3454,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/agentkeepalive/node_modules/ms</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -3162,6 +3484,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/aggregate-error</property>
+      </properties>
     </component>
     <component type="library" bom-ref="ajv@6.12.6">
       <author>Evgeny Poberezkin</author>
@@ -3195,6 +3520,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/ajv</property>
+      </properties>
     </component>
     <component type="library" bom-ref="ansi-regex@2.1.1">
       <author>Sindre Sorhus</author>
@@ -3220,6 +3548,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/ansi-regex</property>
+      </properties>
     </component>
     <component type="library" bom-ref="ansi-styles@3.2.1">
       <author>Sindre Sorhus</author>
@@ -3245,6 +3576,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/ansi-styles</property>
+      </properties>
     </component>
     <component type="library" bom-ref="anymatch@3.1.2">
       <author>Elan Shanker</author>
@@ -3274,6 +3608,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/anymatch</property>
+      </properties>
       <components>
         <component type="library" bom-ref="anymatch@3.1.2|normalize-path@3.0.0">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -3307,6 +3644,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/anymatch/node_modules/normalize-path</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -3333,6 +3673,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/append-field</property>
+      </properties>
     </component>
     <component type="library" bom-ref="aproba@1.2.0">
       <author>Rebecca Turner &lt;me@re-becca.org&gt;</author>
@@ -3366,6 +3709,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/aproba</property>
+      </properties>
     </component>
     <component type="library" bom-ref="archive-type@4.0.0">
       <author>Kevin Mårtensson</author>
@@ -3391,6 +3737,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/archive-type</property>
+      </properties>
       <components>
         <component type="library" bom-ref="archive-type@4.0.0|file-type@4.4.0">
           <author>Sindre Sorhus</author>
@@ -3416,6 +3765,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/archive-type/node_modules/file-type</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -3451,6 +3803,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/archiver-utils</property>
+      </properties>
     </component>
     <component type="library" bom-ref="archiver@1.3.0">
       <author>Chris Talkington</author>
@@ -3484,6 +3839,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/archiver</property>
+      </properties>
     </component>
     <component type="library" bom-ref="are-we-there-yet@1.1.7">
       <author>Rebecca Turner (http://re-becca.org)</author>
@@ -3517,6 +3875,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/are-we-there-yet</property>
+      </properties>
     </component>
     <component type="library" bom-ref="arg@4.1.3">
       <author>Josh Junon &lt;junon@zeit.co&gt;</author>
@@ -3542,6 +3903,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/arg</property>
+      </properties>
     </component>
     <component type="library" bom-ref="argparse@1.0.10">
       <name>argparse</name>
@@ -3566,6 +3930,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/argparse</property>
+      </properties>
       <components>
         <component type="library" bom-ref="argparse@1.0.10|sprintf-js@1.0.3">
           <author>Alexandru Marasteanu &lt;hello@alexei.ro&gt; (http://alexei.ro/)</author>
@@ -3591,6 +3958,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/argparse/node_modules/sprintf-js</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -3626,6 +3996,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/arr-diff</property>
+      </properties>
     </component>
     <component type="library" bom-ref="arr-flatten@1.1.0">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -3659,6 +4032,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/arr-flatten</property>
+      </properties>
     </component>
     <component type="library" bom-ref="arr-union@3.1.0">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -3692,6 +4068,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/arr-union</property>
+      </properties>
     </component>
     <component type="library" bom-ref="array-each@1.0.1">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -3725,6 +4104,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/array-each</property>
+      </properties>
     </component>
     <component type="library" bom-ref="array-flatten@1.1.1">
       <author>Blake Embrey</author>
@@ -3758,6 +4140,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/array-flatten</property>
+      </properties>
     </component>
     <component type="library" bom-ref="array-slice@1.1.0">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -3791,6 +4176,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/array-slice</property>
+      </properties>
     </component>
     <component type="library" bom-ref="array-unique@0.3.2">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -3824,6 +4212,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/array-unique</property>
+      </properties>
     </component>
     <component type="library" bom-ref="asap@2.0.6">
       <name>asap</name>
@@ -3848,6 +4239,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/asap</property>
+      </properties>
     </component>
     <component type="library" bom-ref="asn1@0.2.6">
       <author>Joyent (joyent.com)</author>
@@ -3873,6 +4267,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/asn1</property>
+      </properties>
     </component>
     <component type="library" bom-ref="assert-never@1.2.1">
       <author>Daniel Lytkin &lt;dan.lytkin@gmail.com&gt;</author>
@@ -3898,6 +4295,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/assert-never</property>
+      </properties>
     </component>
     <component type="library" bom-ref="assert-plus@1.0.0">
       <author>Mark Cavage &lt;mcavage@gmail.com&gt;</author>
@@ -3923,6 +4323,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/assert-plus</property>
+      </properties>
     </component>
     <component type="library" bom-ref="assign-symbols@1.0.0">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -3956,6 +4359,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/assign-symbols</property>
+      </properties>
     </component>
     <component type="library" bom-ref="async@2.6.4">
       <author>Caolan McMahon</author>
@@ -3989,6 +4395,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/async</property>
+      </properties>
     </component>
     <component type="library" bom-ref="asynckit@0.4.0">
       <author>Alex Indigo &lt;iam@alexindigo.com&gt;</author>
@@ -4022,6 +4431,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/asynckit</property>
+      </properties>
     </component>
     <component type="library" bom-ref="at-least-node@1.0.0">
       <author>Ryan Zimmerman &lt;opensrc@ryanzim.com&gt;</author>
@@ -4055,6 +4467,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/at-least-node</property>
+      </properties>
     </component>
     <component type="library" bom-ref="atob@2.1.2">
       <author>AJ ONeal &lt;coolaj86@gmail.com&gt; (https://coolaj86.com)</author>
@@ -4082,6 +4497,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/atob</property>
+      </properties>
     </component>
     <component type="library" bom-ref="available-typed-arrays@1.0.5">
       <author>Jordan Harband &lt;ljharb@gmail.com&gt;</author>
@@ -4115,6 +4533,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/available-typed-arrays</property>
+      </properties>
     </component>
     <component type="library" bom-ref="aws-sign2@0.7.0">
       <author>Mikeal Rogers &lt;mikeal.rogers@gmail.com&gt; (http://www.futurealoof.com)</author>
@@ -4140,6 +4561,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/aws-sign2</property>
+      </properties>
     </component>
     <component type="library" bom-ref="aws4@1.11.0">
       <author>Michael Hart &lt;michael.hart.au@gmail.com&gt; (https://github.com/mhart)</author>
@@ -4165,6 +4589,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/aws4</property>
+      </properties>
     </component>
     <component type="library" bom-ref="babel-walk@3.0.0-canary-5">
       <author>Timothy Gu &lt;timothygu99@gmail.com&gt;</author>
@@ -4190,6 +4617,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/babel-walk</property>
+      </properties>
     </component>
     <component type="library" bom-ref="balanced-match@1.0.2">
       <author>Julian Gruber</author>
@@ -4219,6 +4649,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/balanced-match</property>
+      </properties>
     </component>
     <component type="library" bom-ref="base@0.11.2">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -4252,6 +4685,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/base</property>
+      </properties>
       <components>
         <component type="library" bom-ref="base@0.11.2|define-property@1.0.0">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -4285,6 +4721,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/base/node_modules/define-property</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -4296,6 +4735,12 @@
       <hashes>
         <hash alg="SHA-512">6b5788162e11f724ab6e232ec931b1e5ef76b911f9b5063a900acd70568a05495e2282e3763060ed9c66dccaa6dca9a47f6ec72d1ff57e7c57f6af0643b21abe</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <url>https://github.com/niklasvh/base64-arraybuffer/blob/master/LICENSE-MIT</url>
+        </license>
+      </licenses>
       <purl>pkg:npm/base64-arraybuffer@0.1.4</purl>
       <externalReferences>
         <reference type="distribution">
@@ -4315,6 +4760,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/base64-arraybuffer</property>
+      </properties>
     </component>
     <component type="library" bom-ref="base64-js@1.5.1">
       <author>T. Jameson Little &lt;t.jameson.little@gmail.com&gt;</author>
@@ -4348,6 +4796,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/base64-js</property>
+      </properties>
     </component>
     <component type="library" bom-ref="base64id@2.0.0">
       <author>Kristian Faeldt &lt;faeldt_kristian@cyberagent.co.jp&gt;</author>
@@ -4373,6 +4824,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/base64id</property>
+      </properties>
     </component>
     <component type="library" bom-ref="base64url@0.0.6">
       <author>Brian J Brennan</author>
@@ -4398,6 +4852,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/base64url</property>
+      </properties>
     </component>
     <component type="library" bom-ref="basic-auth@2.0.1">
       <name>basic-auth</name>
@@ -4422,6 +4879,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/basic-auth</property>
+      </properties>
     </component>
     <component type="library" bom-ref="batch@0.6.1">
       <author>TJ Holowaychuk &lt;tj@vision-media.ca&gt;</author>
@@ -4447,6 +4907,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/batch</property>
+      </properties>
     </component>
     <component type="library" bom-ref="bcrypt-pbkdf@1.0.2">
       <name>bcrypt-pbkdf</name>
@@ -4471,6 +4934,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/bcrypt-pbkdf</property>
+      </properties>
     </component>
     <component type="library" bom-ref="big-integer@1.6.51">
       <author>Peter Olson &lt;peter.e.c.olson+npm@gmail.com&gt;</author>
@@ -4492,6 +4958,9 @@
           <comment>as detected from npm-ls property "resolved"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/big-integer</property>
+      </properties>
     </component>
     <component type="library" bom-ref="binary-extensions@2.2.0">
       <author>Sindre Sorhus</author>
@@ -4517,6 +4986,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/binary-extensions</property>
+      </properties>
     </component>
     <component type="library" bom-ref="binary@0.3.0">
       <author>James Halliday</author>
@@ -4542,6 +5014,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/binary</property>
+      </properties>
     </component>
     <component type="library" bom-ref="bindings@1.5.0">
       <author>Nathan Rajlich &lt;nathan@tootallnate.net&gt; (http://tootallnate.net)</author>
@@ -4575,6 +5050,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/bindings</property>
+      </properties>
     </component>
     <component type="library" bom-ref="bintrees@1.0.2">
       <author>Vadim Graboys &lt;dimva13@gmail.com&gt;</author>
@@ -4600,6 +5078,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/bintrees</property>
+      </properties>
     </component>
     <component type="library" bom-ref="bl@1.2.3">
       <name>bl</name>
@@ -4628,6 +5109,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/bl</property>
+      </properties>
     </component>
     <component type="library" bom-ref="bluebird@3.7.2">
       <author>Petka Antonov</author>
@@ -4661,6 +5145,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/bluebird</property>
+      </properties>
     </component>
     <component type="library" bom-ref="body-parser@1.20.1">
       <name>body-parser</name>
@@ -4685,6 +5172,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/body-parser</property>
+      </properties>
     </component>
     <component type="library" bom-ref="bower-config@1.4.3">
       <author>Twitter</author>
@@ -4714,6 +5204,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/bower-config</property>
+      </properties>
       <components>
         <component type="library" bom-ref="bower-config@1.4.3|minimist@0.2.2">
           <author>James Halliday</author>
@@ -4743,6 +5236,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/bower-config/node_modules/minimist</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -4774,6 +5270,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/brace-expansion</property>
+      </properties>
     </component>
     <component type="library" bom-ref="braces@2.3.2">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -4807,6 +5306,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/braces</property>
+      </properties>
       <components>
         <component type="library" bom-ref="braces@2.3.2|extend-shallow@2.0.1">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -4840,6 +5342,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/braces/node_modules/extend-shallow</property>
+          </properties>
         </component>
         <component type="library" bom-ref="braces@2.3.2|is-extendable@0.1.1">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -4873,6 +5378,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/braces/node_modules/is-extendable</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -4908,6 +5416,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/brotli</property>
+      </properties>
     </component>
     <component type="library" bom-ref="buffer-alloc-unsafe@1.1.0">
       <name>buffer-alloc-unsafe</name>
@@ -4931,6 +5442,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/buffer-alloc-unsafe</property>
+      </properties>
     </component>
     <component type="library" bom-ref="buffer-alloc@1.2.0">
       <name>buffer-alloc</name>
@@ -4954,6 +5468,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/buffer-alloc</property>
+      </properties>
     </component>
     <component type="library" bom-ref="buffer-crc32@0.2.13">
       <author>Brian J. Brennan &lt;brianloveswords@gmail.com&gt;</author>
@@ -4966,6 +5483,10 @@
       <licenses>
         <license>
           <id>MIT</id>
+        </license>
+        <license>
+          <id>MIT</id>
+          <url>https://github.com/brianloveswords/buffer-crc32/raw/master/LICENSE</url>
         </license>
       </licenses>
       <purl>pkg:npm/buffer-crc32@0.2.13</purl>
@@ -4983,6 +5504,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/buffer-crc32</property>
+      </properties>
     </component>
     <component type="library" bom-ref="buffer-fill@1.0.0">
       <name>buffer-fill</name>
@@ -5006,6 +5530,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/buffer-fill</property>
+      </properties>
     </component>
     <component type="library" bom-ref="buffer-from@1.1.2">
       <name>buffer-from</name>
@@ -5029,6 +5556,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/buffer-from</property>
+      </properties>
     </component>
     <component type="library" bom-ref="buffer-indexof-polyfill@1.0.2">
       <author>https://github.com/sarosia</author>
@@ -5062,6 +5592,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/buffer-indexof-polyfill</property>
+      </properties>
     </component>
     <component type="library" bom-ref="buffer@5.7.1">
       <author>Feross Aboukhadijeh</author>
@@ -5095,6 +5628,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/buffer</property>
+      </properties>
     </component>
     <component type="library" bom-ref="buffers@0.1.1">
       <author>James Halliday &lt;mail@substack.net&gt; (http://substack.net)</author>
@@ -5115,6 +5651,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/buffers</property>
+      </properties>
     </component>
     <component type="library" bom-ref="busboy@0.2.14">
       <author>Brian White &lt;mscdex@mscdex.net&gt;</author>
@@ -5124,6 +5663,12 @@
       <hashes>
         <hash alg="SHA-512">2275850e89af964123fb158b05f53702f9db558a9e4d6990a29896d2d596132e727a1626d9890611ce7db149b0ff8b72e598ff6f45871acd4b81e72e052046ae</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <url>http://github.com/mscdex/busboy/raw/master/LICENSE</url>
+        </license>
+      </licenses>
       <purl>pkg:npm/busboy@0.2.14</purl>
       <externalReferences>
         <reference type="distribution">
@@ -5135,6 +5680,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/busboy</property>
+      </properties>
       <components>
         <component type="library" bom-ref="busboy@0.2.14|isarray@0.0.1">
           <author>Julian Gruber</author>
@@ -5164,6 +5712,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/busboy/node_modules/isarray</property>
+          </properties>
         </component>
         <component type="library" bom-ref="busboy@0.2.14|readable-stream@1.1.14">
           <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me/)</author>
@@ -5189,6 +5740,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/busboy/node_modules/readable-stream</property>
+          </properties>
         </component>
         <component type="library" bom-ref="busboy@0.2.14|string_decoder@0.10.31">
           <name>string_decoder</name>
@@ -5217,6 +5771,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/busboy/node_modules/string_decoder</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -5252,6 +5809,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/byline</property>
+      </properties>
     </component>
     <component type="library" bom-ref="bytes@3.1.2">
       <author>TJ Holowaychuk &lt;tj@vision-media.ca&gt; (http://tjholowaychuk.com)</author>
@@ -5277,6 +5837,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/bytes</property>
+      </properties>
     </component>
     <component type="library" bom-ref="cacache@15.3.0">
       <name>cacache</name>
@@ -5301,6 +5864,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/cacache</property>
+      </properties>
     </component>
     <component type="library" bom-ref="cache-base@1.0.1">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -5334,6 +5900,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/cache-base</property>
+      </properties>
     </component>
     <component type="library" bom-ref="cacheable-request@2.1.4">
       <author>Luke Childs &lt;lukechilds123@gmail.com&gt; (http://lukechilds.co.uk)</author>
@@ -5367,6 +5936,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/cacheable-request</property>
+      </properties>
       <components>
         <component type="library" bom-ref="cacheable-request@2.1.4|get-stream@3.0.0">
           <author>Sindre Sorhus</author>
@@ -5392,6 +5964,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/cacheable-request/node_modules/get-stream</property>
+          </properties>
         </component>
         <component type="library" bom-ref="cacheable-request@2.1.4|lowercase-keys@1.0.0">
           <author>Sindre Sorhus</author>
@@ -5417,6 +5992,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/cacheable-request/node_modules/lowercase-keys</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -5452,6 +6030,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/call-bind</property>
+      </properties>
     </component>
     <component type="library" bom-ref="camelcase@5.3.1">
       <author>Sindre Sorhus</author>
@@ -5477,6 +6058,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/camelcase</property>
+      </properties>
     </component>
     <component type="library" bom-ref="caseless@0.12.0">
       <author>Mikeal Rogers &lt;mikeal.rogers@gmail.com&gt;</author>
@@ -5506,6 +6090,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/caseless</property>
+      </properties>
     </component>
     <component type="library" bom-ref="chainsaw@0.1.0">
       <author>James Halliday &lt;mail@substack.net&gt; (http://substack.net)</author>
@@ -5531,6 +6118,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/chainsaw</property>
+      </properties>
     </component>
     <component type="library" bom-ref="chalk@2.4.2">
       <name>chalk</name>
@@ -5555,6 +6145,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/chalk</property>
+      </properties>
     </component>
     <component type="library" bom-ref="character-parser@2.2.0">
       <author>ForbesLindesay</author>
@@ -5580,6 +6173,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/character-parser</property>
+      </properties>
     </component>
     <component type="library" bom-ref="check-dependencies@1.1.0">
       <author>Michał Gołębiowski-Owczarek</author>
@@ -5613,6 +6209,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/check-dependencies</property>
+      </properties>
       <components>
         <component type="library" bom-ref="check-dependencies@1.1.0|semver@5.7.1">
           <name>semver</name>
@@ -5637,6 +6236,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/check-dependencies/node_modules/semver</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -5672,6 +6274,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/check-types</property>
+      </properties>
     </component>
     <component type="library" bom-ref="chokidar@3.5.3">
       <author>Paul Miller (https://paulmillr.com)</author>
@@ -5705,6 +6310,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/chokidar</property>
+      </properties>
       <components>
         <component type="library" bom-ref="chokidar@3.5.3|braces@3.0.2">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -5738,6 +6346,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/chokidar/node_modules/braces</property>
+          </properties>
         </component>
         <component type="library" bom-ref="chokidar@3.5.3|fill-range@7.0.1">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -5771,6 +6382,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/chokidar/node_modules/fill-range</property>
+          </properties>
         </component>
         <component type="library" bom-ref="chokidar@3.5.3|is-glob@4.0.3">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -5804,6 +6418,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/chokidar/node_modules/is-glob</property>
+          </properties>
         </component>
         <component type="library" bom-ref="chokidar@3.5.3|is-number@7.0.0">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -5837,6 +6454,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/chokidar/node_modules/is-number</property>
+          </properties>
         </component>
         <component type="library" bom-ref="chokidar@3.5.3|normalize-path@3.0.0">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -5870,6 +6490,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/chokidar/node_modules/normalize-path</property>
+          </properties>
         </component>
         <component type="library" bom-ref="chokidar@3.5.3|to-regex-range@5.0.1">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -5903,6 +6526,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/chokidar/node_modules/to-regex-range</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -5930,6 +6556,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/chownr</property>
+      </properties>
     </component>
     <component type="library" bom-ref="clarinet@0.12.5">
       <author>Nuno Job &lt;nunojobpinto@gmail.com&gt; (http://nunojob.com/)</author>
@@ -5963,6 +6592,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/clarinet</property>
+      </properties>
     </component>
     <component type="library" bom-ref="class-utils@0.3.6">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -5996,6 +6628,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/class-utils</property>
+      </properties>
       <components>
         <component type="library" bom-ref="class-utils@0.3.6|define-property@0.2.5">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -6029,6 +6664,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/class-utils/node_modules/define-property</property>
+          </properties>
         </component>
         <component type="library" bom-ref="class-utils@0.3.6|is-accessor-descriptor@0.1.6">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -6062,6 +6700,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/class-utils/node_modules/is-accessor-descriptor</property>
+          </properties>
           <components>
             <component type="library" bom-ref="class-utils@0.3.6|is-accessor-descriptor@0.1.6|kind-of@3.2.2">
               <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -6095,6 +6736,9 @@
                   <comment>as detected from PackageJson property "homepage"</comment>
                 </reference>
               </externalReferences>
+              <properties>
+                <property name="cdx:npm:package:installPath">node_modules/class-utils/node_modules/is-accessor-descriptor/node_modules/kind-of</property>
+              </properties>
             </component>
           </components>
         </component>
@@ -6130,6 +6774,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/class-utils/node_modules/is-data-descriptor</property>
+          </properties>
           <components>
             <component type="library" bom-ref="class-utils@0.3.6|is-data-descriptor@0.1.4|kind-of@3.2.2">
               <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -6163,6 +6810,9 @@
                   <comment>as detected from PackageJson property "homepage"</comment>
                 </reference>
               </externalReferences>
+              <properties>
+                <property name="cdx:npm:package:installPath">node_modules/class-utils/node_modules/is-data-descriptor/node_modules/kind-of</property>
+              </properties>
             </component>
           </components>
         </component>
@@ -6198,6 +6848,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/class-utils/node_modules/is-descriptor</property>
+          </properties>
         </component>
         <component type="library" bom-ref="class-utils@0.3.6|kind-of@5.1.0">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -6231,6 +6884,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/class-utils/node_modules/kind-of</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -6258,6 +6914,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/clean-stack</property>
+      </properties>
     </component>
     <component type="library" bom-ref="cliui@5.0.0">
       <author>Ben Coe &lt;ben@npmjs.com&gt;</author>
@@ -6283,6 +6942,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/cliui</property>
+      </properties>
       <components>
         <component type="library" bom-ref="cliui@5.0.0|ansi-regex@4.1.1">
           <author>Sindre Sorhus</author>
@@ -6308,6 +6970,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/cliui/node_modules/ansi-regex</property>
+          </properties>
         </component>
         <component type="library" bom-ref="cliui@5.0.0|emoji-regex@7.0.3">
           <author>Mathias Bynens</author>
@@ -6341,6 +7006,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/cliui/node_modules/emoji-regex</property>
+          </properties>
         </component>
         <component type="library" bom-ref="cliui@5.0.0|is-fullwidth-code-point@2.0.0">
           <author>Sindre Sorhus</author>
@@ -6366,6 +7034,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/cliui/node_modules/is-fullwidth-code-point</property>
+          </properties>
         </component>
         <component type="library" bom-ref="cliui@5.0.0|string-width@3.1.0">
           <author>Sindre Sorhus</author>
@@ -6391,6 +7062,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/cliui/node_modules/string-width</property>
+          </properties>
         </component>
         <component type="library" bom-ref="cliui@5.0.0|strip-ansi@5.2.0">
           <author>Sindre Sorhus</author>
@@ -6416,6 +7090,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/cliui/node_modules/strip-ansi</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -6451,6 +7128,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/clone-response</property>
+      </properties>
     </component>
     <component type="library" bom-ref="clone@2.1.2">
       <author>Paul Vorbach &lt;paul@vorba.ch&gt; (http://paul.vorba.ch/)</author>
@@ -6480,6 +7160,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/clone</property>
+      </properties>
     </component>
     <component type="library" bom-ref="code-point-at@1.1.0">
       <author>Sindre Sorhus</author>
@@ -6505,6 +7188,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/code-point-at</property>
+      </properties>
     </component>
     <component type="library" bom-ref="collection-visit@1.0.0">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -6538,6 +7224,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/collection-visit</property>
+      </properties>
     </component>
     <component type="library" bom-ref="color-convert@1.9.3">
       <author>Heather Arthur &lt;fayearthur@gmail.com&gt;</author>
@@ -6563,6 +7252,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/color-convert</property>
+      </properties>
     </component>
     <component type="library" bom-ref="color-name@1.1.3">
       <author>DY &lt;dfcreative@gmail.com&gt;</author>
@@ -6592,6 +7284,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/color-name</property>
+      </properties>
     </component>
     <component type="library" bom-ref="color-string@1.9.1">
       <author>Heather Arthur &lt;fayearthur@gmail.com&gt;</author>
@@ -6617,6 +7312,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/color-string</property>
+      </properties>
     </component>
     <component type="library" bom-ref="color-support@1.1.3">
       <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me/)</author>
@@ -6642,6 +7340,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/color-support</property>
+      </properties>
     </component>
     <component type="library" bom-ref="color@3.2.1">
       <name>color</name>
@@ -6666,6 +7367,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/color</property>
+      </properties>
     </component>
     <component type="library" bom-ref="colors@1.4.0">
       <author>Marak Squires</author>
@@ -6699,6 +7403,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/colors</property>
+      </properties>
     </component>
     <component type="library" bom-ref="colorspace@1.1.4">
       <author>Arnout Kazemier</author>
@@ -6732,6 +7439,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/colorspace</property>
+      </properties>
     </component>
     <component type="library" bom-ref="combined-stream@1.0.8">
       <author>Felix Geisendörfer &lt;felix@debuggable.com&gt; (http://debuggable.com/)</author>
@@ -6761,6 +7471,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/combined-stream</property>
+      </properties>
     </component>
     <component type="library" bom-ref="commander@2.20.3">
       <author>TJ Holowaychuk &lt;tj@vision-media.ca&gt;</author>
@@ -6786,6 +7499,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/commander</property>
+      </properties>
     </component>
     <component type="library" bom-ref="component-emitter@1.3.0">
       <name>component-emitter</name>
@@ -6810,6 +7526,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/component-emitter</property>
+      </properties>
     </component>
     <component type="library" bom-ref="component-type@1.2.1">
       <name>component-type</name>
@@ -6834,6 +7553,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/component-type</property>
+      </properties>
     </component>
     <component type="library" bom-ref="compress-commons@1.2.2">
       <author>Chris Talkington</author>
@@ -6867,6 +7589,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/compress-commons</property>
+      </properties>
     </component>
     <component type="library" bom-ref="compressible@2.0.18">
       <name>compressible</name>
@@ -6891,6 +7616,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/compressible</property>
+      </properties>
     </component>
     <component type="library" bom-ref="compression@1.7.4">
       <name>compression</name>
@@ -6915,6 +7643,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/compression</property>
+      </properties>
       <components>
         <component type="library" bom-ref="compression@1.7.4|bytes@3.0.0">
           <author>TJ Holowaychuk &lt;tj@vision-media.ca&gt; (http://tjholowaychuk.com)</author>
@@ -6940,6 +7671,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/compression/node_modules/bytes</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -6967,6 +7701,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/concat-map</property>
+      </properties>
     </component>
     <component type="library" bom-ref="concat-stream@1.6.2">
       <author>Max Ogden &lt;max@maxogden.com&gt;</author>
@@ -6996,6 +7733,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/concat-stream</property>
+      </properties>
     </component>
     <component type="library" bom-ref="concurrently@5.3.0">
       <author>Kimmo Brunfeldt</author>
@@ -7021,6 +7761,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/concurrently</property>
+      </properties>
       <components>
         <component type="library" bom-ref="concurrently@5.3.0|supports-color@6.1.0">
           <author>Sindre Sorhus</author>
@@ -7046,6 +7789,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/concurrently/node_modules/supports-color</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -7077,6 +7823,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/config</property>
+      </properties>
     </component>
     <component type="library" bom-ref="console-control-strings@1.1.0">
       <author>Rebecca Turner &lt;me@re-becca.org&gt; (http://re-becca.org/)</author>
@@ -7102,6 +7851,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/console-control-strings</property>
+      </properties>
     </component>
     <component type="library" bom-ref="constantinople@4.0.1">
       <author>ForbesLindesay</author>
@@ -7127,6 +7879,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/constantinople</property>
+      </properties>
     </component>
     <component type="library" bom-ref="content-disposition@0.5.4">
       <author>Douglas Christopher Wilson &lt;doug@somethingdoug.com&gt;</author>
@@ -7152,6 +7907,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/content-disposition</property>
+      </properties>
       <components>
         <component type="library" bom-ref="content-disposition@0.5.4|safe-buffer@5.2.1">
           <author>Feross Aboukhadijeh</author>
@@ -7185,6 +7943,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/content-disposition/node_modules/safe-buffer</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -7212,6 +7973,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/content-type</property>
+      </properties>
     </component>
     <component type="library" bom-ref="cookie-parser@1.4.6">
       <author>TJ Holowaychuk &lt;tj@vision-media.ca&gt; (http://tjholowaychuk.com)</author>
@@ -7237,6 +8001,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/cookie-parser</property>
+      </properties>
     </component>
     <component type="library" bom-ref="cookie-signature@1.0.6">
       <author>TJ Holowaychuk &lt;tj@learnboost.com&gt;</author>
@@ -7262,6 +8029,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/cookie-signature</property>
+      </properties>
     </component>
     <component type="library" bom-ref="cookie@0.4.1">
       <author>Roman Shtylman &lt;shtylman@gmail.com&gt;</author>
@@ -7287,6 +8057,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/cookie</property>
+      </properties>
     </component>
     <component type="library" bom-ref="copy-descriptor@0.1.1">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -7320,6 +8093,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/copy-descriptor</property>
+      </properties>
     </component>
     <component type="library" bom-ref="core-util-is@1.0.3">
       <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me/)</author>
@@ -7349,6 +8125,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/core-util-is</property>
+      </properties>
     </component>
     <component type="library" bom-ref="cors@2.8.5">
       <author>Troy Goode &lt;troygoode@gmail.com&gt; (https://github.com/troygoode/)</author>
@@ -7374,6 +8153,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/cors</property>
+      </properties>
     </component>
     <component type="library" bom-ref="crc@3.8.0">
       <author>Alex Gorbatchev</author>
@@ -7407,6 +8189,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/crc</property>
+      </properties>
     </component>
     <component type="library" bom-ref="crc32-stream@2.0.0">
       <author>Chris Talkington</author>
@@ -7440,6 +8225,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/crc32-stream</property>
+      </properties>
     </component>
     <component type="library" bom-ref="create-require@1.1.1">
       <name>create-require</name>
@@ -7464,6 +8252,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/create-require</property>
+      </properties>
     </component>
     <component type="library" bom-ref="crypto-js@3.3.0">
       <author>Evan Vosberg</author>
@@ -7493,6 +8284,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/crypto-js</property>
+      </properties>
     </component>
     <component type="library" bom-ref="dashdash@1.14.1">
       <author>Trent Mick &lt;trentm@gmail.com&gt; (http://trentm.com)</author>
@@ -7518,6 +8312,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/dashdash</property>
+      </properties>
     </component>
     <component type="library" bom-ref="date-fns@2.29.3">
       <name>date-fns</name>
@@ -7542,6 +8339,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/date-fns</property>
+      </properties>
     </component>
     <component type="library" bom-ref="dateformat@3.0.3">
       <author>Steven Levithan</author>
@@ -7571,6 +8371,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/dateformat</property>
+      </properties>
     </component>
     <component type="library" bom-ref="debug@2.6.9">
       <author>TJ Holowaychuk &lt;tj@vision-media.ca&gt;</author>
@@ -7596,6 +8399,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/debug</property>
+      </properties>
     </component>
     <component type="library" bom-ref="decamelize@1.2.0">
       <author>Sindre Sorhus</author>
@@ -7621,6 +8427,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/decamelize</property>
+      </properties>
     </component>
     <component type="library" bom-ref="decode-uri-component@0.2.0">
       <author>Sam Verschueren</author>
@@ -7646,6 +8455,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/decode-uri-component</property>
+      </properties>
     </component>
     <component type="library" bom-ref="decompress-response@3.3.0">
       <name>decompress-response</name>
@@ -7670,6 +8482,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/decompress-response</property>
+      </properties>
     </component>
     <component type="library" bom-ref="decompress-tar@4.1.1">
       <author>Kevin Mårtensson</author>
@@ -7695,6 +8510,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/decompress-tar</property>
+      </properties>
       <components>
         <component type="library" bom-ref="decompress-tar@4.1.1|file-type@5.2.0">
           <author>Sindre Sorhus</author>
@@ -7720,6 +8538,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/decompress-tar/node_modules/file-type</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -7747,6 +8568,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/decompress-tarbz2</property>
+      </properties>
       <components>
         <component type="library" bom-ref="decompress-tarbz2@4.1.1|file-type@6.2.0">
           <author>Sindre Sorhus</author>
@@ -7772,6 +8596,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/decompress-tarbz2/node_modules/file-type</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -7799,6 +8626,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/decompress-targz</property>
+      </properties>
       <components>
         <component type="library" bom-ref="decompress-targz@4.1.1|file-type@5.2.0">
           <author>Sindre Sorhus</author>
@@ -7824,6 +8654,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/decompress-targz/node_modules/file-type</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -7851,6 +8684,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/decompress-unzip</property>
+      </properties>
       <components>
         <component type="library" bom-ref="decompress-unzip@4.0.1|file-type@3.9.0">
           <author>Sindre Sorhus</author>
@@ -7876,6 +8712,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/decompress-unzip/node_modules/file-type</property>
+          </properties>
         </component>
         <component type="library" bom-ref="decompress-unzip@4.0.1|get-stream@2.3.1">
           <author>Sindre Sorhus</author>
@@ -7901,6 +8740,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/decompress-unzip/node_modules/get-stream</property>
+          </properties>
         </component>
         <component type="library" bom-ref="decompress-unzip@4.0.1|pify@2.3.0">
           <author>Sindre Sorhus</author>
@@ -7926,6 +8768,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/decompress-unzip/node_modules/pify</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -7953,6 +8798,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/decompress</property>
+      </properties>
       <components>
         <component type="library" bom-ref="decompress@4.2.1|make-dir@1.3.0">
           <author>Sindre Sorhus</author>
@@ -7978,6 +8826,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/decompress/node_modules/make-dir</property>
+          </properties>
           <components>
             <component type="library" bom-ref="decompress@4.2.1|make-dir@1.3.0|pify@3.0.0">
               <author>Sindre Sorhus</author>
@@ -8003,6 +8854,9 @@
                   <comment>as detected from PackageJson property "repository"</comment>
                 </reference>
               </externalReferences>
+              <properties>
+                <property name="cdx:npm:package:installPath">node_modules/decompress/node_modules/make-dir/node_modules/pify</property>
+              </properties>
             </component>
           </components>
         </component>
@@ -8030,6 +8884,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/decompress/node_modules/pify</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -8057,6 +8914,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/deep-equal</property>
+      </properties>
     </component>
     <component type="library" bom-ref="deep-extend@0.6.0">
       <author>Viacheslav Lotsmanov &lt;lotsmanov89@gmail.com&gt;</author>
@@ -8069,6 +8929,10 @@
       <licenses>
         <license>
           <id>MIT</id>
+        </license>
+        <license>
+          <id>MIT</id>
+          <url>https://raw.githubusercontent.com/unclechu/node-deep-extend/master/LICENSE</url>
         </license>
       </licenses>
       <purl>pkg:npm/deep-extend@0.6.0</purl>
@@ -8090,6 +8954,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/deep-extend</property>
+      </properties>
     </component>
     <component type="library" bom-ref="deep-is@0.1.4">
       <author>Thorsten Lorenz</author>
@@ -8115,6 +8982,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/deep-is</property>
+      </properties>
     </component>
     <component type="library" bom-ref="define-properties@1.1.4">
       <author>Jordan Harband &lt;ljharb@gmail.com&gt;</author>
@@ -8140,6 +9010,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/define-properties</property>
+      </properties>
     </component>
     <component type="library" bom-ref="define-property@2.0.2">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -8173,6 +9046,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/define-property</property>
+      </properties>
     </component>
     <component type="library" bom-ref="delayed-stream@1.0.0">
       <author>Felix Geisendörfer &lt;felix@debuggable.com&gt; (http://debuggable.com/)</author>
@@ -8202,6 +9078,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/delayed-stream</property>
+      </properties>
     </component>
     <component type="library" bom-ref="delegates@1.0.0">
       <name>delegates</name>
@@ -8226,6 +9105,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/delegates</property>
+      </properties>
     </component>
     <component type="library" bom-ref="depd@2.0.0">
       <author>Douglas Christopher Wilson &lt;doug@somethingdoug.com&gt;</author>
@@ -8251,6 +9133,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/depd</property>
+      </properties>
     </component>
     <component type="library" bom-ref="destroy@1.2.0">
       <author>Jonathan Ong</author>
@@ -8276,6 +9161,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/destroy</property>
+      </properties>
     </component>
     <component type="library" bom-ref="detect-file@1.0.0">
       <author>Brian Woodward (https://github.com/doowb)</author>
@@ -8309,6 +9197,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/detect-file</property>
+      </properties>
     </component>
     <component type="library" bom-ref="detect-libc@1.0.3">
       <author>Lovell Fuller &lt;npm@lovell.info&gt;</author>
@@ -8334,6 +9225,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/detect-libc</property>
+      </properties>
     </component>
     <component type="library" bom-ref="dfa@1.2.0">
       <author>Devon Govett &lt;devongovett@gmail.com&gt;</author>
@@ -8367,6 +9261,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/dfa</property>
+      </properties>
     </component>
     <component type="library" bom-ref="dicer@0.2.5">
       <author>Brian White &lt;mscdex@mscdex.net&gt;</author>
@@ -8376,6 +9273,12 @@
       <hashes>
         <hash alg="SHA-512">143bdbb67abb77394fcf4c32625384c627c311972ef21fab12b11781fc6a98b7d17c2fe4262744161e3e79f7c944edcfd3199fab23db48c1b42ef78d45f4ca56</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <url>http://github.com/mscdex/dicer/raw/master/LICENSE</url>
+        </license>
+      </licenses>
       <purl>pkg:npm/dicer@0.2.5</purl>
       <externalReferences>
         <reference type="distribution">
@@ -8387,6 +9290,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/dicer</property>
+      </properties>
       <components>
         <component type="library" bom-ref="dicer@0.2.5|isarray@0.0.1">
           <author>Julian Gruber</author>
@@ -8416,6 +9322,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/dicer/node_modules/isarray</property>
+          </properties>
         </component>
         <component type="library" bom-ref="dicer@0.2.5|readable-stream@1.1.14">
           <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me/)</author>
@@ -8441,6 +9350,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/dicer/node_modules/readable-stream</property>
+          </properties>
         </component>
         <component type="library" bom-ref="dicer@0.2.5|string_decoder@0.10.31">
           <name>string_decoder</name>
@@ -8469,6 +9381,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/dicer/node_modules/string_decoder</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -8499,6 +9414,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/diff</property>
+      </properties>
     </component>
     <component type="library" bom-ref="doctypes@1.1.0">
       <author>ForbesLindesay</author>
@@ -8524,6 +9442,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/doctypes</property>
+      </properties>
     </component>
     <component type="library" bom-ref="domelementtype@1.3.1">
       <author>Felix Boehm &lt;me@feedic.com&gt;</author>
@@ -8549,6 +9470,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/domelementtype</property>
+      </properties>
     </component>
     <component type="library" bom-ref="domhandler@2.1.0">
       <author>Felix Boehm &lt;me@feedic.com&gt;</author>
@@ -8569,6 +9493,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/domhandler</property>
+      </properties>
     </component>
     <component type="library" bom-ref="domutils@1.1.6">
       <author>Felix Boehm &lt;me@feedic.com&gt;</author>
@@ -8589,6 +9516,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/domutils</property>
+      </properties>
     </component>
     <component type="library" bom-ref="dottie@2.0.2">
       <author>Mick Hansen &lt;maker@mhansen.io&gt;</author>
@@ -8614,6 +9544,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/dottie</property>
+      </properties>
     </component>
     <component type="library" bom-ref="double-ended-queue@0.9.7">
       <author>Petka Antonov</author>
@@ -8647,6 +9580,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/double-ended-queue</property>
+      </properties>
     </component>
     <component type="library" bom-ref="doublearray@0.0.2">
       <author>takuyaa</author>
@@ -8680,6 +9616,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/doublearray</property>
+      </properties>
     </component>
     <component type="library" bom-ref="download@8.0.0">
       <author>Kevin Mårtensson</author>
@@ -8705,6 +9644,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/download</property>
+      </properties>
       <components>
         <component type="library" bom-ref="download@8.0.0|file-type@11.1.0">
           <author>Sindre Sorhus</author>
@@ -8730,6 +9672,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/download/node_modules/file-type</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -8757,6 +9702,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/duplexer2</property>
+      </properties>
     </component>
     <component type="library" bom-ref="duplexer3@0.1.5">
       <name>duplexer3</name>
@@ -8781,6 +9729,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/duplexer3</property>
+      </properties>
     </component>
     <component type="library" bom-ref="dynamic-dedupe@0.3.0">
       <author>Thorsten Lorenz</author>
@@ -8805,6 +9756,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/dynamic-dedupe</property>
+      </properties>
     </component>
     <component type="library" bom-ref="ecc-jsbn@0.1.2">
       <author>Jeremie Miller</author>
@@ -8838,6 +9792,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/ecc-jsbn</property>
+      </properties>
     </component>
     <component type="library" bom-ref="ee-first@1.1.1">
       <author>Jonathan Ong</author>
@@ -8863,6 +9820,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/ee-first</property>
+      </properties>
     </component>
     <component type="library" bom-ref="eivindfjeldstad-dot@0.0.1">
       <name>eivindfjeldstad-dot</name>
@@ -8895,6 +9855,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/eivindfjeldstad-dot</property>
+      </properties>
     </component>
     <component type="library" bom-ref="emoji-regex@8.0.0">
       <author>Mathias Bynens</author>
@@ -8928,6 +9891,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/emoji-regex</property>
+      </properties>
     </component>
     <component type="library" bom-ref="enabled@2.0.0">
       <author>Arnout Kazemier</author>
@@ -8953,6 +9919,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/enabled</property>
+      </properties>
     </component>
     <component type="library" bom-ref="encodeurl@1.0.2">
       <name>encodeurl</name>
@@ -8977,6 +9946,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/encodeurl</property>
+      </properties>
     </component>
     <component type="library" bom-ref="encoding@0.1.13">
       <author>Andris Reinman</author>
@@ -9002,6 +9974,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/encoding</property>
+      </properties>
       <components>
         <component type="library" bom-ref="encoding@0.1.13|iconv-lite@0.6.3">
           <author>Alexander Shtuchkin &lt;ashtuchkin@gmail.com&gt;</author>
@@ -9035,6 +10010,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/encoding/node_modules/iconv-lite</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -9070,6 +10048,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/end-of-stream</property>
+      </properties>
     </component>
     <component type="library" bom-ref="engine.io-parser@4.0.3">
       <name>engine.io-parser</name>
@@ -9094,6 +10075,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/engine.io-parser</property>
+      </properties>
     </component>
     <component type="library" bom-ref="engine.io@4.1.2">
       <author>Guillermo Rauch &lt;guillermo@learnboost.com&gt;</author>
@@ -9119,6 +10103,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/engine.io</property>
+      </properties>
       <components>
         <component type="library" bom-ref="engine.io@4.1.2|debug@4.3.4">
           <author>Josh Junon &lt;josh.junon@protonmail.com&gt;</author>
@@ -9144,6 +10131,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/engine.io/node_modules/debug</property>
+          </properties>
         </component>
         <component type="library" bom-ref="engine.io@4.1.2|ms@2.1.2">
           <name>ms</name>
@@ -9168,6 +10158,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/engine.io/node_modules/ms</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -9195,6 +10188,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/env-paths</property>
+      </properties>
     </component>
     <component type="library" bom-ref="err-code@1.1.2">
       <author>IndigoUnited &lt;hello@indigounited.com&gt; (http://indigounited.com)</author>
@@ -9224,6 +10220,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/err-code</property>
+      </properties>
     </component>
     <component type="library" bom-ref="error-ex@1.3.2">
       <name>error-ex</name>
@@ -9248,6 +10247,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/error-ex</property>
+      </properties>
     </component>
     <component type="library" bom-ref="errorhandler@1.5.1">
       <name>errorhandler</name>
@@ -9272,6 +10274,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/errorhandler</property>
+      </properties>
     </component>
     <component type="library" bom-ref="es-get-iterator@1.1.2">
       <author>Jordan Harband &lt;ljharb@gmail.com&gt;</author>
@@ -9305,6 +10310,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/es-get-iterator</property>
+      </properties>
     </component>
     <component type="library" bom-ref="escape-html@1.0.3">
       <name>escape-html</name>
@@ -9329,6 +10337,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/escape-html</property>
+      </properties>
     </component>
     <component type="library" bom-ref="escape-string-regexp@1.0.5">
       <author>Sindre Sorhus</author>
@@ -9354,6 +10365,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/escape-string-regexp</property>
+      </properties>
     </component>
     <component type="library" bom-ref="escodegen@2.0.0">
       <name>escodegen</name>
@@ -9382,6 +10396,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/escodegen</property>
+      </properties>
     </component>
     <component type="library" bom-ref="esprima@4.0.1">
       <author>Ariya Hidayat</author>
@@ -9415,6 +10432,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/esprima</property>
+      </properties>
     </component>
     <component type="library" bom-ref="estraverse@5.3.0">
       <name>estraverse</name>
@@ -9443,6 +10463,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/estraverse</property>
+      </properties>
     </component>
     <component type="library" bom-ref="esutils@2.0.3">
       <name>esutils</name>
@@ -9471,6 +10494,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/esutils</property>
+      </properties>
     </component>
     <component type="library" bom-ref="etag@1.8.1">
       <name>etag</name>
@@ -9495,6 +10521,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/etag</property>
+      </properties>
     </component>
     <component type="library" bom-ref="eventemitter2@0.4.14">
       <author>hij1nx &lt;paolo@async.ly&gt; http://twitter.com/hij1nx</author>
@@ -9520,6 +10549,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/eventemitter2</property>
+      </properties>
     </component>
     <component type="library" bom-ref="eventemitter3@1.1.1">
       <author>Arnout Kazemier</author>
@@ -9549,6 +10581,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/eventemitter3</property>
+      </properties>
     </component>
     <component type="library" bom-ref="exif@0.6.0">
       <name>exif</name>
@@ -9568,6 +10603,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/exif</property>
+      </properties>
     </component>
     <component type="library" bom-ref="exit@0.1.2">
       <author>"Cowboy" Ben Alman</author>
@@ -9577,6 +10615,12 @@
       <hashes>
         <hash alg="SHA-512">664fde34a576cdb8e92b3aec43e9f51baa6855b12b4312742c13895da299d445622f31fe86b2eef5c757238cf0f5d05026c970044a5b4363f5a12ee70f1b3a8d</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <url>https://github.com/cowboy/node-exit/blob/master/LICENSE-MIT</url>
+        </license>
+      </licenses>
       <purl>pkg:npm/exit@0.1.2</purl>
       <externalReferences>
         <reference type="distribution">
@@ -9596,6 +10640,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/exit</property>
+      </properties>
     </component>
     <component type="library" bom-ref="expand-brackets@2.1.4">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -9629,6 +10676,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/expand-brackets</property>
+      </properties>
       <components>
         <component type="library" bom-ref="expand-brackets@2.1.4|define-property@0.2.5">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -9662,6 +10712,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/expand-brackets/node_modules/define-property</property>
+          </properties>
         </component>
         <component type="library" bom-ref="expand-brackets@2.1.4|extend-shallow@2.0.1">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -9695,6 +10748,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/expand-brackets/node_modules/extend-shallow</property>
+          </properties>
         </component>
         <component type="library" bom-ref="expand-brackets@2.1.4|is-accessor-descriptor@0.1.6">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -9728,6 +10784,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/expand-brackets/node_modules/is-accessor-descriptor</property>
+          </properties>
           <components>
             <component type="library" bom-ref="expand-brackets@2.1.4|is-accessor-descriptor@0.1.6|kind-of@3.2.2">
               <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -9761,6 +10820,9 @@
                   <comment>as detected from PackageJson property "homepage"</comment>
                 </reference>
               </externalReferences>
+              <properties>
+                <property name="cdx:npm:package:installPath">node_modules/expand-brackets/node_modules/is-accessor-descriptor/node_modules/kind-of</property>
+              </properties>
             </component>
           </components>
         </component>
@@ -9796,6 +10858,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/expand-brackets/node_modules/is-data-descriptor</property>
+          </properties>
           <components>
             <component type="library" bom-ref="expand-brackets@2.1.4|is-data-descriptor@0.1.4|kind-of@3.2.2">
               <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -9829,6 +10894,9 @@
                   <comment>as detected from PackageJson property "homepage"</comment>
                 </reference>
               </externalReferences>
+              <properties>
+                <property name="cdx:npm:package:installPath">node_modules/expand-brackets/node_modules/is-data-descriptor/node_modules/kind-of</property>
+              </properties>
             </component>
           </components>
         </component>
@@ -9864,6 +10932,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/expand-brackets/node_modules/is-descriptor</property>
+          </properties>
         </component>
         <component type="library" bom-ref="expand-brackets@2.1.4|is-extendable@0.1.1">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -9897,6 +10968,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/expand-brackets/node_modules/is-extendable</property>
+          </properties>
         </component>
         <component type="library" bom-ref="expand-brackets@2.1.4|kind-of@5.1.0">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -9930,6 +11004,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/expand-brackets/node_modules/kind-of</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -9959,6 +11036,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/expand-template</property>
+      </properties>
     </component>
     <component type="library" bom-ref="expand-tilde@2.0.2">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -9992,6 +11072,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/expand-tilde</property>
+      </properties>
     </component>
     <component type="library" bom-ref="express-ipfilter@1.3.1">
       <author>jetersen</author>
@@ -10017,6 +11100,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/express-ipfilter</property>
+      </properties>
     </component>
     <component type="library" bom-ref="express-jwt@0.1.3">
       <author>Matias Woloski</author>
@@ -10026,6 +11112,12 @@
       <hashes>
         <hash alg="SHA-512">086481d1bddb3555c8e93d021797ffe7964a62b220fdbd3ad7b10f99728af44e32d6ad96d70f494e08cf7e1b16c2e3e20ad939b280609b966482ac6086c7da1e</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <url>http://www.opensource.org/licenses/MIT</url>
+        </license>
+      </licenses>
       <purl>pkg:npm/express-jwt@0.1.3</purl>
       <externalReferences>
         <reference type="distribution">
@@ -10041,6 +11133,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/express-jwt</property>
+      </properties>
       <components>
         <component type="library" bom-ref="express-jwt@0.1.3|jsonwebtoken@0.1.0">
           <author>auth0</author>
@@ -10070,6 +11165,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/express-jwt/node_modules/jsonwebtoken</property>
+          </properties>
         </component>
         <component type="library" bom-ref="express-jwt@0.1.3|moment@2.0.0">
           <author>Tim Wood &lt;washwithcare@gmail.com&gt; (http://timwoodcreates.com/)</author>
@@ -10079,6 +11177,11 @@
           <hashes>
             <hash alg="SHA-512">9778c28c225f0baa48b9c6b5dc6329094e2588462f624d7b5e9160a494b22e9f115fe770760ad906fb646a87e622282995ecdb1b55591548106c315149ddfb60</hash>
           </hashes>
+          <licenses>
+            <license>
+              <id>MIT</id>
+            </license>
+          </licenses>
           <purl>pkg:npm/moment@2.0.0</purl>
           <externalReferences>
             <reference type="distribution">
@@ -10098,6 +11201,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/express-jwt/node_modules/moment</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -10129,6 +11235,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/express-rate-limit</property>
+      </properties>
     </component>
     <component type="library" bom-ref="express-robots-txt@0.4.1">
       <author>modosc (http://github.com/modosc)</author>
@@ -10162,6 +11271,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/express-robots-txt</property>
+      </properties>
     </component>
     <component type="library" bom-ref="express-security.txt@2.0.0">
       <name>express-security.txt</name>
@@ -10193,6 +11305,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/express-security.txt</property>
+      </properties>
     </component>
     <component type="library" bom-ref="express@4.18.2">
       <author>TJ Holowaychuk &lt;tj@vision-media.ca&gt;</author>
@@ -10222,6 +11337,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/express</property>
+      </properties>
       <components>
         <component type="library" bom-ref="express@4.18.2|cookie@0.5.0">
           <author>Roman Shtylman &lt;shtylman@gmail.com&gt;</author>
@@ -10247,6 +11365,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/express/node_modules/cookie</property>
+          </properties>
         </component>
         <component type="library" bom-ref="express@4.18.2|safe-buffer@5.2.1">
           <author>Feross Aboukhadijeh</author>
@@ -10280,6 +11401,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/express/node_modules/safe-buffer</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -10307,6 +11431,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/ext-list</property>
+      </properties>
     </component>
     <component type="library" bom-ref="ext-name@5.0.0">
       <author>Kevin Mårtensson</author>
@@ -10332,6 +11459,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/ext-name</property>
+      </properties>
     </component>
     <component type="library" bom-ref="extend-shallow@3.0.2">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -10365,6 +11495,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/extend-shallow</property>
+      </properties>
     </component>
     <component type="library" bom-ref="extend@3.0.2">
       <author>Stefan Thomas &lt;justmoon@members.fsf.org&gt; (http://www.justmoon.net)</author>
@@ -10390,6 +11523,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/extend</property>
+      </properties>
     </component>
     <component type="library" bom-ref="extglob@2.0.4">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -10423,6 +11559,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/extglob</property>
+      </properties>
       <components>
         <component type="library" bom-ref="extglob@2.0.4|define-property@1.0.0">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -10456,6 +11595,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/extglob/node_modules/define-property</property>
+          </properties>
         </component>
         <component type="library" bom-ref="extglob@2.0.4|extend-shallow@2.0.1">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -10489,6 +11631,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/extglob/node_modules/extend-shallow</property>
+          </properties>
         </component>
         <component type="library" bom-ref="extglob@2.0.4|is-extendable@0.1.1">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -10522,6 +11667,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/extglob/node_modules/is-extendable</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -10548,6 +11696,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/extsprintf</property>
+      </properties>
     </component>
     <component type="library" bom-ref="fast-deep-equal@3.1.3">
       <author>Evgeny Poberezkin</author>
@@ -10581,6 +11732,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/fast-deep-equal</property>
+      </properties>
     </component>
     <component type="library" bom-ref="fast-json-stable-stringify@2.1.0">
       <author>James Halliday</author>
@@ -10610,6 +11764,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/fast-json-stable-stringify</property>
+      </properties>
     </component>
     <component type="library" bom-ref="fast-levenshtein@2.0.6">
       <author>Ramesh Nair &lt;ram@hiddentao.com&gt; (http://www.hiddentao.com/)</author>
@@ -10635,6 +11792,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/fast-levenshtein</property>
+      </properties>
     </component>
     <component type="library" bom-ref="fast.js@0.1.1">
       <author>Charles Pick &lt;charles@codemix.com&gt;</author>
@@ -10668,6 +11828,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/fast.js</property>
+      </properties>
     </component>
     <component type="library" bom-ref="fd-slicer@1.1.0">
       <author>Andrew Kelley &lt;superjoe30@gmail.com&gt;</author>
@@ -10697,6 +11860,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/fd-slicer</property>
+      </properties>
     </component>
     <component type="library" bom-ref="feature-policy@0.5.0">
       <author>Evan Hahn &lt;me@evanhahn.com&gt; (https://evanhahn.com)</author>
@@ -10730,6 +11896,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/feature-policy</property>
+      </properties>
     </component>
     <component type="library" bom-ref="fecha@4.2.3">
       <author>Taylor Hakes</author>
@@ -10763,6 +11932,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/fecha</property>
+      </properties>
     </component>
     <component type="library" bom-ref="file-js@0.3.0">
       <author>nspragg@gmail.com</author>
@@ -10796,6 +11968,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/file-js</property>
+      </properties>
       <components>
         <component type="library" bom-ref="file-js@0.3.0|brace-expansion@1.1.11">
           <author>Julian Gruber</author>
@@ -10825,6 +12000,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/file-js/node_modules/brace-expansion</property>
+          </properties>
         </component>
         <component type="library" bom-ref="file-js@0.3.0|minimatch@3.1.2">
           <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me)</author>
@@ -10850,6 +12028,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/file-js/node_modules/minimatch</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -10877,6 +12058,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/file-stream-rotator</property>
+      </properties>
     </component>
     <component type="library" bom-ref="file-type@16.5.4">
       <author>Sindre Sorhus</author>
@@ -10902,6 +12086,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/file-type</property>
+      </properties>
     </component>
     <component type="library" bom-ref="file-uri-to-path@1.0.0">
       <author>Nathan Rajlich &lt;nathan@tootallnate.net&gt; (http://n8.io/)</author>
@@ -10935,6 +12122,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/file-uri-to-path</property>
+      </properties>
     </component>
     <component type="library" bom-ref="filehound@1.17.6">
       <name>filehound</name>
@@ -10967,6 +12157,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/filehound</property>
+      </properties>
     </component>
     <component type="library" bom-ref="filename-reserved-regex@2.0.0">
       <author>Sindre Sorhus</author>
@@ -10992,6 +12185,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/filename-reserved-regex</property>
+      </properties>
     </component>
     <component type="library" bom-ref="filenamify@3.0.0">
       <author>Sindre Sorhus</author>
@@ -11017,6 +12213,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/filenamify</property>
+      </properties>
     </component>
     <component type="library" bom-ref="filesniffer@1.0.3">
       <name>filesniffer</name>
@@ -11049,6 +12248,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/filesniffer</property>
+      </properties>
     </component>
     <component type="library" bom-ref="fill-range@4.0.0">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -11082,6 +12284,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/fill-range</property>
+      </properties>
       <components>
         <component type="library" bom-ref="fill-range@4.0.0|extend-shallow@2.0.1">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -11115,6 +12320,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/fill-range/node_modules/extend-shallow</property>
+          </properties>
         </component>
         <component type="library" bom-ref="fill-range@4.0.0|is-extendable@0.1.1">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -11148,6 +12356,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/fill-range/node_modules/is-extendable</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -11179,6 +12390,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/finale-rest</property>
+      </properties>
     </component>
     <component type="library" bom-ref="finalhandler@1.2.0">
       <author>Douglas Christopher Wilson &lt;doug@somethingdoug.com&gt;</author>
@@ -11204,6 +12418,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/finalhandler</property>
+      </properties>
     </component>
     <component type="library" bom-ref="find-up@3.0.0">
       <author>Sindre Sorhus</author>
@@ -11229,6 +12446,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/find-up</property>
+      </properties>
     </component>
     <component type="library" bom-ref="findup-sync@2.0.0">
       <author>"Cowboy" Ben Alman (http://benalman.com)</author>
@@ -11254,6 +12474,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/findup-sync</property>
+      </properties>
     </component>
     <component type="library" bom-ref="fined@1.2.0">
       <author>Gulp Team &lt;team@gulpjs.com&gt; (http://gulpjs.com/)</author>
@@ -11279,6 +12502,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/fined</property>
+      </properties>
     </component>
     <component type="library" bom-ref="flagged-respawn@1.0.1">
       <author>Gulp Team &lt;team@gulpjs.com&gt; (http://gulpjs.com/)</author>
@@ -11304,6 +12530,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/flagged-respawn</property>
+      </properties>
     </component>
     <component type="library" bom-ref="fn.name@1.1.0">
       <author>Arnout Kazemier</author>
@@ -11337,6 +12566,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/fn.name</property>
+      </properties>
     </component>
     <component type="library" bom-ref="fontkit@1.9.0">
       <author>Devon Govett &lt;devongovett@gmail.com&gt;</author>
@@ -11362,6 +12594,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/fontkit</property>
+      </properties>
     </component>
     <component type="library" bom-ref="for-each@0.3.3">
       <author>Raynos &lt;raynos2@gmail.com&gt;</author>
@@ -11374,6 +12609,10 @@
       <licenses>
         <license>
           <id>MIT</id>
+        </license>
+        <license>
+          <id>MIT</id>
+          <url>http://github.com/Raynos/for-each/raw/master/LICENSE</url>
         </license>
       </licenses>
       <purl>pkg:npm/for-each@0.3.3</purl>
@@ -11395,6 +12634,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/for-each</property>
+      </properties>
     </component>
     <component type="library" bom-ref="for-in@1.0.2">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -11428,6 +12670,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/for-in</property>
+      </properties>
     </component>
     <component type="library" bom-ref="for-own@1.0.0">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -11461,6 +12706,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/for-own</property>
+      </properties>
     </component>
     <component type="library" bom-ref="foreachasync@3.0.0">
       <author>AJ ONeal &lt;coolaj86@gmail.com&gt; (http://coolaj86.com/)</author>
@@ -11494,6 +12742,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/foreachasync</property>
+      </properties>
     </component>
     <component type="library" bom-ref="forever-agent@0.6.1">
       <author>Mikeal Rogers &lt;mikeal.rogers@gmail.com&gt; (http://www.futurealoof.com)</author>
@@ -11519,6 +12770,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/forever-agent</property>
+      </properties>
     </component>
     <component type="library" bom-ref="form-data@2.3.3">
       <author>Felix Geisendörfer &lt;felix@debuggable.com&gt; (http://debuggable.com/)</author>
@@ -11544,6 +12798,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/form-data</property>
+      </properties>
     </component>
     <component type="library" bom-ref="formatio@1.1.1">
       <author>Christian Johansen</author>
@@ -11568,6 +12825,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/formatio</property>
+      </properties>
     </component>
     <component type="library" bom-ref="forwarded@0.2.0">
       <name>forwarded</name>
@@ -11592,6 +12852,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/forwarded</property>
+      </properties>
     </component>
     <component type="library" bom-ref="fragment-cache@0.2.1">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -11625,6 +12888,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/fragment-cache</property>
+      </properties>
     </component>
     <component type="library" bom-ref="fresh@0.5.2">
       <author>TJ Holowaychuk &lt;tj@vision-media.ca&gt; (http://tjholowaychuk.com)</author>
@@ -11650,6 +12916,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/fresh</property>
+      </properties>
     </component>
     <component type="library" bom-ref="from2@2.3.0">
       <author>Hugh Kennedy &lt;hughskennedy@gmail.com&gt; (http://hughsk.io/)</author>
@@ -11683,6 +12952,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/from2</property>
+      </properties>
     </component>
     <component type="library" bom-ref="fs-constants@1.0.0">
       <author>Mathias Buus (@mafintosh)</author>
@@ -11716,6 +12988,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/fs-constants</property>
+      </properties>
     </component>
     <component type="library" bom-ref="fs-extra@9.1.0">
       <author>JP Richardson &lt;jprichardson@gmail.com&gt;</author>
@@ -11745,6 +13020,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/fs-extra</property>
+      </properties>
     </component>
     <component type="library" bom-ref="fs-minipass@2.1.0">
       <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me/)</author>
@@ -11778,6 +13056,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/fs-minipass</property>
+      </properties>
     </component>
     <component type="library" bom-ref="fs.realpath@1.0.0">
       <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me/)</author>
@@ -11803,6 +13084,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/fs.realpath</property>
+      </properties>
     </component>
     <component type="library" bom-ref="fstream@1.0.12">
       <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me/)</author>
@@ -11828,6 +13112,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/fstream</property>
+      </properties>
       <components>
         <component type="library" bom-ref="fstream@1.0.12|mkdirp@0.5.6">
           <author>James Halliday &lt;mail@substack.net&gt; (http://substack.net)</author>
@@ -11853,6 +13140,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/fstream/node_modules/mkdirp</property>
+          </properties>
         </component>
         <component type="library" bom-ref="fstream@1.0.12|rimraf@2.7.1">
           <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me/)</author>
@@ -11878,6 +13168,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/fstream/node_modules/rimraf</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -11913,6 +13206,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/function-bind</property>
+      </properties>
     </component>
     <component type="library" bom-ref="functions-have-names@1.2.3">
       <author>Jordan Harband &lt;ljharb@gmail.com&gt;</author>
@@ -11946,6 +13242,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/functions-have-names</property>
+      </properties>
     </component>
     <component type="library" bom-ref="fuzzball@1.4.0">
       <author>Nolan Kaplan &lt;nolan@nolankaplan.com&gt;</author>
@@ -11971,6 +13270,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/fuzzball</property>
+      </properties>
     </component>
     <component type="library" bom-ref="gauge@2.7.4">
       <author>Rebecca Turner &lt;me@re-becca.org&gt;</author>
@@ -12004,6 +13306,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/gauge</property>
+      </properties>
     </component>
     <component type="library" bom-ref="geojson-utils@1.1.0">
       <author>Max Ogden</author>
@@ -12029,6 +13334,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/geojson-utils</property>
+      </properties>
     </component>
     <component type="library" bom-ref="get-caller-file@2.0.5">
       <author>Stefan Penner</author>
@@ -12061,6 +13369,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/get-caller-file</property>
+      </properties>
     </component>
     <component type="library" bom-ref="get-intrinsic@1.1.3">
       <author>Jordan Harband &lt;ljharb@gmail.com&gt;</author>
@@ -12094,6 +13405,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/get-intrinsic</property>
+      </properties>
     </component>
     <component type="library" bom-ref="get-stream@4.1.0">
       <author>Sindre Sorhus</author>
@@ -12119,6 +13433,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/get-stream</property>
+      </properties>
     </component>
     <component type="library" bom-ref="get-value@2.0.6">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -12152,6 +13469,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/get-value</property>
+      </properties>
     </component>
     <component type="library" bom-ref="getobject@1.0.2">
       <author>"Cowboy" Ben Alman</author>
@@ -12161,6 +13481,12 @@
       <hashes>
         <hash alg="SHA-512">db36e50c168571bdeb078ac5efb5d59ee20d384da1da4fce9ea5c08b2d08ad3c547d5d62169de56b7de8010558f690a9594dbaf1615856ddadef586532e2ec3a</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <url>https://github.com/cowboy/node-getobject/blob/master/LICENSE-MIT</url>
+        </license>
+      </licenses>
       <purl>pkg:npm/getobject@1.0.2</purl>
       <externalReferences>
         <reference type="distribution">
@@ -12180,6 +13506,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/getobject</property>
+      </properties>
     </component>
     <component type="library" bom-ref="getpass@0.1.7">
       <author>Alex Wilson &lt;alex.wilson@joyent.com&gt;</author>
@@ -12205,6 +13534,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/getpass</property>
+      </properties>
     </component>
     <component type="library" bom-ref="github-from-package@0.0.0">
       <author>James Halliday</author>
@@ -12234,6 +13566,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/github-from-package</property>
+      </properties>
     </component>
     <component type="library" bom-ref="glob-parent@5.1.2">
       <author>Gulp Team &lt;team@gulpjs.com&gt; (https://gulpjs.com/)</author>
@@ -12259,6 +13594,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/glob-parent</property>
+      </properties>
       <components>
         <component type="library" bom-ref="glob-parent@5.1.2|is-glob@4.0.3">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -12292,6 +13630,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/glob-parent/node_modules/is-glob</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -12319,6 +13660,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/glob</property>
+      </properties>
       <components>
         <component type="library" bom-ref="glob@7.2.3|brace-expansion@1.1.11">
           <author>Julian Gruber</author>
@@ -12348,6 +13692,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/glob/node_modules/brace-expansion</property>
+          </properties>
         </component>
         <component type="library" bom-ref="glob@7.2.3|minimatch@3.1.2">
           <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me)</author>
@@ -12373,6 +13720,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/glob/node_modules/minimatch</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -12408,6 +13758,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/global-modules</property>
+      </properties>
     </component>
     <component type="library" bom-ref="global-prefix@1.0.2">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -12441,6 +13794,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/global-prefix</property>
+      </properties>
       <components>
         <component type="library" bom-ref="global-prefix@1.0.2|which@1.3.1">
           <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me)</author>
@@ -12466,6 +13822,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/global-prefix/node_modules/which</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -12501,6 +13860,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/gopd</property>
+      </properties>
     </component>
     <component type="library" bom-ref="got@8.3.2">
       <name>got</name>
@@ -12525,6 +13887,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/got</property>
+      </properties>
       <components>
         <component type="library" bom-ref="got@8.3.2|get-stream@3.0.0">
           <author>Sindre Sorhus</author>
@@ -12550,6 +13915,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/got/node_modules/get-stream</property>
+          </properties>
         </component>
         <component type="library" bom-ref="got@8.3.2|pify@3.0.0">
           <author>Sindre Sorhus</author>
@@ -12575,6 +13943,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/got/node_modules/pify</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -12601,6 +13972,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/graceful-fs</property>
+      </properties>
     </component>
     <component type="library" bom-ref="grunt-cli@1.4.3">
       <author>Grunt Development Team (http://gruntjs.com/development-team)</author>
@@ -12626,6 +14000,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/grunt-cli</property>
+      </properties>
       <components>
         <component type="library" bom-ref="grunt-cli@1.4.3|nopt@4.0.3">
           <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me/)</author>
@@ -12651,6 +14028,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/grunt-cli/node_modules/nopt</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -12678,6 +14058,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/grunt-contrib-compress</property>
+      </properties>
       <components>
         <component type="library" bom-ref="grunt-contrib-compress@1.6.0|ansi-styles@2.2.1">
           <author>Sindre Sorhus</author>
@@ -12703,6 +14086,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/grunt-contrib-compress/node_modules/ansi-styles</property>
+          </properties>
         </component>
         <component type="library" bom-ref="grunt-contrib-compress@1.6.0|chalk@1.1.3">
           <name>chalk</name>
@@ -12727,6 +14113,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/grunt-contrib-compress/node_modules/chalk</property>
+          </properties>
         </component>
         <component type="library" bom-ref="grunt-contrib-compress@1.6.0|supports-color@2.0.0">
           <author>Sindre Sorhus</author>
@@ -12752,6 +14141,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/grunt-contrib-compress/node_modules/supports-color</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -12783,6 +14175,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/grunt-known-options</property>
+      </properties>
     </component>
     <component type="library" bom-ref="grunt-legacy-log-utils@2.1.0">
       <author>"Cowboy" Ben Alman (http://benalman.com/)</author>
@@ -12816,6 +14211,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/grunt-legacy-log-utils</property>
+      </properties>
       <components>
         <component type="library" bom-ref="grunt-legacy-log-utils@2.1.0|ansi-styles@4.3.0">
           <author>Sindre Sorhus</author>
@@ -12841,6 +14239,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/grunt-legacy-log-utils/node_modules/ansi-styles</property>
+          </properties>
         </component>
         <component type="library" bom-ref="grunt-legacy-log-utils@2.1.0|chalk@4.1.2">
           <name>chalk</name>
@@ -12865,6 +14266,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/grunt-legacy-log-utils/node_modules/chalk</property>
+          </properties>
         </component>
         <component type="library" bom-ref="grunt-legacy-log-utils@2.1.0|color-convert@2.0.1">
           <author>Heather Arthur &lt;fayearthur@gmail.com&gt;</author>
@@ -12890,6 +14294,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/grunt-legacy-log-utils/node_modules/color-convert</property>
+          </properties>
         </component>
         <component type="library" bom-ref="grunt-legacy-log-utils@2.1.0|color-name@1.1.4">
           <author>DY &lt;dfcreative@gmail.com&gt;</author>
@@ -12919,6 +14326,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/grunt-legacy-log-utils/node_modules/color-name</property>
+          </properties>
         </component>
         <component type="library" bom-ref="grunt-legacy-log-utils@2.1.0|has-flag@4.0.0">
           <author>Sindre Sorhus</author>
@@ -12944,6 +14354,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/grunt-legacy-log-utils/node_modules/has-flag</property>
+          </properties>
         </component>
         <component type="library" bom-ref="grunt-legacy-log-utils@2.1.0|supports-color@7.2.0">
           <author>Sindre Sorhus</author>
@@ -12969,6 +14382,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/grunt-legacy-log-utils/node_modules/supports-color</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -13004,6 +14420,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/grunt-legacy-log</property>
+      </properties>
       <components>
         <component type="library" bom-ref="grunt-legacy-log@3.0.0|colors@1.1.2">
           <author>Marak Squires</author>
@@ -13037,6 +14456,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/grunt-legacy-log/node_modules/colors</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -13072,6 +14494,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/grunt-legacy-util</property>
+      </properties>
       <components>
         <component type="library" bom-ref="grunt-legacy-util@2.0.1|async@3.2.4">
           <author>Caolan McMahon</author>
@@ -13105,6 +14530,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/grunt-legacy-util/node_modules/async</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -13116,6 +14544,12 @@
       <hashes>
         <hash alg="SHA-512">60b88341ab38e198a5fdb3648561423fade923291348ce1368dcd73e257b9e23241d179f9a9c857b96968919f80ace6e24c2e15da77ca63ac08b604e9a44e465</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <url>https://github.com/exo-dev/grunt-replace-json/blob/master/LICENCE.md</url>
+        </license>
+      </licenses>
       <purl>pkg:npm/grunt-replace-json@0.1.0</purl>
       <externalReferences>
         <reference type="distribution">
@@ -13135,6 +14569,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/grunt-replace-json</property>
+      </properties>
     </component>
     <component type="library" bom-ref="grunt@1.5.3">
       <author>Grunt Development Team (https://gruntjs.com/development-team)</author>
@@ -13164,6 +14601,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/grunt</property>
+      </properties>
       <components>
         <component type="library" bom-ref="grunt@1.5.3|brace-expansion@1.1.11">
           <author>Julian Gruber</author>
@@ -13193,6 +14633,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/grunt/node_modules/brace-expansion</property>
+          </properties>
         </component>
         <component type="library" bom-ref="grunt@1.5.3|findup-sync@0.3.0">
           <author>"Cowboy" Ben Alman</author>
@@ -13202,6 +14645,12 @@
           <hashes>
             <hash alg="SHA-512">cfc36bc218bac33c4d3086f196b4f3b945ba296b8a928819ffb39d0d5abed3e9319fbeca507d678a9c7c894eacbaa907a9ce32ea7edaf40f08a66c58fe94e35a</hash>
           </hashes>
+          <licenses>
+            <license>
+              <id>MIT</id>
+              <url>https://github.com/cowboy/node-findup-sync/blob/master/LICENSE-MIT</url>
+            </license>
+          </licenses>
           <purl>pkg:npm/findup-sync@0.3.0</purl>
           <externalReferences>
             <reference type="distribution">
@@ -13221,6 +14670,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/grunt/node_modules/findup-sync</property>
+          </properties>
           <components>
             <component type="library" bom-ref="grunt@1.5.3|findup-sync@0.3.0|glob@5.0.15">
               <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me/)</author>
@@ -13246,6 +14698,9 @@
                   <comment>as detected from PackageJson property "repository.url"</comment>
                 </reference>
               </externalReferences>
+              <properties>
+                <property name="cdx:npm:package:installPath">node_modules/grunt/node_modules/findup-sync/node_modules/glob</property>
+              </properties>
             </component>
           </components>
         </component>
@@ -13273,6 +14728,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/grunt/node_modules/glob</property>
+          </properties>
         </component>
         <component type="library" bom-ref="grunt@1.5.3|minimatch@3.0.8">
           <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me)</author>
@@ -13298,6 +14756,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/grunt/node_modules/minimatch</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -13329,6 +14790,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/handlebars</property>
+      </properties>
       <components>
         <component type="library" bom-ref="handlebars@4.7.7|wordwrap@1.0.0">
           <author>James Halliday</author>
@@ -13354,6 +14818,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/handlebars/node_modules/wordwrap</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -13389,6 +14856,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/har-schema</property>
+      </properties>
     </component>
     <component type="library" bom-ref="har-validator@5.1.5">
       <author>Ahmad Nassri &lt;ahmad@ahmadnassri.com&gt; (https://www.ahmadnassri.com/)</author>
@@ -13422,6 +14892,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/har-validator</property>
+      </properties>
     </component>
     <component type="library" bom-ref="has-ansi@2.0.0">
       <author>Sindre Sorhus</author>
@@ -13447,6 +14920,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/has-ansi</property>
+      </properties>
     </component>
     <component type="library" bom-ref="has-bigints@1.0.2">
       <author>Jordan Harband &lt;ljharb@gmail.com&gt;</author>
@@ -13480,6 +14956,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/has-bigints</property>
+      </properties>
     </component>
     <component type="library" bom-ref="has-flag@3.0.0">
       <author>Sindre Sorhus</author>
@@ -13505,6 +14984,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/has-flag</property>
+      </properties>
     </component>
     <component type="library" bom-ref="has-property-descriptors@1.0.0">
       <author>Jordan Harband &lt;ljharb@gmail.com&gt;</author>
@@ -13538,6 +15020,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/has-property-descriptors</property>
+      </properties>
     </component>
     <component type="library" bom-ref="has-symbol-support-x@1.4.2">
       <author>Graham Fairweather</author>
@@ -13571,6 +15056,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/has-symbol-support-x</property>
+      </properties>
     </component>
     <component type="library" bom-ref="has-symbols@1.0.3">
       <author>Jordan Harband</author>
@@ -13604,6 +15092,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/has-symbols</property>
+      </properties>
     </component>
     <component type="library" bom-ref="has-to-string-tag-x@1.4.1">
       <author>Graham Fairweather</author>
@@ -13637,6 +15128,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/has-to-string-tag-x</property>
+      </properties>
     </component>
     <component type="library" bom-ref="has-tostringtag@1.0.0">
       <author>Jordan Harband</author>
@@ -13670,6 +15164,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/has-tostringtag</property>
+      </properties>
     </component>
     <component type="library" bom-ref="has-unicode@2.0.1">
       <author>Rebecca Turner &lt;me@re-becca.org&gt;</author>
@@ -13703,6 +15200,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/has-unicode</property>
+      </properties>
     </component>
     <component type="library" bom-ref="has-value@1.0.0">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -13736,6 +15236,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/has-value</property>
+      </properties>
     </component>
     <component type="library" bom-ref="has-values@1.0.0">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -13769,6 +15272,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/has-values</property>
+      </properties>
       <components>
         <component type="library" bom-ref="has-values@1.0.0|kind-of@4.0.0">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -13802,6 +15308,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/has-values/node_modules/kind-of</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -13816,6 +15325,10 @@
       <licenses>
         <license>
           <id>MIT</id>
+        </license>
+        <license>
+          <id>MIT</id>
+          <url>https://github.com/tarruda/has/blob/master/LICENSE-MIT</url>
         </license>
       </licenses>
       <purl>pkg:npm/has@1.0.3</purl>
@@ -13837,6 +15350,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/has</property>
+      </properties>
     </component>
     <component type="library" bom-ref="hashids@2.2.10">
       <author>hashids.org &lt;npm@invent.life&gt; (https://github.com/hashids)</author>
@@ -13870,6 +15386,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/hashids</property>
+      </properties>
     </component>
     <component type="library" bom-ref="hbs@4.2.0">
       <author>Don Park &lt;donpark@docuverse.com&gt; (http://blog.docuverse.com)</author>
@@ -13895,6 +15414,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/hbs</property>
+      </properties>
     </component>
     <component type="library" bom-ref="he@0.4.1">
       <author>Mathias Bynens</author>
@@ -13904,6 +15426,12 @@
       <hashes>
         <hash alg="SHA-512">c059f526572c81b71611ac10e80d46ced80d45197a53212d6804480e901e1f7737e53ffd89dfd040abdaa75340cfa624da82ab2b05d0659144452d2d97d13426</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <url>http://mths.be/mit</url>
+        </license>
+      </licenses>
       <purl>pkg:npm/he@0.4.1</purl>
       <externalReferences>
         <reference type="distribution">
@@ -13923,6 +15451,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/he</property>
+      </properties>
     </component>
     <component type="library" bom-ref="heap@0.2.7">
       <author>Xueqiao Xu &lt;xueqiaoxu@gmail.com&gt;</author>
@@ -13952,6 +15483,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/heap</property>
+      </properties>
     </component>
     <component type="library" bom-ref="helmet@4.6.0">
       <author>Adam Baldwin &lt;adam@npmjs.com&gt; (https://evilpacket.net)</author>
@@ -13985,6 +15519,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/helmet</property>
+      </properties>
     </component>
     <component type="library" bom-ref="hoister@0.0.2">
       <author>Matt McKegg</author>
@@ -14014,6 +15551,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/hoister</property>
+      </properties>
     </component>
     <component type="library" bom-ref="homedir-polyfill@1.0.3">
       <author>Brian Woodward (https://github.com/doowb)</author>
@@ -14047,6 +15587,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/homedir-polyfill</property>
+      </properties>
     </component>
     <component type="library" bom-ref="hooker@0.2.3">
       <author>"Cowboy" Ben Alman</author>
@@ -14056,6 +15599,12 @@
       <hashes>
         <hash alg="SHA-512">b7e51eac2b10be24b29802270f4d4fc3e0e7feeb26cf5b113bedd9935fa5c7c7a0f962a90f6ba57305aa1c72f4f9ab1e441afedfebc88621b52b5253c1a21c4c</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <url>https://github.com/cowboy/javascript-hooker/blob/master/LICENSE-MIT</url>
+        </license>
+      </licenses>
       <purl>pkg:npm/hooker@0.2.3</purl>
       <externalReferences>
         <reference type="distribution">
@@ -14075,6 +15624,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/hooker</property>
+      </properties>
     </component>
     <component type="library" bom-ref="hosted-git-info@2.8.9">
       <author>Rebecca Turner &lt;me@re-becca.org&gt; (http://re-becca.org)</author>
@@ -14108,6 +15660,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/hosted-git-info</property>
+      </properties>
     </component>
     <component type="library" bom-ref="html-entities@1.4.0">
       <author>Marat Dulin</author>
@@ -14133,6 +15688,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/html-entities</property>
+      </properties>
     </component>
     <component type="library" bom-ref="htmlparser2@3.3.0">
       <author>Felix Boehm &lt;me@feedic.com&gt;</author>
@@ -14142,6 +15700,12 @@
       <hashes>
         <hash alg="SHA-512">67c8bade7eec7ae3ef45ed4f432ae39a8552b6fedb8cc6b4b24ace97f93ab674ffe56a4f36bcd62c1d4783f749c415c7fcce8a66f9b6e494065428901b15112d</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <url>http://github.com/fb55/htmlparser2/raw/master/LICENSE</url>
+        </license>
+      </licenses>
       <purl>pkg:npm/htmlparser2@3.3.0</purl>
       <externalReferences>
         <reference type="distribution">
@@ -14157,6 +15721,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/htmlparser2</property>
+      </properties>
       <components>
         <component type="library" bom-ref="htmlparser2@3.3.0|isarray@0.0.1">
           <author>Julian Gruber</author>
@@ -14186,6 +15753,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/htmlparser2/node_modules/isarray</property>
+          </properties>
         </component>
         <component type="library" bom-ref="htmlparser2@3.3.0|readable-stream@1.0.34">
           <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me/)</author>
@@ -14211,6 +15781,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/htmlparser2/node_modules/readable-stream</property>
+          </properties>
         </component>
         <component type="library" bom-ref="htmlparser2@3.3.0|string_decoder@0.10.31">
           <name>string_decoder</name>
@@ -14239,6 +15812,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/htmlparser2/node_modules/string_decoder</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -14266,6 +15842,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/http-cache-semantics</property>
+      </properties>
     </component>
     <component type="library" bom-ref="http-errors@2.0.0">
       <author>Jonathan Ong &lt;me@jongleberry.com&gt; (http://jongleberry.com)</author>
@@ -14291,6 +15870,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/http-errors</property>
+      </properties>
     </component>
     <component type="library" bom-ref="http-proxy-agent@5.0.0">
       <author>Nathan Rajlich &lt;nathan@tootallnate.net&gt; (http://n8.io/)</author>
@@ -14320,6 +15902,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/http-proxy-agent</property>
+      </properties>
       <components>
         <component type="library" bom-ref="http-proxy-agent@5.0.0|debug@4.3.4">
           <author>Josh Junon &lt;josh.junon@protonmail.com&gt;</author>
@@ -14345,6 +15930,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/http-proxy-agent/node_modules/debug</property>
+          </properties>
         </component>
         <component type="library" bom-ref="http-proxy-agent@5.0.0|ms@2.1.2">
           <name>ms</name>
@@ -14369,6 +15957,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/http-proxy-agent/node_modules/ms</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -14404,6 +15995,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/http-signature</property>
+      </properties>
     </component>
     <component type="library" bom-ref="https-proxy-agent@5.0.1">
       <author>Nathan Rajlich &lt;nathan@tootallnate.net&gt; (http://n8.io/)</author>
@@ -14433,6 +16027,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/https-proxy-agent</property>
+      </properties>
       <components>
         <component type="library" bom-ref="https-proxy-agent@5.0.1|debug@4.3.4">
           <author>Josh Junon &lt;josh.junon@protonmail.com&gt;</author>
@@ -14458,6 +16055,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/https-proxy-agent/node_modules/debug</property>
+          </properties>
         </component>
         <component type="library" bom-ref="https-proxy-agent@5.0.1|ms@2.1.2">
           <name>ms</name>
@@ -14482,6 +16082,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/https-proxy-agent/node_modules/ms</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -14509,6 +16112,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/humanize-ms</property>
+      </properties>
     </component>
     <component type="library" bom-ref="i18n@0.11.1">
       <author>Marcus Spiegel &lt;marcus.spiegel@gmail.com&gt;</author>
@@ -14538,6 +16144,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/i18n</property>
+      </properties>
     </component>
     <component type="library" bom-ref="iconv-lite@0.4.24">
       <author>Alexander Shtuchkin &lt;ashtuchkin@gmail.com&gt;</author>
@@ -14571,6 +16180,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/iconv-lite</property>
+      </properties>
     </component>
     <component type="library" bom-ref="ieee754@1.2.1">
       <author>Feross Aboukhadijeh</author>
@@ -14596,6 +16208,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/ieee754</property>
+      </properties>
     </component>
     <component type="library" bom-ref="ignore-walk@3.0.4">
       <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me/)</author>
@@ -14621,6 +16236,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/ignore-walk</property>
+      </properties>
       <components>
         <component type="library" bom-ref="ignore-walk@3.0.4|brace-expansion@1.1.11">
           <author>Julian Gruber</author>
@@ -14650,6 +16268,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/ignore-walk/node_modules/brace-expansion</property>
+          </properties>
         </component>
         <component type="library" bom-ref="ignore-walk@3.0.4|minimatch@3.1.2">
           <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me)</author>
@@ -14675,6 +16296,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/ignore-walk/node_modules/minimatch</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -14709,6 +16333,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/iltorb</property>
+      </properties>
     </component>
     <component type="library" bom-ref="imurmurhash@0.1.4">
       <author>Jens Taylor</author>
@@ -14742,6 +16369,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/imurmurhash</property>
+      </properties>
     </component>
     <component type="library" bom-ref="indent-string@4.0.0">
       <author>Sindre Sorhus</author>
@@ -14767,6 +16397,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/indent-string</property>
+      </properties>
     </component>
     <component type="library" bom-ref="infer-owner@1.0.4">
       <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (https://izs.me)</author>
@@ -14792,6 +16425,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/infer-owner</property>
+      </properties>
     </component>
     <component type="library" bom-ref="inflection@1.13.4">
       <author>dreamerslab &lt;ben@dreamerslab.com&gt;</author>
@@ -14817,6 +16453,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/inflection</property>
+      </properties>
     </component>
     <component type="library" bom-ref="inflight@1.0.6">
       <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me/)</author>
@@ -14850,6 +16489,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/inflight</property>
+      </properties>
     </component>
     <component type="library" bom-ref="inherits@2.0.4">
       <name>inherits</name>
@@ -14874,6 +16516,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/inherits</property>
+      </properties>
     </component>
     <component type="library" bom-ref="ini@1.3.8">
       <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me/)</author>
@@ -14899,6 +16544,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/ini</property>
+      </properties>
     </component>
     <component type="library" bom-ref="interpret@1.1.0">
       <author>Tyler Kellen</author>
@@ -14932,6 +16580,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/interpret</property>
+      </properties>
     </component>
     <component type="library" bom-ref="into-stream@3.1.0">
       <author>Sindre Sorhus</author>
@@ -14957,6 +16608,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/into-stream</property>
+      </properties>
     </component>
     <component type="library" bom-ref="invariant@2.2.4">
       <author>Andres Suarez &lt;zertosh@gmail.com&gt;</author>
@@ -14982,6 +16636,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/invariant</property>
+      </properties>
     </component>
     <component type="library" bom-ref="ip@1.1.8">
       <author>Fedor Indutny &lt;fedor@indutny.com&gt;</author>
@@ -15010,6 +16667,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/ip</property>
+      </properties>
     </component>
     <component type="library" bom-ref="ip6@0.2.10">
       <author>Qian Chen</author>
@@ -15043,6 +16703,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/ip6</property>
+      </properties>
     </component>
     <component type="library" bom-ref="ipaddr.js@1.9.1">
       <author>whitequark &lt;whitequark@whitequark.org&gt;</author>
@@ -15068,6 +16731,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/ipaddr.js</property>
+      </properties>
     </component>
     <component type="library" bom-ref="is-absolute@1.0.0">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -15101,6 +16767,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/is-absolute</property>
+      </properties>
     </component>
     <component type="library" bom-ref="is-accessor-descriptor@1.0.0">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -15134,6 +16803,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/is-accessor-descriptor</property>
+      </properties>
     </component>
     <component type="library" bom-ref="is-arguments@1.1.1">
       <author>Jordan Harband</author>
@@ -15167,6 +16839,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/is-arguments</property>
+      </properties>
     </component>
     <component type="library" bom-ref="is-arrayish@0.2.1">
       <author>Qix (http://github.com/qix-)</author>
@@ -15192,6 +16867,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/is-arrayish</property>
+      </properties>
     </component>
     <component type="library" bom-ref="is-bigint@1.0.4">
       <author>Jordan Harband &lt;ljharb@gmail.com&gt;</author>
@@ -15225,6 +16903,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/is-bigint</property>
+      </properties>
     </component>
     <component type="library" bom-ref="is-binary-path@2.1.0">
       <author>Sindre Sorhus</author>
@@ -15250,6 +16931,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/is-binary-path</property>
+      </properties>
     </component>
     <component type="library" bom-ref="is-boolean-object@1.1.2">
       <author>Jordan Harband &lt;ljharb@gmail.com&gt;</author>
@@ -15275,6 +16959,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/is-boolean-object</property>
+      </properties>
     </component>
     <component type="library" bom-ref="is-buffer@1.1.6">
       <author>Feross Aboukhadijeh</author>
@@ -15304,6 +16991,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/is-buffer</property>
+      </properties>
     </component>
     <component type="library" bom-ref="is-callable@1.2.7">
       <author>Jordan Harband</author>
@@ -15329,6 +17019,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/is-callable</property>
+      </properties>
     </component>
     <component type="library" bom-ref="is-core-module@2.11.0">
       <author>Jordan Harband &lt;ljharb@gmail.com&gt;</author>
@@ -15362,6 +17055,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/is-core-module</property>
+      </properties>
     </component>
     <component type="library" bom-ref="is-data-descriptor@1.0.0">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -15395,6 +17091,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/is-data-descriptor</property>
+      </properties>
     </component>
     <component type="library" bom-ref="is-date-object@1.0.5">
       <author>Jordan Harband</author>
@@ -15420,6 +17119,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/is-date-object</property>
+      </properties>
     </component>
     <component type="library" bom-ref="is-descriptor@1.0.2">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -15453,6 +17155,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/is-descriptor</property>
+      </properties>
     </component>
     <component type="library" bom-ref="is-docker@2.2.1">
       <author>Sindre Sorhus</author>
@@ -15478,6 +17183,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/is-docker</property>
+      </properties>
     </component>
     <component type="library" bom-ref="is-expression@4.0.0">
       <author>Timothy Gu &lt;timothygu99@gmail.com&gt;</author>
@@ -15503,6 +17211,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/is-expression</property>
+      </properties>
     </component>
     <component type="library" bom-ref="is-extendable@1.0.1">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -15536,6 +17247,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/is-extendable</property>
+      </properties>
     </component>
     <component type="library" bom-ref="is-extglob@2.1.1">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -15569,6 +17283,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/is-extglob</property>
+      </properties>
     </component>
     <component type="library" bom-ref="is-fullwidth-code-point@1.0.0">
       <author>Sindre Sorhus</author>
@@ -15594,6 +17311,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/is-fullwidth-code-point</property>
+      </properties>
     </component>
     <component type="library" bom-ref="is-generator-function@1.0.10">
       <author>Jordan Harband &lt;ljharb@gmail.com&gt;</author>
@@ -15623,6 +17343,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/is-generator-function</property>
+      </properties>
     </component>
     <component type="library" bom-ref="is-glob@3.1.0">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -15656,6 +17379,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/is-glob</property>
+      </properties>
     </component>
     <component type="library" bom-ref="is-heroku@2.0.0">
       <author>Sindre Sorhus</author>
@@ -15681,6 +17407,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/is-heroku</property>
+      </properties>
     </component>
     <component type="library" bom-ref="is-lambda@1.0.1">
       <author>Thomas Watson Steen &lt;w@tson.dk&gt; (https://twitter.com/wa7son)</author>
@@ -15714,6 +17443,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/is-lambda</property>
+      </properties>
     </component>
     <component type="library" bom-ref="is-map@2.0.2">
       <author>Jordan Harband &lt;ljharb@gmail.com&gt;</author>
@@ -15747,6 +17479,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/is-map</property>
+      </properties>
     </component>
     <component type="library" bom-ref="is-natural-number@4.0.1">
       <author>Shinnosuke Watanabe (https://github.com/shinnn)</author>
@@ -15772,6 +17507,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/is-natural-number</property>
+      </properties>
     </component>
     <component type="library" bom-ref="is-number-like@1.0.8">
       <author>Vigour.io &lt;dev@vigour.io&gt;</author>
@@ -15805,6 +17543,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/is-number-like</property>
+      </properties>
     </component>
     <component type="library" bom-ref="is-number-object@1.0.7">
       <author>Jordan Harband &lt;ljharb@gmail.com&gt;</author>
@@ -15838,6 +17579,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/is-number-object</property>
+      </properties>
     </component>
     <component type="library" bom-ref="is-number@3.0.0">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -15871,6 +17615,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/is-number</property>
+      </properties>
       <components>
         <component type="library" bom-ref="is-number@3.0.0|kind-of@3.2.2">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -15904,6 +17651,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/is-number/node_modules/kind-of</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -15918,6 +17668,10 @@
       <licenses>
         <license>
           <id>MIT</id>
+        </license>
+        <license>
+          <id>MIT</id>
+          <url>http://github.com/inspect-js/is-object/raw/master/LICENSE</url>
         </license>
       </licenses>
       <purl>pkg:npm/is-object@1.0.2</purl>
@@ -15939,6 +17693,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/is-object</property>
+      </properties>
     </component>
     <component type="library" bom-ref="is-plain-obj@1.1.0">
       <author>Sindre Sorhus</author>
@@ -15964,6 +17721,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/is-plain-obj</property>
+      </properties>
     </component>
     <component type="library" bom-ref="is-plain-object@2.0.4">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -15997,6 +17757,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/is-plain-object</property>
+      </properties>
     </component>
     <component type="library" bom-ref="is-promise@2.2.2">
       <author>ForbesLindesay</author>
@@ -16022,6 +17785,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/is-promise</property>
+      </properties>
     </component>
     <component type="library" bom-ref="is-regex@1.1.4">
       <author>Jordan Harband &lt;ljharb@gmail.com&gt;</author>
@@ -16055,6 +17821,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/is-regex</property>
+      </properties>
     </component>
     <component type="library" bom-ref="is-relative@1.0.0">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -16088,6 +17857,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/is-relative</property>
+      </properties>
     </component>
     <component type="library" bom-ref="is-retry-allowed@1.2.0">
       <author>Vsevolod Strukchinsky</author>
@@ -16113,6 +17885,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/is-retry-allowed</property>
+      </properties>
     </component>
     <component type="library" bom-ref="is-set@2.0.2">
       <author>Jordan Harband &lt;ljharb@gmail.com&gt;</author>
@@ -16146,6 +17921,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/is-set</property>
+      </properties>
     </component>
     <component type="library" bom-ref="is-stream@1.1.0">
       <author>Sindre Sorhus</author>
@@ -16171,6 +17949,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/is-stream</property>
+      </properties>
     </component>
     <component type="library" bom-ref="is-string@1.0.7">
       <author>Jordan Harband &lt;ljharb@gmail.com&gt;</author>
@@ -16196,6 +17977,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/is-string</property>
+      </properties>
     </component>
     <component type="library" bom-ref="is-symbol@1.0.4">
       <author>Jordan Harband &lt;ljharb@gmail.com&gt;</author>
@@ -16225,6 +18009,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/is-symbol</property>
+      </properties>
     </component>
     <component type="library" bom-ref="is-typed-array@1.1.10">
       <author>Jordan Harband</author>
@@ -16250,6 +18037,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/is-typed-array</property>
+      </properties>
     </component>
     <component type="library" bom-ref="is-typedarray@1.0.0">
       <author>Hugh Kennedy &lt;hughskennedy@gmail.com&gt; (http://hughsk.io/)</author>
@@ -16283,6 +18073,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/is-typedarray</property>
+      </properties>
     </component>
     <component type="library" bom-ref="is-unc-path@1.0.0">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -16316,6 +18109,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/is-unc-path</property>
+      </properties>
     </component>
     <component type="library" bom-ref="is-weakmap@2.0.1">
       <author>Jordan Harband &lt;ljharb@gmail.com&gt;</author>
@@ -16349,6 +18145,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/is-weakmap</property>
+      </properties>
     </component>
     <component type="library" bom-ref="is-weakset@2.0.2">
       <author>Jordan Harband &lt;ljharb@gmail.com&gt;</author>
@@ -16382,6 +18181,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/is-weakset</property>
+      </properties>
     </component>
     <component type="library" bom-ref="is-windows@1.0.2">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -16415,6 +18217,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/is-windows</property>
+      </properties>
     </component>
     <component type="library" bom-ref="isarray@2.0.5">
       <author>Julian Gruber</author>
@@ -16444,6 +18249,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/isarray</property>
+      </properties>
     </component>
     <component type="library" bom-ref="isexe@2.0.0">
       <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me/)</author>
@@ -16477,6 +18285,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/isexe</property>
+      </properties>
     </component>
     <component type="library" bom-ref="isobject@3.0.1">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -16510,6 +18321,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/isobject</property>
+      </properties>
     </component>
     <component type="library" bom-ref="isstream@0.1.2">
       <author>Rod Vagg &lt;rod@vagg.org&gt;</author>
@@ -16543,6 +18357,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/isstream</property>
+      </properties>
     </component>
     <component type="library" bom-ref="isurl@1.0.0">
       <author>Steven Vachon &lt;contact@svachon.com&gt; (https://www.svachon.com/)</author>
@@ -16568,6 +18385,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/isurl</property>
+      </properties>
     </component>
     <component type="library" bom-ref="js-stringify@1.0.2">
       <author>ForbesLindesay</author>
@@ -16593,6 +18413,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/js-stringify</property>
+      </properties>
     </component>
     <component type="library" bom-ref="js-tokens@4.0.0">
       <author>Simon Lydell</author>
@@ -16618,6 +18441,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/js-tokens</property>
+      </properties>
     </component>
     <component type="library" bom-ref="js-yaml@3.14.1">
       <author>Vladimir Zapparov &lt;dervus.grim@gmail.com&gt;</author>
@@ -16647,6 +18473,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/js-yaml</property>
+      </properties>
     </component>
     <component type="library" bom-ref="jsbn@0.1.1">
       <author>Tom Wu</author>
@@ -16672,6 +18501,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/jsbn</property>
+      </properties>
     </component>
     <component type="library" bom-ref="json-buffer@3.0.0">
       <author>Dominic Tarr &lt;dominic.tarr@gmail.com&gt; (http://dominictarr.com)</author>
@@ -16701,6 +18533,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/json-buffer</property>
+      </properties>
     </component>
     <component type="library" bom-ref="json-parse-better-errors@1.0.2">
       <author>Kat Marchán</author>
@@ -16726,6 +18561,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/json-parse-better-errors</property>
+      </properties>
     </component>
     <component type="library" bom-ref="json-schema-traverse@0.4.1">
       <author>Evgeny Poberezkin</author>
@@ -16759,6 +18597,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/json-schema-traverse</property>
+      </properties>
     </component>
     <component type="library" bom-ref="json-schema@0.4.0">
       <author>Kris Zyp</author>
@@ -16782,6 +18623,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/json-schema</property>
+      </properties>
     </component>
     <component type="library" bom-ref="json-stringify-safe@5.0.1">
       <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me)</author>
@@ -16815,6 +18659,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/json-stringify-safe</property>
+      </properties>
     </component>
     <component type="library" bom-ref="json5@2.2.1">
       <author>Aseem Kishore &lt;aseem.kishore@gmail.com&gt;</author>
@@ -16848,6 +18695,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/json5</property>
+      </properties>
     </component>
     <component type="library" bom-ref="jsonfile@6.1.0">
       <author>JP Richardson &lt;jprichardson@gmail.com&gt;</author>
@@ -16869,6 +18719,9 @@
           <comment>as detected from npm-ls property "resolved"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/jsonfile</property>
+      </properties>
     </component>
     <component type="library" bom-ref="jsonwebtoken@0.4.0">
       <author>auth0</author>
@@ -16898,6 +18751,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/jsonwebtoken</property>
+      </properties>
     </component>
     <component type="library" bom-ref="jsprim@1.4.2">
       <name>jsprim</name>
@@ -16922,6 +18778,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/jsprim</property>
+      </properties>
     </component>
     <component type="library" bom-ref="jssha@3.3.0">
       <author>Brian Turek &lt;brian.turek@gmail.com&gt;</author>
@@ -16955,6 +18814,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/jssha</property>
+      </properties>
     </component>
     <component type="library" bom-ref="jstransformer@1.0.0">
       <author>ForbesLindesay</author>
@@ -16980,6 +18842,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/jstransformer</property>
+      </properties>
     </component>
     <component type="library" bom-ref="juicy-chat-bot@0.6.6">
       <author>Björn Kimminich &lt;bjoern.kimminich@owasp.org&gt; (https://kimminich.de)</author>
@@ -17013,6 +18878,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/juicy-chat-bot</property>
+      </properties>
     </component>
     <component type="library" bom-ref="jwa@0.0.1">
       <author>Brian J. Brennan</author>
@@ -17038,6 +18906,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/jwa</property>
+      </properties>
     </component>
     <component type="library" bom-ref="jws@0.2.6">
       <author>Brian J Brennan</author>
@@ -17063,6 +18934,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/jws</property>
+      </properties>
     </component>
     <component type="library" bom-ref="keyv@3.0.0">
       <author>Luke Childs &lt;lukechilds123@gmail.com&gt; (http://lukechilds.co.uk)</author>
@@ -17096,6 +18970,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/keyv</property>
+      </properties>
     </component>
     <component type="library" bom-ref="kind-of@6.0.3">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -17129,6 +19006,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/kind-of</property>
+      </properties>
     </component>
     <component type="library" bom-ref="kuler@2.0.0">
       <author>Arnout Kazemier</author>
@@ -17162,6 +19042,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/kuler</property>
+      </properties>
     </component>
     <component type="library" bom-ref="kuromoji@0.1.2">
       <author>Takuya Asano &lt;takuya.a@gmail.com&gt;</author>
@@ -17195,6 +19078,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/kuromoji</property>
+      </properties>
     </component>
     <component type="library" bom-ref="lazystream@1.0.1">
       <author>Jonas Pommerening</author>
@@ -17228,6 +19114,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/lazystream</property>
+      </properties>
     </component>
     <component type="library" bom-ref="levn@0.3.0">
       <author>George Zahariev &lt;z@georgezahariev.com&gt;</author>
@@ -17261,6 +19150,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/levn</property>
+      </properties>
     </component>
     <component type="library" bom-ref="libxmljs2@0.30.1">
       <author>marudor</author>
@@ -17290,6 +19182,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/libxmljs2</property>
+      </properties>
       <components>
         <component type="library" bom-ref="libxmljs2@0.30.1|nan@2.15.0">
           <name>nan</name>
@@ -17314,6 +19209,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/libxmljs2/node_modules/nan</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -17341,6 +19239,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/liftup</property>
+      </properties>
       <components>
         <component type="library" bom-ref="liftup@3.0.1|braces@3.0.2">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -17374,6 +19275,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/liftup/node_modules/braces</property>
+          </properties>
         </component>
         <component type="library" bom-ref="liftup@3.0.1|fill-range@7.0.1">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -17407,6 +19311,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/liftup/node_modules/fill-range</property>
+          </properties>
         </component>
         <component type="library" bom-ref="liftup@3.0.1|findup-sync@4.0.0">
           <author>Gulp Team &lt;team@gulpjs.com&gt; (https://gulpjs.com/)</author>
@@ -17432,6 +19339,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/liftup/node_modules/findup-sync</property>
+          </properties>
         </component>
         <component type="library" bom-ref="liftup@3.0.1|is-glob@4.0.3">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -17465,6 +19375,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/liftup/node_modules/is-glob</property>
+          </properties>
         </component>
         <component type="library" bom-ref="liftup@3.0.1|is-number@7.0.0">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -17498,6 +19411,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/liftup/node_modules/is-number</property>
+          </properties>
         </component>
         <component type="library" bom-ref="liftup@3.0.1|micromatch@4.0.5">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -17531,6 +19447,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/liftup/node_modules/micromatch</property>
+          </properties>
         </component>
         <component type="library" bom-ref="liftup@3.0.1|to-regex-range@5.0.1">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -17564,6 +19483,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/liftup/node_modules/to-regex-range</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -17599,6 +19521,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/linebreak</property>
+      </properties>
       <components>
         <component type="library" bom-ref="linebreak@1.1.0|base64-js@0.0.8">
           <author>T. Jameson Little &lt;t.jameson.little@gmail.com&gt;</author>
@@ -17624,6 +19549,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/linebreak/node_modules/base64-js</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -17647,6 +19575,9 @@
           <comment>as detected from npm-ls property "resolved"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/listenercount</property>
+      </properties>
     </component>
     <component type="library" bom-ref="locate-path@3.0.0">
       <author>Sindre Sorhus</author>
@@ -17672,6 +19603,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/locate-path</property>
+      </properties>
     </component>
     <component type="library" bom-ref="lodash.camelcase@4.3.0">
       <author>John-David Dalton &lt;john.david.dalton@gmail.com&gt; (http://allyoucanleet.com/)</author>
@@ -17701,6 +19635,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/lodash.camelcase</property>
+      </properties>
     </component>
     <component type="library" bom-ref="lodash.isfinite@3.3.2">
       <author>John-David Dalton &lt;john.david.dalton@gmail.com&gt; (http://allyoucanleet.com/)</author>
@@ -17730,6 +19667,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/lodash.isfinite</property>
+      </properties>
     </component>
     <component type="library" bom-ref="lodash.set@4.3.2">
       <author>John-David Dalton &lt;john.david.dalton@gmail.com&gt; (http://allyoucanleet.com/)</author>
@@ -17759,6 +19699,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/lodash.set</property>
+      </properties>
     </component>
     <component type="library" bom-ref="lodash@4.17.21">
       <author>John-David Dalton &lt;john.david.dalton@gmail.com&gt;</author>
@@ -17788,6 +19731,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/lodash</property>
+      </properties>
     </component>
     <component type="library" bom-ref="logform@2.4.2">
       <author>Charlie Robbins &lt;charlie.robbins@gmail.com&gt;</author>
@@ -17821,6 +19767,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/logform</property>
+      </properties>
       <components>
         <component type="library" bom-ref="logform@2.4.2|ms@2.1.3">
           <name>ms</name>
@@ -17845,6 +19794,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/logform/node_modules/ms</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -17880,6 +19832,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/lolex</property>
+      </properties>
     </component>
     <component type="library" bom-ref="loose-envify@1.4.0">
       <author>Andres Suarez &lt;zertosh@gmail.com&gt;</author>
@@ -17909,6 +19864,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/loose-envify</property>
+      </properties>
     </component>
     <component type="library" bom-ref="lowercase-keys@1.0.1">
       <author>Sindre Sorhus</author>
@@ -17934,6 +19892,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/lowercase-keys</property>
+      </properties>
     </component>
     <component type="library" bom-ref="lru-cache@6.0.0">
       <author>Isaac Z. Schlueter &lt;i@izs.me&gt;</author>
@@ -17959,6 +19920,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/lru-cache</property>
+      </properties>
     </component>
     <component type="library" bom-ref="make-dir@2.1.0">
       <author>Sindre Sorhus</author>
@@ -17984,6 +19948,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/make-dir</property>
+      </properties>
       <components>
         <component type="library" bom-ref="make-dir@2.1.0|semver@5.7.1">
           <name>semver</name>
@@ -18008,6 +19975,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/make-dir/node_modules/semver</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -18043,6 +20013,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/make-error</property>
+      </properties>
     </component>
     <component type="library" bom-ref="make-fetch-happen@9.1.0">
       <author>Kat Marchán</author>
@@ -18068,6 +20041,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/make-fetch-happen</property>
+      </properties>
       <components>
         <component type="library" bom-ref="make-fetch-happen@9.1.0|@tootallnate/once@1.1.2">
           <author>Nathan Rajlich &lt;nathan@tootallnate.net&gt; (http://n8.io/)</author>
@@ -18098,6 +20074,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/make-fetch-happen/node_modules/@tootallnate/once</property>
+          </properties>
         </component>
         <component type="library" bom-ref="make-fetch-happen@9.1.0|debug@4.3.4">
           <author>Josh Junon &lt;josh.junon@protonmail.com&gt;</author>
@@ -18123,6 +20102,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/make-fetch-happen/node_modules/debug</property>
+          </properties>
         </component>
         <component type="library" bom-ref="make-fetch-happen@9.1.0|http-cache-semantics@4.1.0">
           <author>Kornel Lesiński &lt;kornel@geekhood.net&gt; (https://kornel.ski/)</author>
@@ -18148,6 +20130,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/make-fetch-happen/node_modules/http-cache-semantics</property>
+          </properties>
         </component>
         <component type="library" bom-ref="make-fetch-happen@9.1.0|http-proxy-agent@4.0.1">
           <author>Nathan Rajlich &lt;nathan@tootallnate.net&gt; (http://n8.io/)</author>
@@ -18177,6 +20162,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/make-fetch-happen/node_modules/http-proxy-agent</property>
+          </properties>
         </component>
         <component type="library" bom-ref="make-fetch-happen@9.1.0|ms@2.1.2">
           <name>ms</name>
@@ -18201,6 +20189,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/make-fetch-happen/node_modules/ms</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -18236,6 +20227,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/make-iterator</property>
+      </properties>
     </component>
     <component type="library" bom-ref="make-plural@6.2.2">
       <author>Eemeli Aro &lt;eemeli@gmail.com&gt;</author>
@@ -18269,6 +20263,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/make-plural</property>
+      </properties>
     </component>
     <component type="library" bom-ref="map-cache@0.2.2">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -18302,6 +20299,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/map-cache</property>
+      </properties>
     </component>
     <component type="library" bom-ref="map-visit@1.0.0">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -18335,6 +20335,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/map-visit</property>
+      </properties>
     </component>
     <component type="library" bom-ref="marsdb@0.6.11">
       <author>Artem Artemev</author>
@@ -18360,6 +20363,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/marsdb</property>
+      </properties>
     </component>
     <component type="library" bom-ref="math-interval-parser@2.0.1">
       <author>Dmitry Semigradsky</author>
@@ -18385,6 +20391,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/math-interval-parser</property>
+      </properties>
     </component>
     <component type="library" bom-ref="media-typer@0.3.0">
       <author>Douglas Christopher Wilson &lt;doug@somethingdoug.com&gt;</author>
@@ -18410,6 +20419,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/media-typer</property>
+      </properties>
     </component>
     <component type="library" bom-ref="merge-descriptors@1.0.1">
       <author>Jonathan Ong</author>
@@ -18435,6 +20447,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/merge-descriptors</property>
+      </properties>
     </component>
     <component type="library" bom-ref="messageformat-formatters@2.0.1">
       <author>Eemeli Aro &lt;eemeli@gmail.com&gt;</author>
@@ -18464,6 +20479,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/messageformat-formatters</property>
+      </properties>
     </component>
     <component type="library" bom-ref="messageformat-parser@4.1.3">
       <name>messageformat-parser</name>
@@ -18492,6 +20510,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/messageformat-parser</property>
+      </properties>
     </component>
     <component type="library" bom-ref="messageformat@2.3.0">
       <author>Alex Sexton &lt;alexsexton@gmail.com&gt;</author>
@@ -18521,6 +20542,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/messageformat</property>
+      </properties>
       <components>
         <component type="library" bom-ref="messageformat@2.3.0|make-plural@4.3.0">
           <author>Eemeli Aro &lt;eemeli@gmail.com&gt;</author>
@@ -18554,6 +20578,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/messageformat/node_modules/make-plural</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -18580,6 +20607,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/methods</property>
+      </properties>
     </component>
     <component type="library" bom-ref="micromatch@3.1.10">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -18613,6 +20643,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/micromatch</property>
+      </properties>
     </component>
     <component type="library" bom-ref="mime-db@1.52.0">
       <name>mime-db</name>
@@ -18637,6 +20670,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/mime-db</property>
+      </properties>
     </component>
     <component type="library" bom-ref="mime-types@2.1.35">
       <name>mime-types</name>
@@ -18661,6 +20697,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/mime-types</property>
+      </properties>
     </component>
     <component type="library" bom-ref="mime@1.6.0">
       <author>Robert Kieffer</author>
@@ -18686,6 +20725,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/mime</property>
+      </properties>
     </component>
     <component type="library" bom-ref="mimic-response@1.0.1">
       <author>Sindre Sorhus</author>
@@ -18711,6 +20753,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/mimic-response</property>
+      </properties>
     </component>
     <component type="library" bom-ref="minimatch@5.1.0">
       <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me)</author>
@@ -18736,6 +20781,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/minimatch</property>
+      </properties>
     </component>
     <component type="library" bom-ref="minimist@1.2.7">
       <author>James Halliday</author>
@@ -18765,6 +20813,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/minimist</property>
+      </properties>
     </component>
     <component type="library" bom-ref="minipass-collect@1.0.2">
       <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (https://izs.me)</author>
@@ -18786,6 +20837,9 @@
           <comment>as detected from npm-ls property "resolved"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/minipass-collect</property>
+      </properties>
     </component>
     <component type="library" bom-ref="minipass-fetch@1.4.1">
       <name>minipass-fetch</name>
@@ -18810,6 +20864,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/minipass-fetch</property>
+      </properties>
     </component>
     <component type="library" bom-ref="minipass-flush@1.0.5">
       <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (https://izs.me)</author>
@@ -18835,6 +20892,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/minipass-flush</property>
+      </properties>
     </component>
     <component type="library" bom-ref="minipass-pipeline@1.2.4">
       <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (https://izs.me)</author>
@@ -18856,6 +20916,9 @@
           <comment>as detected from npm-ls property "resolved"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/minipass-pipeline</property>
+      </properties>
     </component>
     <component type="library" bom-ref="minipass-sized@1.0.3">
       <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (https://izs.me)</author>
@@ -18881,6 +20944,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/minipass-sized</property>
+      </properties>
     </component>
     <component type="library" bom-ref="minipass@3.3.4">
       <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me/)</author>
@@ -18906,6 +20972,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/minipass</property>
+      </properties>
     </component>
     <component type="library" bom-ref="minizlib@2.1.2">
       <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me/)</author>
@@ -18931,6 +21000,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/minizlib</property>
+      </properties>
     </component>
     <component type="library" bom-ref="mixin-deep@1.3.2">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -18964,6 +21036,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/mixin-deep</property>
+      </properties>
     </component>
     <component type="library" bom-ref="mkdirp-classic@0.5.3">
       <author>Mathias Buus (@mafintosh)</author>
@@ -18997,6 +21072,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/mkdirp-classic</property>
+      </properties>
     </component>
     <component type="library" bom-ref="mkdirp@1.0.4">
       <name>mkdirp</name>
@@ -19021,6 +21099,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/mkdirp</property>
+      </properties>
     </component>
     <component type="library" bom-ref="moment-timezone@0.5.38">
       <author>Tim Wood &lt;washwithcare@gmail.com&gt; (http://timwoodcreates.com/)</author>
@@ -19054,6 +21135,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/moment-timezone</property>
+      </properties>
     </component>
     <component type="library" bom-ref="moment@2.29.4">
       <author>Iskren Ivov Chernev &lt;iskren.chernev@gmail.com&gt; (https://github.com/ichernev)</author>
@@ -19087,6 +21171,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/moment</property>
+      </properties>
     </component>
     <component type="library" bom-ref="morgan@1.10.0">
       <name>morgan</name>
@@ -19111,6 +21198,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/morgan</property>
+      </properties>
       <components>
         <component type="library" bom-ref="morgan@1.10.0|on-finished@2.3.0">
           <name>on-finished</name>
@@ -19135,6 +21225,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/morgan/node_modules/on-finished</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -19170,6 +21263,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/mout</property>
+      </properties>
     </component>
     <component type="library" bom-ref="ms@2.0.0">
       <name>ms</name>
@@ -19194,6 +21290,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/ms</property>
+      </properties>
     </component>
     <component type="library" bom-ref="multer@1.4.4">
       <name>multer</name>
@@ -19218,6 +21317,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/multer</property>
+      </properties>
       <components>
         <component type="library" bom-ref="multer@1.4.4|mkdirp@0.5.6">
           <author>James Halliday &lt;mail@substack.net&gt; (http://substack.net)</author>
@@ -19243,6 +21345,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/multer/node_modules/mkdirp</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -19274,6 +21379,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/mustache</property>
+      </properties>
     </component>
     <component type="library" bom-ref="nan@2.17.0">
       <name>nan</name>
@@ -19298,6 +21406,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/nan</property>
+      </properties>
     </component>
     <component type="library" bom-ref="nanomatch@1.2.13">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -19331,6 +21442,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/nanomatch</property>
+      </properties>
     </component>
     <component type="library" bom-ref="napi-build-utils@1.0.2">
       <author>Jim Schlight</author>
@@ -19364,6 +21478,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/napi-build-utils</property>
+      </properties>
     </component>
     <component type="library" bom-ref="needle@2.9.1">
       <author>Tomás Pollak &lt;tomas@forkhq.com&gt;</author>
@@ -19389,6 +21506,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/needle</property>
+      </properties>
       <components>
         <component type="library" bom-ref="needle@2.9.1|debug@3.2.7">
           <author>TJ Holowaychuk &lt;tj@vision-media.ca&gt;</author>
@@ -19414,6 +21534,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/needle/node_modules/debug</property>
+          </properties>
         </component>
         <component type="library" bom-ref="needle@2.9.1|ms@2.1.3">
           <name>ms</name>
@@ -19438,6 +21561,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/needle/node_modules/ms</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -19464,6 +21590,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/negotiator</property>
+      </properties>
     </component>
     <component type="library" bom-ref="neo-async@2.6.2">
       <name>neo-async</name>
@@ -19488,6 +21617,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/neo-async</property>
+      </properties>
     </component>
     <component type="library" bom-ref="node-abi@2.30.1">
       <author>Lukas Geiger</author>
@@ -19521,6 +21653,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/node-abi</property>
+      </properties>
       <components>
         <component type="library" bom-ref="node-abi@2.30.1|semver@5.7.1">
           <name>semver</name>
@@ -19545,6 +21680,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/node-abi/node_modules/semver</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -19579,6 +21717,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/node-addon-api</property>
+      </properties>
     </component>
     <component type="library" bom-ref="node-fetch@2.6.7">
       <author>David Frank</author>
@@ -19612,6 +21753,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/node-fetch</property>
+      </properties>
     </component>
     <component type="library" bom-ref="node-gyp@8.4.1">
       <author>Nathan Rajlich &lt;nathan@tootallnate.net&gt; (http://tootallnate.net)</author>
@@ -19637,6 +21781,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/node-gyp</property>
+      </properties>
       <components>
         <component type="library" bom-ref="node-gyp@8.4.1|ansi-regex@5.0.1">
           <author>Sindre Sorhus</author>
@@ -19662,6 +21809,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/node-gyp/node_modules/ansi-regex</property>
+          </properties>
         </component>
         <component type="library" bom-ref="node-gyp@8.4.1|are-we-there-yet@3.0.1">
           <author>GitHub Inc.</author>
@@ -19695,6 +21845,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/node-gyp/node_modules/are-we-there-yet</property>
+          </properties>
         </component>
         <component type="library" bom-ref="node-gyp@8.4.1|gauge@4.0.4">
           <author>GitHub Inc.</author>
@@ -19728,6 +21881,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/node-gyp/node_modules/gauge</property>
+          </properties>
         </component>
         <component type="library" bom-ref="node-gyp@8.4.1|is-fullwidth-code-point@3.0.0">
           <author>Sindre Sorhus</author>
@@ -19753,6 +21909,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/node-gyp/node_modules/is-fullwidth-code-point</property>
+          </properties>
         </component>
         <component type="library" bom-ref="node-gyp@8.4.1|nopt@5.0.0">
           <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me/)</author>
@@ -19778,6 +21937,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/node-gyp/node_modules/nopt</property>
+          </properties>
         </component>
         <component type="library" bom-ref="node-gyp@8.4.1|npmlog@6.0.2">
           <author>GitHub Inc.</author>
@@ -19803,6 +21965,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/node-gyp/node_modules/npmlog</property>
+          </properties>
         </component>
         <component type="library" bom-ref="node-gyp@8.4.1|readable-stream@3.6.0">
           <name>readable-stream</name>
@@ -19827,6 +21992,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/node-gyp/node_modules/readable-stream</property>
+          </properties>
         </component>
         <component type="library" bom-ref="node-gyp@8.4.1|string-width@4.2.3">
           <author>Sindre Sorhus</author>
@@ -19852,6 +22020,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/node-gyp/node_modules/string-width</property>
+          </properties>
         </component>
         <component type="library" bom-ref="node-gyp@8.4.1|strip-ansi@6.0.1">
           <author>Sindre Sorhus</author>
@@ -19877,6 +22048,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/node-gyp/node_modules/strip-ansi</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -19904,6 +22078,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/node-pre-gyp</property>
+      </properties>
       <components>
         <component type="library" bom-ref="node-pre-gyp@0.15.0|chownr@1.1.4">
           <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me/)</author>
@@ -19929,6 +22106,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/node-pre-gyp/node_modules/chownr</property>
+          </properties>
         </component>
         <component type="library" bom-ref="node-pre-gyp@0.15.0|fs-minipass@1.2.7">
           <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me/)</author>
@@ -19962,6 +22142,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/node-pre-gyp/node_modules/fs-minipass</property>
+          </properties>
         </component>
         <component type="library" bom-ref="node-pre-gyp@0.15.0|minipass@2.9.0">
           <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me/)</author>
@@ -19987,6 +22170,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/node-pre-gyp/node_modules/minipass</property>
+          </properties>
         </component>
         <component type="library" bom-ref="node-pre-gyp@0.15.0|minizlib@1.3.3">
           <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me/)</author>
@@ -20012,6 +22198,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/node-pre-gyp/node_modules/minizlib</property>
+          </properties>
         </component>
         <component type="library" bom-ref="node-pre-gyp@0.15.0|mkdirp@0.5.6">
           <author>James Halliday &lt;mail@substack.net&gt; (http://substack.net)</author>
@@ -20037,6 +22226,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/node-pre-gyp/node_modules/mkdirp</property>
+          </properties>
         </component>
         <component type="library" bom-ref="node-pre-gyp@0.15.0|nopt@4.0.3">
           <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me/)</author>
@@ -20062,6 +22254,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/node-pre-gyp/node_modules/nopt</property>
+          </properties>
         </component>
         <component type="library" bom-ref="node-pre-gyp@0.15.0|rimraf@2.7.1">
           <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me/)</author>
@@ -20087,6 +22282,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/node-pre-gyp/node_modules/rimraf</property>
+          </properties>
         </component>
         <component type="library" bom-ref="node-pre-gyp@0.15.0|safe-buffer@5.2.1">
           <author>Feross Aboukhadijeh</author>
@@ -20120,6 +22318,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/node-pre-gyp/node_modules/safe-buffer</property>
+          </properties>
         </component>
         <component type="library" bom-ref="node-pre-gyp@0.15.0|semver@5.7.1">
           <name>semver</name>
@@ -20144,6 +22345,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/node-pre-gyp/node_modules/semver</property>
+          </properties>
         </component>
         <component type="library" bom-ref="node-pre-gyp@0.15.0|tar@4.4.19">
           <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me/)</author>
@@ -20169,6 +22373,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/node-pre-gyp/node_modules/tar</property>
+          </properties>
         </component>
         <component type="library" bom-ref="node-pre-gyp@0.15.0|yallist@3.1.1">
           <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me/)</author>
@@ -20194,6 +22401,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/node-pre-gyp/node_modules/yallist</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -20220,6 +22430,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/noop-logger</property>
+      </properties>
     </component>
     <component type="library" bom-ref="nopt@3.0.6">
       <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me/)</author>
@@ -20245,6 +22458,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/nopt</property>
+      </properties>
     </component>
     <component type="library" bom-ref="normalize-package-data@2.5.0">
       <author>Meryn Stol &lt;merynstol@gmail.com&gt;</author>
@@ -20270,6 +22486,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/normalize-package-data</property>
+      </properties>
       <components>
         <component type="library" bom-ref="normalize-package-data@2.5.0|semver@5.7.1">
           <name>semver</name>
@@ -20294,6 +22513,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/normalize-package-data/node_modules/semver</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -20329,6 +22551,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/normalize-path</property>
+      </properties>
     </component>
     <component type="library" bom-ref="normalize-url@2.0.1">
       <author>Sindre Sorhus</author>
@@ -20354,6 +22579,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/normalize-url</property>
+      </properties>
     </component>
     <component type="library" bom-ref="notevil@1.3.3">
       <author>Matt McKegg</author>
@@ -20383,6 +22611,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/notevil</property>
+      </properties>
       <components>
         <component type="library" bom-ref="notevil@1.3.3|esprima@1.0.4">
           <name>esprima</name>
@@ -20391,6 +22622,12 @@
           <hashes>
             <hash alg="SHA-512">ae9e5d30a37ccc4b3d75f8bd8345f50a52e657ffd647293f475e66a6914d202205446e4ff7654fed9d38a7ca64fbe800068f56dad63e907caee8fd661078264c</hash>
           </hashes>
+          <licenses>
+            <license>
+              <name>BSD</name>
+              <url>http://github.com/ariya/esprima/raw/master/LICENSE.BSD</url>
+            </license>
+          </licenses>
           <purl>pkg:npm/esprima@1.0.4</purl>
           <externalReferences>
             <reference type="distribution">
@@ -20406,6 +22643,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/notevil/node_modules/esprima</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -20433,6 +22673,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/npm-bundled</property>
+      </properties>
     </component>
     <component type="library" bom-ref="npm-normalize-package-bin@1.0.1">
       <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (https://izs.me)</author>
@@ -20458,6 +22701,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/npm-normalize-package-bin</property>
+      </properties>
     </component>
     <component type="library" bom-ref="npm-packlist@1.4.8">
       <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me/)</author>
@@ -20491,6 +22737,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/npm-packlist</property>
+      </properties>
     </component>
     <component type="library" bom-ref="npmlog@4.1.2">
       <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me/)</author>
@@ -20516,6 +22765,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/npmlog</property>
+      </properties>
     </component>
     <component type="library" bom-ref="number-is-nan@1.0.1">
       <author>Sindre Sorhus</author>
@@ -20541,6 +22793,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/number-is-nan</property>
+      </properties>
     </component>
     <component type="library" bom-ref="oauth-sign@0.9.0">
       <author>Mikeal Rogers &lt;mikeal.rogers@gmail.com&gt; (http://www.futurealoof.com)</author>
@@ -20566,6 +22821,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/oauth-sign</property>
+      </properties>
     </component>
     <component type="library" bom-ref="object-assign@4.1.1">
       <author>Sindre Sorhus</author>
@@ -20591,6 +22849,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/object-assign</property>
+      </properties>
     </component>
     <component type="library" bom-ref="object-copy@0.1.0">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -20624,6 +22885,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/object-copy</property>
+      </properties>
       <components>
         <component type="library" bom-ref="object-copy@0.1.0|define-property@0.2.5">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -20657,6 +22921,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/object-copy/node_modules/define-property</property>
+          </properties>
         </component>
         <component type="library" bom-ref="object-copy@0.1.0|is-accessor-descriptor@0.1.6">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -20690,6 +22957,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/object-copy/node_modules/is-accessor-descriptor</property>
+          </properties>
         </component>
         <component type="library" bom-ref="object-copy@0.1.0|is-data-descriptor@0.1.4">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -20723,6 +22993,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/object-copy/node_modules/is-data-descriptor</property>
+          </properties>
         </component>
         <component type="library" bom-ref="object-copy@0.1.0|is-descriptor@0.1.6">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -20756,6 +23029,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/object-copy/node_modules/is-descriptor</property>
+          </properties>
           <components>
             <component type="library" bom-ref="object-copy@0.1.0|is-descriptor@0.1.6|kind-of@5.1.0">
               <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -20789,6 +23065,9 @@
                   <comment>as detected from PackageJson property "homepage"</comment>
                 </reference>
               </externalReferences>
+              <properties>
+                <property name="cdx:npm:package:installPath">node_modules/object-copy/node_modules/is-descriptor/node_modules/kind-of</property>
+              </properties>
             </component>
           </components>
         </component>
@@ -20824,6 +23103,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/object-copy/node_modules/kind-of</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -20855,6 +23137,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/object-inspect</property>
+      </properties>
     </component>
     <component type="library" bom-ref="object-is@1.1.5">
       <author>Jordan Harband</author>
@@ -20888,6 +23173,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/object-is</property>
+      </properties>
     </component>
     <component type="library" bom-ref="object-keys@1.1.1">
       <author>Jordan Harband</author>
@@ -20913,6 +23201,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/object-keys</property>
+      </properties>
     </component>
     <component type="library" bom-ref="object-visit@1.0.1">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -20946,6 +23237,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/object-visit</property>
+      </properties>
     </component>
     <component type="library" bom-ref="object.assign@4.1.4">
       <author>Jordan Harband</author>
@@ -20971,6 +23265,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/object.assign</property>
+      </properties>
     </component>
     <component type="library" bom-ref="object.defaults@1.1.0">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -21004,6 +23301,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/object.defaults</property>
+      </properties>
     </component>
     <component type="library" bom-ref="object.map@1.0.1">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -21037,6 +23337,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/object.map</property>
+      </properties>
     </component>
     <component type="library" bom-ref="object.pick@1.3.0">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -21070,6 +23373,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/object.pick</property>
+      </properties>
     </component>
     <component type="library" bom-ref="on-finished@2.4.1">
       <name>on-finished</name>
@@ -21094,6 +23400,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/on-finished</property>
+      </properties>
     </component>
     <component type="library" bom-ref="on-headers@1.0.2">
       <author>Douglas Christopher Wilson &lt;doug@somethingdoug.com&gt;</author>
@@ -21119,6 +23428,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/on-headers</property>
+      </properties>
     </component>
     <component type="library" bom-ref="once@1.4.0">
       <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me/)</author>
@@ -21144,6 +23456,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/once</property>
+      </properties>
     </component>
     <component type="library" bom-ref="one-time@1.0.0">
       <author>Arnout Kazemier</author>
@@ -21169,6 +23484,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/one-time</property>
+      </properties>
     </component>
     <component type="library" bom-ref="opentype.js@0.7.3">
       <author>Frederik De Bleser</author>
@@ -21194,6 +23512,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/opentype.js</property>
+      </properties>
     </component>
     <component type="library" bom-ref="optionator@0.8.3">
       <author>George Zahariev &lt;z@georgezahariev.com&gt;</author>
@@ -21227,6 +23548,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/optionator</property>
+      </properties>
     </component>
     <component type="library" bom-ref="os-homedir@1.0.2">
       <author>Sindre Sorhus</author>
@@ -21252,6 +23576,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/os-homedir</property>
+      </properties>
     </component>
     <component type="library" bom-ref="os-tmpdir@1.0.2">
       <author>Sindre Sorhus</author>
@@ -21277,6 +23604,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/os-tmpdir</property>
+      </properties>
     </component>
     <component type="library" bom-ref="osenv@0.1.5">
       <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me/)</author>
@@ -21302,6 +23632,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/osenv</property>
+      </properties>
     </component>
     <component type="library" bom-ref="otplib@12.0.1">
       <author>Gerald Yeo &lt;contact@fusedthought.com&gt;</author>
@@ -21331,6 +23664,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/otplib</property>
+      </properties>
     </component>
     <component type="library" bom-ref="p-cancelable@0.4.1">
       <author>Sindre Sorhus</author>
@@ -21356,6 +23692,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/p-cancelable</property>
+      </properties>
     </component>
     <component type="library" bom-ref="p-event@2.3.1">
       <author>Sindre Sorhus</author>
@@ -21381,6 +23720,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/p-event</property>
+      </properties>
     </component>
     <component type="library" bom-ref="p-finally@1.0.0">
       <author>Sindre Sorhus</author>
@@ -21406,6 +23748,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/p-finally</property>
+      </properties>
     </component>
     <component type="library" bom-ref="p-is-promise@1.1.0">
       <author>Sindre Sorhus</author>
@@ -21431,6 +23776,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/p-is-promise</property>
+      </properties>
     </component>
     <component type="library" bom-ref="p-limit@2.3.0">
       <author>Sindre Sorhus</author>
@@ -21456,6 +23804,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/p-limit</property>
+      </properties>
     </component>
     <component type="library" bom-ref="p-locate@3.0.0">
       <author>Sindre Sorhus</author>
@@ -21481,6 +23832,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/p-locate</property>
+      </properties>
     </component>
     <component type="library" bom-ref="p-map@4.0.0">
       <author>Sindre Sorhus</author>
@@ -21506,6 +23860,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/p-map</property>
+      </properties>
     </component>
     <component type="library" bom-ref="p-timeout@2.0.1">
       <author>Sindre Sorhus</author>
@@ -21531,6 +23888,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/p-timeout</property>
+      </properties>
     </component>
     <component type="library" bom-ref="p-try@2.2.0">
       <author>Sindre Sorhus</author>
@@ -21556,6 +23916,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/p-try</property>
+      </properties>
     </component>
     <component type="library" bom-ref="pako@0.2.9">
       <name>pako</name>
@@ -21584,6 +23947,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/pako</property>
+      </properties>
     </component>
     <component type="library" bom-ref="parse-filepath@1.0.2">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -21617,6 +23983,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/parse-filepath</property>
+      </properties>
     </component>
     <component type="library" bom-ref="parse-json@4.0.0">
       <author>Sindre Sorhus</author>
@@ -21642,6 +24011,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/parse-json</property>
+      </properties>
     </component>
     <component type="library" bom-ref="parse-passwd@1.0.0">
       <author>Brian Woodward (https://github.com/doowb)</author>
@@ -21675,6 +24047,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/parse-passwd</property>
+      </properties>
     </component>
     <component type="library" bom-ref="parseurl@1.3.3">
       <name>parseurl</name>
@@ -21699,6 +24074,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/parseurl</property>
+      </properties>
     </component>
     <component type="library" bom-ref="pascalcase@0.1.1">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -21732,6 +24110,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/pascalcase</property>
+      </properties>
     </component>
     <component type="library" bom-ref="path-exists@3.0.0">
       <author>Sindre Sorhus</author>
@@ -21757,6 +24138,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/path-exists</property>
+      </properties>
     </component>
     <component type="library" bom-ref="path-is-absolute@1.0.1">
       <author>Sindre Sorhus</author>
@@ -21782,6 +24166,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/path-is-absolute</property>
+      </properties>
     </component>
     <component type="library" bom-ref="path-parse@1.0.7">
       <author>Javier Blanco &lt;http://jbgutierrez.info&gt;</author>
@@ -21815,6 +24202,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/path-parse</property>
+      </properties>
     </component>
     <component type="library" bom-ref="path-root-regex@0.1.2">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -21848,6 +24238,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/path-root-regex</property>
+      </properties>
     </component>
     <component type="library" bom-ref="path-root@0.1.1">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -21881,6 +24274,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/path-root</property>
+      </properties>
     </component>
     <component type="library" bom-ref="path-to-regexp@0.1.7">
       <name>path-to-regexp</name>
@@ -21905,6 +24301,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/path-to-regexp</property>
+      </properties>
     </component>
     <component type="library" bom-ref="pdfkit@0.11.0">
       <author>Devon Govett</author>
@@ -21938,6 +24337,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/pdfkit</property>
+      </properties>
     </component>
     <component type="library" bom-ref="peek-readable@4.1.0">
       <author>Borewit</author>
@@ -21967,6 +24369,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/peek-readable</property>
+      </properties>
     </component>
     <component type="library" bom-ref="pend@1.2.0">
       <author>Andrew Kelley &lt;superjoe30@gmail.com&gt;</author>
@@ -21996,6 +24401,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/pend</property>
+      </properties>
     </component>
     <component type="library" bom-ref="performance-now@2.1.0">
       <author>Braveg1rl &lt;braveg1rl@outlook.com&gt;</author>
@@ -22029,6 +24437,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/performance-now</property>
+      </properties>
     </component>
     <component type="library" bom-ref="pg-connection-string@2.5.0">
       <author>Blaine Bublitz &lt;blaine@iceddev.com&gt; (http://iceddev.com/)</author>
@@ -22062,6 +24473,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/pg-connection-string</property>
+      </properties>
     </component>
     <component type="library" bom-ref="picomatch@2.3.1">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -22095,6 +24509,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/picomatch</property>
+      </properties>
     </component>
     <component type="library" bom-ref="pify@4.0.1">
       <author>Sindre Sorhus</author>
@@ -22120,6 +24537,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/pify</property>
+      </properties>
     </component>
     <component type="library" bom-ref="pinkie-promise@2.0.1">
       <author>Vsevolod Strukchinsky</author>
@@ -22145,6 +24565,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/pinkie-promise</property>
+      </properties>
     </component>
     <component type="library" bom-ref="pinkie@2.0.4">
       <author>Vsevolod Strukchinsky</author>
@@ -22170,6 +24593,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/pinkie</property>
+      </properties>
     </component>
     <component type="library" bom-ref="png-js@1.0.0">
       <author>Devon Govett</author>
@@ -22194,6 +24620,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/png-js</property>
+      </properties>
     </component>
     <component type="library" bom-ref="portscanner@2.2.0">
       <name>portscanner</name>
@@ -22226,6 +24655,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/portscanner</property>
+      </properties>
     </component>
     <component type="library" bom-ref="posix-character-classes@0.1.1">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -22259,6 +24691,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/posix-character-classes</property>
+      </properties>
     </component>
     <component type="library" bom-ref="prebuild-install@5.3.6">
       <author>Mathias Buus (@mafintosh)</author>
@@ -22292,6 +24727,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/prebuild-install</property>
+      </properties>
     </component>
     <component type="library" bom-ref="prelude-ls@1.1.2">
       <author>George Zahariev &lt;z@georgezahariev.com&gt;</author>
@@ -22301,6 +24739,12 @@
       <hashes>
         <hash alg="SHA-512">112176dd5e12286ea55521998183696ec89a02475a6fa6603b17b9da9efe2a27775b7bb76f147855f77fa36d5d98dee34add08c20678bf9314776e8512d5c4f7</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <url>https://raw.github.com/gkz/prelude-ls/master/LICENSE</url>
+        </license>
+      </licenses>
       <purl>pkg:npm/prelude-ls@1.1.2</purl>
       <externalReferences>
         <reference type="distribution">
@@ -22320,6 +24764,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/prelude-ls</property>
+      </properties>
     </component>
     <component type="library" bom-ref="prepend-http@2.0.0">
       <author>Sindre Sorhus</author>
@@ -22345,6 +24792,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/prepend-http</property>
+      </properties>
     </component>
     <component type="library" bom-ref="pretty-bytes@4.0.2">
       <author>Sindre Sorhus</author>
@@ -22370,6 +24820,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/pretty-bytes</property>
+      </properties>
     </component>
     <component type="library" bom-ref="process-nextick-args@2.0.1">
       <name>process-nextick-args</name>
@@ -22402,6 +24855,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/process-nextick-args</property>
+      </properties>
     </component>
     <component type="library" bom-ref="prom-client@12.0.0">
       <author>Simon Nyberg</author>
@@ -22427,6 +24883,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/prom-client</property>
+      </properties>
     </component>
     <component type="library" bom-ref="promise-inflight@1.0.1">
       <author>Rebecca Turner &lt;me@re-becca.org&gt; (http://re-becca.org/)</author>
@@ -22460,6 +24919,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/promise-inflight</property>
+      </properties>
     </component>
     <component type="library" bom-ref="promise-retry@2.0.1">
       <author>IndigoUnited &lt;hello@indigounited.com&gt; (http://indigounited.com)</author>
@@ -22489,6 +24951,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/promise-retry</property>
+      </properties>
       <components>
         <component type="library" bom-ref="promise-retry@2.0.1|err-code@2.0.3">
           <author>IndigoUnited &lt;hello@indigounited.com&gt; (http://indigounited.com)</author>
@@ -22518,6 +24983,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/promise-retry/node_modules/err-code</property>
+          </properties>
         </component>
         <component type="library" bom-ref="promise-retry@2.0.1|retry@0.12.0">
           <author>Tim Koschützki &lt;tim@debuggable.com&gt; (http://debuggable.com/)</author>
@@ -22547,6 +25015,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/promise-retry/node_modules/retry</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -22574,6 +25045,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/promise</property>
+      </properties>
     </component>
     <component type="library" bom-ref="proper-lockfile@1.2.0">
       <author>IndigoUnited &lt;hello@indigounited.com&gt; (http://indigounited.com)</author>
@@ -22603,6 +25077,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/proper-lockfile</property>
+      </properties>
     </component>
     <component type="library" bom-ref="proxy-addr@2.0.7">
       <author>Douglas Christopher Wilson &lt;doug@somethingdoug.com&gt;</author>
@@ -22628,6 +25105,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/proxy-addr</property>
+      </properties>
     </component>
     <component type="library" bom-ref="psl@1.9.0">
       <author>Lupo Montero &lt;lupomontero@gmail.com&gt; (https://lupomontero.com/)</author>
@@ -22649,6 +25129,9 @@
           <comment>as detected from npm-ls property "resolved"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/psl</property>
+      </properties>
     </component>
     <component type="library" bom-ref="pug-attrs@3.0.0">
       <author>Forbes Lindesay</author>
@@ -22674,6 +25157,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/pug-attrs</property>
+      </properties>
     </component>
     <component type="library" bom-ref="pug-code-gen@3.0.2">
       <author>Forbes Lindesay</author>
@@ -22699,6 +25185,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/pug-code-gen</property>
+      </properties>
     </component>
     <component type="library" bom-ref="pug-error@2.0.0">
       <author>Forbes Lindesay</author>
@@ -22724,6 +25213,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/pug-error</property>
+      </properties>
     </component>
     <component type="library" bom-ref="pug-filters@4.0.0">
       <author>Forbes Lindesay</author>
@@ -22749,6 +25241,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/pug-filters</property>
+      </properties>
     </component>
     <component type="library" bom-ref="pug-lexer@5.0.1">
       <author>ForbesLindesay</author>
@@ -22774,6 +25269,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/pug-lexer</property>
+      </properties>
     </component>
     <component type="library" bom-ref="pug-linker@4.0.0">
       <author>Forbes Lindesay</author>
@@ -22799,6 +25297,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/pug-linker</property>
+      </properties>
     </component>
     <component type="library" bom-ref="pug-load@3.0.0">
       <author>ForbesLindesay</author>
@@ -22824,6 +25325,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/pug-load</property>
+      </properties>
     </component>
     <component type="library" bom-ref="pug-parser@6.0.0">
       <author>ForbesLindesay</author>
@@ -22849,6 +25353,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/pug-parser</property>
+      </properties>
     </component>
     <component type="library" bom-ref="pug-runtime@3.0.1">
       <author>ForbesLindesay</author>
@@ -22874,6 +25381,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/pug-runtime</property>
+      </properties>
     </component>
     <component type="library" bom-ref="pug-strip-comments@2.0.0">
       <author>Timothy Gu &lt;timothygu99@gmail.com&gt;</author>
@@ -22899,6 +25409,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/pug-strip-comments</property>
+      </properties>
     </component>
     <component type="library" bom-ref="pug-walk@2.0.0">
       <author>ForbesLindesay</author>
@@ -22924,6 +25437,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/pug-walk</property>
+      </properties>
     </component>
     <component type="library" bom-ref="pug@3.0.2">
       <author>TJ Holowaychuk &lt;tj@vision-media.ca&gt;</author>
@@ -22953,6 +25469,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/pug</property>
+      </properties>
     </component>
     <component type="library" bom-ref="pump@3.0.0">
       <author>Mathias Buus Madsen &lt;mathiasbuus@gmail.com&gt;</author>
@@ -22978,6 +25497,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/pump</property>
+      </properties>
     </component>
     <component type="library" bom-ref="punycode@2.1.1">
       <author>Mathias Bynens</author>
@@ -23011,6 +25533,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/punycode</property>
+      </properties>
     </component>
     <component type="library" bom-ref="qs@6.11.0">
       <name>qs</name>
@@ -23039,6 +25564,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/qs</property>
+      </properties>
     </component>
     <component type="library" bom-ref="query-string@5.1.1">
       <author>Sindre Sorhus</author>
@@ -23064,6 +25592,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/query-string</property>
+      </properties>
     </component>
     <component type="library" bom-ref="range_check@2.0.4">
       <author>Kevin Whitman (https://github.com/keverw)</author>
@@ -23089,6 +25620,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/range_check</property>
+      </properties>
     </component>
     <component type="library" bom-ref="range-parser@1.2.1">
       <author>TJ Holowaychuk &lt;tj@vision-media.ca&gt; (http://tjholowaychuk.com)</author>
@@ -23114,6 +25648,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/range-parser</property>
+      </properties>
     </component>
     <component type="library" bom-ref="raw-body@2.5.1">
       <author>Jonathan Ong &lt;me@jongleberry.com&gt; (http://jongleberry.com)</author>
@@ -23139,6 +25676,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/raw-body</property>
+      </properties>
     </component>
     <component type="library" bom-ref="rc@1.2.8">
       <author>Dominic Tarr &lt;dominic.tarr@gmail.com&gt; (dominictarr.com)</author>
@@ -23162,6 +25702,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/rc</property>
+      </properties>
     </component>
     <component type="library" bom-ref="read-pkg@4.0.1">
       <author>Sindre Sorhus</author>
@@ -23187,6 +25730,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/read-pkg</property>
+      </properties>
       <components>
         <component type="library" bom-ref="read-pkg@4.0.1|pify@3.0.0">
           <author>Sindre Sorhus</author>
@@ -23212,6 +25758,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/read-pkg/node_modules/pify</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -23238,6 +25787,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/readable-stream</property>
+      </properties>
       <components>
         <component type="library" bom-ref="readable-stream@2.3.7|isarray@1.0.0">
           <author>Julian Gruber</author>
@@ -23267,6 +25819,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/readable-stream/node_modules/isarray</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -23298,6 +25853,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/readable-web-to-node-stream</property>
+      </properties>
       <components>
         <component type="library" bom-ref="readable-web-to-node-stream@3.0.2|readable-stream@3.6.0">
           <name>readable-stream</name>
@@ -23322,6 +25880,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/readable-web-to-node-stream/node_modules/readable-stream</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -23357,6 +25918,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/readdirp</property>
+      </properties>
     </component>
     <component type="library" bom-ref="rechoir@0.7.1">
       <author>Gulp Team &lt;team@gulpjs.com&gt; (http://gulpjs.com/)</author>
@@ -23382,6 +25946,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/rechoir</property>
+      </properties>
     </component>
     <component type="library" bom-ref="regex-not@1.0.2">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -23415,6 +25982,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/regex-not</property>
+      </properties>
     </component>
     <component type="library" bom-ref="regexp.prototype.flags@1.4.3">
       <author>Jordan Harband &lt;ljharb@gmail.com&gt;</author>
@@ -23440,6 +26010,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/regexp.prototype.flags</property>
+      </properties>
     </component>
     <component type="library" bom-ref="remove-trailing-separator@1.1.0">
       <author>darsain</author>
@@ -23473,6 +26046,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/remove-trailing-separator</property>
+      </properties>
     </component>
     <component type="library" bom-ref="repeat-element@1.1.4">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -23506,6 +26082,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/repeat-element</property>
+      </properties>
     </component>
     <component type="library" bom-ref="repeat-string@1.6.1">
       <author>Jon Schlinkert (http://github.com/jonschlinkert)</author>
@@ -23539,6 +26118,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/repeat-string</property>
+      </properties>
     </component>
     <component type="library" bom-ref="replace@1.2.2">
       <author>Alessandro Maclaine &lt;almaclaine@gmail.com&gt;</author>
@@ -23564,6 +26146,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/replace</property>
+      </properties>
       <components>
         <component type="library" bom-ref="replace@1.2.2|ansi-regex@5.0.1">
           <author>Sindre Sorhus</author>
@@ -23589,6 +26174,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/replace/node_modules/ansi-regex</property>
+          </properties>
         </component>
         <component type="library" bom-ref="replace@1.2.2|ansi-styles@4.3.0">
           <author>Sindre Sorhus</author>
@@ -23614,6 +26202,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/replace/node_modules/ansi-styles</property>
+          </properties>
         </component>
         <component type="library" bom-ref="replace@1.2.2|brace-expansion@1.1.11">
           <author>Julian Gruber</author>
@@ -23643,6 +26234,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/replace/node_modules/brace-expansion</property>
+          </properties>
         </component>
         <component type="library" bom-ref="replace@1.2.2|cliui@6.0.0">
           <author>Ben Coe &lt;ben@npmjs.com&gt;</author>
@@ -23668,6 +26262,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/replace/node_modules/cliui</property>
+          </properties>
         </component>
         <component type="library" bom-ref="replace@1.2.2|color-convert@2.0.1">
           <author>Heather Arthur &lt;fayearthur@gmail.com&gt;</author>
@@ -23693,6 +26290,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/replace/node_modules/color-convert</property>
+          </properties>
         </component>
         <component type="library" bom-ref="replace@1.2.2|color-name@1.1.4">
           <author>DY &lt;dfcreative@gmail.com&gt;</author>
@@ -23722,6 +26322,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/replace/node_modules/color-name</property>
+          </properties>
         </component>
         <component type="library" bom-ref="replace@1.2.2|find-up@4.1.0">
           <author>Sindre Sorhus</author>
@@ -23747,6 +26350,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/replace/node_modules/find-up</property>
+          </properties>
         </component>
         <component type="library" bom-ref="replace@1.2.2|is-fullwidth-code-point@3.0.0">
           <author>Sindre Sorhus</author>
@@ -23772,6 +26378,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/replace/node_modules/is-fullwidth-code-point</property>
+          </properties>
         </component>
         <component type="library" bom-ref="replace@1.2.2|locate-path@5.0.0">
           <author>Sindre Sorhus</author>
@@ -23797,6 +26406,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/replace/node_modules/locate-path</property>
+          </properties>
         </component>
         <component type="library" bom-ref="replace@1.2.2|minimatch@3.0.5">
           <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me)</author>
@@ -23822,6 +26434,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/replace/node_modules/minimatch</property>
+          </properties>
         </component>
         <component type="library" bom-ref="replace@1.2.2|p-locate@4.1.0">
           <author>Sindre Sorhus</author>
@@ -23847,6 +26462,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/replace/node_modules/p-locate</property>
+          </properties>
         </component>
         <component type="library" bom-ref="replace@1.2.2|path-exists@4.0.0">
           <author>Sindre Sorhus</author>
@@ -23872,6 +26490,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/replace/node_modules/path-exists</property>
+          </properties>
         </component>
         <component type="library" bom-ref="replace@1.2.2|string-width@4.2.3">
           <author>Sindre Sorhus</author>
@@ -23897,6 +26518,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/replace/node_modules/string-width</property>
+          </properties>
         </component>
         <component type="library" bom-ref="replace@1.2.2|strip-ansi@6.0.1">
           <author>Sindre Sorhus</author>
@@ -23922,6 +26546,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/replace/node_modules/strip-ansi</property>
+          </properties>
         </component>
         <component type="library" bom-ref="replace@1.2.2|wrap-ansi@6.2.0">
           <author>Sindre Sorhus</author>
@@ -23947,6 +26574,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/replace/node_modules/wrap-ansi</property>
+          </properties>
         </component>
         <component type="library" bom-ref="replace@1.2.2|yargs-parser@18.1.3">
           <author>Ben Coe &lt;ben@npmjs.com&gt;</author>
@@ -23972,6 +26602,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/replace/node_modules/yargs-parser</property>
+          </properties>
         </component>
         <component type="library" bom-ref="replace@1.2.2|yargs@15.4.1">
           <name>yargs</name>
@@ -24000,6 +26633,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/replace/node_modules/yargs</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -24031,6 +26667,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/request</property>
+      </properties>
       <components>
         <component type="library" bom-ref="request@2.88.2|qs@6.5.3">
           <name>qs</name>
@@ -24059,6 +26698,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/request/node_modules/qs</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -24094,6 +26736,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/require-directory</property>
+      </properties>
     </component>
     <component type="library" bom-ref="require-main-filename@2.0.0">
       <author>Ben Coe &lt;ben@npmjs.com&gt;</author>
@@ -24127,6 +26772,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/require-main-filename</property>
+      </properties>
     </component>
     <component type="library" bom-ref="resolve-dir@1.0.1">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -24160,6 +26808,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/resolve-dir</property>
+      </properties>
     </component>
     <component type="library" bom-ref="resolve-url@0.2.1">
       <author>Simon Lydell</author>
@@ -24185,6 +26836,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/resolve-url</property>
+      </properties>
     </component>
     <component type="library" bom-ref="resolve@1.22.1">
       <author>James Halliday</author>
@@ -24210,6 +26864,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/resolve</property>
+      </properties>
     </component>
     <component type="library" bom-ref="responselike@1.0.2">
       <author>lukechilds</author>
@@ -24235,6 +26892,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/responselike</property>
+      </properties>
     </component>
     <component type="library" bom-ref="restructure@2.0.1">
       <author>Devon Govett &lt;devongovett@gmail.com&gt;</author>
@@ -24268,6 +26928,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/restructure</property>
+      </properties>
     </component>
     <component type="library" bom-ref="ret@0.1.15">
       <author>Roly Fentanes (https://github.com/fent)</author>
@@ -24293,6 +26956,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/ret</property>
+      </properties>
     </component>
     <component type="library" bom-ref="retry-as-promised@6.1.0">
       <author>Mick Hansen &lt;maker@mhansen.io&gt;</author>
@@ -24326,6 +26992,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/retry-as-promised</property>
+      </properties>
     </component>
     <component type="library" bom-ref="retry@0.10.1">
       <author>Tim Koschützki &lt;tim@debuggable.com&gt; (http://debuggable.com/)</author>
@@ -24355,6 +27024,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/retry</property>
+      </properties>
     </component>
     <component type="library" bom-ref="rimraf@3.0.2">
       <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me/)</author>
@@ -24380,6 +27052,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/rimraf</property>
+      </properties>
     </component>
     <component type="library" bom-ref="rxjs@6.6.7">
       <author>Ben Lesh &lt;ben@benlesh.com&gt;</author>
@@ -24413,6 +27088,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/rxjs</property>
+      </properties>
       <components>
         <component type="library" bom-ref="rxjs@6.6.7|tslib@1.14.1">
           <author>Microsoft Corp.</author>
@@ -24446,6 +27124,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/rxjs/node_modules/tslib</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -24481,6 +27162,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/safe-buffer</property>
+      </properties>
     </component>
     <component type="library" bom-ref="safe-regex@1.1.0">
       <author>James Halliday</author>
@@ -24510,6 +27194,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/safe-regex</property>
+      </properties>
     </component>
     <component type="library" bom-ref="safe-stable-stringify@2.4.1">
       <author>Ruben Bridgewater</author>
@@ -24543,6 +27230,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/safe-stable-stringify</property>
+      </properties>
     </component>
     <component type="library" bom-ref="safer-buffer@2.1.2">
       <author>Nikita Skovoroda</author>
@@ -24572,6 +27262,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/safer-buffer</property>
+      </properties>
     </component>
     <component type="library" bom-ref="samsam@1.1.2">
       <author>Christian Johansen</author>
@@ -24596,6 +27289,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/samsam</property>
+      </properties>
     </component>
     <component type="library" bom-ref="sanitize-filename@1.6.3">
       <author>Parsha Pourkhomami</author>
@@ -24617,6 +27313,9 @@
           <comment>as detected from npm-ls property "resolved"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/sanitize-filename</property>
+      </properties>
     </component>
     <component type="library" bom-ref="sanitize-html@1.4.2">
       <author>P'unk Avenue LLC</author>
@@ -24642,6 +27341,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/sanitize-html</property>
+      </properties>
       <components>
         <component type="library" bom-ref="sanitize-html@1.4.2|lodash@2.4.2">
           <author>John-David Dalton &lt;john.david.dalton@gmail.com&gt; (http://allyoucanleet.com/)</author>
@@ -24675,6 +27377,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/sanitize-html/node_modules/lodash</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -24702,6 +27407,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/sax</property>
+      </properties>
     </component>
     <component type="library" bom-ref="seek-bzip@1.0.6">
       <name>seek-bzip</name>
@@ -24726,6 +27434,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/seek-bzip</property>
+      </properties>
     </component>
     <component type="library" bom-ref="semver@7.3.8">
       <author>GitHub Inc.</author>
@@ -24751,6 +27462,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/semver</property>
+      </properties>
     </component>
     <component type="library" bom-ref="send@0.18.0">
       <author>TJ Holowaychuk &lt;tj@vision-media.ca&gt;</author>
@@ -24776,6 +27490,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/send</property>
+      </properties>
       <components>
         <component type="library" bom-ref="send@0.18.0|ms@2.1.3">
           <name>ms</name>
@@ -24800,6 +27517,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/send/node_modules/ms</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -24827,6 +27547,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/sequelize-pool</property>
+      </properties>
     </component>
     <component type="library" bom-ref="sequelize@6.25.3">
       <name>sequelize</name>
@@ -24859,6 +27582,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/sequelize</property>
+      </properties>
       <components>
         <component type="library" bom-ref="sequelize@6.25.3|debug@4.3.4">
           <author>Josh Junon &lt;josh.junon@protonmail.com&gt;</author>
@@ -24884,6 +27610,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/sequelize/node_modules/debug</property>
+          </properties>
         </component>
         <component type="library" bom-ref="sequelize@6.25.3|ms@2.1.2">
           <name>ms</name>
@@ -24908,6 +27637,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/sequelize/node_modules/ms</property>
+          </properties>
         </component>
         <component type="library" bom-ref="sequelize@6.25.3|uuid@8.3.2">
           <name>uuid</name>
@@ -24932,6 +27664,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/sequelize/node_modules/uuid</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -24959,6 +27694,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/serve-index</property>
+      </properties>
       <components>
         <component type="library" bom-ref="serve-index@1.9.1|depd@1.1.2">
           <author>Douglas Christopher Wilson &lt;doug@somethingdoug.com&gt;</author>
@@ -24984,6 +27722,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/serve-index/node_modules/depd</property>
+          </properties>
         </component>
         <component type="library" bom-ref="serve-index@1.9.1|http-errors@1.6.3">
           <author>Jonathan Ong &lt;me@jongleberry.com&gt; (http://jongleberry.com)</author>
@@ -25009,6 +27750,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/serve-index/node_modules/http-errors</property>
+          </properties>
         </component>
         <component type="library" bom-ref="serve-index@1.9.1|inherits@2.0.3">
           <name>inherits</name>
@@ -25033,6 +27777,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/serve-index/node_modules/inherits</property>
+          </properties>
         </component>
         <component type="library" bom-ref="serve-index@1.9.1|setprototypeof@1.1.0">
           <author>Wes Todd</author>
@@ -25066,6 +27813,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/serve-index/node_modules/setprototypeof</property>
+          </properties>
         </component>
         <component type="library" bom-ref="serve-index@1.9.1|statuses@1.5.0">
           <name>statuses</name>
@@ -25090,6 +27840,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/serve-index/node_modules/statuses</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -25117,6 +27870,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/serve-static</property>
+      </properties>
     </component>
     <component type="library" bom-ref="set-blocking@2.0.0">
       <author>Ben Coe &lt;ben@npmjs.com&gt;</author>
@@ -25150,6 +27906,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/set-blocking</property>
+      </properties>
     </component>
     <component type="library" bom-ref="set-value@2.0.1">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -25183,6 +27942,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/set-value</property>
+      </properties>
       <components>
         <component type="library" bom-ref="set-value@2.0.1|extend-shallow@2.0.1">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -25216,6 +27978,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/set-value/node_modules/extend-shallow</property>
+          </properties>
         </component>
         <component type="library" bom-ref="set-value@2.0.1|is-extendable@0.1.1">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -25249,6 +28014,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/set-value/node_modules/is-extendable</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -25276,6 +28044,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/setimmediate</property>
+      </properties>
     </component>
     <component type="library" bom-ref="setprototypeof@1.2.0">
       <author>Wes Todd</author>
@@ -25309,6 +28080,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/setprototypeof</property>
+      </properties>
     </component>
     <component type="library" bom-ref="side-channel@1.0.4">
       <author>Jordan Harband &lt;ljharb@gmail.com&gt;</author>
@@ -25342,6 +28116,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/side-channel</property>
+      </properties>
     </component>
     <component type="library" bom-ref="signal-exit@3.0.7">
       <author>Ben Coe &lt;ben@npmjs.com&gt;</author>
@@ -25375,6 +28152,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/signal-exit</property>
+      </properties>
     </component>
     <component type="library" bom-ref="simple-concat@1.0.1">
       <author>Feross Aboukhadijeh</author>
@@ -25408,6 +28188,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/simple-concat</property>
+      </properties>
     </component>
     <component type="library" bom-ref="simple-get@3.1.1">
       <author>Feross Aboukhadijeh</author>
@@ -25441,6 +28224,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/simple-get</property>
+      </properties>
       <components>
         <component type="library" bom-ref="simple-get@3.1.1|decompress-response@4.2.1">
           <author>Sindre Sorhus</author>
@@ -25466,6 +28252,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/simple-get/node_modules/decompress-response</property>
+          </properties>
         </component>
         <component type="library" bom-ref="simple-get@3.1.1|mimic-response@2.1.0">
           <author>Sindre Sorhus</author>
@@ -25491,6 +28280,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/simple-get/node_modules/mimic-response</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -25518,6 +28310,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/simple-swizzle</property>
+      </properties>
       <components>
         <component type="library" bom-ref="simple-swizzle@0.2.2|is-arrayish@0.3.2">
           <author>Qix (http://github.com/qix-)</author>
@@ -25543,6 +28338,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/simple-swizzle/node_modules/is-arrayish</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -25578,6 +28376,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/sinon</property>
+      </properties>
     </component>
     <component type="library" bom-ref="smart-buffer@4.2.0">
       <author>Josh Glazebrook</author>
@@ -25611,6 +28412,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/smart-buffer</property>
+      </properties>
     </component>
     <component type="library" bom-ref="snapdragon-node@2.1.1">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -25644,6 +28448,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/snapdragon-node</property>
+      </properties>
       <components>
         <component type="library" bom-ref="snapdragon-node@2.1.1|define-property@1.0.0">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -25677,6 +28484,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/snapdragon-node/node_modules/define-property</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -25712,6 +28522,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/snapdragon-util</property>
+      </properties>
       <components>
         <component type="library" bom-ref="snapdragon-util@3.0.1|kind-of@3.2.2">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -25745,6 +28558,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/snapdragon-util/node_modules/kind-of</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -25780,6 +28596,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/snapdragon</property>
+      </properties>
       <components>
         <component type="library" bom-ref="snapdragon@0.8.2|define-property@0.2.5">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -25813,6 +28632,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/snapdragon/node_modules/define-property</property>
+          </properties>
         </component>
         <component type="library" bom-ref="snapdragon@0.8.2|extend-shallow@2.0.1">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -25846,6 +28668,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/snapdragon/node_modules/extend-shallow</property>
+          </properties>
         </component>
         <component type="library" bom-ref="snapdragon@0.8.2|is-accessor-descriptor@0.1.6">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -25879,6 +28704,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/snapdragon/node_modules/is-accessor-descriptor</property>
+          </properties>
           <components>
             <component type="library" bom-ref="snapdragon@0.8.2|is-accessor-descriptor@0.1.6|kind-of@3.2.2">
               <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -25912,6 +28740,9 @@
                   <comment>as detected from PackageJson property "homepage"</comment>
                 </reference>
               </externalReferences>
+              <properties>
+                <property name="cdx:npm:package:installPath">node_modules/snapdragon/node_modules/is-accessor-descriptor/node_modules/kind-of</property>
+              </properties>
             </component>
           </components>
         </component>
@@ -25947,6 +28778,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/snapdragon/node_modules/is-data-descriptor</property>
+          </properties>
           <components>
             <component type="library" bom-ref="snapdragon@0.8.2|is-data-descriptor@0.1.4|kind-of@3.2.2">
               <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -25980,6 +28814,9 @@
                   <comment>as detected from PackageJson property "homepage"</comment>
                 </reference>
               </externalReferences>
+              <properties>
+                <property name="cdx:npm:package:installPath">node_modules/snapdragon/node_modules/is-data-descriptor/node_modules/kind-of</property>
+              </properties>
             </component>
           </components>
         </component>
@@ -26015,6 +28852,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/snapdragon/node_modules/is-descriptor</property>
+          </properties>
         </component>
         <component type="library" bom-ref="snapdragon@0.8.2|is-extendable@0.1.1">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -26048,6 +28888,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/snapdragon/node_modules/is-extendable</property>
+          </properties>
         </component>
         <component type="library" bom-ref="snapdragon@0.8.2|kind-of@5.1.0">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -26081,6 +28924,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/snapdragon/node_modules/kind-of</property>
+          </properties>
         </component>
         <component type="library" bom-ref="snapdragon@0.8.2|source-map@0.5.7">
           <author>Nick Fitzgerald &lt;nfitzgerald@mozilla.com&gt;</author>
@@ -26110,6 +28956,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/snapdragon/node_modules/source-map</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -26136,6 +28985,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/socket.io-adapter</property>
+      </properties>
     </component>
     <component type="library" bom-ref="socket.io-parser@4.0.5">
       <name>socket.io-parser</name>
@@ -26160,6 +29012,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/socket.io-parser</property>
+      </properties>
       <components>
         <component type="library" bom-ref="socket.io-parser@4.0.5|debug@4.3.4">
           <author>Josh Junon &lt;josh.junon@protonmail.com&gt;</author>
@@ -26185,6 +29040,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/socket.io-parser/node_modules/debug</property>
+          </properties>
         </component>
         <component type="library" bom-ref="socket.io-parser@4.0.5|ms@2.1.2">
           <name>ms</name>
@@ -26209,6 +29067,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/socket.io-parser/node_modules/ms</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -26235,6 +29096,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/socket.io</property>
+      </properties>
       <components>
         <component type="library" bom-ref="socket.io@3.1.2|debug@4.3.4">
           <author>Josh Junon &lt;josh.junon@protonmail.com&gt;</author>
@@ -26260,6 +29124,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/socket.io/node_modules/debug</property>
+          </properties>
         </component>
         <component type="library" bom-ref="socket.io@3.1.2|ms@2.1.2">
           <name>ms</name>
@@ -26284,6 +29151,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/socket.io/node_modules/ms</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -26319,6 +29189,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/socks-proxy-agent</property>
+      </properties>
       <components>
         <component type="library" bom-ref="socks-proxy-agent@6.2.1|debug@4.3.4">
           <author>Josh Junon &lt;josh.junon@protonmail.com&gt;</author>
@@ -26344,6 +29217,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/socks-proxy-agent/node_modules/debug</property>
+          </properties>
         </component>
         <component type="library" bom-ref="socks-proxy-agent@6.2.1|ms@2.1.2">
           <name>ms</name>
@@ -26368,6 +29244,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/socks-proxy-agent/node_modules/ms</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -26403,6 +29282,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/socks</property>
+      </properties>
       <components>
         <component type="library" bom-ref="socks@2.7.1|ip@2.0.0">
           <author>Fedor Indutny &lt;fedor@indutny.com&gt;</author>
@@ -26431,6 +29313,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/socks/node_modules/ip</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -26458,6 +29343,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/sort-keys-length</property>
+      </properties>
       <components>
         <component type="library" bom-ref="sort-keys-length@1.0.1|sort-keys@1.1.2">
           <author>Sindre Sorhus</author>
@@ -26483,6 +29371,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/sort-keys-length/node_modules/sort-keys</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -26510,6 +29401,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/sort-keys</property>
+      </properties>
     </component>
     <component type="library" bom-ref="source-map-resolve@0.5.3">
       <author>Simon Lydell</author>
@@ -26535,6 +29429,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/source-map-resolve</property>
+      </properties>
     </component>
     <component type="library" bom-ref="source-map-support@0.5.21">
       <name>source-map-support</name>
@@ -26563,6 +29460,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/source-map-support</property>
+      </properties>
     </component>
     <component type="library" bom-ref="source-map-url@0.4.1">
       <author>Simon Lydell</author>
@@ -26588,6 +29488,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/source-map-url</property>
+      </properties>
     </component>
     <component type="library" bom-ref="source-map@0.6.1">
       <author>Nick Fitzgerald &lt;nfitzgerald@mozilla.com&gt;</author>
@@ -26617,6 +29520,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/source-map</property>
+      </properties>
     </component>
     <component type="library" bom-ref="spawn-command@0.0.2-1">
       <author>Maciej Małecki &lt;me@mmalecki.com&gt;</author>
@@ -26642,6 +29548,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/spawn-command</property>
+      </properties>
     </component>
     <component type="library" bom-ref="spdx-correct@3.1.1">
       <author>Kyle E. Mitchell &lt;kyle@kemitchell.com&gt; (https://kemitchell.com)</author>
@@ -26667,6 +29576,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/spdx-correct</property>
+      </properties>
     </component>
     <component type="library" bom-ref="spdx-exceptions@2.3.0">
       <author>The Linux Foundation</author>
@@ -26692,6 +29604,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/spdx-exceptions</property>
+      </properties>
     </component>
     <component type="library" bom-ref="spdx-expression-parse@3.0.1">
       <author>Kyle E. Mitchell &lt;kyle@kemitchell.com&gt; (https://kemitchell.com)</author>
@@ -26717,6 +29632,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/spdx-expression-parse</property>
+      </properties>
     </component>
     <component type="library" bom-ref="spdx-license-ids@3.0.12">
       <author>Shinnosuke Watanabe (https://github.com/shinnn)</author>
@@ -26742,6 +29660,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/spdx-license-ids</property>
+      </properties>
     </component>
     <component type="library" bom-ref="split-string@3.1.0">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -26775,6 +29696,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/split-string</property>
+      </properties>
     </component>
     <component type="library" bom-ref="sprintf-js@1.1.2">
       <author>Alexandru Mărășteanu &lt;hello@alexei.ro&gt;</author>
@@ -26800,6 +29724,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/sprintf-js</property>
+      </properties>
     </component>
     <component type="library" bom-ref="sqlite3@5.1.2">
       <author>Mapbox</author>
@@ -26829,6 +29756,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/sqlite3</property>
+      </properties>
     </component>
     <component type="library" bom-ref="sshpk@1.17.0">
       <author>Joyent, Inc</author>
@@ -26862,6 +29792,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/sshpk</property>
+      </properties>
     </component>
     <component type="library" bom-ref="ssri@8.0.1">
       <author>Kat Marchán</author>
@@ -26887,6 +29820,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/ssri</property>
+      </properties>
     </component>
     <component type="library" bom-ref="stack-trace@0.0.10">
       <author>Felix Geisendörfer &lt;felix@debuggable.com&gt; (http://debuggable.com/)</author>
@@ -26916,6 +29852,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/stack-trace</property>
+      </properties>
     </component>
     <component type="library" bom-ref="static-extend@0.1.2">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -26949,6 +29888,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/static-extend</property>
+      </properties>
       <components>
         <component type="library" bom-ref="static-extend@0.1.2|define-property@0.2.5">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -26982,6 +29924,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/static-extend/node_modules/define-property</property>
+          </properties>
         </component>
         <component type="library" bom-ref="static-extend@0.1.2|is-accessor-descriptor@0.1.6">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -27015,6 +29960,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/static-extend/node_modules/is-accessor-descriptor</property>
+          </properties>
           <components>
             <component type="library" bom-ref="static-extend@0.1.2|is-accessor-descriptor@0.1.6|kind-of@3.2.2">
               <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -27048,6 +29996,9 @@
                   <comment>as detected from PackageJson property "homepage"</comment>
                 </reference>
               </externalReferences>
+              <properties>
+                <property name="cdx:npm:package:installPath">node_modules/static-extend/node_modules/is-accessor-descriptor/node_modules/kind-of</property>
+              </properties>
             </component>
           </components>
         </component>
@@ -27083,6 +30034,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/static-extend/node_modules/is-data-descriptor</property>
+          </properties>
           <components>
             <component type="library" bom-ref="static-extend@0.1.2|is-data-descriptor@0.1.4|kind-of@3.2.2">
               <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -27116,6 +30070,9 @@
                   <comment>as detected from PackageJson property "homepage"</comment>
                 </reference>
               </externalReferences>
+              <properties>
+                <property name="cdx:npm:package:installPath">node_modules/static-extend/node_modules/is-data-descriptor/node_modules/kind-of</property>
+              </properties>
             </component>
           </components>
         </component>
@@ -27151,6 +30108,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/static-extend/node_modules/is-descriptor</property>
+          </properties>
         </component>
         <component type="library" bom-ref="static-extend@0.1.2|kind-of@5.1.0">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -27184,6 +30144,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/static-extend/node_modules/kind-of</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -27210,6 +30173,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/statuses</property>
+      </properties>
     </component>
     <component type="library" bom-ref="stream-buffers@2.2.0">
       <author>Sam Day &lt;me@samcday.com.au&gt;</author>
@@ -27235,6 +30201,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/stream-buffers</property>
+      </properties>
     </component>
     <component type="library" bom-ref="streamsearch@0.1.2">
       <author>Brian White &lt;mscdex@mscdex.net&gt;</author>
@@ -27244,6 +30213,12 @@
       <hashes>
         <hash alg="SHA-512">8e8b3cbbef892a6d0045c4944c06573950b4992a31ec1867eac060b72ef73f57f72467fbc86d9c9536c134751d75efe476f3f614449a9bebccea5f2306b3711c</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <url>http://github.com/mscdex/streamsearch/raw/master/LICENSE</url>
+        </license>
+      </licenses>
       <purl>pkg:npm/streamsearch@0.1.2</purl>
       <externalReferences>
         <reference type="distribution">
@@ -27255,6 +30230,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/streamsearch</property>
+      </properties>
     </component>
     <component type="library" bom-ref="strict-uri-encode@1.1.0">
       <author>Kevin Mårtensson</author>
@@ -27280,6 +30258,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/strict-uri-encode</property>
+      </properties>
     </component>
     <component type="library" bom-ref="string_decoder@1.1.1">
       <name>string_decoder</name>
@@ -27308,6 +30289,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/string_decoder</property>
+      </properties>
     </component>
     <component type="library" bom-ref="string-width@1.0.2">
       <author>Sindre Sorhus</author>
@@ -27333,6 +30317,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/string-width</property>
+      </properties>
     </component>
     <component type="library" bom-ref="string.fromcodepoint@0.2.1">
       <author>Mathias Bynens</author>
@@ -27342,6 +30329,12 @@
       <hashes>
         <hash alg="SHA-512">9faf47df53a7c5219267265b80196f6085e5acc849434750017d63b354038696941face6537418963d3b6c2c023653cebb7a115c8b9b18f9768031a71ec882aa</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <url>http://mths.be/mit</url>
+        </license>
+      </licenses>
       <purl>pkg:npm/string.fromcodepoint@0.2.1</purl>
       <externalReferences>
         <reference type="distribution">
@@ -27361,6 +30354,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/string.fromcodepoint</property>
+      </properties>
     </component>
     <component type="library" bom-ref="string.prototype.codepointat@0.2.1">
       <author>Mathias Bynens</author>
@@ -27394,6 +30390,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/string.prototype.codepointat</property>
+      </properties>
     </component>
     <component type="library" bom-ref="strip-ansi@3.0.1">
       <author>Sindre Sorhus</author>
@@ -27419,6 +30418,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/strip-ansi</property>
+      </properties>
     </component>
     <component type="library" bom-ref="strip-bom@3.0.0">
       <author>Sindre Sorhus</author>
@@ -27444,6 +30446,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/strip-bom</property>
+      </properties>
     </component>
     <component type="library" bom-ref="strip-dirs@2.1.0">
       <author>Shinnosuke Watanabe (https://github.com/shinnn)</author>
@@ -27469,6 +30474,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/strip-dirs</property>
+      </properties>
     </component>
     <component type="library" bom-ref="strip-json-comments@2.0.1">
       <author>Sindre Sorhus</author>
@@ -27494,6 +30502,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/strip-json-comments</property>
+      </properties>
     </component>
     <component type="library" bom-ref="strip-outer@1.0.1">
       <author>Sindre Sorhus</author>
@@ -27519,6 +30530,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/strip-outer</property>
+      </properties>
     </component>
     <component type="library" bom-ref="strtok3@6.3.0">
       <author>Borewit</author>
@@ -27548,6 +30562,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/strtok3</property>
+      </properties>
     </component>
     <component type="library" bom-ref="supports-color@5.5.0">
       <author>Sindre Sorhus</author>
@@ -27573,6 +30590,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/supports-color</property>
+      </properties>
     </component>
     <component type="library" bom-ref="supports-preserve-symlinks-flag@1.0.0">
       <author>Jordan Harband &lt;ljharb@gmail.com&gt;</author>
@@ -27606,6 +30626,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/supports-preserve-symlinks-flag</property>
+      </properties>
     </component>
     <component type="library" bom-ref="svg-captcha@1.4.0">
       <author>Weilin Shi</author>
@@ -27639,6 +30662,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/svg-captcha</property>
+      </properties>
     </component>
     <component type="library" bom-ref="swagger-ui-dist@4.15.2">
       <name>swagger-ui-dist</name>
@@ -27658,6 +30684,9 @@
           <comment>as detected from npm-ls property "resolved"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/swagger-ui-dist</property>
+      </properties>
     </component>
     <component type="library" bom-ref="swagger-ui-express@4.5.0">
       <author>Stephen Scott</author>
@@ -27687,6 +30716,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/swagger-ui-express</property>
+      </properties>
     </component>
     <component type="library" bom-ref="tar-fs@2.1.1">
       <author>Mathias Buus</author>
@@ -27720,6 +30752,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/tar-fs</property>
+      </properties>
       <components>
         <component type="library" bom-ref="tar-fs@2.1.1|bl@4.1.0">
           <name>bl</name>
@@ -27748,6 +30783,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/tar-fs/node_modules/bl</property>
+          </properties>
         </component>
         <component type="library" bom-ref="tar-fs@2.1.1|chownr@1.1.4">
           <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me/)</author>
@@ -27773,6 +30811,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/tar-fs/node_modules/chownr</property>
+          </properties>
         </component>
         <component type="library" bom-ref="tar-fs@2.1.1|readable-stream@3.6.0">
           <name>readable-stream</name>
@@ -27797,6 +30838,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/tar-fs/node_modules/readable-stream</property>
+          </properties>
         </component>
         <component type="library" bom-ref="tar-fs@2.1.1|tar-stream@2.2.0">
           <author>Mathias Buus &lt;mathiasbuus@gmail.com&gt;</author>
@@ -27830,6 +30874,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/tar-fs/node_modules/tar-stream</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -27865,6 +30912,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/tar-stream</property>
+      </properties>
     </component>
     <component type="library" bom-ref="tar@6.1.12">
       <author>GitHub Inc.</author>
@@ -27890,6 +30940,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/tar</property>
+      </properties>
     </component>
     <component type="library" bom-ref="tdigest@0.1.2">
       <author>Will Welch &lt;welch@quietplease.com&gt; (http://quietplease.com/)</author>
@@ -27923,6 +30976,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/tdigest</property>
+      </properties>
     </component>
     <component type="library" bom-ref="text-hex@1.0.0">
       <author>Arnout Kazemier</author>
@@ -27956,6 +31012,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/text-hex</property>
+      </properties>
     </component>
     <component type="library" bom-ref="thirty-two@1.0.2">
       <author>Chris Umbel &lt;chris@chrisumbel.com&gt;</author>
@@ -27976,6 +31035,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/thirty-two</property>
+      </properties>
     </component>
     <component type="library" bom-ref="through@2.3.8">
       <author>Dominic Tarr &lt;dominic.tarr@gmail.com&gt; (dominictarr.com)</author>
@@ -28005,6 +31067,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/through</property>
+      </properties>
     </component>
     <component type="library" bom-ref="timed-out@4.0.1">
       <author>Vsevolod Strukchinsky</author>
@@ -28030,6 +31095,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/timed-out</property>
+      </properties>
     </component>
     <component type="library" bom-ref="tiny-inflate@1.0.3">
       <author>Devon Govett &lt;devongovett@gmail.com&gt;</author>
@@ -28063,6 +31131,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/tiny-inflate</property>
+      </properties>
     </component>
     <component type="library" bom-ref="to-buffer@1.1.1">
       <author>Mathias Buus (@mafintosh)</author>
@@ -28096,6 +31167,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/to-buffer</property>
+      </properties>
     </component>
     <component type="library" bom-ref="to-fast-properties@2.0.0">
       <author>Sindre Sorhus</author>
@@ -28121,6 +31195,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/to-fast-properties</property>
+      </properties>
     </component>
     <component type="library" bom-ref="to-object-path@0.3.0">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -28154,6 +31231,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/to-object-path</property>
+      </properties>
       <components>
         <component type="library" bom-ref="to-object-path@0.3.0|kind-of@3.2.2">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -28187,6 +31267,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/to-object-path/node_modules/kind-of</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -28222,6 +31305,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/to-regex-range</property>
+      </properties>
     </component>
     <component type="library" bom-ref="to-regex@3.0.2">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -28255,6 +31341,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/to-regex</property>
+      </properties>
     </component>
     <component type="library" bom-ref="toidentifier@1.0.1">
       <author>Douglas Christopher Wilson &lt;doug@somethingdoug.com&gt;</author>
@@ -28280,6 +31369,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/toidentifier</property>
+      </properties>
     </component>
     <component type="library" bom-ref="token-stream@1.0.0">
       <author>ForbesLindesay</author>
@@ -28305,6 +31397,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/token-stream</property>
+      </properties>
     </component>
     <component type="library" bom-ref="token-types@4.2.1">
       <author>Borewit</author>
@@ -28334,6 +31429,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/token-types</property>
+      </properties>
     </component>
     <component type="library" bom-ref="toposort-class@1.0.1">
       <name>toposort-class</name>
@@ -28358,6 +31456,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/toposort-class</property>
+      </properties>
     </component>
     <component type="library" bom-ref="tough-cookie@2.5.0">
       <author>Jeremy Stashewsky</author>
@@ -28391,6 +31492,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/tough-cookie</property>
+      </properties>
     </component>
     <component type="library" bom-ref="tr46@0.0.3">
       <author>Sebastian Mayr &lt;npm@smayr.name&gt;</author>
@@ -28424,6 +31528,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/tr46</property>
+      </properties>
     </component>
     <component type="library" bom-ref="traverse@0.3.9">
       <author>James Halliday</author>
@@ -28449,6 +31556,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/traverse</property>
+      </properties>
     </component>
     <component type="library" bom-ref="tree-kill@1.2.2">
       <author>Peteris Krumins</author>
@@ -28478,6 +31588,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/tree-kill</property>
+      </properties>
     </component>
     <component type="library" bom-ref="trim-repeated@1.0.0">
       <author>Sindre Sorhus</author>
@@ -28503,6 +31616,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/trim-repeated</property>
+      </properties>
     </component>
     <component type="library" bom-ref="triple-beam@1.3.0">
       <author>Charlie Robbins &lt;charlie.robbins@gmail.com&gt;</author>
@@ -28536,6 +31652,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/triple-beam</property>
+      </properties>
     </component>
     <component type="library" bom-ref="truncate-utf8-bytes@1.0.2">
       <author>Carl Xiong &lt;xiongc05@gmail.com&gt;</author>
@@ -28569,6 +31688,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/truncate-utf8-bytes</property>
+      </properties>
     </component>
     <component type="library" bom-ref="ts-node-dev@1.1.8">
       <name>ts-node-dev</name>
@@ -28593,6 +31715,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/ts-node-dev</property>
+      </properties>
       <components>
         <component type="library" bom-ref="ts-node-dev@1.1.8|rimraf@2.7.1">
           <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me/)</author>
@@ -28618,6 +31743,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/ts-node-dev/node_modules/rimraf</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -28653,6 +31781,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/ts-node</property>
+      </properties>
     </component>
     <component type="library" bom-ref="tsconfig@7.0.0">
       <author>Blake Embrey</author>
@@ -28686,6 +31817,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/tsconfig</property>
+      </properties>
     </component>
     <component type="library" bom-ref="tslib@2.4.1">
       <author>Microsoft Corp.</author>
@@ -28719,6 +31853,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/tslib</property>
+      </properties>
     </component>
     <component type="library" bom-ref="tunnel-agent@0.6.0">
       <author>Mikeal Rogers &lt;mikeal.rogers@gmail.com&gt; (http://www.futurealoof.com)</author>
@@ -28744,6 +31881,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/tunnel-agent</property>
+      </properties>
     </component>
     <component type="library" bom-ref="tweetnacl@0.14.5">
       <author>TweetNaCl-js contributors</author>
@@ -28777,6 +31917,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/tweetnacl</property>
+      </properties>
     </component>
     <component type="library" bom-ref="type-check@0.3.2">
       <author>George Zahariev &lt;z@georgezahariev.com&gt;</author>
@@ -28810,6 +31953,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/type-check</property>
+      </properties>
     </component>
     <component type="library" bom-ref="type-is@1.6.18">
       <name>type-is</name>
@@ -28834,6 +31980,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/type-is</property>
+      </properties>
     </component>
     <component type="library" bom-ref="typecast@0.0.1">
       <name>typecast</name>
@@ -28858,6 +32007,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/typecast</property>
+      </properties>
     </component>
     <component type="library" bom-ref="typedarray@0.0.6">
       <author>James Halliday</author>
@@ -28887,6 +32039,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/typedarray</property>
+      </properties>
     </component>
     <component type="library" bom-ref="typescript@4.8.4">
       <author>Microsoft Corp.</author>
@@ -28920,6 +32075,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/typescript</property>
+      </properties>
     </component>
     <component type="library" bom-ref="uglify-js@3.17.4">
       <author>Mihai Bazon &lt;mihai.bazon@gmail.com&gt; (http://lisperator.net/)</author>
@@ -28945,6 +32103,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/uglify-js</property>
+      </properties>
     </component>
     <component type="library" bom-ref="unbzip2-stream@1.4.3">
       <author>Jan Bölsche &lt;jan@lagomorph.de&gt;</author>
@@ -28974,6 +32135,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/unbzip2-stream</property>
+      </properties>
     </component>
     <component type="library" bom-ref="unc-path-regex@0.1.2">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -29007,6 +32171,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/unc-path-regex</property>
+      </properties>
     </component>
     <component type="library" bom-ref="underscore.string@3.3.6">
       <name>underscore.string</name>
@@ -29039,6 +32206,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/underscore.string</property>
+      </properties>
     </component>
     <component type="library" bom-ref="unicode-properties@1.4.1">
       <author>Devon Govett &lt;devongovett@gmail.com&gt;</author>
@@ -29072,6 +32242,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/unicode-properties</property>
+      </properties>
     </component>
     <component type="library" bom-ref="unicode-trie@2.0.0">
       <author>Devon Govett &lt;devongovett@gmail.com&gt;</author>
@@ -29105,6 +32278,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/unicode-trie</property>
+      </properties>
     </component>
     <component type="library" bom-ref="union-value@1.0.1">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -29138,6 +32314,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/union-value</property>
+      </properties>
       <components>
         <component type="library" bom-ref="union-value@1.0.1|is-extendable@0.1.1">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -29171,6 +32350,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/union-value/node_modules/is-extendable</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -29206,6 +32388,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/unique-filename</property>
+      </properties>
     </component>
     <component type="library" bom-ref="unique-slug@2.0.2">
       <author>Rebecca Turner &lt;me@re-becca.org&gt; (http://re-becca.org)</author>
@@ -29231,6 +32416,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/unique-slug</property>
+      </properties>
     </component>
     <component type="library" bom-ref="unit-compare@1.0.1">
       <author>nspragg@gmail.com</author>
@@ -29264,6 +32452,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/unit-compare</property>
+      </properties>
     </component>
     <component type="library" bom-ref="universalify@2.0.0">
       <author>Ryan Zimmerman &lt;opensrc@ryanzim.com&gt;</author>
@@ -29297,6 +32488,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/universalify</property>
+      </properties>
     </component>
     <component type="library" bom-ref="unpipe@1.0.0">
       <author>Douglas Christopher Wilson &lt;doug@somethingdoug.com&gt;</author>
@@ -29322,6 +32516,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/unpipe</property>
+      </properties>
     </component>
     <component type="library" bom-ref="unset-value@1.0.0">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -29355,6 +32552,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/unset-value</property>
+      </properties>
       <components>
         <component type="library" bom-ref="unset-value@1.0.0|has-value@0.3.1">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -29388,6 +32588,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/unset-value/node_modules/has-value</property>
+          </properties>
           <components>
             <component type="library" bom-ref="unset-value@1.0.0|has-value@0.3.1|isobject@2.1.0">
               <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -29421,6 +32624,9 @@
                   <comment>as detected from PackageJson property "homepage"</comment>
                 </reference>
               </externalReferences>
+              <properties>
+                <property name="cdx:npm:package:installPath">node_modules/unset-value/node_modules/has-value/node_modules/isobject</property>
+              </properties>
             </component>
           </components>
         </component>
@@ -29456,6 +32662,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/unset-value/node_modules/has-values</property>
+          </properties>
         </component>
         <component type="library" bom-ref="unset-value@1.0.0|isarray@1.0.0">
           <author>Julian Gruber</author>
@@ -29485,6 +32694,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/unset-value/node_modules/isarray</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -29512,6 +32724,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/untildify</property>
+      </properties>
     </component>
     <component type="library" bom-ref="unzipper@0.9.15">
       <author>Evan Oxfeld &lt;eoxfeld@gmail.com&gt;</author>
@@ -29537,6 +32752,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/unzipper</property>
+      </properties>
       <components>
         <component type="library" bom-ref="unzipper@0.9.15|bluebird@3.4.7">
           <author>Petka Antonov</author>
@@ -29570,6 +32788,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/unzipper/node_modules/bluebird</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -29605,6 +32826,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/uri-js</property>
+      </properties>
     </component>
     <component type="library" bom-ref="urix@0.1.0">
       <author>Simon Lydell</author>
@@ -29630,6 +32854,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/urix</property>
+      </properties>
     </component>
     <component type="library" bom-ref="url-parse-lax@3.0.0">
       <author>Sindre Sorhus</author>
@@ -29655,6 +32882,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/url-parse-lax</property>
+      </properties>
     </component>
     <component type="library" bom-ref="url-to-options@1.0.1">
       <author>Steven Vachon &lt;contact@svachon.com&gt; (https://www.svachon.com/)</author>
@@ -29680,6 +32910,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/url-to-options</property>
+      </properties>
     </component>
     <component type="library" bom-ref="use@3.1.1">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -29713,6 +32946,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/use</property>
+      </properties>
     </component>
     <component type="library" bom-ref="utf8-byte-length@1.0.4">
       <author>Carl Xiong &lt;xiongc05@gmail.com&gt;</author>
@@ -29746,6 +32982,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/utf8-byte-length</property>
+      </properties>
     </component>
     <component type="library" bom-ref="util-deprecate@1.0.2">
       <author>Nathan Rajlich &lt;nathan@tootallnate.net&gt; (http://n8.io/)</author>
@@ -29779,6 +33018,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/util-deprecate</property>
+      </properties>
     </component>
     <component type="library" bom-ref="util@0.12.5">
       <author>Joyent</author>
@@ -29808,6 +33050,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/util</property>
+      </properties>
     </component>
     <component type="library" bom-ref="utils-merge@1.0.1">
       <author>Jared Hanson</author>
@@ -29820,6 +33065,10 @@
       <licenses>
         <license>
           <id>MIT</id>
+        </license>
+        <license>
+          <id>MIT</id>
+          <url>http://opensource.org/licenses/MIT</url>
         </license>
       </licenses>
       <purl>pkg:npm/utils-merge@1.0.1</purl>
@@ -29837,6 +33086,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/utils-merge</property>
+      </properties>
     </component>
     <component type="library" bom-ref="uuid@3.4.0">
       <name>uuid</name>
@@ -29861,6 +33113,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/uuid</property>
+      </properties>
     </component>
     <component type="library" bom-ref="v8flags@3.2.0">
       <author>Gulp Team &lt;team@gulpjs.com&gt; (http://gulpjs.com/)</author>
@@ -29886,6 +33141,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/v8flags</property>
+      </properties>
     </component>
     <component type="library" bom-ref="validate-npm-package-license@3.0.4">
       <author>Kyle E. Mitchell &lt;kyle@kemitchell.com&gt; (https://kemitchell.com)</author>
@@ -29911,6 +33169,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/validate-npm-package-license</property>
+      </properties>
     </component>
     <component type="library" bom-ref="validate@4.5.1">
       <author>Eivind Fjeldstad</author>
@@ -29936,6 +33197,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/validate</property>
+      </properties>
     </component>
     <component type="library" bom-ref="validator@13.7.0">
       <author>Chris O'Hara &lt;cohara87@gmail.com&gt;</author>
@@ -29969,6 +33233,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/validator</property>
+      </properties>
     </component>
     <component type="library" bom-ref="vary@1.1.2">
       <author>Douglas Christopher Wilson &lt;doug@somethingdoug.com&gt;</author>
@@ -29994,6 +33261,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/vary</property>
+      </properties>
     </component>
     <component type="library" bom-ref="verror@1.10.0">
       <name>verror</name>
@@ -30018,6 +33288,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/verror</property>
+      </properties>
       <components>
         <component type="library" bom-ref="verror@1.10.0|core-util-is@1.0.2">
           <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me/)</author>
@@ -30047,6 +33320,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/verror/node_modules/core-util-is</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -30074,6 +33350,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/vm2</property>
+      </properties>
       <components>
         <component type="library" bom-ref="vm2@3.9.11|acorn@8.8.1">
           <name>acorn</name>
@@ -30102,6 +33381,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/vm2/node_modules/acorn</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -30137,6 +33419,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/void-elements</property>
+      </properties>
     </component>
     <component type="library" bom-ref="walk@2.3.15">
       <author>AJ ONeal &lt;coolaj86@gmail.com&gt;</author>
@@ -30168,6 +33453,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/walk</property>
+      </properties>
     </component>
     <component type="library" bom-ref="walkdir@0.0.11">
       <author>Ryan Day &lt;soldair@gmail.com&gt;</author>
@@ -30197,6 +33485,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/walkdir</property>
+      </properties>
     </component>
     <component type="library" bom-ref="webidl-conversions@3.0.1">
       <author>Domenic Denicola &lt;d@domenic.me&gt; (https://domenic.me/)</author>
@@ -30222,6 +33513,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/webidl-conversions</property>
+      </properties>
     </component>
     <component type="library" bom-ref="whatwg-url@5.0.0">
       <author>Sebastian Mayr &lt;github@smayr.name&gt;</author>
@@ -30247,6 +33541,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/whatwg-url</property>
+      </properties>
     </component>
     <component type="library" bom-ref="which-boxed-primitive@1.0.2">
       <author>Jordan Harband &lt;ljharb@gmail.com&gt;</author>
@@ -30280,6 +33577,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/which-boxed-primitive</property>
+      </properties>
     </component>
     <component type="library" bom-ref="which-collection@1.0.1">
       <author>Jordan Harband &lt;ljharb@gmail.com&gt;</author>
@@ -30313,6 +33613,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/which-collection</property>
+      </properties>
     </component>
     <component type="library" bom-ref="which-module@2.0.0">
       <author>nexdrew</author>
@@ -30346,6 +33649,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/which-module</property>
+      </properties>
     </component>
     <component type="library" bom-ref="which-pm-runs@1.1.0">
       <author>Zoltan Kochan</author>
@@ -30379,6 +33685,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/which-pm-runs</property>
+      </properties>
     </component>
     <component type="library" bom-ref="which-typed-array@1.1.9">
       <author>Jordan Harband</author>
@@ -30404,6 +33713,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/which-typed-array</property>
+      </properties>
     </component>
     <component type="library" bom-ref="which@2.0.2">
       <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me)</author>
@@ -30429,6 +33741,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/which</property>
+      </properties>
     </component>
     <component type="library" bom-ref="wide-align@1.1.5">
       <author>Rebecca Turner &lt;me@re-becca.org&gt; (http://re-becca.org/)</author>
@@ -30454,6 +33769,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/wide-align</property>
+      </properties>
     </component>
     <component type="library" bom-ref="winston-transport@4.5.0">
       <author>Charlie Robbins &lt;charlie.robbins@gmail.com&gt;</author>
@@ -30483,6 +33801,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/winston-transport</property>
+      </properties>
       <components>
         <component type="library" bom-ref="winston-transport@4.5.0|readable-stream@3.6.0">
           <name>readable-stream</name>
@@ -30507,6 +33828,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/winston-transport/node_modules/readable-stream</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -30534,6 +33858,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/winston</property>
+      </properties>
       <components>
         <component type="library" bom-ref="winston@3.8.2|async@3.2.4">
           <author>Caolan McMahon</author>
@@ -30567,6 +33894,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/winston/node_modules/async</property>
+          </properties>
         </component>
         <component type="library" bom-ref="winston@3.8.2|is-stream@2.0.1">
           <author>Sindre Sorhus</author>
@@ -30592,6 +33922,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/winston/node_modules/is-stream</property>
+          </properties>
         </component>
         <component type="library" bom-ref="winston@3.8.2|readable-stream@3.6.0">
           <name>readable-stream</name>
@@ -30616,6 +33949,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/winston/node_modules/readable-stream</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -30643,6 +33979,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/with</property>
+      </properties>
     </component>
     <component type="library" bom-ref="wkx@0.5.0">
       <author>Christian Schwarz</author>
@@ -30668,6 +34007,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/wkx</property>
+      </properties>
     </component>
     <component type="library" bom-ref="word-wrap@1.2.3">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -30701,6 +34043,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/word-wrap</property>
+      </properties>
     </component>
     <component type="library" bom-ref="wordwrap@0.0.3">
       <author>James Halliday</author>
@@ -30726,6 +34071,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/wordwrap</property>
+      </properties>
     </component>
     <component type="library" bom-ref="wrap-ansi@5.1.0">
       <author>Sindre Sorhus</author>
@@ -30751,6 +34099,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/wrap-ansi</property>
+      </properties>
       <components>
         <component type="library" bom-ref="wrap-ansi@5.1.0|ansi-regex@4.1.1">
           <author>Sindre Sorhus</author>
@@ -30776,6 +34127,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/wrap-ansi/node_modules/ansi-regex</property>
+          </properties>
         </component>
         <component type="library" bom-ref="wrap-ansi@5.1.0|emoji-regex@7.0.3">
           <author>Mathias Bynens</author>
@@ -30809,6 +34163,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/wrap-ansi/node_modules/emoji-regex</property>
+          </properties>
         </component>
         <component type="library" bom-ref="wrap-ansi@5.1.0|is-fullwidth-code-point@2.0.0">
           <author>Sindre Sorhus</author>
@@ -30834,6 +34191,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/wrap-ansi/node_modules/is-fullwidth-code-point</property>
+          </properties>
         </component>
         <component type="library" bom-ref="wrap-ansi@5.1.0|string-width@3.1.0">
           <author>Sindre Sorhus</author>
@@ -30859,6 +34219,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/wrap-ansi/node_modules/string-width</property>
+          </properties>
         </component>
         <component type="library" bom-ref="wrap-ansi@5.1.0|strip-ansi@5.2.0">
           <author>Sindre Sorhus</author>
@@ -30884,6 +34247,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/wrap-ansi/node_modules/strip-ansi</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -30919,6 +34285,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/wrappy</property>
+      </properties>
     </component>
     <component type="library" bom-ref="ws@7.4.6">
       <author>Einar Otto Stangvik &lt;einaros@gmail.com&gt; (http://2x.io)</author>
@@ -30952,6 +34321,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/ws</property>
+      </properties>
     </component>
     <component type="library" bom-ref="xtend@4.0.2">
       <author>Raynos &lt;raynos2@gmail.com&gt;</author>
@@ -30985,6 +34357,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/xtend</property>
+      </properties>
     </component>
     <component type="library" bom-ref="y18n@4.0.3">
       <author>Ben Coe &lt;ben@npmjs.com&gt;</author>
@@ -31014,6 +34389,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/y18n</property>
+      </properties>
     </component>
     <component type="library" bom-ref="yallist@4.0.0">
       <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me/)</author>
@@ -31039,6 +34417,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/yallist</property>
+      </properties>
     </component>
     <component type="library" bom-ref="yaml-schema-validator@1.2.3">
       <author>Ketan Saxena</author>
@@ -31064,6 +34445,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/yaml-schema-validator</property>
+      </properties>
     </component>
     <component type="library" bom-ref="yargs-parser@13.1.2">
       <author>Ben Coe &lt;ben@npmjs.com&gt;</author>
@@ -31085,6 +34469,9 @@
           <comment>as detected from npm-ls property "resolved"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/yargs-parser</property>
+      </properties>
     </component>
     <component type="library" bom-ref="yargs@13.3.2">
       <name>yargs</name>
@@ -31113,6 +34500,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/yargs</property>
+      </properties>
       <components>
         <component type="library" bom-ref="yargs@13.3.2|ansi-regex@4.1.1">
           <author>Sindre Sorhus</author>
@@ -31138,6 +34528,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/yargs/node_modules/ansi-regex</property>
+          </properties>
         </component>
         <component type="library" bom-ref="yargs@13.3.2|emoji-regex@7.0.3">
           <author>Mathias Bynens</author>
@@ -31171,6 +34564,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/yargs/node_modules/emoji-regex</property>
+          </properties>
         </component>
         <component type="library" bom-ref="yargs@13.3.2|is-fullwidth-code-point@2.0.0">
           <author>Sindre Sorhus</author>
@@ -31196,6 +34592,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/yargs/node_modules/is-fullwidth-code-point</property>
+          </properties>
         </component>
         <component type="library" bom-ref="yargs@13.3.2|string-width@3.1.0">
           <author>Sindre Sorhus</author>
@@ -31221,6 +34620,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/yargs/node_modules/string-width</property>
+          </properties>
         </component>
         <component type="library" bom-ref="yargs@13.3.2|strip-ansi@5.2.0">
           <author>Sindre Sorhus</author>
@@ -31246,6 +34648,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/yargs/node_modules/strip-ansi</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -31281,6 +34686,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/yauzl</property>
+      </properties>
     </component>
     <component type="library" bom-ref="yn@3.1.1">
       <author>Sindre Sorhus</author>
@@ -31306,6 +34714,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/yn</property>
+      </properties>
     </component>
     <component type="library" bom-ref="z85@0.0.2">
       <author>Michael Sealand &lt;msealand@gmail.com&gt;</author>
@@ -31339,6 +34750,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/z85</property>
+      </properties>
     </component>
     <component type="library" bom-ref="zip-stream@1.2.0">
       <author>Chris Talkington</author>
@@ -31372,6 +34786,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/zip-stream</property>
+      </properties>
     </component>
     <component type="library" bom-ref="zlibjs@0.3.1">
       <author>Yuta Imaya</author>
@@ -31401,6 +34818,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/zlibjs</property>
+      </properties>
     </component>
   </components>
   <dependencies>

--- a/demo/juice-shop/example-results/bom.1.3.xml
+++ b/demo/juice-shop/example-results/bom.1.3.xml
@@ -34,7 +34,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath"/>
+        <property name="cdx:npm:package:path"/>
         <property name="cdx:npm:package:private">true</property>
       </properties>
     </component>
@@ -70,7 +70,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@babel/helper-string-parser</property>
+        <property name="cdx:npm:package:path">node_modules/@babel/helper-string-parser</property>
       </properties>
     </component>
     <component type="library" bom-ref="@babel/helper-validator-identifier@7.19.1">
@@ -99,7 +99,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@babel/helper-validator-identifier</property>
+        <property name="cdx:npm:package:path">node_modules/@babel/helper-validator-identifier</property>
       </properties>
     </component>
     <component type="library" bom-ref="@babel/parser@7.20.2">
@@ -136,7 +136,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@babel/parser</property>
+        <property name="cdx:npm:package:path">node_modules/@babel/parser</property>
       </properties>
     </component>
     <component type="library" bom-ref="@babel/types@7.20.2">
@@ -173,7 +173,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@babel/types</property>
+        <property name="cdx:npm:package:path">node_modules/@babel/types</property>
       </properties>
     </component>
     <component type="library" bom-ref="@colors/colors@1.5.0">
@@ -210,7 +210,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@colors/colors</property>
+        <property name="cdx:npm:package:path">node_modules/@colors/colors</property>
       </properties>
     </component>
     <component type="library" bom-ref="@dabh/diagnostics@2.0.3">
@@ -247,7 +247,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@dabh/diagnostics</property>
+        <property name="cdx:npm:package:path">node_modules/@dabh/diagnostics</property>
       </properties>
     </component>
     <component type="library" bom-ref="@gar/promisify@1.1.3">
@@ -276,7 +276,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@gar/promisify</property>
+        <property name="cdx:npm:package:path">node_modules/@gar/promisify</property>
       </properties>
     </component>
     <component type="library" bom-ref="@mapbox/node-pre-gyp@1.0.10">
@@ -305,7 +305,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@mapbox/node-pre-gyp</property>
+        <property name="cdx:npm:package:path">node_modules/@mapbox/node-pre-gyp</property>
       </properties>
       <components>
         <component type="library" bom-ref="@mapbox/node-pre-gyp@1.0.10|ansi-regex@5.0.1">
@@ -333,7 +333,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/@mapbox/node-pre-gyp/node_modules/ansi-regex</property>
+            <property name="cdx:npm:package:path">node_modules/@mapbox/node-pre-gyp/node_modules/ansi-regex</property>
           </properties>
         </component>
         <component type="library" bom-ref="@mapbox/node-pre-gyp@1.0.10|are-we-there-yet@2.0.0">
@@ -369,7 +369,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/@mapbox/node-pre-gyp/node_modules/are-we-there-yet</property>
+            <property name="cdx:npm:package:path">node_modules/@mapbox/node-pre-gyp/node_modules/are-we-there-yet</property>
           </properties>
         </component>
         <component type="library" bom-ref="@mapbox/node-pre-gyp@1.0.10|detect-libc@2.0.1">
@@ -397,7 +397,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/@mapbox/node-pre-gyp/node_modules/detect-libc</property>
+            <property name="cdx:npm:package:path">node_modules/@mapbox/node-pre-gyp/node_modules/detect-libc</property>
           </properties>
         </component>
         <component type="library" bom-ref="@mapbox/node-pre-gyp@1.0.10|gauge@3.0.2">
@@ -433,7 +433,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/@mapbox/node-pre-gyp/node_modules/gauge</property>
+            <property name="cdx:npm:package:path">node_modules/@mapbox/node-pre-gyp/node_modules/gauge</property>
           </properties>
         </component>
         <component type="library" bom-ref="@mapbox/node-pre-gyp@1.0.10|is-fullwidth-code-point@3.0.0">
@@ -461,7 +461,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/@mapbox/node-pre-gyp/node_modules/is-fullwidth-code-point</property>
+            <property name="cdx:npm:package:path">node_modules/@mapbox/node-pre-gyp/node_modules/is-fullwidth-code-point</property>
           </properties>
         </component>
         <component type="library" bom-ref="@mapbox/node-pre-gyp@1.0.10|make-dir@3.1.0">
@@ -489,7 +489,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/@mapbox/node-pre-gyp/node_modules/make-dir</property>
+            <property name="cdx:npm:package:path">node_modules/@mapbox/node-pre-gyp/node_modules/make-dir</property>
           </properties>
           <components>
             <component type="library" bom-ref="@mapbox/node-pre-gyp@1.0.10|make-dir@3.1.0|semver@6.3.0">
@@ -516,7 +516,7 @@
                 </reference>
               </externalReferences>
               <properties>
-                <property name="cdx:npm:package:installPath">node_modules/@mapbox/node-pre-gyp/node_modules/make-dir/node_modules/semver</property>
+                <property name="cdx:npm:package:path">node_modules/@mapbox/node-pre-gyp/node_modules/make-dir/node_modules/semver</property>
               </properties>
             </component>
           </components>
@@ -546,7 +546,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/@mapbox/node-pre-gyp/node_modules/nopt</property>
+            <property name="cdx:npm:package:path">node_modules/@mapbox/node-pre-gyp/node_modules/nopt</property>
           </properties>
         </component>
         <component type="library" bom-ref="@mapbox/node-pre-gyp@1.0.10|npmlog@5.0.1">
@@ -574,7 +574,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/@mapbox/node-pre-gyp/node_modules/npmlog</property>
+            <property name="cdx:npm:package:path">node_modules/@mapbox/node-pre-gyp/node_modules/npmlog</property>
           </properties>
         </component>
         <component type="library" bom-ref="@mapbox/node-pre-gyp@1.0.10|readable-stream@3.6.0">
@@ -601,7 +601,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/@mapbox/node-pre-gyp/node_modules/readable-stream</property>
+            <property name="cdx:npm:package:path">node_modules/@mapbox/node-pre-gyp/node_modules/readable-stream</property>
           </properties>
         </component>
         <component type="library" bom-ref="@mapbox/node-pre-gyp@1.0.10|string-width@4.2.3">
@@ -629,7 +629,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/@mapbox/node-pre-gyp/node_modules/string-width</property>
+            <property name="cdx:npm:package:path">node_modules/@mapbox/node-pre-gyp/node_modules/string-width</property>
           </properties>
         </component>
         <component type="library" bom-ref="@mapbox/node-pre-gyp@1.0.10|strip-ansi@6.0.1">
@@ -657,7 +657,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/@mapbox/node-pre-gyp/node_modules/strip-ansi</property>
+            <property name="cdx:npm:package:path">node_modules/@mapbox/node-pre-gyp/node_modules/strip-ansi</property>
           </properties>
         </component>
       </components>
@@ -692,7 +692,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/core-loader</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/core-loader</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/core@4.23.4">
@@ -725,7 +725,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/core</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/core</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/evaluator@4.22.7">
@@ -758,7 +758,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/evaluator</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/evaluator</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-all@4.24.0">
@@ -791,7 +791,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-all</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/lang-all</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-ar@4.23.4">
@@ -824,7 +824,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-ar</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/lang-ar</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-bn@4.23.4">
@@ -857,7 +857,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-bn</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/lang-bn</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-ca@4.23.4">
@@ -890,7 +890,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-ca</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/lang-ca</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-cs@4.23.4">
@@ -923,7 +923,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-cs</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/lang-cs</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-da@4.23.4">
@@ -956,7 +956,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-da</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/lang-da</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-de@4.23.4">
@@ -989,7 +989,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-de</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/lang-de</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-el@4.23.4">
@@ -1022,7 +1022,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-el</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/lang-el</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-en-min@4.23.4">
@@ -1055,7 +1055,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-en-min</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/lang-en-min</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-en@4.23.4">
@@ -1088,7 +1088,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-en</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/lang-en</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-es@4.23.4">
@@ -1121,7 +1121,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-es</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/lang-es</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-eu@4.23.4">
@@ -1154,7 +1154,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-eu</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/lang-eu</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-fa@4.23.4">
@@ -1187,7 +1187,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-fa</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/lang-fa</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-fi@4.23.4">
@@ -1220,7 +1220,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-fi</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/lang-fi</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-fr@4.23.4">
@@ -1253,7 +1253,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-fr</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/lang-fr</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-ga@4.23.4">
@@ -1286,7 +1286,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-ga</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/lang-ga</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-gl@4.23.4">
@@ -1319,7 +1319,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-gl</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/lang-gl</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-hi@4.23.4">
@@ -1352,7 +1352,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-hi</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/lang-hi</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-hu@4.23.4">
@@ -1385,7 +1385,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-hu</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/lang-hu</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-hy@4.23.4">
@@ -1418,7 +1418,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-hy</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/lang-hy</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-id@4.23.4">
@@ -1451,7 +1451,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-id</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/lang-id</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-it@4.23.4">
@@ -1484,7 +1484,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-it</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/lang-it</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-ja@4.24.0">
@@ -1517,7 +1517,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-ja</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/lang-ja</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-ko@4.23.4">
@@ -1550,7 +1550,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-ko</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/lang-ko</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-lt@4.23.4">
@@ -1583,7 +1583,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-lt</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/lang-lt</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-ms@4.23.4">
@@ -1616,7 +1616,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-ms</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/lang-ms</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-ne@4.23.4">
@@ -1649,7 +1649,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-ne</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/lang-ne</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-nl@4.23.4">
@@ -1682,7 +1682,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-nl</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/lang-nl</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-no@4.23.4">
@@ -1715,7 +1715,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-no</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/lang-no</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-pl@4.23.4">
@@ -1748,7 +1748,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-pl</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/lang-pl</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-pt@4.23.4">
@@ -1781,7 +1781,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-pt</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/lang-pt</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-ro@4.23.4">
@@ -1814,7 +1814,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-ro</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/lang-ro</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-ru@4.23.4">
@@ -1847,7 +1847,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-ru</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/lang-ru</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-sl@4.23.4">
@@ -1880,7 +1880,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-sl</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/lang-sl</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-sr@4.23.4">
@@ -1913,7 +1913,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-sr</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/lang-sr</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-sv@4.23.4">
@@ -1946,7 +1946,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-sv</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/lang-sv</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-ta@4.23.4">
@@ -1979,7 +1979,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-ta</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/lang-ta</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-th@4.23.4">
@@ -2012,7 +2012,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-th</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/lang-th</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-tl@4.23.4">
@@ -2045,7 +2045,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-tl</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/lang-tl</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-tr@4.23.4">
@@ -2078,7 +2078,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-tr</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/lang-tr</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-uk@4.23.4">
@@ -2111,7 +2111,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-uk</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/lang-uk</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-zh@4.23.4">
@@ -2144,7 +2144,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-zh</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/lang-zh</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/language-min@4.22.7">
@@ -2177,7 +2177,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/language-min</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/language-min</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/language@4.22.7">
@@ -2210,7 +2210,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/language</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/language</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/ner@4.23.4">
@@ -2243,7 +2243,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/ner</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/ner</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/neural@4.22.7">
@@ -2276,7 +2276,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/neural</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/neural</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/nlg@4.23.4">
@@ -2309,7 +2309,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/nlg</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/nlg</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/nlp@4.23.5">
@@ -2342,7 +2342,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/nlp</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/nlp</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/nlu@4.23.5">
@@ -2375,7 +2375,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/nlu</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/nlu</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/request@4.22.7">
@@ -2408,7 +2408,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/request</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/request</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/sentiment@4.23.4">
@@ -2441,7 +2441,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/sentiment</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/sentiment</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/similarity@4.22.7">
@@ -2474,7 +2474,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/similarity</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/similarity</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/slot@4.22.17">
@@ -2507,7 +2507,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/slot</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/slot</property>
       </properties>
     </component>
     <component type="library" bom-ref="@npmcli/fs@1.1.1">
@@ -2532,7 +2532,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@npmcli/fs</property>
+        <property name="cdx:npm:package:path">node_modules/@npmcli/fs</property>
       </properties>
     </component>
     <component type="library" bom-ref="@npmcli/move-file@1.1.2">
@@ -2560,7 +2560,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@npmcli/move-file</property>
+        <property name="cdx:npm:package:path">node_modules/@npmcli/move-file</property>
       </properties>
     </component>
     <component type="library" bom-ref="@otplib/core@12.0.1">
@@ -2593,7 +2593,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@otplib/core</property>
+        <property name="cdx:npm:package:path">node_modules/@otplib/core</property>
       </properties>
     </component>
     <component type="library" bom-ref="@otplib/plugin-crypto@12.0.1">
@@ -2626,7 +2626,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@otplib/plugin-crypto</property>
+        <property name="cdx:npm:package:path">node_modules/@otplib/plugin-crypto</property>
       </properties>
     </component>
     <component type="library" bom-ref="@otplib/plugin-thirty-two@12.0.1">
@@ -2659,7 +2659,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@otplib/plugin-thirty-two</property>
+        <property name="cdx:npm:package:path">node_modules/@otplib/plugin-thirty-two</property>
       </properties>
     </component>
     <component type="library" bom-ref="@otplib/preset-default@12.0.1">
@@ -2692,7 +2692,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@otplib/preset-default</property>
+        <property name="cdx:npm:package:path">node_modules/@otplib/preset-default</property>
       </properties>
     </component>
     <component type="library" bom-ref="@otplib/preset-v11@12.0.1">
@@ -2725,7 +2725,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@otplib/preset-v11</property>
+        <property name="cdx:npm:package:path">node_modules/@otplib/preset-v11</property>
       </properties>
     </component>
     <component type="library" bom-ref="@sindresorhus/is@0.7.0">
@@ -2754,7 +2754,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@sindresorhus/is</property>
+        <property name="cdx:npm:package:path">node_modules/@sindresorhus/is</property>
       </properties>
     </component>
     <component type="library" bom-ref="@swc/helpers@0.3.17">
@@ -2791,7 +2791,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@swc/helpers</property>
+        <property name="cdx:npm:package:path">node_modules/@swc/helpers</property>
       </properties>
     </component>
     <component type="library" bom-ref="@tokenizer/token@0.3.0">
@@ -2824,7 +2824,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@tokenizer/token</property>
+        <property name="cdx:npm:package:path">node_modules/@tokenizer/token</property>
       </properties>
     </component>
     <component type="library" bom-ref="@tootallnate/once@2.0.0">
@@ -2857,7 +2857,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@tootallnate/once</property>
+        <property name="cdx:npm:package:path">node_modules/@tootallnate/once</property>
       </properties>
     </component>
     <component type="library" bom-ref="@types/component-emitter@1.2.11">
@@ -2889,7 +2889,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@types/component-emitter</property>
+        <property name="cdx:npm:package:path">node_modules/@types/component-emitter</property>
       </properties>
     </component>
     <component type="library" bom-ref="@types/cookie@0.4.1">
@@ -2921,7 +2921,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@types/cookie</property>
+        <property name="cdx:npm:package:path">node_modules/@types/cookie</property>
       </properties>
     </component>
     <component type="library" bom-ref="@types/cors@2.8.12">
@@ -2953,7 +2953,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@types/cors</property>
+        <property name="cdx:npm:package:path">node_modules/@types/cors</property>
       </properties>
     </component>
     <component type="library" bom-ref="@types/debug@4.1.7">
@@ -2985,7 +2985,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@types/debug</property>
+        <property name="cdx:npm:package:path">node_modules/@types/debug</property>
       </properties>
     </component>
     <component type="library" bom-ref="@types/ms@0.7.31">
@@ -3013,7 +3013,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@types/ms</property>
+        <property name="cdx:npm:package:path">node_modules/@types/ms</property>
       </properties>
     </component>
     <component type="library" bom-ref="@types/node@18.11.9">
@@ -3045,7 +3045,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@types/node</property>
+        <property name="cdx:npm:package:path">node_modules/@types/node</property>
       </properties>
     </component>
     <component type="library" bom-ref="@types/strip-bom@3.0.0">
@@ -3074,7 +3074,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@types/strip-bom</property>
+        <property name="cdx:npm:package:path">node_modules/@types/strip-bom</property>
       </properties>
     </component>
     <component type="library" bom-ref="@types/strip-json-comments@0.0.30">
@@ -3102,7 +3102,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@types/strip-json-comments</property>
+        <property name="cdx:npm:package:path">node_modules/@types/strip-json-comments</property>
       </properties>
     </component>
     <component type="library" bom-ref="@types/validator@13.7.10">
@@ -3134,7 +3134,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@types/validator</property>
+        <property name="cdx:npm:package:path">node_modules/@types/validator</property>
       </properties>
     </component>
     <component type="library" bom-ref="abbrev@1.1.1">
@@ -3162,7 +3162,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/abbrev</property>
+        <property name="cdx:npm:package:path">node_modules/abbrev</property>
       </properties>
     </component>
     <component type="library" bom-ref="accepts@1.3.8">
@@ -3189,7 +3189,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/accepts</property>
+        <property name="cdx:npm:package:path">node_modules/accepts</property>
       </properties>
     </component>
     <component type="library" bom-ref="acorn-walk@8.2.0">
@@ -3220,7 +3220,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/acorn-walk</property>
+        <property name="cdx:npm:package:path">node_modules/acorn-walk</property>
       </properties>
     </component>
     <component type="library" bom-ref="acorn@7.4.1">
@@ -3251,7 +3251,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/acorn</property>
+        <property name="cdx:npm:package:path">node_modules/acorn</property>
       </properties>
     </component>
     <component type="library" bom-ref="agent-base@6.0.2">
@@ -3283,7 +3283,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/agent-base</property>
+        <property name="cdx:npm:package:path">node_modules/agent-base</property>
       </properties>
       <components>
         <component type="library" bom-ref="agent-base@6.0.2|debug@4.3.4">
@@ -3311,7 +3311,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/agent-base/node_modules/debug</property>
+            <property name="cdx:npm:package:path">node_modules/agent-base/node_modules/debug</property>
           </properties>
         </component>
         <component type="library" bom-ref="agent-base@6.0.2|ms@2.1.2">
@@ -3338,7 +3338,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/agent-base/node_modules/ms</property>
+            <property name="cdx:npm:package:path">node_modules/agent-base/node_modules/ms</property>
           </properties>
         </component>
       </components>
@@ -3372,7 +3372,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/agentkeepalive</property>
+        <property name="cdx:npm:package:path">node_modules/agentkeepalive</property>
       </properties>
       <components>
         <component type="library" bom-ref="agentkeepalive@4.2.1|debug@4.3.4">
@@ -3400,7 +3400,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/agentkeepalive/node_modules/debug</property>
+            <property name="cdx:npm:package:path">node_modules/agentkeepalive/node_modules/debug</property>
           </properties>
         </component>
         <component type="library" bom-ref="agentkeepalive@4.2.1|depd@1.1.2">
@@ -3428,7 +3428,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/agentkeepalive/node_modules/depd</property>
+            <property name="cdx:npm:package:path">node_modules/agentkeepalive/node_modules/depd</property>
           </properties>
         </component>
         <component type="library" bom-ref="agentkeepalive@4.2.1|ms@2.1.2">
@@ -3455,7 +3455,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/agentkeepalive/node_modules/ms</property>
+            <property name="cdx:npm:package:path">node_modules/agentkeepalive/node_modules/ms</property>
           </properties>
         </component>
       </components>
@@ -3485,7 +3485,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/aggregate-error</property>
+        <property name="cdx:npm:package:path">node_modules/aggregate-error</property>
       </properties>
     </component>
     <component type="library" bom-ref="ajv@6.12.6">
@@ -3521,7 +3521,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/ajv</property>
+        <property name="cdx:npm:package:path">node_modules/ajv</property>
       </properties>
     </component>
     <component type="library" bom-ref="ansi-regex@2.1.1">
@@ -3549,7 +3549,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/ansi-regex</property>
+        <property name="cdx:npm:package:path">node_modules/ansi-regex</property>
       </properties>
     </component>
     <component type="library" bom-ref="ansi-styles@3.2.1">
@@ -3577,7 +3577,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/ansi-styles</property>
+        <property name="cdx:npm:package:path">node_modules/ansi-styles</property>
       </properties>
     </component>
     <component type="library" bom-ref="anymatch@3.1.2">
@@ -3609,7 +3609,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/anymatch</property>
+        <property name="cdx:npm:package:path">node_modules/anymatch</property>
       </properties>
       <components>
         <component type="library" bom-ref="anymatch@3.1.2|normalize-path@3.0.0">
@@ -3645,7 +3645,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/anymatch/node_modules/normalize-path</property>
+            <property name="cdx:npm:package:path">node_modules/anymatch/node_modules/normalize-path</property>
           </properties>
         </component>
       </components>
@@ -3674,7 +3674,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/append-field</property>
+        <property name="cdx:npm:package:path">node_modules/append-field</property>
       </properties>
     </component>
     <component type="library" bom-ref="aproba@1.2.0">
@@ -3710,7 +3710,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/aproba</property>
+        <property name="cdx:npm:package:path">node_modules/aproba</property>
       </properties>
     </component>
     <component type="library" bom-ref="archive-type@4.0.0">
@@ -3738,7 +3738,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/archive-type</property>
+        <property name="cdx:npm:package:path">node_modules/archive-type</property>
       </properties>
       <components>
         <component type="library" bom-ref="archive-type@4.0.0|file-type@4.4.0">
@@ -3766,7 +3766,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/archive-type/node_modules/file-type</property>
+            <property name="cdx:npm:package:path">node_modules/archive-type/node_modules/file-type</property>
           </properties>
         </component>
       </components>
@@ -3804,7 +3804,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/archiver-utils</property>
+        <property name="cdx:npm:package:path">node_modules/archiver-utils</property>
       </properties>
     </component>
     <component type="library" bom-ref="archiver@1.3.0">
@@ -3840,7 +3840,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/archiver</property>
+        <property name="cdx:npm:package:path">node_modules/archiver</property>
       </properties>
     </component>
     <component type="library" bom-ref="are-we-there-yet@1.1.7">
@@ -3876,7 +3876,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/are-we-there-yet</property>
+        <property name="cdx:npm:package:path">node_modules/are-we-there-yet</property>
       </properties>
     </component>
     <component type="library" bom-ref="arg@4.1.3">
@@ -3904,7 +3904,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/arg</property>
+        <property name="cdx:npm:package:path">node_modules/arg</property>
       </properties>
     </component>
     <component type="library" bom-ref="argparse@1.0.10">
@@ -3931,7 +3931,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/argparse</property>
+        <property name="cdx:npm:package:path">node_modules/argparse</property>
       </properties>
       <components>
         <component type="library" bom-ref="argparse@1.0.10|sprintf-js@1.0.3">
@@ -3959,7 +3959,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/argparse/node_modules/sprintf-js</property>
+            <property name="cdx:npm:package:path">node_modules/argparse/node_modules/sprintf-js</property>
           </properties>
         </component>
       </components>
@@ -3997,7 +3997,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/arr-diff</property>
+        <property name="cdx:npm:package:path">node_modules/arr-diff</property>
       </properties>
     </component>
     <component type="library" bom-ref="arr-flatten@1.1.0">
@@ -4033,7 +4033,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/arr-flatten</property>
+        <property name="cdx:npm:package:path">node_modules/arr-flatten</property>
       </properties>
     </component>
     <component type="library" bom-ref="arr-union@3.1.0">
@@ -4069,7 +4069,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/arr-union</property>
+        <property name="cdx:npm:package:path">node_modules/arr-union</property>
       </properties>
     </component>
     <component type="library" bom-ref="array-each@1.0.1">
@@ -4105,7 +4105,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/array-each</property>
+        <property name="cdx:npm:package:path">node_modules/array-each</property>
       </properties>
     </component>
     <component type="library" bom-ref="array-flatten@1.1.1">
@@ -4141,7 +4141,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/array-flatten</property>
+        <property name="cdx:npm:package:path">node_modules/array-flatten</property>
       </properties>
     </component>
     <component type="library" bom-ref="array-slice@1.1.0">
@@ -4177,7 +4177,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/array-slice</property>
+        <property name="cdx:npm:package:path">node_modules/array-slice</property>
       </properties>
     </component>
     <component type="library" bom-ref="array-unique@0.3.2">
@@ -4213,7 +4213,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/array-unique</property>
+        <property name="cdx:npm:package:path">node_modules/array-unique</property>
       </properties>
     </component>
     <component type="library" bom-ref="asap@2.0.6">
@@ -4240,7 +4240,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/asap</property>
+        <property name="cdx:npm:package:path">node_modules/asap</property>
       </properties>
     </component>
     <component type="library" bom-ref="asn1@0.2.6">
@@ -4268,7 +4268,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/asn1</property>
+        <property name="cdx:npm:package:path">node_modules/asn1</property>
       </properties>
     </component>
     <component type="library" bom-ref="assert-never@1.2.1">
@@ -4296,7 +4296,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/assert-never</property>
+        <property name="cdx:npm:package:path">node_modules/assert-never</property>
       </properties>
     </component>
     <component type="library" bom-ref="assert-plus@1.0.0">
@@ -4324,7 +4324,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/assert-plus</property>
+        <property name="cdx:npm:package:path">node_modules/assert-plus</property>
       </properties>
     </component>
     <component type="library" bom-ref="assign-symbols@1.0.0">
@@ -4360,7 +4360,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/assign-symbols</property>
+        <property name="cdx:npm:package:path">node_modules/assign-symbols</property>
       </properties>
     </component>
     <component type="library" bom-ref="async@2.6.4">
@@ -4396,7 +4396,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/async</property>
+        <property name="cdx:npm:package:path">node_modules/async</property>
       </properties>
     </component>
     <component type="library" bom-ref="asynckit@0.4.0">
@@ -4432,7 +4432,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/asynckit</property>
+        <property name="cdx:npm:package:path">node_modules/asynckit</property>
       </properties>
     </component>
     <component type="library" bom-ref="at-least-node@1.0.0">
@@ -4468,7 +4468,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/at-least-node</property>
+        <property name="cdx:npm:package:path">node_modules/at-least-node</property>
       </properties>
     </component>
     <component type="library" bom-ref="atob@2.1.2">
@@ -4498,7 +4498,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/atob</property>
+        <property name="cdx:npm:package:path">node_modules/atob</property>
       </properties>
     </component>
     <component type="library" bom-ref="available-typed-arrays@1.0.5">
@@ -4534,7 +4534,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/available-typed-arrays</property>
+        <property name="cdx:npm:package:path">node_modules/available-typed-arrays</property>
       </properties>
     </component>
     <component type="library" bom-ref="aws-sign2@0.7.0">
@@ -4562,7 +4562,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/aws-sign2</property>
+        <property name="cdx:npm:package:path">node_modules/aws-sign2</property>
       </properties>
     </component>
     <component type="library" bom-ref="aws4@1.11.0">
@@ -4590,7 +4590,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/aws4</property>
+        <property name="cdx:npm:package:path">node_modules/aws4</property>
       </properties>
     </component>
     <component type="library" bom-ref="babel-walk@3.0.0-canary-5">
@@ -4618,7 +4618,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/babel-walk</property>
+        <property name="cdx:npm:package:path">node_modules/babel-walk</property>
       </properties>
     </component>
     <component type="library" bom-ref="balanced-match@1.0.2">
@@ -4650,7 +4650,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/balanced-match</property>
+        <property name="cdx:npm:package:path">node_modules/balanced-match</property>
       </properties>
     </component>
     <component type="library" bom-ref="base@0.11.2">
@@ -4686,7 +4686,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/base</property>
+        <property name="cdx:npm:package:path">node_modules/base</property>
       </properties>
       <components>
         <component type="library" bom-ref="base@0.11.2|define-property@1.0.0">
@@ -4722,7 +4722,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/base/node_modules/define-property</property>
+            <property name="cdx:npm:package:path">node_modules/base/node_modules/define-property</property>
           </properties>
         </component>
       </components>
@@ -4761,7 +4761,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/base64-arraybuffer</property>
+        <property name="cdx:npm:package:path">node_modules/base64-arraybuffer</property>
       </properties>
     </component>
     <component type="library" bom-ref="base64-js@1.5.1">
@@ -4797,7 +4797,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/base64-js</property>
+        <property name="cdx:npm:package:path">node_modules/base64-js</property>
       </properties>
     </component>
     <component type="library" bom-ref="base64id@2.0.0">
@@ -4825,7 +4825,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/base64id</property>
+        <property name="cdx:npm:package:path">node_modules/base64id</property>
       </properties>
     </component>
     <component type="library" bom-ref="base64url@0.0.6">
@@ -4853,7 +4853,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/base64url</property>
+        <property name="cdx:npm:package:path">node_modules/base64url</property>
       </properties>
     </component>
     <component type="library" bom-ref="basic-auth@2.0.1">
@@ -4880,7 +4880,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/basic-auth</property>
+        <property name="cdx:npm:package:path">node_modules/basic-auth</property>
       </properties>
     </component>
     <component type="library" bom-ref="batch@0.6.1">
@@ -4908,7 +4908,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/batch</property>
+        <property name="cdx:npm:package:path">node_modules/batch</property>
       </properties>
     </component>
     <component type="library" bom-ref="bcrypt-pbkdf@1.0.2">
@@ -4935,7 +4935,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/bcrypt-pbkdf</property>
+        <property name="cdx:npm:package:path">node_modules/bcrypt-pbkdf</property>
       </properties>
     </component>
     <component type="library" bom-ref="big-integer@1.6.51">
@@ -4959,7 +4959,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/big-integer</property>
+        <property name="cdx:npm:package:path">node_modules/big-integer</property>
       </properties>
     </component>
     <component type="library" bom-ref="binary-extensions@2.2.0">
@@ -4987,7 +4987,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/binary-extensions</property>
+        <property name="cdx:npm:package:path">node_modules/binary-extensions</property>
       </properties>
     </component>
     <component type="library" bom-ref="binary@0.3.0">
@@ -5015,7 +5015,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/binary</property>
+        <property name="cdx:npm:package:path">node_modules/binary</property>
       </properties>
     </component>
     <component type="library" bom-ref="bindings@1.5.0">
@@ -5051,7 +5051,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/bindings</property>
+        <property name="cdx:npm:package:path">node_modules/bindings</property>
       </properties>
     </component>
     <component type="library" bom-ref="bintrees@1.0.2">
@@ -5079,7 +5079,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/bintrees</property>
+        <property name="cdx:npm:package:path">node_modules/bintrees</property>
       </properties>
     </component>
     <component type="library" bom-ref="bl@1.2.3">
@@ -5110,7 +5110,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/bl</property>
+        <property name="cdx:npm:package:path">node_modules/bl</property>
       </properties>
     </component>
     <component type="library" bom-ref="bluebird@3.7.2">
@@ -5146,7 +5146,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/bluebird</property>
+        <property name="cdx:npm:package:path">node_modules/bluebird</property>
       </properties>
     </component>
     <component type="library" bom-ref="body-parser@1.20.1">
@@ -5173,7 +5173,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/body-parser</property>
+        <property name="cdx:npm:package:path">node_modules/body-parser</property>
       </properties>
     </component>
     <component type="library" bom-ref="bower-config@1.4.3">
@@ -5205,7 +5205,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/bower-config</property>
+        <property name="cdx:npm:package:path">node_modules/bower-config</property>
       </properties>
       <components>
         <component type="library" bom-ref="bower-config@1.4.3|minimist@0.2.2">
@@ -5237,7 +5237,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/bower-config/node_modules/minimist</property>
+            <property name="cdx:npm:package:path">node_modules/bower-config/node_modules/minimist</property>
           </properties>
         </component>
       </components>
@@ -5271,7 +5271,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/brace-expansion</property>
+        <property name="cdx:npm:package:path">node_modules/brace-expansion</property>
       </properties>
     </component>
     <component type="library" bom-ref="braces@2.3.2">
@@ -5307,7 +5307,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/braces</property>
+        <property name="cdx:npm:package:path">node_modules/braces</property>
       </properties>
       <components>
         <component type="library" bom-ref="braces@2.3.2|extend-shallow@2.0.1">
@@ -5343,7 +5343,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/braces/node_modules/extend-shallow</property>
+            <property name="cdx:npm:package:path">node_modules/braces/node_modules/extend-shallow</property>
           </properties>
         </component>
         <component type="library" bom-ref="braces@2.3.2|is-extendable@0.1.1">
@@ -5379,7 +5379,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/braces/node_modules/is-extendable</property>
+            <property name="cdx:npm:package:path">node_modules/braces/node_modules/is-extendable</property>
           </properties>
         </component>
       </components>
@@ -5417,7 +5417,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/brotli</property>
+        <property name="cdx:npm:package:path">node_modules/brotli</property>
       </properties>
     </component>
     <component type="library" bom-ref="buffer-alloc-unsafe@1.1.0">
@@ -5443,7 +5443,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/buffer-alloc-unsafe</property>
+        <property name="cdx:npm:package:path">node_modules/buffer-alloc-unsafe</property>
       </properties>
     </component>
     <component type="library" bom-ref="buffer-alloc@1.2.0">
@@ -5469,7 +5469,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/buffer-alloc</property>
+        <property name="cdx:npm:package:path">node_modules/buffer-alloc</property>
       </properties>
     </component>
     <component type="library" bom-ref="buffer-crc32@0.2.13">
@@ -5505,7 +5505,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/buffer-crc32</property>
+        <property name="cdx:npm:package:path">node_modules/buffer-crc32</property>
       </properties>
     </component>
     <component type="library" bom-ref="buffer-fill@1.0.0">
@@ -5531,7 +5531,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/buffer-fill</property>
+        <property name="cdx:npm:package:path">node_modules/buffer-fill</property>
       </properties>
     </component>
     <component type="library" bom-ref="buffer-from@1.1.2">
@@ -5557,7 +5557,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/buffer-from</property>
+        <property name="cdx:npm:package:path">node_modules/buffer-from</property>
       </properties>
     </component>
     <component type="library" bom-ref="buffer-indexof-polyfill@1.0.2">
@@ -5593,7 +5593,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/buffer-indexof-polyfill</property>
+        <property name="cdx:npm:package:path">node_modules/buffer-indexof-polyfill</property>
       </properties>
     </component>
     <component type="library" bom-ref="buffer@5.7.1">
@@ -5629,7 +5629,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/buffer</property>
+        <property name="cdx:npm:package:path">node_modules/buffer</property>
       </properties>
     </component>
     <component type="library" bom-ref="buffers@0.1.1">
@@ -5652,7 +5652,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/buffers</property>
+        <property name="cdx:npm:package:path">node_modules/buffers</property>
       </properties>
     </component>
     <component type="library" bom-ref="busboy@0.2.14">
@@ -5681,7 +5681,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/busboy</property>
+        <property name="cdx:npm:package:path">node_modules/busboy</property>
       </properties>
       <components>
         <component type="library" bom-ref="busboy@0.2.14|isarray@0.0.1">
@@ -5713,7 +5713,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/busboy/node_modules/isarray</property>
+            <property name="cdx:npm:package:path">node_modules/busboy/node_modules/isarray</property>
           </properties>
         </component>
         <component type="library" bom-ref="busboy@0.2.14|readable-stream@1.1.14">
@@ -5741,7 +5741,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/busboy/node_modules/readable-stream</property>
+            <property name="cdx:npm:package:path">node_modules/busboy/node_modules/readable-stream</property>
           </properties>
         </component>
         <component type="library" bom-ref="busboy@0.2.14|string_decoder@0.10.31">
@@ -5772,7 +5772,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/busboy/node_modules/string_decoder</property>
+            <property name="cdx:npm:package:path">node_modules/busboy/node_modules/string_decoder</property>
           </properties>
         </component>
       </components>
@@ -5810,7 +5810,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/byline</property>
+        <property name="cdx:npm:package:path">node_modules/byline</property>
       </properties>
     </component>
     <component type="library" bom-ref="bytes@3.1.2">
@@ -5838,7 +5838,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/bytes</property>
+        <property name="cdx:npm:package:path">node_modules/bytes</property>
       </properties>
     </component>
     <component type="library" bom-ref="cacache@15.3.0">
@@ -5865,7 +5865,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/cacache</property>
+        <property name="cdx:npm:package:path">node_modules/cacache</property>
       </properties>
     </component>
     <component type="library" bom-ref="cache-base@1.0.1">
@@ -5901,7 +5901,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/cache-base</property>
+        <property name="cdx:npm:package:path">node_modules/cache-base</property>
       </properties>
     </component>
     <component type="library" bom-ref="cacheable-request@2.1.4">
@@ -5937,7 +5937,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/cacheable-request</property>
+        <property name="cdx:npm:package:path">node_modules/cacheable-request</property>
       </properties>
       <components>
         <component type="library" bom-ref="cacheable-request@2.1.4|get-stream@3.0.0">
@@ -5965,7 +5965,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/cacheable-request/node_modules/get-stream</property>
+            <property name="cdx:npm:package:path">node_modules/cacheable-request/node_modules/get-stream</property>
           </properties>
         </component>
         <component type="library" bom-ref="cacheable-request@2.1.4|lowercase-keys@1.0.0">
@@ -5993,7 +5993,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/cacheable-request/node_modules/lowercase-keys</property>
+            <property name="cdx:npm:package:path">node_modules/cacheable-request/node_modules/lowercase-keys</property>
           </properties>
         </component>
       </components>
@@ -6031,7 +6031,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/call-bind</property>
+        <property name="cdx:npm:package:path">node_modules/call-bind</property>
       </properties>
     </component>
     <component type="library" bom-ref="camelcase@5.3.1">
@@ -6059,7 +6059,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/camelcase</property>
+        <property name="cdx:npm:package:path">node_modules/camelcase</property>
       </properties>
     </component>
     <component type="library" bom-ref="caseless@0.12.0">
@@ -6091,7 +6091,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/caseless</property>
+        <property name="cdx:npm:package:path">node_modules/caseless</property>
       </properties>
     </component>
     <component type="library" bom-ref="chainsaw@0.1.0">
@@ -6119,7 +6119,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/chainsaw</property>
+        <property name="cdx:npm:package:path">node_modules/chainsaw</property>
       </properties>
     </component>
     <component type="library" bom-ref="chalk@2.4.2">
@@ -6146,7 +6146,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/chalk</property>
+        <property name="cdx:npm:package:path">node_modules/chalk</property>
       </properties>
     </component>
     <component type="library" bom-ref="character-parser@2.2.0">
@@ -6174,7 +6174,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/character-parser</property>
+        <property name="cdx:npm:package:path">node_modules/character-parser</property>
       </properties>
     </component>
     <component type="library" bom-ref="check-dependencies@1.1.0">
@@ -6210,7 +6210,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/check-dependencies</property>
+        <property name="cdx:npm:package:path">node_modules/check-dependencies</property>
       </properties>
       <components>
         <component type="library" bom-ref="check-dependencies@1.1.0|semver@5.7.1">
@@ -6237,7 +6237,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/check-dependencies/node_modules/semver</property>
+            <property name="cdx:npm:package:path">node_modules/check-dependencies/node_modules/semver</property>
           </properties>
         </component>
       </components>
@@ -6275,7 +6275,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/check-types</property>
+        <property name="cdx:npm:package:path">node_modules/check-types</property>
       </properties>
     </component>
     <component type="library" bom-ref="chokidar@3.5.3">
@@ -6311,7 +6311,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/chokidar</property>
+        <property name="cdx:npm:package:path">node_modules/chokidar</property>
       </properties>
       <components>
         <component type="library" bom-ref="chokidar@3.5.3|braces@3.0.2">
@@ -6347,7 +6347,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/chokidar/node_modules/braces</property>
+            <property name="cdx:npm:package:path">node_modules/chokidar/node_modules/braces</property>
           </properties>
         </component>
         <component type="library" bom-ref="chokidar@3.5.3|fill-range@7.0.1">
@@ -6383,7 +6383,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/chokidar/node_modules/fill-range</property>
+            <property name="cdx:npm:package:path">node_modules/chokidar/node_modules/fill-range</property>
           </properties>
         </component>
         <component type="library" bom-ref="chokidar@3.5.3|is-glob@4.0.3">
@@ -6419,7 +6419,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/chokidar/node_modules/is-glob</property>
+            <property name="cdx:npm:package:path">node_modules/chokidar/node_modules/is-glob</property>
           </properties>
         </component>
         <component type="library" bom-ref="chokidar@3.5.3|is-number@7.0.0">
@@ -6455,7 +6455,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/chokidar/node_modules/is-number</property>
+            <property name="cdx:npm:package:path">node_modules/chokidar/node_modules/is-number</property>
           </properties>
         </component>
         <component type="library" bom-ref="chokidar@3.5.3|normalize-path@3.0.0">
@@ -6491,7 +6491,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/chokidar/node_modules/normalize-path</property>
+            <property name="cdx:npm:package:path">node_modules/chokidar/node_modules/normalize-path</property>
           </properties>
         </component>
         <component type="library" bom-ref="chokidar@3.5.3|to-regex-range@5.0.1">
@@ -6527,7 +6527,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/chokidar/node_modules/to-regex-range</property>
+            <property name="cdx:npm:package:path">node_modules/chokidar/node_modules/to-regex-range</property>
           </properties>
         </component>
       </components>
@@ -6557,7 +6557,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/chownr</property>
+        <property name="cdx:npm:package:path">node_modules/chownr</property>
       </properties>
     </component>
     <component type="library" bom-ref="clarinet@0.12.5">
@@ -6593,7 +6593,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/clarinet</property>
+        <property name="cdx:npm:package:path">node_modules/clarinet</property>
       </properties>
     </component>
     <component type="library" bom-ref="class-utils@0.3.6">
@@ -6629,7 +6629,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/class-utils</property>
+        <property name="cdx:npm:package:path">node_modules/class-utils</property>
       </properties>
       <components>
         <component type="library" bom-ref="class-utils@0.3.6|define-property@0.2.5">
@@ -6665,7 +6665,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/class-utils/node_modules/define-property</property>
+            <property name="cdx:npm:package:path">node_modules/class-utils/node_modules/define-property</property>
           </properties>
         </component>
         <component type="library" bom-ref="class-utils@0.3.6|is-accessor-descriptor@0.1.6">
@@ -6701,7 +6701,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/class-utils/node_modules/is-accessor-descriptor</property>
+            <property name="cdx:npm:package:path">node_modules/class-utils/node_modules/is-accessor-descriptor</property>
           </properties>
           <components>
             <component type="library" bom-ref="class-utils@0.3.6|is-accessor-descriptor@0.1.6|kind-of@3.2.2">
@@ -6737,7 +6737,7 @@
                 </reference>
               </externalReferences>
               <properties>
-                <property name="cdx:npm:package:installPath">node_modules/class-utils/node_modules/is-accessor-descriptor/node_modules/kind-of</property>
+                <property name="cdx:npm:package:path">node_modules/class-utils/node_modules/is-accessor-descriptor/node_modules/kind-of</property>
               </properties>
             </component>
           </components>
@@ -6775,7 +6775,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/class-utils/node_modules/is-data-descriptor</property>
+            <property name="cdx:npm:package:path">node_modules/class-utils/node_modules/is-data-descriptor</property>
           </properties>
           <components>
             <component type="library" bom-ref="class-utils@0.3.6|is-data-descriptor@0.1.4|kind-of@3.2.2">
@@ -6811,7 +6811,7 @@
                 </reference>
               </externalReferences>
               <properties>
-                <property name="cdx:npm:package:installPath">node_modules/class-utils/node_modules/is-data-descriptor/node_modules/kind-of</property>
+                <property name="cdx:npm:package:path">node_modules/class-utils/node_modules/is-data-descriptor/node_modules/kind-of</property>
               </properties>
             </component>
           </components>
@@ -6849,7 +6849,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/class-utils/node_modules/is-descriptor</property>
+            <property name="cdx:npm:package:path">node_modules/class-utils/node_modules/is-descriptor</property>
           </properties>
         </component>
         <component type="library" bom-ref="class-utils@0.3.6|kind-of@5.1.0">
@@ -6885,7 +6885,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/class-utils/node_modules/kind-of</property>
+            <property name="cdx:npm:package:path">node_modules/class-utils/node_modules/kind-of</property>
           </properties>
         </component>
       </components>
@@ -6915,7 +6915,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/clean-stack</property>
+        <property name="cdx:npm:package:path">node_modules/clean-stack</property>
       </properties>
     </component>
     <component type="library" bom-ref="cliui@5.0.0">
@@ -6943,7 +6943,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/cliui</property>
+        <property name="cdx:npm:package:path">node_modules/cliui</property>
       </properties>
       <components>
         <component type="library" bom-ref="cliui@5.0.0|ansi-regex@4.1.1">
@@ -6971,7 +6971,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/cliui/node_modules/ansi-regex</property>
+            <property name="cdx:npm:package:path">node_modules/cliui/node_modules/ansi-regex</property>
           </properties>
         </component>
         <component type="library" bom-ref="cliui@5.0.0|emoji-regex@7.0.3">
@@ -7007,7 +7007,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/cliui/node_modules/emoji-regex</property>
+            <property name="cdx:npm:package:path">node_modules/cliui/node_modules/emoji-regex</property>
           </properties>
         </component>
         <component type="library" bom-ref="cliui@5.0.0|is-fullwidth-code-point@2.0.0">
@@ -7035,7 +7035,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/cliui/node_modules/is-fullwidth-code-point</property>
+            <property name="cdx:npm:package:path">node_modules/cliui/node_modules/is-fullwidth-code-point</property>
           </properties>
         </component>
         <component type="library" bom-ref="cliui@5.0.0|string-width@3.1.0">
@@ -7063,7 +7063,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/cliui/node_modules/string-width</property>
+            <property name="cdx:npm:package:path">node_modules/cliui/node_modules/string-width</property>
           </properties>
         </component>
         <component type="library" bom-ref="cliui@5.0.0|strip-ansi@5.2.0">
@@ -7091,7 +7091,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/cliui/node_modules/strip-ansi</property>
+            <property name="cdx:npm:package:path">node_modules/cliui/node_modules/strip-ansi</property>
           </properties>
         </component>
       </components>
@@ -7129,7 +7129,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/clone-response</property>
+        <property name="cdx:npm:package:path">node_modules/clone-response</property>
       </properties>
     </component>
     <component type="library" bom-ref="clone@2.1.2">
@@ -7161,7 +7161,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/clone</property>
+        <property name="cdx:npm:package:path">node_modules/clone</property>
       </properties>
     </component>
     <component type="library" bom-ref="code-point-at@1.1.0">
@@ -7189,7 +7189,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/code-point-at</property>
+        <property name="cdx:npm:package:path">node_modules/code-point-at</property>
       </properties>
     </component>
     <component type="library" bom-ref="collection-visit@1.0.0">
@@ -7225,7 +7225,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/collection-visit</property>
+        <property name="cdx:npm:package:path">node_modules/collection-visit</property>
       </properties>
     </component>
     <component type="library" bom-ref="color-convert@1.9.3">
@@ -7253,7 +7253,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/color-convert</property>
+        <property name="cdx:npm:package:path">node_modules/color-convert</property>
       </properties>
     </component>
     <component type="library" bom-ref="color-name@1.1.3">
@@ -7285,7 +7285,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/color-name</property>
+        <property name="cdx:npm:package:path">node_modules/color-name</property>
       </properties>
     </component>
     <component type="library" bom-ref="color-string@1.9.1">
@@ -7313,7 +7313,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/color-string</property>
+        <property name="cdx:npm:package:path">node_modules/color-string</property>
       </properties>
     </component>
     <component type="library" bom-ref="color-support@1.1.3">
@@ -7341,7 +7341,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/color-support</property>
+        <property name="cdx:npm:package:path">node_modules/color-support</property>
       </properties>
     </component>
     <component type="library" bom-ref="color@3.2.1">
@@ -7368,7 +7368,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/color</property>
+        <property name="cdx:npm:package:path">node_modules/color</property>
       </properties>
     </component>
     <component type="library" bom-ref="colors@1.4.0">
@@ -7404,7 +7404,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/colors</property>
+        <property name="cdx:npm:package:path">node_modules/colors</property>
       </properties>
     </component>
     <component type="library" bom-ref="colorspace@1.1.4">
@@ -7440,7 +7440,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/colorspace</property>
+        <property name="cdx:npm:package:path">node_modules/colorspace</property>
       </properties>
     </component>
     <component type="library" bom-ref="combined-stream@1.0.8">
@@ -7472,7 +7472,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/combined-stream</property>
+        <property name="cdx:npm:package:path">node_modules/combined-stream</property>
       </properties>
     </component>
     <component type="library" bom-ref="commander@2.20.3">
@@ -7500,7 +7500,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/commander</property>
+        <property name="cdx:npm:package:path">node_modules/commander</property>
       </properties>
     </component>
     <component type="library" bom-ref="component-emitter@1.3.0">
@@ -7527,7 +7527,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/component-emitter</property>
+        <property name="cdx:npm:package:path">node_modules/component-emitter</property>
       </properties>
     </component>
     <component type="library" bom-ref="component-type@1.2.1">
@@ -7554,7 +7554,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/component-type</property>
+        <property name="cdx:npm:package:path">node_modules/component-type</property>
       </properties>
     </component>
     <component type="library" bom-ref="compress-commons@1.2.2">
@@ -7590,7 +7590,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/compress-commons</property>
+        <property name="cdx:npm:package:path">node_modules/compress-commons</property>
       </properties>
     </component>
     <component type="library" bom-ref="compressible@2.0.18">
@@ -7617,7 +7617,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/compressible</property>
+        <property name="cdx:npm:package:path">node_modules/compressible</property>
       </properties>
     </component>
     <component type="library" bom-ref="compression@1.7.4">
@@ -7644,7 +7644,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/compression</property>
+        <property name="cdx:npm:package:path">node_modules/compression</property>
       </properties>
       <components>
         <component type="library" bom-ref="compression@1.7.4|bytes@3.0.0">
@@ -7672,7 +7672,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/compression/node_modules/bytes</property>
+            <property name="cdx:npm:package:path">node_modules/compression/node_modules/bytes</property>
           </properties>
         </component>
       </components>
@@ -7702,7 +7702,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/concat-map</property>
+        <property name="cdx:npm:package:path">node_modules/concat-map</property>
       </properties>
     </component>
     <component type="library" bom-ref="concat-stream@1.6.2">
@@ -7734,7 +7734,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/concat-stream</property>
+        <property name="cdx:npm:package:path">node_modules/concat-stream</property>
       </properties>
     </component>
     <component type="library" bom-ref="concurrently@5.3.0">
@@ -7762,7 +7762,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/concurrently</property>
+        <property name="cdx:npm:package:path">node_modules/concurrently</property>
       </properties>
       <components>
         <component type="library" bom-ref="concurrently@5.3.0|supports-color@6.1.0">
@@ -7790,7 +7790,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/concurrently/node_modules/supports-color</property>
+            <property name="cdx:npm:package:path">node_modules/concurrently/node_modules/supports-color</property>
           </properties>
         </component>
       </components>
@@ -7824,7 +7824,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/config</property>
+        <property name="cdx:npm:package:path">node_modules/config</property>
       </properties>
     </component>
     <component type="library" bom-ref="console-control-strings@1.1.0">
@@ -7852,7 +7852,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/console-control-strings</property>
+        <property name="cdx:npm:package:path">node_modules/console-control-strings</property>
       </properties>
     </component>
     <component type="library" bom-ref="constantinople@4.0.1">
@@ -7880,7 +7880,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/constantinople</property>
+        <property name="cdx:npm:package:path">node_modules/constantinople</property>
       </properties>
     </component>
     <component type="library" bom-ref="content-disposition@0.5.4">
@@ -7908,7 +7908,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/content-disposition</property>
+        <property name="cdx:npm:package:path">node_modules/content-disposition</property>
       </properties>
       <components>
         <component type="library" bom-ref="content-disposition@0.5.4|safe-buffer@5.2.1">
@@ -7944,7 +7944,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/content-disposition/node_modules/safe-buffer</property>
+            <property name="cdx:npm:package:path">node_modules/content-disposition/node_modules/safe-buffer</property>
           </properties>
         </component>
       </components>
@@ -7974,7 +7974,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/content-type</property>
+        <property name="cdx:npm:package:path">node_modules/content-type</property>
       </properties>
     </component>
     <component type="library" bom-ref="cookie-parser@1.4.6">
@@ -8002,7 +8002,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/cookie-parser</property>
+        <property name="cdx:npm:package:path">node_modules/cookie-parser</property>
       </properties>
     </component>
     <component type="library" bom-ref="cookie-signature@1.0.6">
@@ -8030,7 +8030,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/cookie-signature</property>
+        <property name="cdx:npm:package:path">node_modules/cookie-signature</property>
       </properties>
     </component>
     <component type="library" bom-ref="cookie@0.4.1">
@@ -8058,7 +8058,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/cookie</property>
+        <property name="cdx:npm:package:path">node_modules/cookie</property>
       </properties>
     </component>
     <component type="library" bom-ref="copy-descriptor@0.1.1">
@@ -8094,7 +8094,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/copy-descriptor</property>
+        <property name="cdx:npm:package:path">node_modules/copy-descriptor</property>
       </properties>
     </component>
     <component type="library" bom-ref="core-util-is@1.0.3">
@@ -8126,7 +8126,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/core-util-is</property>
+        <property name="cdx:npm:package:path">node_modules/core-util-is</property>
       </properties>
     </component>
     <component type="library" bom-ref="cors@2.8.5">
@@ -8154,7 +8154,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/cors</property>
+        <property name="cdx:npm:package:path">node_modules/cors</property>
       </properties>
     </component>
     <component type="library" bom-ref="crc@3.8.0">
@@ -8190,7 +8190,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/crc</property>
+        <property name="cdx:npm:package:path">node_modules/crc</property>
       </properties>
     </component>
     <component type="library" bom-ref="crc32-stream@2.0.0">
@@ -8226,7 +8226,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/crc32-stream</property>
+        <property name="cdx:npm:package:path">node_modules/crc32-stream</property>
       </properties>
     </component>
     <component type="library" bom-ref="create-require@1.1.1">
@@ -8253,7 +8253,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/create-require</property>
+        <property name="cdx:npm:package:path">node_modules/create-require</property>
       </properties>
     </component>
     <component type="library" bom-ref="crypto-js@3.3.0">
@@ -8285,7 +8285,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/crypto-js</property>
+        <property name="cdx:npm:package:path">node_modules/crypto-js</property>
       </properties>
     </component>
     <component type="library" bom-ref="dashdash@1.14.1">
@@ -8313,7 +8313,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/dashdash</property>
+        <property name="cdx:npm:package:path">node_modules/dashdash</property>
       </properties>
     </component>
     <component type="library" bom-ref="date-fns@2.29.3">
@@ -8340,7 +8340,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/date-fns</property>
+        <property name="cdx:npm:package:path">node_modules/date-fns</property>
       </properties>
     </component>
     <component type="library" bom-ref="dateformat@3.0.3">
@@ -8372,7 +8372,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/dateformat</property>
+        <property name="cdx:npm:package:path">node_modules/dateformat</property>
       </properties>
     </component>
     <component type="library" bom-ref="debug@2.6.9">
@@ -8400,7 +8400,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/debug</property>
+        <property name="cdx:npm:package:path">node_modules/debug</property>
       </properties>
     </component>
     <component type="library" bom-ref="decamelize@1.2.0">
@@ -8428,7 +8428,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/decamelize</property>
+        <property name="cdx:npm:package:path">node_modules/decamelize</property>
       </properties>
     </component>
     <component type="library" bom-ref="decode-uri-component@0.2.0">
@@ -8456,7 +8456,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/decode-uri-component</property>
+        <property name="cdx:npm:package:path">node_modules/decode-uri-component</property>
       </properties>
     </component>
     <component type="library" bom-ref="decompress-response@3.3.0">
@@ -8483,7 +8483,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/decompress-response</property>
+        <property name="cdx:npm:package:path">node_modules/decompress-response</property>
       </properties>
     </component>
     <component type="library" bom-ref="decompress-tar@4.1.1">
@@ -8511,7 +8511,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/decompress-tar</property>
+        <property name="cdx:npm:package:path">node_modules/decompress-tar</property>
       </properties>
       <components>
         <component type="library" bom-ref="decompress-tar@4.1.1|file-type@5.2.0">
@@ -8539,7 +8539,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/decompress-tar/node_modules/file-type</property>
+            <property name="cdx:npm:package:path">node_modules/decompress-tar/node_modules/file-type</property>
           </properties>
         </component>
       </components>
@@ -8569,7 +8569,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/decompress-tarbz2</property>
+        <property name="cdx:npm:package:path">node_modules/decompress-tarbz2</property>
       </properties>
       <components>
         <component type="library" bom-ref="decompress-tarbz2@4.1.1|file-type@6.2.0">
@@ -8597,7 +8597,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/decompress-tarbz2/node_modules/file-type</property>
+            <property name="cdx:npm:package:path">node_modules/decompress-tarbz2/node_modules/file-type</property>
           </properties>
         </component>
       </components>
@@ -8627,7 +8627,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/decompress-targz</property>
+        <property name="cdx:npm:package:path">node_modules/decompress-targz</property>
       </properties>
       <components>
         <component type="library" bom-ref="decompress-targz@4.1.1|file-type@5.2.0">
@@ -8655,7 +8655,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/decompress-targz/node_modules/file-type</property>
+            <property name="cdx:npm:package:path">node_modules/decompress-targz/node_modules/file-type</property>
           </properties>
         </component>
       </components>
@@ -8685,7 +8685,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/decompress-unzip</property>
+        <property name="cdx:npm:package:path">node_modules/decompress-unzip</property>
       </properties>
       <components>
         <component type="library" bom-ref="decompress-unzip@4.0.1|file-type@3.9.0">
@@ -8713,7 +8713,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/decompress-unzip/node_modules/file-type</property>
+            <property name="cdx:npm:package:path">node_modules/decompress-unzip/node_modules/file-type</property>
           </properties>
         </component>
         <component type="library" bom-ref="decompress-unzip@4.0.1|get-stream@2.3.1">
@@ -8741,7 +8741,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/decompress-unzip/node_modules/get-stream</property>
+            <property name="cdx:npm:package:path">node_modules/decompress-unzip/node_modules/get-stream</property>
           </properties>
         </component>
         <component type="library" bom-ref="decompress-unzip@4.0.1|pify@2.3.0">
@@ -8769,7 +8769,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/decompress-unzip/node_modules/pify</property>
+            <property name="cdx:npm:package:path">node_modules/decompress-unzip/node_modules/pify</property>
           </properties>
         </component>
       </components>
@@ -8799,7 +8799,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/decompress</property>
+        <property name="cdx:npm:package:path">node_modules/decompress</property>
       </properties>
       <components>
         <component type="library" bom-ref="decompress@4.2.1|make-dir@1.3.0">
@@ -8827,7 +8827,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/decompress/node_modules/make-dir</property>
+            <property name="cdx:npm:package:path">node_modules/decompress/node_modules/make-dir</property>
           </properties>
           <components>
             <component type="library" bom-ref="decompress@4.2.1|make-dir@1.3.0|pify@3.0.0">
@@ -8855,7 +8855,7 @@
                 </reference>
               </externalReferences>
               <properties>
-                <property name="cdx:npm:package:installPath">node_modules/decompress/node_modules/make-dir/node_modules/pify</property>
+                <property name="cdx:npm:package:path">node_modules/decompress/node_modules/make-dir/node_modules/pify</property>
               </properties>
             </component>
           </components>
@@ -8885,7 +8885,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/decompress/node_modules/pify</property>
+            <property name="cdx:npm:package:path">node_modules/decompress/node_modules/pify</property>
           </properties>
         </component>
       </components>
@@ -8915,7 +8915,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/deep-equal</property>
+        <property name="cdx:npm:package:path">node_modules/deep-equal</property>
       </properties>
     </component>
     <component type="library" bom-ref="deep-extend@0.6.0">
@@ -8955,7 +8955,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/deep-extend</property>
+        <property name="cdx:npm:package:path">node_modules/deep-extend</property>
       </properties>
     </component>
     <component type="library" bom-ref="deep-is@0.1.4">
@@ -8983,7 +8983,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/deep-is</property>
+        <property name="cdx:npm:package:path">node_modules/deep-is</property>
       </properties>
     </component>
     <component type="library" bom-ref="define-properties@1.1.4">
@@ -9011,7 +9011,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/define-properties</property>
+        <property name="cdx:npm:package:path">node_modules/define-properties</property>
       </properties>
     </component>
     <component type="library" bom-ref="define-property@2.0.2">
@@ -9047,7 +9047,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/define-property</property>
+        <property name="cdx:npm:package:path">node_modules/define-property</property>
       </properties>
     </component>
     <component type="library" bom-ref="delayed-stream@1.0.0">
@@ -9079,7 +9079,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/delayed-stream</property>
+        <property name="cdx:npm:package:path">node_modules/delayed-stream</property>
       </properties>
     </component>
     <component type="library" bom-ref="delegates@1.0.0">
@@ -9106,7 +9106,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/delegates</property>
+        <property name="cdx:npm:package:path">node_modules/delegates</property>
       </properties>
     </component>
     <component type="library" bom-ref="depd@2.0.0">
@@ -9134,7 +9134,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/depd</property>
+        <property name="cdx:npm:package:path">node_modules/depd</property>
       </properties>
     </component>
     <component type="library" bom-ref="destroy@1.2.0">
@@ -9162,7 +9162,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/destroy</property>
+        <property name="cdx:npm:package:path">node_modules/destroy</property>
       </properties>
     </component>
     <component type="library" bom-ref="detect-file@1.0.0">
@@ -9198,7 +9198,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/detect-file</property>
+        <property name="cdx:npm:package:path">node_modules/detect-file</property>
       </properties>
     </component>
     <component type="library" bom-ref="detect-libc@1.0.3">
@@ -9226,7 +9226,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/detect-libc</property>
+        <property name="cdx:npm:package:path">node_modules/detect-libc</property>
       </properties>
     </component>
     <component type="library" bom-ref="dfa@1.2.0">
@@ -9262,7 +9262,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/dfa</property>
+        <property name="cdx:npm:package:path">node_modules/dfa</property>
       </properties>
     </component>
     <component type="library" bom-ref="dicer@0.2.5">
@@ -9291,7 +9291,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/dicer</property>
+        <property name="cdx:npm:package:path">node_modules/dicer</property>
       </properties>
       <components>
         <component type="library" bom-ref="dicer@0.2.5|isarray@0.0.1">
@@ -9323,7 +9323,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/dicer/node_modules/isarray</property>
+            <property name="cdx:npm:package:path">node_modules/dicer/node_modules/isarray</property>
           </properties>
         </component>
         <component type="library" bom-ref="dicer@0.2.5|readable-stream@1.1.14">
@@ -9351,7 +9351,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/dicer/node_modules/readable-stream</property>
+            <property name="cdx:npm:package:path">node_modules/dicer/node_modules/readable-stream</property>
           </properties>
         </component>
         <component type="library" bom-ref="dicer@0.2.5|string_decoder@0.10.31">
@@ -9382,7 +9382,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/dicer/node_modules/string_decoder</property>
+            <property name="cdx:npm:package:path">node_modules/dicer/node_modules/string_decoder</property>
           </properties>
         </component>
       </components>
@@ -9415,7 +9415,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/diff</property>
+        <property name="cdx:npm:package:path">node_modules/diff</property>
       </properties>
     </component>
     <component type="library" bom-ref="doctypes@1.1.0">
@@ -9443,7 +9443,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/doctypes</property>
+        <property name="cdx:npm:package:path">node_modules/doctypes</property>
       </properties>
     </component>
     <component type="library" bom-ref="domelementtype@1.3.1">
@@ -9471,7 +9471,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/domelementtype</property>
+        <property name="cdx:npm:package:path">node_modules/domelementtype</property>
       </properties>
     </component>
     <component type="library" bom-ref="domhandler@2.1.0">
@@ -9494,7 +9494,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/domhandler</property>
+        <property name="cdx:npm:package:path">node_modules/domhandler</property>
       </properties>
     </component>
     <component type="library" bom-ref="domutils@1.1.6">
@@ -9517,7 +9517,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/domutils</property>
+        <property name="cdx:npm:package:path">node_modules/domutils</property>
       </properties>
     </component>
     <component type="library" bom-ref="dottie@2.0.2">
@@ -9545,7 +9545,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/dottie</property>
+        <property name="cdx:npm:package:path">node_modules/dottie</property>
       </properties>
     </component>
     <component type="library" bom-ref="double-ended-queue@0.9.7">
@@ -9581,7 +9581,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/double-ended-queue</property>
+        <property name="cdx:npm:package:path">node_modules/double-ended-queue</property>
       </properties>
     </component>
     <component type="library" bom-ref="doublearray@0.0.2">
@@ -9617,7 +9617,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/doublearray</property>
+        <property name="cdx:npm:package:path">node_modules/doublearray</property>
       </properties>
     </component>
     <component type="library" bom-ref="download@8.0.0">
@@ -9645,7 +9645,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/download</property>
+        <property name="cdx:npm:package:path">node_modules/download</property>
       </properties>
       <components>
         <component type="library" bom-ref="download@8.0.0|file-type@11.1.0">
@@ -9673,7 +9673,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/download/node_modules/file-type</property>
+            <property name="cdx:npm:package:path">node_modules/download/node_modules/file-type</property>
           </properties>
         </component>
       </components>
@@ -9703,7 +9703,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/duplexer2</property>
+        <property name="cdx:npm:package:path">node_modules/duplexer2</property>
       </properties>
     </component>
     <component type="library" bom-ref="duplexer3@0.1.5">
@@ -9730,7 +9730,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/duplexer3</property>
+        <property name="cdx:npm:package:path">node_modules/duplexer3</property>
       </properties>
     </component>
     <component type="library" bom-ref="dynamic-dedupe@0.3.0">
@@ -9757,7 +9757,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/dynamic-dedupe</property>
+        <property name="cdx:npm:package:path">node_modules/dynamic-dedupe</property>
       </properties>
     </component>
     <component type="library" bom-ref="ecc-jsbn@0.1.2">
@@ -9793,7 +9793,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/ecc-jsbn</property>
+        <property name="cdx:npm:package:path">node_modules/ecc-jsbn</property>
       </properties>
     </component>
     <component type="library" bom-ref="ee-first@1.1.1">
@@ -9821,7 +9821,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/ee-first</property>
+        <property name="cdx:npm:package:path">node_modules/ee-first</property>
       </properties>
     </component>
     <component type="library" bom-ref="eivindfjeldstad-dot@0.0.1">
@@ -9856,7 +9856,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/eivindfjeldstad-dot</property>
+        <property name="cdx:npm:package:path">node_modules/eivindfjeldstad-dot</property>
       </properties>
     </component>
     <component type="library" bom-ref="emoji-regex@8.0.0">
@@ -9892,7 +9892,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/emoji-regex</property>
+        <property name="cdx:npm:package:path">node_modules/emoji-regex</property>
       </properties>
     </component>
     <component type="library" bom-ref="enabled@2.0.0">
@@ -9920,7 +9920,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/enabled</property>
+        <property name="cdx:npm:package:path">node_modules/enabled</property>
       </properties>
     </component>
     <component type="library" bom-ref="encodeurl@1.0.2">
@@ -9947,7 +9947,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/encodeurl</property>
+        <property name="cdx:npm:package:path">node_modules/encodeurl</property>
       </properties>
     </component>
     <component type="library" bom-ref="encoding@0.1.13">
@@ -9975,7 +9975,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/encoding</property>
+        <property name="cdx:npm:package:path">node_modules/encoding</property>
       </properties>
       <components>
         <component type="library" bom-ref="encoding@0.1.13|iconv-lite@0.6.3">
@@ -10011,7 +10011,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/encoding/node_modules/iconv-lite</property>
+            <property name="cdx:npm:package:path">node_modules/encoding/node_modules/iconv-lite</property>
           </properties>
         </component>
       </components>
@@ -10049,7 +10049,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/end-of-stream</property>
+        <property name="cdx:npm:package:path">node_modules/end-of-stream</property>
       </properties>
     </component>
     <component type="library" bom-ref="engine.io-parser@4.0.3">
@@ -10076,7 +10076,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/engine.io-parser</property>
+        <property name="cdx:npm:package:path">node_modules/engine.io-parser</property>
       </properties>
     </component>
     <component type="library" bom-ref="engine.io@4.1.2">
@@ -10104,7 +10104,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/engine.io</property>
+        <property name="cdx:npm:package:path">node_modules/engine.io</property>
       </properties>
       <components>
         <component type="library" bom-ref="engine.io@4.1.2|debug@4.3.4">
@@ -10132,7 +10132,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/engine.io/node_modules/debug</property>
+            <property name="cdx:npm:package:path">node_modules/engine.io/node_modules/debug</property>
           </properties>
         </component>
         <component type="library" bom-ref="engine.io@4.1.2|ms@2.1.2">
@@ -10159,7 +10159,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/engine.io/node_modules/ms</property>
+            <property name="cdx:npm:package:path">node_modules/engine.io/node_modules/ms</property>
           </properties>
         </component>
       </components>
@@ -10189,7 +10189,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/env-paths</property>
+        <property name="cdx:npm:package:path">node_modules/env-paths</property>
       </properties>
     </component>
     <component type="library" bom-ref="err-code@1.1.2">
@@ -10221,7 +10221,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/err-code</property>
+        <property name="cdx:npm:package:path">node_modules/err-code</property>
       </properties>
     </component>
     <component type="library" bom-ref="error-ex@1.3.2">
@@ -10248,7 +10248,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/error-ex</property>
+        <property name="cdx:npm:package:path">node_modules/error-ex</property>
       </properties>
     </component>
     <component type="library" bom-ref="errorhandler@1.5.1">
@@ -10275,7 +10275,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/errorhandler</property>
+        <property name="cdx:npm:package:path">node_modules/errorhandler</property>
       </properties>
     </component>
     <component type="library" bom-ref="es-get-iterator@1.1.2">
@@ -10311,7 +10311,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/es-get-iterator</property>
+        <property name="cdx:npm:package:path">node_modules/es-get-iterator</property>
       </properties>
     </component>
     <component type="library" bom-ref="escape-html@1.0.3">
@@ -10338,7 +10338,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/escape-html</property>
+        <property name="cdx:npm:package:path">node_modules/escape-html</property>
       </properties>
     </component>
     <component type="library" bom-ref="escape-string-regexp@1.0.5">
@@ -10366,7 +10366,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/escape-string-regexp</property>
+        <property name="cdx:npm:package:path">node_modules/escape-string-regexp</property>
       </properties>
     </component>
     <component type="library" bom-ref="escodegen@2.0.0">
@@ -10397,7 +10397,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/escodegen</property>
+        <property name="cdx:npm:package:path">node_modules/escodegen</property>
       </properties>
     </component>
     <component type="library" bom-ref="esprima@4.0.1">
@@ -10433,7 +10433,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/esprima</property>
+        <property name="cdx:npm:package:path">node_modules/esprima</property>
       </properties>
     </component>
     <component type="library" bom-ref="estraverse@5.3.0">
@@ -10464,7 +10464,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/estraverse</property>
+        <property name="cdx:npm:package:path">node_modules/estraverse</property>
       </properties>
     </component>
     <component type="library" bom-ref="esutils@2.0.3">
@@ -10495,7 +10495,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/esutils</property>
+        <property name="cdx:npm:package:path">node_modules/esutils</property>
       </properties>
     </component>
     <component type="library" bom-ref="etag@1.8.1">
@@ -10522,7 +10522,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/etag</property>
+        <property name="cdx:npm:package:path">node_modules/etag</property>
       </properties>
     </component>
     <component type="library" bom-ref="eventemitter2@0.4.14">
@@ -10550,7 +10550,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/eventemitter2</property>
+        <property name="cdx:npm:package:path">node_modules/eventemitter2</property>
       </properties>
     </component>
     <component type="library" bom-ref="eventemitter3@1.1.1">
@@ -10582,7 +10582,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/eventemitter3</property>
+        <property name="cdx:npm:package:path">node_modules/eventemitter3</property>
       </properties>
     </component>
     <component type="library" bom-ref="exif@0.6.0">
@@ -10604,7 +10604,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/exif</property>
+        <property name="cdx:npm:package:path">node_modules/exif</property>
       </properties>
     </component>
     <component type="library" bom-ref="exit@0.1.2">
@@ -10641,7 +10641,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/exit</property>
+        <property name="cdx:npm:package:path">node_modules/exit</property>
       </properties>
     </component>
     <component type="library" bom-ref="expand-brackets@2.1.4">
@@ -10677,7 +10677,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/expand-brackets</property>
+        <property name="cdx:npm:package:path">node_modules/expand-brackets</property>
       </properties>
       <components>
         <component type="library" bom-ref="expand-brackets@2.1.4|define-property@0.2.5">
@@ -10713,7 +10713,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/expand-brackets/node_modules/define-property</property>
+            <property name="cdx:npm:package:path">node_modules/expand-brackets/node_modules/define-property</property>
           </properties>
         </component>
         <component type="library" bom-ref="expand-brackets@2.1.4|extend-shallow@2.0.1">
@@ -10749,7 +10749,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/expand-brackets/node_modules/extend-shallow</property>
+            <property name="cdx:npm:package:path">node_modules/expand-brackets/node_modules/extend-shallow</property>
           </properties>
         </component>
         <component type="library" bom-ref="expand-brackets@2.1.4|is-accessor-descriptor@0.1.6">
@@ -10785,7 +10785,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/expand-brackets/node_modules/is-accessor-descriptor</property>
+            <property name="cdx:npm:package:path">node_modules/expand-brackets/node_modules/is-accessor-descriptor</property>
           </properties>
           <components>
             <component type="library" bom-ref="expand-brackets@2.1.4|is-accessor-descriptor@0.1.6|kind-of@3.2.2">
@@ -10821,7 +10821,7 @@
                 </reference>
               </externalReferences>
               <properties>
-                <property name="cdx:npm:package:installPath">node_modules/expand-brackets/node_modules/is-accessor-descriptor/node_modules/kind-of</property>
+                <property name="cdx:npm:package:path">node_modules/expand-brackets/node_modules/is-accessor-descriptor/node_modules/kind-of</property>
               </properties>
             </component>
           </components>
@@ -10859,7 +10859,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/expand-brackets/node_modules/is-data-descriptor</property>
+            <property name="cdx:npm:package:path">node_modules/expand-brackets/node_modules/is-data-descriptor</property>
           </properties>
           <components>
             <component type="library" bom-ref="expand-brackets@2.1.4|is-data-descriptor@0.1.4|kind-of@3.2.2">
@@ -10895,7 +10895,7 @@
                 </reference>
               </externalReferences>
               <properties>
-                <property name="cdx:npm:package:installPath">node_modules/expand-brackets/node_modules/is-data-descriptor/node_modules/kind-of</property>
+                <property name="cdx:npm:package:path">node_modules/expand-brackets/node_modules/is-data-descriptor/node_modules/kind-of</property>
               </properties>
             </component>
           </components>
@@ -10933,7 +10933,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/expand-brackets/node_modules/is-descriptor</property>
+            <property name="cdx:npm:package:path">node_modules/expand-brackets/node_modules/is-descriptor</property>
           </properties>
         </component>
         <component type="library" bom-ref="expand-brackets@2.1.4|is-extendable@0.1.1">
@@ -10969,7 +10969,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/expand-brackets/node_modules/is-extendable</property>
+            <property name="cdx:npm:package:path">node_modules/expand-brackets/node_modules/is-extendable</property>
           </properties>
         </component>
         <component type="library" bom-ref="expand-brackets@2.1.4|kind-of@5.1.0">
@@ -11005,7 +11005,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/expand-brackets/node_modules/kind-of</property>
+            <property name="cdx:npm:package:path">node_modules/expand-brackets/node_modules/kind-of</property>
           </properties>
         </component>
       </components>
@@ -11037,7 +11037,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/expand-template</property>
+        <property name="cdx:npm:package:path">node_modules/expand-template</property>
       </properties>
     </component>
     <component type="library" bom-ref="expand-tilde@2.0.2">
@@ -11073,7 +11073,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/expand-tilde</property>
+        <property name="cdx:npm:package:path">node_modules/expand-tilde</property>
       </properties>
     </component>
     <component type="library" bom-ref="express-ipfilter@1.3.1">
@@ -11101,7 +11101,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/express-ipfilter</property>
+        <property name="cdx:npm:package:path">node_modules/express-ipfilter</property>
       </properties>
     </component>
     <component type="library" bom-ref="express-jwt@0.1.3">
@@ -11134,7 +11134,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/express-jwt</property>
+        <property name="cdx:npm:package:path">node_modules/express-jwt</property>
       </properties>
       <components>
         <component type="library" bom-ref="express-jwt@0.1.3|jsonwebtoken@0.1.0">
@@ -11166,7 +11166,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/express-jwt/node_modules/jsonwebtoken</property>
+            <property name="cdx:npm:package:path">node_modules/express-jwt/node_modules/jsonwebtoken</property>
           </properties>
         </component>
         <component type="library" bom-ref="express-jwt@0.1.3|moment@2.0.0">
@@ -11202,7 +11202,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/express-jwt/node_modules/moment</property>
+            <property name="cdx:npm:package:path">node_modules/express-jwt/node_modules/moment</property>
           </properties>
         </component>
       </components>
@@ -11236,7 +11236,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/express-rate-limit</property>
+        <property name="cdx:npm:package:path">node_modules/express-rate-limit</property>
       </properties>
     </component>
     <component type="library" bom-ref="express-robots-txt@0.4.1">
@@ -11272,7 +11272,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/express-robots-txt</property>
+        <property name="cdx:npm:package:path">node_modules/express-robots-txt</property>
       </properties>
     </component>
     <component type="library" bom-ref="express-security.txt@2.0.0">
@@ -11306,7 +11306,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/express-security.txt</property>
+        <property name="cdx:npm:package:path">node_modules/express-security.txt</property>
       </properties>
     </component>
     <component type="library" bom-ref="express@4.18.2">
@@ -11338,7 +11338,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/express</property>
+        <property name="cdx:npm:package:path">node_modules/express</property>
       </properties>
       <components>
         <component type="library" bom-ref="express@4.18.2|cookie@0.5.0">
@@ -11366,7 +11366,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/express/node_modules/cookie</property>
+            <property name="cdx:npm:package:path">node_modules/express/node_modules/cookie</property>
           </properties>
         </component>
         <component type="library" bom-ref="express@4.18.2|safe-buffer@5.2.1">
@@ -11402,7 +11402,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/express/node_modules/safe-buffer</property>
+            <property name="cdx:npm:package:path">node_modules/express/node_modules/safe-buffer</property>
           </properties>
         </component>
       </components>
@@ -11432,7 +11432,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/ext-list</property>
+        <property name="cdx:npm:package:path">node_modules/ext-list</property>
       </properties>
     </component>
     <component type="library" bom-ref="ext-name@5.0.0">
@@ -11460,7 +11460,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/ext-name</property>
+        <property name="cdx:npm:package:path">node_modules/ext-name</property>
       </properties>
     </component>
     <component type="library" bom-ref="extend-shallow@3.0.2">
@@ -11496,7 +11496,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/extend-shallow</property>
+        <property name="cdx:npm:package:path">node_modules/extend-shallow</property>
       </properties>
     </component>
     <component type="library" bom-ref="extend@3.0.2">
@@ -11524,7 +11524,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/extend</property>
+        <property name="cdx:npm:package:path">node_modules/extend</property>
       </properties>
     </component>
     <component type="library" bom-ref="extglob@2.0.4">
@@ -11560,7 +11560,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/extglob</property>
+        <property name="cdx:npm:package:path">node_modules/extglob</property>
       </properties>
       <components>
         <component type="library" bom-ref="extglob@2.0.4|define-property@1.0.0">
@@ -11596,7 +11596,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/extglob/node_modules/define-property</property>
+            <property name="cdx:npm:package:path">node_modules/extglob/node_modules/define-property</property>
           </properties>
         </component>
         <component type="library" bom-ref="extglob@2.0.4|extend-shallow@2.0.1">
@@ -11632,7 +11632,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/extglob/node_modules/extend-shallow</property>
+            <property name="cdx:npm:package:path">node_modules/extglob/node_modules/extend-shallow</property>
           </properties>
         </component>
         <component type="library" bom-ref="extglob@2.0.4|is-extendable@0.1.1">
@@ -11668,7 +11668,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/extglob/node_modules/is-extendable</property>
+            <property name="cdx:npm:package:path">node_modules/extglob/node_modules/is-extendable</property>
           </properties>
         </component>
       </components>
@@ -11697,7 +11697,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/extsprintf</property>
+        <property name="cdx:npm:package:path">node_modules/extsprintf</property>
       </properties>
     </component>
     <component type="library" bom-ref="fast-deep-equal@3.1.3">
@@ -11733,7 +11733,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/fast-deep-equal</property>
+        <property name="cdx:npm:package:path">node_modules/fast-deep-equal</property>
       </properties>
     </component>
     <component type="library" bom-ref="fast-json-stable-stringify@2.1.0">
@@ -11765,7 +11765,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/fast-json-stable-stringify</property>
+        <property name="cdx:npm:package:path">node_modules/fast-json-stable-stringify</property>
       </properties>
     </component>
     <component type="library" bom-ref="fast-levenshtein@2.0.6">
@@ -11793,7 +11793,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/fast-levenshtein</property>
+        <property name="cdx:npm:package:path">node_modules/fast-levenshtein</property>
       </properties>
     </component>
     <component type="library" bom-ref="fast.js@0.1.1">
@@ -11829,7 +11829,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/fast.js</property>
+        <property name="cdx:npm:package:path">node_modules/fast.js</property>
       </properties>
     </component>
     <component type="library" bom-ref="fd-slicer@1.1.0">
@@ -11861,7 +11861,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/fd-slicer</property>
+        <property name="cdx:npm:package:path">node_modules/fd-slicer</property>
       </properties>
     </component>
     <component type="library" bom-ref="feature-policy@0.5.0">
@@ -11897,7 +11897,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/feature-policy</property>
+        <property name="cdx:npm:package:path">node_modules/feature-policy</property>
       </properties>
     </component>
     <component type="library" bom-ref="fecha@4.2.3">
@@ -11933,7 +11933,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/fecha</property>
+        <property name="cdx:npm:package:path">node_modules/fecha</property>
       </properties>
     </component>
     <component type="library" bom-ref="file-js@0.3.0">
@@ -11969,7 +11969,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/file-js</property>
+        <property name="cdx:npm:package:path">node_modules/file-js</property>
       </properties>
       <components>
         <component type="library" bom-ref="file-js@0.3.0|brace-expansion@1.1.11">
@@ -12001,7 +12001,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/file-js/node_modules/brace-expansion</property>
+            <property name="cdx:npm:package:path">node_modules/file-js/node_modules/brace-expansion</property>
           </properties>
         </component>
         <component type="library" bom-ref="file-js@0.3.0|minimatch@3.1.2">
@@ -12029,7 +12029,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/file-js/node_modules/minimatch</property>
+            <property name="cdx:npm:package:path">node_modules/file-js/node_modules/minimatch</property>
           </properties>
         </component>
       </components>
@@ -12059,7 +12059,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/file-stream-rotator</property>
+        <property name="cdx:npm:package:path">node_modules/file-stream-rotator</property>
       </properties>
     </component>
     <component type="library" bom-ref="file-type@16.5.4">
@@ -12087,7 +12087,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/file-type</property>
+        <property name="cdx:npm:package:path">node_modules/file-type</property>
       </properties>
     </component>
     <component type="library" bom-ref="file-uri-to-path@1.0.0">
@@ -12123,7 +12123,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/file-uri-to-path</property>
+        <property name="cdx:npm:package:path">node_modules/file-uri-to-path</property>
       </properties>
     </component>
     <component type="library" bom-ref="filehound@1.17.6">
@@ -12158,7 +12158,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/filehound</property>
+        <property name="cdx:npm:package:path">node_modules/filehound</property>
       </properties>
     </component>
     <component type="library" bom-ref="filename-reserved-regex@2.0.0">
@@ -12186,7 +12186,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/filename-reserved-regex</property>
+        <property name="cdx:npm:package:path">node_modules/filename-reserved-regex</property>
       </properties>
     </component>
     <component type="library" bom-ref="filenamify@3.0.0">
@@ -12214,7 +12214,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/filenamify</property>
+        <property name="cdx:npm:package:path">node_modules/filenamify</property>
       </properties>
     </component>
     <component type="library" bom-ref="filesniffer@1.0.3">
@@ -12249,7 +12249,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/filesniffer</property>
+        <property name="cdx:npm:package:path">node_modules/filesniffer</property>
       </properties>
     </component>
     <component type="library" bom-ref="fill-range@4.0.0">
@@ -12285,7 +12285,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/fill-range</property>
+        <property name="cdx:npm:package:path">node_modules/fill-range</property>
       </properties>
       <components>
         <component type="library" bom-ref="fill-range@4.0.0|extend-shallow@2.0.1">
@@ -12321,7 +12321,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/fill-range/node_modules/extend-shallow</property>
+            <property name="cdx:npm:package:path">node_modules/fill-range/node_modules/extend-shallow</property>
           </properties>
         </component>
         <component type="library" bom-ref="fill-range@4.0.0|is-extendable@0.1.1">
@@ -12357,7 +12357,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/fill-range/node_modules/is-extendable</property>
+            <property name="cdx:npm:package:path">node_modules/fill-range/node_modules/is-extendable</property>
           </properties>
         </component>
       </components>
@@ -12391,7 +12391,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/finale-rest</property>
+        <property name="cdx:npm:package:path">node_modules/finale-rest</property>
       </properties>
     </component>
     <component type="library" bom-ref="finalhandler@1.2.0">
@@ -12419,7 +12419,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/finalhandler</property>
+        <property name="cdx:npm:package:path">node_modules/finalhandler</property>
       </properties>
     </component>
     <component type="library" bom-ref="find-up@3.0.0">
@@ -12447,7 +12447,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/find-up</property>
+        <property name="cdx:npm:package:path">node_modules/find-up</property>
       </properties>
     </component>
     <component type="library" bom-ref="findup-sync@2.0.0">
@@ -12475,7 +12475,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/findup-sync</property>
+        <property name="cdx:npm:package:path">node_modules/findup-sync</property>
       </properties>
     </component>
     <component type="library" bom-ref="fined@1.2.0">
@@ -12503,7 +12503,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/fined</property>
+        <property name="cdx:npm:package:path">node_modules/fined</property>
       </properties>
     </component>
     <component type="library" bom-ref="flagged-respawn@1.0.1">
@@ -12531,7 +12531,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/flagged-respawn</property>
+        <property name="cdx:npm:package:path">node_modules/flagged-respawn</property>
       </properties>
     </component>
     <component type="library" bom-ref="fn.name@1.1.0">
@@ -12567,7 +12567,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/fn.name</property>
+        <property name="cdx:npm:package:path">node_modules/fn.name</property>
       </properties>
     </component>
     <component type="library" bom-ref="fontkit@1.9.0">
@@ -12595,7 +12595,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/fontkit</property>
+        <property name="cdx:npm:package:path">node_modules/fontkit</property>
       </properties>
     </component>
     <component type="library" bom-ref="for-each@0.3.3">
@@ -12635,7 +12635,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/for-each</property>
+        <property name="cdx:npm:package:path">node_modules/for-each</property>
       </properties>
     </component>
     <component type="library" bom-ref="for-in@1.0.2">
@@ -12671,7 +12671,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/for-in</property>
+        <property name="cdx:npm:package:path">node_modules/for-in</property>
       </properties>
     </component>
     <component type="library" bom-ref="for-own@1.0.0">
@@ -12707,7 +12707,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/for-own</property>
+        <property name="cdx:npm:package:path">node_modules/for-own</property>
       </properties>
     </component>
     <component type="library" bom-ref="foreachasync@3.0.0">
@@ -12743,7 +12743,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/foreachasync</property>
+        <property name="cdx:npm:package:path">node_modules/foreachasync</property>
       </properties>
     </component>
     <component type="library" bom-ref="forever-agent@0.6.1">
@@ -12771,7 +12771,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/forever-agent</property>
+        <property name="cdx:npm:package:path">node_modules/forever-agent</property>
       </properties>
     </component>
     <component type="library" bom-ref="form-data@2.3.3">
@@ -12799,7 +12799,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/form-data</property>
+        <property name="cdx:npm:package:path">node_modules/form-data</property>
       </properties>
     </component>
     <component type="library" bom-ref="formatio@1.1.1">
@@ -12826,7 +12826,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/formatio</property>
+        <property name="cdx:npm:package:path">node_modules/formatio</property>
       </properties>
     </component>
     <component type="library" bom-ref="forwarded@0.2.0">
@@ -12853,7 +12853,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/forwarded</property>
+        <property name="cdx:npm:package:path">node_modules/forwarded</property>
       </properties>
     </component>
     <component type="library" bom-ref="fragment-cache@0.2.1">
@@ -12889,7 +12889,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/fragment-cache</property>
+        <property name="cdx:npm:package:path">node_modules/fragment-cache</property>
       </properties>
     </component>
     <component type="library" bom-ref="fresh@0.5.2">
@@ -12917,7 +12917,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/fresh</property>
+        <property name="cdx:npm:package:path">node_modules/fresh</property>
       </properties>
     </component>
     <component type="library" bom-ref="from2@2.3.0">
@@ -12953,7 +12953,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/from2</property>
+        <property name="cdx:npm:package:path">node_modules/from2</property>
       </properties>
     </component>
     <component type="library" bom-ref="fs-constants@1.0.0">
@@ -12989,7 +12989,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/fs-constants</property>
+        <property name="cdx:npm:package:path">node_modules/fs-constants</property>
       </properties>
     </component>
     <component type="library" bom-ref="fs-extra@9.1.0">
@@ -13021,7 +13021,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/fs-extra</property>
+        <property name="cdx:npm:package:path">node_modules/fs-extra</property>
       </properties>
     </component>
     <component type="library" bom-ref="fs-minipass@2.1.0">
@@ -13057,7 +13057,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/fs-minipass</property>
+        <property name="cdx:npm:package:path">node_modules/fs-minipass</property>
       </properties>
     </component>
     <component type="library" bom-ref="fs.realpath@1.0.0">
@@ -13085,7 +13085,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/fs.realpath</property>
+        <property name="cdx:npm:package:path">node_modules/fs.realpath</property>
       </properties>
     </component>
     <component type="library" bom-ref="fstream@1.0.12">
@@ -13113,7 +13113,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/fstream</property>
+        <property name="cdx:npm:package:path">node_modules/fstream</property>
       </properties>
       <components>
         <component type="library" bom-ref="fstream@1.0.12|mkdirp@0.5.6">
@@ -13141,7 +13141,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/fstream/node_modules/mkdirp</property>
+            <property name="cdx:npm:package:path">node_modules/fstream/node_modules/mkdirp</property>
           </properties>
         </component>
         <component type="library" bom-ref="fstream@1.0.12|rimraf@2.7.1">
@@ -13169,7 +13169,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/fstream/node_modules/rimraf</property>
+            <property name="cdx:npm:package:path">node_modules/fstream/node_modules/rimraf</property>
           </properties>
         </component>
       </components>
@@ -13207,7 +13207,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/function-bind</property>
+        <property name="cdx:npm:package:path">node_modules/function-bind</property>
       </properties>
     </component>
     <component type="library" bom-ref="functions-have-names@1.2.3">
@@ -13243,7 +13243,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/functions-have-names</property>
+        <property name="cdx:npm:package:path">node_modules/functions-have-names</property>
       </properties>
     </component>
     <component type="library" bom-ref="fuzzball@1.4.0">
@@ -13271,7 +13271,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/fuzzball</property>
+        <property name="cdx:npm:package:path">node_modules/fuzzball</property>
       </properties>
     </component>
     <component type="library" bom-ref="gauge@2.7.4">
@@ -13307,7 +13307,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/gauge</property>
+        <property name="cdx:npm:package:path">node_modules/gauge</property>
       </properties>
     </component>
     <component type="library" bom-ref="geojson-utils@1.1.0">
@@ -13335,7 +13335,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/geojson-utils</property>
+        <property name="cdx:npm:package:path">node_modules/geojson-utils</property>
       </properties>
     </component>
     <component type="library" bom-ref="get-caller-file@2.0.5">
@@ -13370,7 +13370,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/get-caller-file</property>
+        <property name="cdx:npm:package:path">node_modules/get-caller-file</property>
       </properties>
     </component>
     <component type="library" bom-ref="get-intrinsic@1.1.3">
@@ -13406,7 +13406,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/get-intrinsic</property>
+        <property name="cdx:npm:package:path">node_modules/get-intrinsic</property>
       </properties>
     </component>
     <component type="library" bom-ref="get-stream@4.1.0">
@@ -13434,7 +13434,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/get-stream</property>
+        <property name="cdx:npm:package:path">node_modules/get-stream</property>
       </properties>
     </component>
     <component type="library" bom-ref="get-value@2.0.6">
@@ -13470,7 +13470,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/get-value</property>
+        <property name="cdx:npm:package:path">node_modules/get-value</property>
       </properties>
     </component>
     <component type="library" bom-ref="getobject@1.0.2">
@@ -13507,7 +13507,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/getobject</property>
+        <property name="cdx:npm:package:path">node_modules/getobject</property>
       </properties>
     </component>
     <component type="library" bom-ref="getpass@0.1.7">
@@ -13535,7 +13535,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/getpass</property>
+        <property name="cdx:npm:package:path">node_modules/getpass</property>
       </properties>
     </component>
     <component type="library" bom-ref="github-from-package@0.0.0">
@@ -13567,7 +13567,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/github-from-package</property>
+        <property name="cdx:npm:package:path">node_modules/github-from-package</property>
       </properties>
     </component>
     <component type="library" bom-ref="glob-parent@5.1.2">
@@ -13595,7 +13595,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/glob-parent</property>
+        <property name="cdx:npm:package:path">node_modules/glob-parent</property>
       </properties>
       <components>
         <component type="library" bom-ref="glob-parent@5.1.2|is-glob@4.0.3">
@@ -13631,7 +13631,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/glob-parent/node_modules/is-glob</property>
+            <property name="cdx:npm:package:path">node_modules/glob-parent/node_modules/is-glob</property>
           </properties>
         </component>
       </components>
@@ -13661,7 +13661,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/glob</property>
+        <property name="cdx:npm:package:path">node_modules/glob</property>
       </properties>
       <components>
         <component type="library" bom-ref="glob@7.2.3|brace-expansion@1.1.11">
@@ -13693,7 +13693,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/glob/node_modules/brace-expansion</property>
+            <property name="cdx:npm:package:path">node_modules/glob/node_modules/brace-expansion</property>
           </properties>
         </component>
         <component type="library" bom-ref="glob@7.2.3|minimatch@3.1.2">
@@ -13721,7 +13721,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/glob/node_modules/minimatch</property>
+            <property name="cdx:npm:package:path">node_modules/glob/node_modules/minimatch</property>
           </properties>
         </component>
       </components>
@@ -13759,7 +13759,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/global-modules</property>
+        <property name="cdx:npm:package:path">node_modules/global-modules</property>
       </properties>
     </component>
     <component type="library" bom-ref="global-prefix@1.0.2">
@@ -13795,7 +13795,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/global-prefix</property>
+        <property name="cdx:npm:package:path">node_modules/global-prefix</property>
       </properties>
       <components>
         <component type="library" bom-ref="global-prefix@1.0.2|which@1.3.1">
@@ -13823,7 +13823,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/global-prefix/node_modules/which</property>
+            <property name="cdx:npm:package:path">node_modules/global-prefix/node_modules/which</property>
           </properties>
         </component>
       </components>
@@ -13861,7 +13861,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/gopd</property>
+        <property name="cdx:npm:package:path">node_modules/gopd</property>
       </properties>
     </component>
     <component type="library" bom-ref="got@8.3.2">
@@ -13888,7 +13888,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/got</property>
+        <property name="cdx:npm:package:path">node_modules/got</property>
       </properties>
       <components>
         <component type="library" bom-ref="got@8.3.2|get-stream@3.0.0">
@@ -13916,7 +13916,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/got/node_modules/get-stream</property>
+            <property name="cdx:npm:package:path">node_modules/got/node_modules/get-stream</property>
           </properties>
         </component>
         <component type="library" bom-ref="got@8.3.2|pify@3.0.0">
@@ -13944,7 +13944,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/got/node_modules/pify</property>
+            <property name="cdx:npm:package:path">node_modules/got/node_modules/pify</property>
           </properties>
         </component>
       </components>
@@ -13973,7 +13973,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/graceful-fs</property>
+        <property name="cdx:npm:package:path">node_modules/graceful-fs</property>
       </properties>
     </component>
     <component type="library" bom-ref="grunt-cli@1.4.3">
@@ -14001,7 +14001,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/grunt-cli</property>
+        <property name="cdx:npm:package:path">node_modules/grunt-cli</property>
       </properties>
       <components>
         <component type="library" bom-ref="grunt-cli@1.4.3|nopt@4.0.3">
@@ -14029,7 +14029,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/grunt-cli/node_modules/nopt</property>
+            <property name="cdx:npm:package:path">node_modules/grunt-cli/node_modules/nopt</property>
           </properties>
         </component>
       </components>
@@ -14059,7 +14059,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/grunt-contrib-compress</property>
+        <property name="cdx:npm:package:path">node_modules/grunt-contrib-compress</property>
       </properties>
       <components>
         <component type="library" bom-ref="grunt-contrib-compress@1.6.0|ansi-styles@2.2.1">
@@ -14087,7 +14087,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/grunt-contrib-compress/node_modules/ansi-styles</property>
+            <property name="cdx:npm:package:path">node_modules/grunt-contrib-compress/node_modules/ansi-styles</property>
           </properties>
         </component>
         <component type="library" bom-ref="grunt-contrib-compress@1.6.0|chalk@1.1.3">
@@ -14114,7 +14114,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/grunt-contrib-compress/node_modules/chalk</property>
+            <property name="cdx:npm:package:path">node_modules/grunt-contrib-compress/node_modules/chalk</property>
           </properties>
         </component>
         <component type="library" bom-ref="grunt-contrib-compress@1.6.0|supports-color@2.0.0">
@@ -14142,7 +14142,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/grunt-contrib-compress/node_modules/supports-color</property>
+            <property name="cdx:npm:package:path">node_modules/grunt-contrib-compress/node_modules/supports-color</property>
           </properties>
         </component>
       </components>
@@ -14176,7 +14176,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/grunt-known-options</property>
+        <property name="cdx:npm:package:path">node_modules/grunt-known-options</property>
       </properties>
     </component>
     <component type="library" bom-ref="grunt-legacy-log-utils@2.1.0">
@@ -14212,7 +14212,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/grunt-legacy-log-utils</property>
+        <property name="cdx:npm:package:path">node_modules/grunt-legacy-log-utils</property>
       </properties>
       <components>
         <component type="library" bom-ref="grunt-legacy-log-utils@2.1.0|ansi-styles@4.3.0">
@@ -14240,7 +14240,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/grunt-legacy-log-utils/node_modules/ansi-styles</property>
+            <property name="cdx:npm:package:path">node_modules/grunt-legacy-log-utils/node_modules/ansi-styles</property>
           </properties>
         </component>
         <component type="library" bom-ref="grunt-legacy-log-utils@2.1.0|chalk@4.1.2">
@@ -14267,7 +14267,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/grunt-legacy-log-utils/node_modules/chalk</property>
+            <property name="cdx:npm:package:path">node_modules/grunt-legacy-log-utils/node_modules/chalk</property>
           </properties>
         </component>
         <component type="library" bom-ref="grunt-legacy-log-utils@2.1.0|color-convert@2.0.1">
@@ -14295,7 +14295,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/grunt-legacy-log-utils/node_modules/color-convert</property>
+            <property name="cdx:npm:package:path">node_modules/grunt-legacy-log-utils/node_modules/color-convert</property>
           </properties>
         </component>
         <component type="library" bom-ref="grunt-legacy-log-utils@2.1.0|color-name@1.1.4">
@@ -14327,7 +14327,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/grunt-legacy-log-utils/node_modules/color-name</property>
+            <property name="cdx:npm:package:path">node_modules/grunt-legacy-log-utils/node_modules/color-name</property>
           </properties>
         </component>
         <component type="library" bom-ref="grunt-legacy-log-utils@2.1.0|has-flag@4.0.0">
@@ -14355,7 +14355,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/grunt-legacy-log-utils/node_modules/has-flag</property>
+            <property name="cdx:npm:package:path">node_modules/grunt-legacy-log-utils/node_modules/has-flag</property>
           </properties>
         </component>
         <component type="library" bom-ref="grunt-legacy-log-utils@2.1.0|supports-color@7.2.0">
@@ -14383,7 +14383,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/grunt-legacy-log-utils/node_modules/supports-color</property>
+            <property name="cdx:npm:package:path">node_modules/grunt-legacy-log-utils/node_modules/supports-color</property>
           </properties>
         </component>
       </components>
@@ -14421,7 +14421,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/grunt-legacy-log</property>
+        <property name="cdx:npm:package:path">node_modules/grunt-legacy-log</property>
       </properties>
       <components>
         <component type="library" bom-ref="grunt-legacy-log@3.0.0|colors@1.1.2">
@@ -14457,7 +14457,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/grunt-legacy-log/node_modules/colors</property>
+            <property name="cdx:npm:package:path">node_modules/grunt-legacy-log/node_modules/colors</property>
           </properties>
         </component>
       </components>
@@ -14495,7 +14495,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/grunt-legacy-util</property>
+        <property name="cdx:npm:package:path">node_modules/grunt-legacy-util</property>
       </properties>
       <components>
         <component type="library" bom-ref="grunt-legacy-util@2.0.1|async@3.2.4">
@@ -14531,7 +14531,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/grunt-legacy-util/node_modules/async</property>
+            <property name="cdx:npm:package:path">node_modules/grunt-legacy-util/node_modules/async</property>
           </properties>
         </component>
       </components>
@@ -14570,7 +14570,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/grunt-replace-json</property>
+        <property name="cdx:npm:package:path">node_modules/grunt-replace-json</property>
       </properties>
     </component>
     <component type="library" bom-ref="grunt@1.5.3">
@@ -14602,7 +14602,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/grunt</property>
+        <property name="cdx:npm:package:path">node_modules/grunt</property>
       </properties>
       <components>
         <component type="library" bom-ref="grunt@1.5.3|brace-expansion@1.1.11">
@@ -14634,7 +14634,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/grunt/node_modules/brace-expansion</property>
+            <property name="cdx:npm:package:path">node_modules/grunt/node_modules/brace-expansion</property>
           </properties>
         </component>
         <component type="library" bom-ref="grunt@1.5.3|findup-sync@0.3.0">
@@ -14671,7 +14671,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/grunt/node_modules/findup-sync</property>
+            <property name="cdx:npm:package:path">node_modules/grunt/node_modules/findup-sync</property>
           </properties>
           <components>
             <component type="library" bom-ref="grunt@1.5.3|findup-sync@0.3.0|glob@5.0.15">
@@ -14699,7 +14699,7 @@
                 </reference>
               </externalReferences>
               <properties>
-                <property name="cdx:npm:package:installPath">node_modules/grunt/node_modules/findup-sync/node_modules/glob</property>
+                <property name="cdx:npm:package:path">node_modules/grunt/node_modules/findup-sync/node_modules/glob</property>
               </properties>
             </component>
           </components>
@@ -14729,7 +14729,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/grunt/node_modules/glob</property>
+            <property name="cdx:npm:package:path">node_modules/grunt/node_modules/glob</property>
           </properties>
         </component>
         <component type="library" bom-ref="grunt@1.5.3|minimatch@3.0.8">
@@ -14757,7 +14757,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/grunt/node_modules/minimatch</property>
+            <property name="cdx:npm:package:path">node_modules/grunt/node_modules/minimatch</property>
           </properties>
         </component>
       </components>
@@ -14791,7 +14791,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/handlebars</property>
+        <property name="cdx:npm:package:path">node_modules/handlebars</property>
       </properties>
       <components>
         <component type="library" bom-ref="handlebars@4.7.7|wordwrap@1.0.0">
@@ -14819,7 +14819,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/handlebars/node_modules/wordwrap</property>
+            <property name="cdx:npm:package:path">node_modules/handlebars/node_modules/wordwrap</property>
           </properties>
         </component>
       </components>
@@ -14857,7 +14857,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/har-schema</property>
+        <property name="cdx:npm:package:path">node_modules/har-schema</property>
       </properties>
     </component>
     <component type="library" bom-ref="har-validator@5.1.5">
@@ -14893,7 +14893,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/har-validator</property>
+        <property name="cdx:npm:package:path">node_modules/har-validator</property>
       </properties>
     </component>
     <component type="library" bom-ref="has-ansi@2.0.0">
@@ -14921,7 +14921,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/has-ansi</property>
+        <property name="cdx:npm:package:path">node_modules/has-ansi</property>
       </properties>
     </component>
     <component type="library" bom-ref="has-bigints@1.0.2">
@@ -14957,7 +14957,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/has-bigints</property>
+        <property name="cdx:npm:package:path">node_modules/has-bigints</property>
       </properties>
     </component>
     <component type="library" bom-ref="has-flag@3.0.0">
@@ -14985,7 +14985,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/has-flag</property>
+        <property name="cdx:npm:package:path">node_modules/has-flag</property>
       </properties>
     </component>
     <component type="library" bom-ref="has-property-descriptors@1.0.0">
@@ -15021,7 +15021,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/has-property-descriptors</property>
+        <property name="cdx:npm:package:path">node_modules/has-property-descriptors</property>
       </properties>
     </component>
     <component type="library" bom-ref="has-symbol-support-x@1.4.2">
@@ -15057,7 +15057,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/has-symbol-support-x</property>
+        <property name="cdx:npm:package:path">node_modules/has-symbol-support-x</property>
       </properties>
     </component>
     <component type="library" bom-ref="has-symbols@1.0.3">
@@ -15093,7 +15093,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/has-symbols</property>
+        <property name="cdx:npm:package:path">node_modules/has-symbols</property>
       </properties>
     </component>
     <component type="library" bom-ref="has-to-string-tag-x@1.4.1">
@@ -15129,7 +15129,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/has-to-string-tag-x</property>
+        <property name="cdx:npm:package:path">node_modules/has-to-string-tag-x</property>
       </properties>
     </component>
     <component type="library" bom-ref="has-tostringtag@1.0.0">
@@ -15165,7 +15165,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/has-tostringtag</property>
+        <property name="cdx:npm:package:path">node_modules/has-tostringtag</property>
       </properties>
     </component>
     <component type="library" bom-ref="has-unicode@2.0.1">
@@ -15201,7 +15201,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/has-unicode</property>
+        <property name="cdx:npm:package:path">node_modules/has-unicode</property>
       </properties>
     </component>
     <component type="library" bom-ref="has-value@1.0.0">
@@ -15237,7 +15237,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/has-value</property>
+        <property name="cdx:npm:package:path">node_modules/has-value</property>
       </properties>
     </component>
     <component type="library" bom-ref="has-values@1.0.0">
@@ -15273,7 +15273,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/has-values</property>
+        <property name="cdx:npm:package:path">node_modules/has-values</property>
       </properties>
       <components>
         <component type="library" bom-ref="has-values@1.0.0|kind-of@4.0.0">
@@ -15309,7 +15309,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/has-values/node_modules/kind-of</property>
+            <property name="cdx:npm:package:path">node_modules/has-values/node_modules/kind-of</property>
           </properties>
         </component>
       </components>
@@ -15351,7 +15351,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/has</property>
+        <property name="cdx:npm:package:path">node_modules/has</property>
       </properties>
     </component>
     <component type="library" bom-ref="hashids@2.2.10">
@@ -15387,7 +15387,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/hashids</property>
+        <property name="cdx:npm:package:path">node_modules/hashids</property>
       </properties>
     </component>
     <component type="library" bom-ref="hbs@4.2.0">
@@ -15415,7 +15415,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/hbs</property>
+        <property name="cdx:npm:package:path">node_modules/hbs</property>
       </properties>
     </component>
     <component type="library" bom-ref="he@0.4.1">
@@ -15452,7 +15452,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/he</property>
+        <property name="cdx:npm:package:path">node_modules/he</property>
       </properties>
     </component>
     <component type="library" bom-ref="heap@0.2.7">
@@ -15484,7 +15484,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/heap</property>
+        <property name="cdx:npm:package:path">node_modules/heap</property>
       </properties>
     </component>
     <component type="library" bom-ref="helmet@4.6.0">
@@ -15520,7 +15520,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/helmet</property>
+        <property name="cdx:npm:package:path">node_modules/helmet</property>
       </properties>
     </component>
     <component type="library" bom-ref="hoister@0.0.2">
@@ -15552,7 +15552,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/hoister</property>
+        <property name="cdx:npm:package:path">node_modules/hoister</property>
       </properties>
     </component>
     <component type="library" bom-ref="homedir-polyfill@1.0.3">
@@ -15588,7 +15588,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/homedir-polyfill</property>
+        <property name="cdx:npm:package:path">node_modules/homedir-polyfill</property>
       </properties>
     </component>
     <component type="library" bom-ref="hooker@0.2.3">
@@ -15625,7 +15625,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/hooker</property>
+        <property name="cdx:npm:package:path">node_modules/hooker</property>
       </properties>
     </component>
     <component type="library" bom-ref="hosted-git-info@2.8.9">
@@ -15661,7 +15661,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/hosted-git-info</property>
+        <property name="cdx:npm:package:path">node_modules/hosted-git-info</property>
       </properties>
     </component>
     <component type="library" bom-ref="html-entities@1.4.0">
@@ -15689,7 +15689,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/html-entities</property>
+        <property name="cdx:npm:package:path">node_modules/html-entities</property>
       </properties>
     </component>
     <component type="library" bom-ref="htmlparser2@3.3.0">
@@ -15722,7 +15722,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/htmlparser2</property>
+        <property name="cdx:npm:package:path">node_modules/htmlparser2</property>
       </properties>
       <components>
         <component type="library" bom-ref="htmlparser2@3.3.0|isarray@0.0.1">
@@ -15754,7 +15754,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/htmlparser2/node_modules/isarray</property>
+            <property name="cdx:npm:package:path">node_modules/htmlparser2/node_modules/isarray</property>
           </properties>
         </component>
         <component type="library" bom-ref="htmlparser2@3.3.0|readable-stream@1.0.34">
@@ -15782,7 +15782,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/htmlparser2/node_modules/readable-stream</property>
+            <property name="cdx:npm:package:path">node_modules/htmlparser2/node_modules/readable-stream</property>
           </properties>
         </component>
         <component type="library" bom-ref="htmlparser2@3.3.0|string_decoder@0.10.31">
@@ -15813,7 +15813,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/htmlparser2/node_modules/string_decoder</property>
+            <property name="cdx:npm:package:path">node_modules/htmlparser2/node_modules/string_decoder</property>
           </properties>
         </component>
       </components>
@@ -15843,7 +15843,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/http-cache-semantics</property>
+        <property name="cdx:npm:package:path">node_modules/http-cache-semantics</property>
       </properties>
     </component>
     <component type="library" bom-ref="http-errors@2.0.0">
@@ -15871,7 +15871,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/http-errors</property>
+        <property name="cdx:npm:package:path">node_modules/http-errors</property>
       </properties>
     </component>
     <component type="library" bom-ref="http-proxy-agent@5.0.0">
@@ -15903,7 +15903,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/http-proxy-agent</property>
+        <property name="cdx:npm:package:path">node_modules/http-proxy-agent</property>
       </properties>
       <components>
         <component type="library" bom-ref="http-proxy-agent@5.0.0|debug@4.3.4">
@@ -15931,7 +15931,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/http-proxy-agent/node_modules/debug</property>
+            <property name="cdx:npm:package:path">node_modules/http-proxy-agent/node_modules/debug</property>
           </properties>
         </component>
         <component type="library" bom-ref="http-proxy-agent@5.0.0|ms@2.1.2">
@@ -15958,7 +15958,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/http-proxy-agent/node_modules/ms</property>
+            <property name="cdx:npm:package:path">node_modules/http-proxy-agent/node_modules/ms</property>
           </properties>
         </component>
       </components>
@@ -15996,7 +15996,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/http-signature</property>
+        <property name="cdx:npm:package:path">node_modules/http-signature</property>
       </properties>
     </component>
     <component type="library" bom-ref="https-proxy-agent@5.0.1">
@@ -16028,7 +16028,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/https-proxy-agent</property>
+        <property name="cdx:npm:package:path">node_modules/https-proxy-agent</property>
       </properties>
       <components>
         <component type="library" bom-ref="https-proxy-agent@5.0.1|debug@4.3.4">
@@ -16056,7 +16056,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/https-proxy-agent/node_modules/debug</property>
+            <property name="cdx:npm:package:path">node_modules/https-proxy-agent/node_modules/debug</property>
           </properties>
         </component>
         <component type="library" bom-ref="https-proxy-agent@5.0.1|ms@2.1.2">
@@ -16083,7 +16083,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/https-proxy-agent/node_modules/ms</property>
+            <property name="cdx:npm:package:path">node_modules/https-proxy-agent/node_modules/ms</property>
           </properties>
         </component>
       </components>
@@ -16113,7 +16113,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/humanize-ms</property>
+        <property name="cdx:npm:package:path">node_modules/humanize-ms</property>
       </properties>
     </component>
     <component type="library" bom-ref="i18n@0.11.1">
@@ -16145,7 +16145,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/i18n</property>
+        <property name="cdx:npm:package:path">node_modules/i18n</property>
       </properties>
     </component>
     <component type="library" bom-ref="iconv-lite@0.4.24">
@@ -16181,7 +16181,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/iconv-lite</property>
+        <property name="cdx:npm:package:path">node_modules/iconv-lite</property>
       </properties>
     </component>
     <component type="library" bom-ref="ieee754@1.2.1">
@@ -16209,7 +16209,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/ieee754</property>
+        <property name="cdx:npm:package:path">node_modules/ieee754</property>
       </properties>
     </component>
     <component type="library" bom-ref="ignore-walk@3.0.4">
@@ -16237,7 +16237,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/ignore-walk</property>
+        <property name="cdx:npm:package:path">node_modules/ignore-walk</property>
       </properties>
       <components>
         <component type="library" bom-ref="ignore-walk@3.0.4|brace-expansion@1.1.11">
@@ -16269,7 +16269,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/ignore-walk/node_modules/brace-expansion</property>
+            <property name="cdx:npm:package:path">node_modules/ignore-walk/node_modules/brace-expansion</property>
           </properties>
         </component>
         <component type="library" bom-ref="ignore-walk@3.0.4|minimatch@3.1.2">
@@ -16297,7 +16297,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/ignore-walk/node_modules/minimatch</property>
+            <property name="cdx:npm:package:path">node_modules/ignore-walk/node_modules/minimatch</property>
           </properties>
         </component>
       </components>
@@ -16334,7 +16334,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/iltorb</property>
+        <property name="cdx:npm:package:path">node_modules/iltorb</property>
       </properties>
     </component>
     <component type="library" bom-ref="imurmurhash@0.1.4">
@@ -16370,7 +16370,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/imurmurhash</property>
+        <property name="cdx:npm:package:path">node_modules/imurmurhash</property>
       </properties>
     </component>
     <component type="library" bom-ref="indent-string@4.0.0">
@@ -16398,7 +16398,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/indent-string</property>
+        <property name="cdx:npm:package:path">node_modules/indent-string</property>
       </properties>
     </component>
     <component type="library" bom-ref="infer-owner@1.0.4">
@@ -16426,7 +16426,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/infer-owner</property>
+        <property name="cdx:npm:package:path">node_modules/infer-owner</property>
       </properties>
     </component>
     <component type="library" bom-ref="inflection@1.13.4">
@@ -16454,7 +16454,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/inflection</property>
+        <property name="cdx:npm:package:path">node_modules/inflection</property>
       </properties>
     </component>
     <component type="library" bom-ref="inflight@1.0.6">
@@ -16490,7 +16490,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/inflight</property>
+        <property name="cdx:npm:package:path">node_modules/inflight</property>
       </properties>
     </component>
     <component type="library" bom-ref="inherits@2.0.4">
@@ -16517,7 +16517,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/inherits</property>
+        <property name="cdx:npm:package:path">node_modules/inherits</property>
       </properties>
     </component>
     <component type="library" bom-ref="ini@1.3.8">
@@ -16545,7 +16545,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/ini</property>
+        <property name="cdx:npm:package:path">node_modules/ini</property>
       </properties>
     </component>
     <component type="library" bom-ref="interpret@1.1.0">
@@ -16581,7 +16581,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/interpret</property>
+        <property name="cdx:npm:package:path">node_modules/interpret</property>
       </properties>
     </component>
     <component type="library" bom-ref="into-stream@3.1.0">
@@ -16609,7 +16609,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/into-stream</property>
+        <property name="cdx:npm:package:path">node_modules/into-stream</property>
       </properties>
     </component>
     <component type="library" bom-ref="invariant@2.2.4">
@@ -16637,7 +16637,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/invariant</property>
+        <property name="cdx:npm:package:path">node_modules/invariant</property>
       </properties>
     </component>
     <component type="library" bom-ref="ip@1.1.8">
@@ -16668,7 +16668,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/ip</property>
+        <property name="cdx:npm:package:path">node_modules/ip</property>
       </properties>
     </component>
     <component type="library" bom-ref="ip6@0.2.10">
@@ -16704,7 +16704,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/ip6</property>
+        <property name="cdx:npm:package:path">node_modules/ip6</property>
       </properties>
     </component>
     <component type="library" bom-ref="ipaddr.js@1.9.1">
@@ -16732,7 +16732,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/ipaddr.js</property>
+        <property name="cdx:npm:package:path">node_modules/ipaddr.js</property>
       </properties>
     </component>
     <component type="library" bom-ref="is-absolute@1.0.0">
@@ -16768,7 +16768,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/is-absolute</property>
+        <property name="cdx:npm:package:path">node_modules/is-absolute</property>
       </properties>
     </component>
     <component type="library" bom-ref="is-accessor-descriptor@1.0.0">
@@ -16804,7 +16804,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/is-accessor-descriptor</property>
+        <property name="cdx:npm:package:path">node_modules/is-accessor-descriptor</property>
       </properties>
     </component>
     <component type="library" bom-ref="is-arguments@1.1.1">
@@ -16840,7 +16840,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/is-arguments</property>
+        <property name="cdx:npm:package:path">node_modules/is-arguments</property>
       </properties>
     </component>
     <component type="library" bom-ref="is-arrayish@0.2.1">
@@ -16868,7 +16868,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/is-arrayish</property>
+        <property name="cdx:npm:package:path">node_modules/is-arrayish</property>
       </properties>
     </component>
     <component type="library" bom-ref="is-bigint@1.0.4">
@@ -16904,7 +16904,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/is-bigint</property>
+        <property name="cdx:npm:package:path">node_modules/is-bigint</property>
       </properties>
     </component>
     <component type="library" bom-ref="is-binary-path@2.1.0">
@@ -16932,7 +16932,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/is-binary-path</property>
+        <property name="cdx:npm:package:path">node_modules/is-binary-path</property>
       </properties>
     </component>
     <component type="library" bom-ref="is-boolean-object@1.1.2">
@@ -16960,7 +16960,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/is-boolean-object</property>
+        <property name="cdx:npm:package:path">node_modules/is-boolean-object</property>
       </properties>
     </component>
     <component type="library" bom-ref="is-buffer@1.1.6">
@@ -16992,7 +16992,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/is-buffer</property>
+        <property name="cdx:npm:package:path">node_modules/is-buffer</property>
       </properties>
     </component>
     <component type="library" bom-ref="is-callable@1.2.7">
@@ -17020,7 +17020,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/is-callable</property>
+        <property name="cdx:npm:package:path">node_modules/is-callable</property>
       </properties>
     </component>
     <component type="library" bom-ref="is-core-module@2.11.0">
@@ -17056,7 +17056,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/is-core-module</property>
+        <property name="cdx:npm:package:path">node_modules/is-core-module</property>
       </properties>
     </component>
     <component type="library" bom-ref="is-data-descriptor@1.0.0">
@@ -17092,7 +17092,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/is-data-descriptor</property>
+        <property name="cdx:npm:package:path">node_modules/is-data-descriptor</property>
       </properties>
     </component>
     <component type="library" bom-ref="is-date-object@1.0.5">
@@ -17120,7 +17120,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/is-date-object</property>
+        <property name="cdx:npm:package:path">node_modules/is-date-object</property>
       </properties>
     </component>
     <component type="library" bom-ref="is-descriptor@1.0.2">
@@ -17156,7 +17156,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/is-descriptor</property>
+        <property name="cdx:npm:package:path">node_modules/is-descriptor</property>
       </properties>
     </component>
     <component type="library" bom-ref="is-docker@2.2.1">
@@ -17184,7 +17184,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/is-docker</property>
+        <property name="cdx:npm:package:path">node_modules/is-docker</property>
       </properties>
     </component>
     <component type="library" bom-ref="is-expression@4.0.0">
@@ -17212,7 +17212,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/is-expression</property>
+        <property name="cdx:npm:package:path">node_modules/is-expression</property>
       </properties>
     </component>
     <component type="library" bom-ref="is-extendable@1.0.1">
@@ -17248,7 +17248,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/is-extendable</property>
+        <property name="cdx:npm:package:path">node_modules/is-extendable</property>
       </properties>
     </component>
     <component type="library" bom-ref="is-extglob@2.1.1">
@@ -17284,7 +17284,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/is-extglob</property>
+        <property name="cdx:npm:package:path">node_modules/is-extglob</property>
       </properties>
     </component>
     <component type="library" bom-ref="is-fullwidth-code-point@1.0.0">
@@ -17312,7 +17312,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/is-fullwidth-code-point</property>
+        <property name="cdx:npm:package:path">node_modules/is-fullwidth-code-point</property>
       </properties>
     </component>
     <component type="library" bom-ref="is-generator-function@1.0.10">
@@ -17344,7 +17344,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/is-generator-function</property>
+        <property name="cdx:npm:package:path">node_modules/is-generator-function</property>
       </properties>
     </component>
     <component type="library" bom-ref="is-glob@3.1.0">
@@ -17380,7 +17380,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/is-glob</property>
+        <property name="cdx:npm:package:path">node_modules/is-glob</property>
       </properties>
     </component>
     <component type="library" bom-ref="is-heroku@2.0.0">
@@ -17408,7 +17408,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/is-heroku</property>
+        <property name="cdx:npm:package:path">node_modules/is-heroku</property>
       </properties>
     </component>
     <component type="library" bom-ref="is-lambda@1.0.1">
@@ -17444,7 +17444,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/is-lambda</property>
+        <property name="cdx:npm:package:path">node_modules/is-lambda</property>
       </properties>
     </component>
     <component type="library" bom-ref="is-map@2.0.2">
@@ -17480,7 +17480,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/is-map</property>
+        <property name="cdx:npm:package:path">node_modules/is-map</property>
       </properties>
     </component>
     <component type="library" bom-ref="is-natural-number@4.0.1">
@@ -17508,7 +17508,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/is-natural-number</property>
+        <property name="cdx:npm:package:path">node_modules/is-natural-number</property>
       </properties>
     </component>
     <component type="library" bom-ref="is-number-like@1.0.8">
@@ -17544,7 +17544,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/is-number-like</property>
+        <property name="cdx:npm:package:path">node_modules/is-number-like</property>
       </properties>
     </component>
     <component type="library" bom-ref="is-number-object@1.0.7">
@@ -17580,7 +17580,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/is-number-object</property>
+        <property name="cdx:npm:package:path">node_modules/is-number-object</property>
       </properties>
     </component>
     <component type="library" bom-ref="is-number@3.0.0">
@@ -17616,7 +17616,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/is-number</property>
+        <property name="cdx:npm:package:path">node_modules/is-number</property>
       </properties>
       <components>
         <component type="library" bom-ref="is-number@3.0.0|kind-of@3.2.2">
@@ -17652,7 +17652,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/is-number/node_modules/kind-of</property>
+            <property name="cdx:npm:package:path">node_modules/is-number/node_modules/kind-of</property>
           </properties>
         </component>
       </components>
@@ -17694,7 +17694,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/is-object</property>
+        <property name="cdx:npm:package:path">node_modules/is-object</property>
       </properties>
     </component>
     <component type="library" bom-ref="is-plain-obj@1.1.0">
@@ -17722,7 +17722,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/is-plain-obj</property>
+        <property name="cdx:npm:package:path">node_modules/is-plain-obj</property>
       </properties>
     </component>
     <component type="library" bom-ref="is-plain-object@2.0.4">
@@ -17758,7 +17758,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/is-plain-object</property>
+        <property name="cdx:npm:package:path">node_modules/is-plain-object</property>
       </properties>
     </component>
     <component type="library" bom-ref="is-promise@2.2.2">
@@ -17786,7 +17786,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/is-promise</property>
+        <property name="cdx:npm:package:path">node_modules/is-promise</property>
       </properties>
     </component>
     <component type="library" bom-ref="is-regex@1.1.4">
@@ -17822,7 +17822,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/is-regex</property>
+        <property name="cdx:npm:package:path">node_modules/is-regex</property>
       </properties>
     </component>
     <component type="library" bom-ref="is-relative@1.0.0">
@@ -17858,7 +17858,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/is-relative</property>
+        <property name="cdx:npm:package:path">node_modules/is-relative</property>
       </properties>
     </component>
     <component type="library" bom-ref="is-retry-allowed@1.2.0">
@@ -17886,7 +17886,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/is-retry-allowed</property>
+        <property name="cdx:npm:package:path">node_modules/is-retry-allowed</property>
       </properties>
     </component>
     <component type="library" bom-ref="is-set@2.0.2">
@@ -17922,7 +17922,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/is-set</property>
+        <property name="cdx:npm:package:path">node_modules/is-set</property>
       </properties>
     </component>
     <component type="library" bom-ref="is-stream@1.1.0">
@@ -17950,7 +17950,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/is-stream</property>
+        <property name="cdx:npm:package:path">node_modules/is-stream</property>
       </properties>
     </component>
     <component type="library" bom-ref="is-string@1.0.7">
@@ -17978,7 +17978,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/is-string</property>
+        <property name="cdx:npm:package:path">node_modules/is-string</property>
       </properties>
     </component>
     <component type="library" bom-ref="is-symbol@1.0.4">
@@ -18010,7 +18010,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/is-symbol</property>
+        <property name="cdx:npm:package:path">node_modules/is-symbol</property>
       </properties>
     </component>
     <component type="library" bom-ref="is-typed-array@1.1.10">
@@ -18038,7 +18038,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/is-typed-array</property>
+        <property name="cdx:npm:package:path">node_modules/is-typed-array</property>
       </properties>
     </component>
     <component type="library" bom-ref="is-typedarray@1.0.0">
@@ -18074,7 +18074,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/is-typedarray</property>
+        <property name="cdx:npm:package:path">node_modules/is-typedarray</property>
       </properties>
     </component>
     <component type="library" bom-ref="is-unc-path@1.0.0">
@@ -18110,7 +18110,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/is-unc-path</property>
+        <property name="cdx:npm:package:path">node_modules/is-unc-path</property>
       </properties>
     </component>
     <component type="library" bom-ref="is-weakmap@2.0.1">
@@ -18146,7 +18146,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/is-weakmap</property>
+        <property name="cdx:npm:package:path">node_modules/is-weakmap</property>
       </properties>
     </component>
     <component type="library" bom-ref="is-weakset@2.0.2">
@@ -18182,7 +18182,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/is-weakset</property>
+        <property name="cdx:npm:package:path">node_modules/is-weakset</property>
       </properties>
     </component>
     <component type="library" bom-ref="is-windows@1.0.2">
@@ -18218,7 +18218,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/is-windows</property>
+        <property name="cdx:npm:package:path">node_modules/is-windows</property>
       </properties>
     </component>
     <component type="library" bom-ref="isarray@2.0.5">
@@ -18250,7 +18250,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/isarray</property>
+        <property name="cdx:npm:package:path">node_modules/isarray</property>
       </properties>
     </component>
     <component type="library" bom-ref="isexe@2.0.0">
@@ -18286,7 +18286,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/isexe</property>
+        <property name="cdx:npm:package:path">node_modules/isexe</property>
       </properties>
     </component>
     <component type="library" bom-ref="isobject@3.0.1">
@@ -18322,7 +18322,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/isobject</property>
+        <property name="cdx:npm:package:path">node_modules/isobject</property>
       </properties>
     </component>
     <component type="library" bom-ref="isstream@0.1.2">
@@ -18358,7 +18358,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/isstream</property>
+        <property name="cdx:npm:package:path">node_modules/isstream</property>
       </properties>
     </component>
     <component type="library" bom-ref="isurl@1.0.0">
@@ -18386,7 +18386,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/isurl</property>
+        <property name="cdx:npm:package:path">node_modules/isurl</property>
       </properties>
     </component>
     <component type="library" bom-ref="js-stringify@1.0.2">
@@ -18414,7 +18414,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/js-stringify</property>
+        <property name="cdx:npm:package:path">node_modules/js-stringify</property>
       </properties>
     </component>
     <component type="library" bom-ref="js-tokens@4.0.0">
@@ -18442,7 +18442,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/js-tokens</property>
+        <property name="cdx:npm:package:path">node_modules/js-tokens</property>
       </properties>
     </component>
     <component type="library" bom-ref="js-yaml@3.14.1">
@@ -18474,7 +18474,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/js-yaml</property>
+        <property name="cdx:npm:package:path">node_modules/js-yaml</property>
       </properties>
     </component>
     <component type="library" bom-ref="jsbn@0.1.1">
@@ -18502,7 +18502,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/jsbn</property>
+        <property name="cdx:npm:package:path">node_modules/jsbn</property>
       </properties>
     </component>
     <component type="library" bom-ref="json-buffer@3.0.0">
@@ -18534,7 +18534,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/json-buffer</property>
+        <property name="cdx:npm:package:path">node_modules/json-buffer</property>
       </properties>
     </component>
     <component type="library" bom-ref="json-parse-better-errors@1.0.2">
@@ -18562,7 +18562,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/json-parse-better-errors</property>
+        <property name="cdx:npm:package:path">node_modules/json-parse-better-errors</property>
       </properties>
     </component>
     <component type="library" bom-ref="json-schema-traverse@0.4.1">
@@ -18598,7 +18598,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/json-schema-traverse</property>
+        <property name="cdx:npm:package:path">node_modules/json-schema-traverse</property>
       </properties>
     </component>
     <component type="library" bom-ref="json-schema@0.4.0">
@@ -18624,7 +18624,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/json-schema</property>
+        <property name="cdx:npm:package:path">node_modules/json-schema</property>
       </properties>
     </component>
     <component type="library" bom-ref="json-stringify-safe@5.0.1">
@@ -18660,7 +18660,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/json-stringify-safe</property>
+        <property name="cdx:npm:package:path">node_modules/json-stringify-safe</property>
       </properties>
     </component>
     <component type="library" bom-ref="json5@2.2.1">
@@ -18696,7 +18696,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/json5</property>
+        <property name="cdx:npm:package:path">node_modules/json5</property>
       </properties>
     </component>
     <component type="library" bom-ref="jsonfile@6.1.0">
@@ -18720,7 +18720,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/jsonfile</property>
+        <property name="cdx:npm:package:path">node_modules/jsonfile</property>
       </properties>
     </component>
     <component type="library" bom-ref="jsonwebtoken@0.4.0">
@@ -18752,7 +18752,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/jsonwebtoken</property>
+        <property name="cdx:npm:package:path">node_modules/jsonwebtoken</property>
       </properties>
     </component>
     <component type="library" bom-ref="jsprim@1.4.2">
@@ -18779,7 +18779,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/jsprim</property>
+        <property name="cdx:npm:package:path">node_modules/jsprim</property>
       </properties>
     </component>
     <component type="library" bom-ref="jssha@3.3.0">
@@ -18815,7 +18815,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/jssha</property>
+        <property name="cdx:npm:package:path">node_modules/jssha</property>
       </properties>
     </component>
     <component type="library" bom-ref="jstransformer@1.0.0">
@@ -18843,7 +18843,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/jstransformer</property>
+        <property name="cdx:npm:package:path">node_modules/jstransformer</property>
       </properties>
     </component>
     <component type="library" bom-ref="juicy-chat-bot@0.6.6">
@@ -18879,7 +18879,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/juicy-chat-bot</property>
+        <property name="cdx:npm:package:path">node_modules/juicy-chat-bot</property>
       </properties>
     </component>
     <component type="library" bom-ref="jwa@0.0.1">
@@ -18907,7 +18907,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/jwa</property>
+        <property name="cdx:npm:package:path">node_modules/jwa</property>
       </properties>
     </component>
     <component type="library" bom-ref="jws@0.2.6">
@@ -18935,7 +18935,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/jws</property>
+        <property name="cdx:npm:package:path">node_modules/jws</property>
       </properties>
     </component>
     <component type="library" bom-ref="keyv@3.0.0">
@@ -18971,7 +18971,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/keyv</property>
+        <property name="cdx:npm:package:path">node_modules/keyv</property>
       </properties>
     </component>
     <component type="library" bom-ref="kind-of@6.0.3">
@@ -19007,7 +19007,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/kind-of</property>
+        <property name="cdx:npm:package:path">node_modules/kind-of</property>
       </properties>
     </component>
     <component type="library" bom-ref="kuler@2.0.0">
@@ -19043,7 +19043,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/kuler</property>
+        <property name="cdx:npm:package:path">node_modules/kuler</property>
       </properties>
     </component>
     <component type="library" bom-ref="kuromoji@0.1.2">
@@ -19079,7 +19079,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/kuromoji</property>
+        <property name="cdx:npm:package:path">node_modules/kuromoji</property>
       </properties>
     </component>
     <component type="library" bom-ref="lazystream@1.0.1">
@@ -19115,7 +19115,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/lazystream</property>
+        <property name="cdx:npm:package:path">node_modules/lazystream</property>
       </properties>
     </component>
     <component type="library" bom-ref="levn@0.3.0">
@@ -19151,7 +19151,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/levn</property>
+        <property name="cdx:npm:package:path">node_modules/levn</property>
       </properties>
     </component>
     <component type="library" bom-ref="libxmljs2@0.30.1">
@@ -19183,7 +19183,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/libxmljs2</property>
+        <property name="cdx:npm:package:path">node_modules/libxmljs2</property>
       </properties>
       <components>
         <component type="library" bom-ref="libxmljs2@0.30.1|nan@2.15.0">
@@ -19210,7 +19210,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/libxmljs2/node_modules/nan</property>
+            <property name="cdx:npm:package:path">node_modules/libxmljs2/node_modules/nan</property>
           </properties>
         </component>
       </components>
@@ -19240,7 +19240,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/liftup</property>
+        <property name="cdx:npm:package:path">node_modules/liftup</property>
       </properties>
       <components>
         <component type="library" bom-ref="liftup@3.0.1|braces@3.0.2">
@@ -19276,7 +19276,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/liftup/node_modules/braces</property>
+            <property name="cdx:npm:package:path">node_modules/liftup/node_modules/braces</property>
           </properties>
         </component>
         <component type="library" bom-ref="liftup@3.0.1|fill-range@7.0.1">
@@ -19312,7 +19312,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/liftup/node_modules/fill-range</property>
+            <property name="cdx:npm:package:path">node_modules/liftup/node_modules/fill-range</property>
           </properties>
         </component>
         <component type="library" bom-ref="liftup@3.0.1|findup-sync@4.0.0">
@@ -19340,7 +19340,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/liftup/node_modules/findup-sync</property>
+            <property name="cdx:npm:package:path">node_modules/liftup/node_modules/findup-sync</property>
           </properties>
         </component>
         <component type="library" bom-ref="liftup@3.0.1|is-glob@4.0.3">
@@ -19376,7 +19376,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/liftup/node_modules/is-glob</property>
+            <property name="cdx:npm:package:path">node_modules/liftup/node_modules/is-glob</property>
           </properties>
         </component>
         <component type="library" bom-ref="liftup@3.0.1|is-number@7.0.0">
@@ -19412,7 +19412,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/liftup/node_modules/is-number</property>
+            <property name="cdx:npm:package:path">node_modules/liftup/node_modules/is-number</property>
           </properties>
         </component>
         <component type="library" bom-ref="liftup@3.0.1|micromatch@4.0.5">
@@ -19448,7 +19448,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/liftup/node_modules/micromatch</property>
+            <property name="cdx:npm:package:path">node_modules/liftup/node_modules/micromatch</property>
           </properties>
         </component>
         <component type="library" bom-ref="liftup@3.0.1|to-regex-range@5.0.1">
@@ -19484,7 +19484,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/liftup/node_modules/to-regex-range</property>
+            <property name="cdx:npm:package:path">node_modules/liftup/node_modules/to-regex-range</property>
           </properties>
         </component>
       </components>
@@ -19522,7 +19522,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/linebreak</property>
+        <property name="cdx:npm:package:path">node_modules/linebreak</property>
       </properties>
       <components>
         <component type="library" bom-ref="linebreak@1.1.0|base64-js@0.0.8">
@@ -19550,7 +19550,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/linebreak/node_modules/base64-js</property>
+            <property name="cdx:npm:package:path">node_modules/linebreak/node_modules/base64-js</property>
           </properties>
         </component>
       </components>
@@ -19576,7 +19576,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/listenercount</property>
+        <property name="cdx:npm:package:path">node_modules/listenercount</property>
       </properties>
     </component>
     <component type="library" bom-ref="locate-path@3.0.0">
@@ -19604,7 +19604,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/locate-path</property>
+        <property name="cdx:npm:package:path">node_modules/locate-path</property>
       </properties>
     </component>
     <component type="library" bom-ref="lodash.camelcase@4.3.0">
@@ -19636,7 +19636,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/lodash.camelcase</property>
+        <property name="cdx:npm:package:path">node_modules/lodash.camelcase</property>
       </properties>
     </component>
     <component type="library" bom-ref="lodash.isfinite@3.3.2">
@@ -19668,7 +19668,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/lodash.isfinite</property>
+        <property name="cdx:npm:package:path">node_modules/lodash.isfinite</property>
       </properties>
     </component>
     <component type="library" bom-ref="lodash.set@4.3.2">
@@ -19700,7 +19700,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/lodash.set</property>
+        <property name="cdx:npm:package:path">node_modules/lodash.set</property>
       </properties>
     </component>
     <component type="library" bom-ref="lodash@4.17.21">
@@ -19732,7 +19732,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/lodash</property>
+        <property name="cdx:npm:package:path">node_modules/lodash</property>
       </properties>
     </component>
     <component type="library" bom-ref="logform@2.4.2">
@@ -19768,7 +19768,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/logform</property>
+        <property name="cdx:npm:package:path">node_modules/logform</property>
       </properties>
       <components>
         <component type="library" bom-ref="logform@2.4.2|ms@2.1.3">
@@ -19795,7 +19795,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/logform/node_modules/ms</property>
+            <property name="cdx:npm:package:path">node_modules/logform/node_modules/ms</property>
           </properties>
         </component>
       </components>
@@ -19833,7 +19833,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/lolex</property>
+        <property name="cdx:npm:package:path">node_modules/lolex</property>
       </properties>
     </component>
     <component type="library" bom-ref="loose-envify@1.4.0">
@@ -19865,7 +19865,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/loose-envify</property>
+        <property name="cdx:npm:package:path">node_modules/loose-envify</property>
       </properties>
     </component>
     <component type="library" bom-ref="lowercase-keys@1.0.1">
@@ -19893,7 +19893,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/lowercase-keys</property>
+        <property name="cdx:npm:package:path">node_modules/lowercase-keys</property>
       </properties>
     </component>
     <component type="library" bom-ref="lru-cache@6.0.0">
@@ -19921,7 +19921,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/lru-cache</property>
+        <property name="cdx:npm:package:path">node_modules/lru-cache</property>
       </properties>
     </component>
     <component type="library" bom-ref="make-dir@2.1.0">
@@ -19949,7 +19949,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/make-dir</property>
+        <property name="cdx:npm:package:path">node_modules/make-dir</property>
       </properties>
       <components>
         <component type="library" bom-ref="make-dir@2.1.0|semver@5.7.1">
@@ -19976,7 +19976,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/make-dir/node_modules/semver</property>
+            <property name="cdx:npm:package:path">node_modules/make-dir/node_modules/semver</property>
           </properties>
         </component>
       </components>
@@ -20014,7 +20014,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/make-error</property>
+        <property name="cdx:npm:package:path">node_modules/make-error</property>
       </properties>
     </component>
     <component type="library" bom-ref="make-fetch-happen@9.1.0">
@@ -20042,7 +20042,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/make-fetch-happen</property>
+        <property name="cdx:npm:package:path">node_modules/make-fetch-happen</property>
       </properties>
       <components>
         <component type="library" bom-ref="make-fetch-happen@9.1.0|@tootallnate/once@1.1.2">
@@ -20075,7 +20075,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/make-fetch-happen/node_modules/@tootallnate/once</property>
+            <property name="cdx:npm:package:path">node_modules/make-fetch-happen/node_modules/@tootallnate/once</property>
           </properties>
         </component>
         <component type="library" bom-ref="make-fetch-happen@9.1.0|debug@4.3.4">
@@ -20103,7 +20103,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/make-fetch-happen/node_modules/debug</property>
+            <property name="cdx:npm:package:path">node_modules/make-fetch-happen/node_modules/debug</property>
           </properties>
         </component>
         <component type="library" bom-ref="make-fetch-happen@9.1.0|http-cache-semantics@4.1.0">
@@ -20131,7 +20131,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/make-fetch-happen/node_modules/http-cache-semantics</property>
+            <property name="cdx:npm:package:path">node_modules/make-fetch-happen/node_modules/http-cache-semantics</property>
           </properties>
         </component>
         <component type="library" bom-ref="make-fetch-happen@9.1.0|http-proxy-agent@4.0.1">
@@ -20163,7 +20163,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/make-fetch-happen/node_modules/http-proxy-agent</property>
+            <property name="cdx:npm:package:path">node_modules/make-fetch-happen/node_modules/http-proxy-agent</property>
           </properties>
         </component>
         <component type="library" bom-ref="make-fetch-happen@9.1.0|ms@2.1.2">
@@ -20190,7 +20190,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/make-fetch-happen/node_modules/ms</property>
+            <property name="cdx:npm:package:path">node_modules/make-fetch-happen/node_modules/ms</property>
           </properties>
         </component>
       </components>
@@ -20228,7 +20228,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/make-iterator</property>
+        <property name="cdx:npm:package:path">node_modules/make-iterator</property>
       </properties>
     </component>
     <component type="library" bom-ref="make-plural@6.2.2">
@@ -20264,7 +20264,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/make-plural</property>
+        <property name="cdx:npm:package:path">node_modules/make-plural</property>
       </properties>
     </component>
     <component type="library" bom-ref="map-cache@0.2.2">
@@ -20300,7 +20300,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/map-cache</property>
+        <property name="cdx:npm:package:path">node_modules/map-cache</property>
       </properties>
     </component>
     <component type="library" bom-ref="map-visit@1.0.0">
@@ -20336,7 +20336,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/map-visit</property>
+        <property name="cdx:npm:package:path">node_modules/map-visit</property>
       </properties>
     </component>
     <component type="library" bom-ref="marsdb@0.6.11">
@@ -20364,7 +20364,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/marsdb</property>
+        <property name="cdx:npm:package:path">node_modules/marsdb</property>
       </properties>
     </component>
     <component type="library" bom-ref="math-interval-parser@2.0.1">
@@ -20392,7 +20392,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/math-interval-parser</property>
+        <property name="cdx:npm:package:path">node_modules/math-interval-parser</property>
       </properties>
     </component>
     <component type="library" bom-ref="media-typer@0.3.0">
@@ -20420,7 +20420,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/media-typer</property>
+        <property name="cdx:npm:package:path">node_modules/media-typer</property>
       </properties>
     </component>
     <component type="library" bom-ref="merge-descriptors@1.0.1">
@@ -20448,7 +20448,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/merge-descriptors</property>
+        <property name="cdx:npm:package:path">node_modules/merge-descriptors</property>
       </properties>
     </component>
     <component type="library" bom-ref="messageformat-formatters@2.0.1">
@@ -20480,7 +20480,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/messageformat-formatters</property>
+        <property name="cdx:npm:package:path">node_modules/messageformat-formatters</property>
       </properties>
     </component>
     <component type="library" bom-ref="messageformat-parser@4.1.3">
@@ -20511,7 +20511,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/messageformat-parser</property>
+        <property name="cdx:npm:package:path">node_modules/messageformat-parser</property>
       </properties>
     </component>
     <component type="library" bom-ref="messageformat@2.3.0">
@@ -20543,7 +20543,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/messageformat</property>
+        <property name="cdx:npm:package:path">node_modules/messageformat</property>
       </properties>
       <components>
         <component type="library" bom-ref="messageformat@2.3.0|make-plural@4.3.0">
@@ -20579,7 +20579,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/messageformat/node_modules/make-plural</property>
+            <property name="cdx:npm:package:path">node_modules/messageformat/node_modules/make-plural</property>
           </properties>
         </component>
       </components>
@@ -20608,7 +20608,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/methods</property>
+        <property name="cdx:npm:package:path">node_modules/methods</property>
       </properties>
     </component>
     <component type="library" bom-ref="micromatch@3.1.10">
@@ -20644,7 +20644,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/micromatch</property>
+        <property name="cdx:npm:package:path">node_modules/micromatch</property>
       </properties>
     </component>
     <component type="library" bom-ref="mime-db@1.52.0">
@@ -20671,7 +20671,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/mime-db</property>
+        <property name="cdx:npm:package:path">node_modules/mime-db</property>
       </properties>
     </component>
     <component type="library" bom-ref="mime-types@2.1.35">
@@ -20698,7 +20698,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/mime-types</property>
+        <property name="cdx:npm:package:path">node_modules/mime-types</property>
       </properties>
     </component>
     <component type="library" bom-ref="mime@1.6.0">
@@ -20726,7 +20726,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/mime</property>
+        <property name="cdx:npm:package:path">node_modules/mime</property>
       </properties>
     </component>
     <component type="library" bom-ref="mimic-response@1.0.1">
@@ -20754,7 +20754,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/mimic-response</property>
+        <property name="cdx:npm:package:path">node_modules/mimic-response</property>
       </properties>
     </component>
     <component type="library" bom-ref="minimatch@5.1.0">
@@ -20782,7 +20782,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/minimatch</property>
+        <property name="cdx:npm:package:path">node_modules/minimatch</property>
       </properties>
     </component>
     <component type="library" bom-ref="minimist@1.2.7">
@@ -20814,7 +20814,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/minimist</property>
+        <property name="cdx:npm:package:path">node_modules/minimist</property>
       </properties>
     </component>
     <component type="library" bom-ref="minipass-collect@1.0.2">
@@ -20838,7 +20838,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/minipass-collect</property>
+        <property name="cdx:npm:package:path">node_modules/minipass-collect</property>
       </properties>
     </component>
     <component type="library" bom-ref="minipass-fetch@1.4.1">
@@ -20865,7 +20865,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/minipass-fetch</property>
+        <property name="cdx:npm:package:path">node_modules/minipass-fetch</property>
       </properties>
     </component>
     <component type="library" bom-ref="minipass-flush@1.0.5">
@@ -20893,7 +20893,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/minipass-flush</property>
+        <property name="cdx:npm:package:path">node_modules/minipass-flush</property>
       </properties>
     </component>
     <component type="library" bom-ref="minipass-pipeline@1.2.4">
@@ -20917,7 +20917,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/minipass-pipeline</property>
+        <property name="cdx:npm:package:path">node_modules/minipass-pipeline</property>
       </properties>
     </component>
     <component type="library" bom-ref="minipass-sized@1.0.3">
@@ -20945,7 +20945,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/minipass-sized</property>
+        <property name="cdx:npm:package:path">node_modules/minipass-sized</property>
       </properties>
     </component>
     <component type="library" bom-ref="minipass@3.3.4">
@@ -20973,7 +20973,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/minipass</property>
+        <property name="cdx:npm:package:path">node_modules/minipass</property>
       </properties>
     </component>
     <component type="library" bom-ref="minizlib@2.1.2">
@@ -21001,7 +21001,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/minizlib</property>
+        <property name="cdx:npm:package:path">node_modules/minizlib</property>
       </properties>
     </component>
     <component type="library" bom-ref="mixin-deep@1.3.2">
@@ -21037,7 +21037,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/mixin-deep</property>
+        <property name="cdx:npm:package:path">node_modules/mixin-deep</property>
       </properties>
     </component>
     <component type="library" bom-ref="mkdirp-classic@0.5.3">
@@ -21073,7 +21073,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/mkdirp-classic</property>
+        <property name="cdx:npm:package:path">node_modules/mkdirp-classic</property>
       </properties>
     </component>
     <component type="library" bom-ref="mkdirp@1.0.4">
@@ -21100,7 +21100,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/mkdirp</property>
+        <property name="cdx:npm:package:path">node_modules/mkdirp</property>
       </properties>
     </component>
     <component type="library" bom-ref="moment-timezone@0.5.38">
@@ -21136,7 +21136,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/moment-timezone</property>
+        <property name="cdx:npm:package:path">node_modules/moment-timezone</property>
       </properties>
     </component>
     <component type="library" bom-ref="moment@2.29.4">
@@ -21172,7 +21172,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/moment</property>
+        <property name="cdx:npm:package:path">node_modules/moment</property>
       </properties>
     </component>
     <component type="library" bom-ref="morgan@1.10.0">
@@ -21199,7 +21199,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/morgan</property>
+        <property name="cdx:npm:package:path">node_modules/morgan</property>
       </properties>
       <components>
         <component type="library" bom-ref="morgan@1.10.0|on-finished@2.3.0">
@@ -21226,7 +21226,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/morgan/node_modules/on-finished</property>
+            <property name="cdx:npm:package:path">node_modules/morgan/node_modules/on-finished</property>
           </properties>
         </component>
       </components>
@@ -21264,7 +21264,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/mout</property>
+        <property name="cdx:npm:package:path">node_modules/mout</property>
       </properties>
     </component>
     <component type="library" bom-ref="ms@2.0.0">
@@ -21291,7 +21291,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/ms</property>
+        <property name="cdx:npm:package:path">node_modules/ms</property>
       </properties>
     </component>
     <component type="library" bom-ref="multer@1.4.4">
@@ -21318,7 +21318,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/multer</property>
+        <property name="cdx:npm:package:path">node_modules/multer</property>
       </properties>
       <components>
         <component type="library" bom-ref="multer@1.4.4|mkdirp@0.5.6">
@@ -21346,7 +21346,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/multer/node_modules/mkdirp</property>
+            <property name="cdx:npm:package:path">node_modules/multer/node_modules/mkdirp</property>
           </properties>
         </component>
       </components>
@@ -21380,7 +21380,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/mustache</property>
+        <property name="cdx:npm:package:path">node_modules/mustache</property>
       </properties>
     </component>
     <component type="library" bom-ref="nan@2.17.0">
@@ -21407,7 +21407,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/nan</property>
+        <property name="cdx:npm:package:path">node_modules/nan</property>
       </properties>
     </component>
     <component type="library" bom-ref="nanomatch@1.2.13">
@@ -21443,7 +21443,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/nanomatch</property>
+        <property name="cdx:npm:package:path">node_modules/nanomatch</property>
       </properties>
     </component>
     <component type="library" bom-ref="napi-build-utils@1.0.2">
@@ -21479,7 +21479,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/napi-build-utils</property>
+        <property name="cdx:npm:package:path">node_modules/napi-build-utils</property>
       </properties>
     </component>
     <component type="library" bom-ref="needle@2.9.1">
@@ -21507,7 +21507,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/needle</property>
+        <property name="cdx:npm:package:path">node_modules/needle</property>
       </properties>
       <components>
         <component type="library" bom-ref="needle@2.9.1|debug@3.2.7">
@@ -21535,7 +21535,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/needle/node_modules/debug</property>
+            <property name="cdx:npm:package:path">node_modules/needle/node_modules/debug</property>
           </properties>
         </component>
         <component type="library" bom-ref="needle@2.9.1|ms@2.1.3">
@@ -21562,7 +21562,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/needle/node_modules/ms</property>
+            <property name="cdx:npm:package:path">node_modules/needle/node_modules/ms</property>
           </properties>
         </component>
       </components>
@@ -21591,7 +21591,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/negotiator</property>
+        <property name="cdx:npm:package:path">node_modules/negotiator</property>
       </properties>
     </component>
     <component type="library" bom-ref="neo-async@2.6.2">
@@ -21618,7 +21618,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/neo-async</property>
+        <property name="cdx:npm:package:path">node_modules/neo-async</property>
       </properties>
     </component>
     <component type="library" bom-ref="node-abi@2.30.1">
@@ -21654,7 +21654,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/node-abi</property>
+        <property name="cdx:npm:package:path">node_modules/node-abi</property>
       </properties>
       <components>
         <component type="library" bom-ref="node-abi@2.30.1|semver@5.7.1">
@@ -21681,7 +21681,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/node-abi/node_modules/semver</property>
+            <property name="cdx:npm:package:path">node_modules/node-abi/node_modules/semver</property>
           </properties>
         </component>
       </components>
@@ -21718,7 +21718,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/node-addon-api</property>
+        <property name="cdx:npm:package:path">node_modules/node-addon-api</property>
       </properties>
     </component>
     <component type="library" bom-ref="node-fetch@2.6.7">
@@ -21754,7 +21754,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/node-fetch</property>
+        <property name="cdx:npm:package:path">node_modules/node-fetch</property>
       </properties>
     </component>
     <component type="library" bom-ref="node-gyp@8.4.1">
@@ -21782,7 +21782,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/node-gyp</property>
+        <property name="cdx:npm:package:path">node_modules/node-gyp</property>
       </properties>
       <components>
         <component type="library" bom-ref="node-gyp@8.4.1|ansi-regex@5.0.1">
@@ -21810,7 +21810,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/node-gyp/node_modules/ansi-regex</property>
+            <property name="cdx:npm:package:path">node_modules/node-gyp/node_modules/ansi-regex</property>
           </properties>
         </component>
         <component type="library" bom-ref="node-gyp@8.4.1|are-we-there-yet@3.0.1">
@@ -21846,7 +21846,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/node-gyp/node_modules/are-we-there-yet</property>
+            <property name="cdx:npm:package:path">node_modules/node-gyp/node_modules/are-we-there-yet</property>
           </properties>
         </component>
         <component type="library" bom-ref="node-gyp@8.4.1|gauge@4.0.4">
@@ -21882,7 +21882,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/node-gyp/node_modules/gauge</property>
+            <property name="cdx:npm:package:path">node_modules/node-gyp/node_modules/gauge</property>
           </properties>
         </component>
         <component type="library" bom-ref="node-gyp@8.4.1|is-fullwidth-code-point@3.0.0">
@@ -21910,7 +21910,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/node-gyp/node_modules/is-fullwidth-code-point</property>
+            <property name="cdx:npm:package:path">node_modules/node-gyp/node_modules/is-fullwidth-code-point</property>
           </properties>
         </component>
         <component type="library" bom-ref="node-gyp@8.4.1|nopt@5.0.0">
@@ -21938,7 +21938,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/node-gyp/node_modules/nopt</property>
+            <property name="cdx:npm:package:path">node_modules/node-gyp/node_modules/nopt</property>
           </properties>
         </component>
         <component type="library" bom-ref="node-gyp@8.4.1|npmlog@6.0.2">
@@ -21966,7 +21966,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/node-gyp/node_modules/npmlog</property>
+            <property name="cdx:npm:package:path">node_modules/node-gyp/node_modules/npmlog</property>
           </properties>
         </component>
         <component type="library" bom-ref="node-gyp@8.4.1|readable-stream@3.6.0">
@@ -21993,7 +21993,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/node-gyp/node_modules/readable-stream</property>
+            <property name="cdx:npm:package:path">node_modules/node-gyp/node_modules/readable-stream</property>
           </properties>
         </component>
         <component type="library" bom-ref="node-gyp@8.4.1|string-width@4.2.3">
@@ -22021,7 +22021,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/node-gyp/node_modules/string-width</property>
+            <property name="cdx:npm:package:path">node_modules/node-gyp/node_modules/string-width</property>
           </properties>
         </component>
         <component type="library" bom-ref="node-gyp@8.4.1|strip-ansi@6.0.1">
@@ -22049,7 +22049,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/node-gyp/node_modules/strip-ansi</property>
+            <property name="cdx:npm:package:path">node_modules/node-gyp/node_modules/strip-ansi</property>
           </properties>
         </component>
       </components>
@@ -22079,7 +22079,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/node-pre-gyp</property>
+        <property name="cdx:npm:package:path">node_modules/node-pre-gyp</property>
       </properties>
       <components>
         <component type="library" bom-ref="node-pre-gyp@0.15.0|chownr@1.1.4">
@@ -22107,7 +22107,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/node-pre-gyp/node_modules/chownr</property>
+            <property name="cdx:npm:package:path">node_modules/node-pre-gyp/node_modules/chownr</property>
           </properties>
         </component>
         <component type="library" bom-ref="node-pre-gyp@0.15.0|fs-minipass@1.2.7">
@@ -22143,7 +22143,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/node-pre-gyp/node_modules/fs-minipass</property>
+            <property name="cdx:npm:package:path">node_modules/node-pre-gyp/node_modules/fs-minipass</property>
           </properties>
         </component>
         <component type="library" bom-ref="node-pre-gyp@0.15.0|minipass@2.9.0">
@@ -22171,7 +22171,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/node-pre-gyp/node_modules/minipass</property>
+            <property name="cdx:npm:package:path">node_modules/node-pre-gyp/node_modules/minipass</property>
           </properties>
         </component>
         <component type="library" bom-ref="node-pre-gyp@0.15.0|minizlib@1.3.3">
@@ -22199,7 +22199,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/node-pre-gyp/node_modules/minizlib</property>
+            <property name="cdx:npm:package:path">node_modules/node-pre-gyp/node_modules/minizlib</property>
           </properties>
         </component>
         <component type="library" bom-ref="node-pre-gyp@0.15.0|mkdirp@0.5.6">
@@ -22227,7 +22227,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/node-pre-gyp/node_modules/mkdirp</property>
+            <property name="cdx:npm:package:path">node_modules/node-pre-gyp/node_modules/mkdirp</property>
           </properties>
         </component>
         <component type="library" bom-ref="node-pre-gyp@0.15.0|nopt@4.0.3">
@@ -22255,7 +22255,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/node-pre-gyp/node_modules/nopt</property>
+            <property name="cdx:npm:package:path">node_modules/node-pre-gyp/node_modules/nopt</property>
           </properties>
         </component>
         <component type="library" bom-ref="node-pre-gyp@0.15.0|rimraf@2.7.1">
@@ -22283,7 +22283,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/node-pre-gyp/node_modules/rimraf</property>
+            <property name="cdx:npm:package:path">node_modules/node-pre-gyp/node_modules/rimraf</property>
           </properties>
         </component>
         <component type="library" bom-ref="node-pre-gyp@0.15.0|safe-buffer@5.2.1">
@@ -22319,7 +22319,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/node-pre-gyp/node_modules/safe-buffer</property>
+            <property name="cdx:npm:package:path">node_modules/node-pre-gyp/node_modules/safe-buffer</property>
           </properties>
         </component>
         <component type="library" bom-ref="node-pre-gyp@0.15.0|semver@5.7.1">
@@ -22346,7 +22346,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/node-pre-gyp/node_modules/semver</property>
+            <property name="cdx:npm:package:path">node_modules/node-pre-gyp/node_modules/semver</property>
           </properties>
         </component>
         <component type="library" bom-ref="node-pre-gyp@0.15.0|tar@4.4.19">
@@ -22374,7 +22374,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/node-pre-gyp/node_modules/tar</property>
+            <property name="cdx:npm:package:path">node_modules/node-pre-gyp/node_modules/tar</property>
           </properties>
         </component>
         <component type="library" bom-ref="node-pre-gyp@0.15.0|yallist@3.1.1">
@@ -22402,7 +22402,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/node-pre-gyp/node_modules/yallist</property>
+            <property name="cdx:npm:package:path">node_modules/node-pre-gyp/node_modules/yallist</property>
           </properties>
         </component>
       </components>
@@ -22431,7 +22431,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/noop-logger</property>
+        <property name="cdx:npm:package:path">node_modules/noop-logger</property>
       </properties>
     </component>
     <component type="library" bom-ref="nopt@3.0.6">
@@ -22459,7 +22459,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/nopt</property>
+        <property name="cdx:npm:package:path">node_modules/nopt</property>
       </properties>
     </component>
     <component type="library" bom-ref="normalize-package-data@2.5.0">
@@ -22487,7 +22487,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/normalize-package-data</property>
+        <property name="cdx:npm:package:path">node_modules/normalize-package-data</property>
       </properties>
       <components>
         <component type="library" bom-ref="normalize-package-data@2.5.0|semver@5.7.1">
@@ -22514,7 +22514,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/normalize-package-data/node_modules/semver</property>
+            <property name="cdx:npm:package:path">node_modules/normalize-package-data/node_modules/semver</property>
           </properties>
         </component>
       </components>
@@ -22552,7 +22552,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/normalize-path</property>
+        <property name="cdx:npm:package:path">node_modules/normalize-path</property>
       </properties>
     </component>
     <component type="library" bom-ref="normalize-url@2.0.1">
@@ -22580,7 +22580,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/normalize-url</property>
+        <property name="cdx:npm:package:path">node_modules/normalize-url</property>
       </properties>
     </component>
     <component type="library" bom-ref="notevil@1.3.3">
@@ -22612,7 +22612,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/notevil</property>
+        <property name="cdx:npm:package:path">node_modules/notevil</property>
       </properties>
       <components>
         <component type="library" bom-ref="notevil@1.3.3|esprima@1.0.4">
@@ -22644,7 +22644,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/notevil/node_modules/esprima</property>
+            <property name="cdx:npm:package:path">node_modules/notevil/node_modules/esprima</property>
           </properties>
         </component>
       </components>
@@ -22674,7 +22674,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/npm-bundled</property>
+        <property name="cdx:npm:package:path">node_modules/npm-bundled</property>
       </properties>
     </component>
     <component type="library" bom-ref="npm-normalize-package-bin@1.0.1">
@@ -22702,7 +22702,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/npm-normalize-package-bin</property>
+        <property name="cdx:npm:package:path">node_modules/npm-normalize-package-bin</property>
       </properties>
     </component>
     <component type="library" bom-ref="npm-packlist@1.4.8">
@@ -22738,7 +22738,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/npm-packlist</property>
+        <property name="cdx:npm:package:path">node_modules/npm-packlist</property>
       </properties>
     </component>
     <component type="library" bom-ref="npmlog@4.1.2">
@@ -22766,7 +22766,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/npmlog</property>
+        <property name="cdx:npm:package:path">node_modules/npmlog</property>
       </properties>
     </component>
     <component type="library" bom-ref="number-is-nan@1.0.1">
@@ -22794,7 +22794,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/number-is-nan</property>
+        <property name="cdx:npm:package:path">node_modules/number-is-nan</property>
       </properties>
     </component>
     <component type="library" bom-ref="oauth-sign@0.9.0">
@@ -22822,7 +22822,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/oauth-sign</property>
+        <property name="cdx:npm:package:path">node_modules/oauth-sign</property>
       </properties>
     </component>
     <component type="library" bom-ref="object-assign@4.1.1">
@@ -22850,7 +22850,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/object-assign</property>
+        <property name="cdx:npm:package:path">node_modules/object-assign</property>
       </properties>
     </component>
     <component type="library" bom-ref="object-copy@0.1.0">
@@ -22886,7 +22886,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/object-copy</property>
+        <property name="cdx:npm:package:path">node_modules/object-copy</property>
       </properties>
       <components>
         <component type="library" bom-ref="object-copy@0.1.0|define-property@0.2.5">
@@ -22922,7 +22922,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/object-copy/node_modules/define-property</property>
+            <property name="cdx:npm:package:path">node_modules/object-copy/node_modules/define-property</property>
           </properties>
         </component>
         <component type="library" bom-ref="object-copy@0.1.0|is-accessor-descriptor@0.1.6">
@@ -22958,7 +22958,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/object-copy/node_modules/is-accessor-descriptor</property>
+            <property name="cdx:npm:package:path">node_modules/object-copy/node_modules/is-accessor-descriptor</property>
           </properties>
         </component>
         <component type="library" bom-ref="object-copy@0.1.0|is-data-descriptor@0.1.4">
@@ -22994,7 +22994,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/object-copy/node_modules/is-data-descriptor</property>
+            <property name="cdx:npm:package:path">node_modules/object-copy/node_modules/is-data-descriptor</property>
           </properties>
         </component>
         <component type="library" bom-ref="object-copy@0.1.0|is-descriptor@0.1.6">
@@ -23030,7 +23030,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/object-copy/node_modules/is-descriptor</property>
+            <property name="cdx:npm:package:path">node_modules/object-copy/node_modules/is-descriptor</property>
           </properties>
           <components>
             <component type="library" bom-ref="object-copy@0.1.0|is-descriptor@0.1.6|kind-of@5.1.0">
@@ -23066,7 +23066,7 @@
                 </reference>
               </externalReferences>
               <properties>
-                <property name="cdx:npm:package:installPath">node_modules/object-copy/node_modules/is-descriptor/node_modules/kind-of</property>
+                <property name="cdx:npm:package:path">node_modules/object-copy/node_modules/is-descriptor/node_modules/kind-of</property>
               </properties>
             </component>
           </components>
@@ -23104,7 +23104,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/object-copy/node_modules/kind-of</property>
+            <property name="cdx:npm:package:path">node_modules/object-copy/node_modules/kind-of</property>
           </properties>
         </component>
       </components>
@@ -23138,7 +23138,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/object-inspect</property>
+        <property name="cdx:npm:package:path">node_modules/object-inspect</property>
       </properties>
     </component>
     <component type="library" bom-ref="object-is@1.1.5">
@@ -23174,7 +23174,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/object-is</property>
+        <property name="cdx:npm:package:path">node_modules/object-is</property>
       </properties>
     </component>
     <component type="library" bom-ref="object-keys@1.1.1">
@@ -23202,7 +23202,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/object-keys</property>
+        <property name="cdx:npm:package:path">node_modules/object-keys</property>
       </properties>
     </component>
     <component type="library" bom-ref="object-visit@1.0.1">
@@ -23238,7 +23238,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/object-visit</property>
+        <property name="cdx:npm:package:path">node_modules/object-visit</property>
       </properties>
     </component>
     <component type="library" bom-ref="object.assign@4.1.4">
@@ -23266,7 +23266,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/object.assign</property>
+        <property name="cdx:npm:package:path">node_modules/object.assign</property>
       </properties>
     </component>
     <component type="library" bom-ref="object.defaults@1.1.0">
@@ -23302,7 +23302,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/object.defaults</property>
+        <property name="cdx:npm:package:path">node_modules/object.defaults</property>
       </properties>
     </component>
     <component type="library" bom-ref="object.map@1.0.1">
@@ -23338,7 +23338,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/object.map</property>
+        <property name="cdx:npm:package:path">node_modules/object.map</property>
       </properties>
     </component>
     <component type="library" bom-ref="object.pick@1.3.0">
@@ -23374,7 +23374,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/object.pick</property>
+        <property name="cdx:npm:package:path">node_modules/object.pick</property>
       </properties>
     </component>
     <component type="library" bom-ref="on-finished@2.4.1">
@@ -23401,7 +23401,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/on-finished</property>
+        <property name="cdx:npm:package:path">node_modules/on-finished</property>
       </properties>
     </component>
     <component type="library" bom-ref="on-headers@1.0.2">
@@ -23429,7 +23429,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/on-headers</property>
+        <property name="cdx:npm:package:path">node_modules/on-headers</property>
       </properties>
     </component>
     <component type="library" bom-ref="once@1.4.0">
@@ -23457,7 +23457,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/once</property>
+        <property name="cdx:npm:package:path">node_modules/once</property>
       </properties>
     </component>
     <component type="library" bom-ref="one-time@1.0.0">
@@ -23485,7 +23485,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/one-time</property>
+        <property name="cdx:npm:package:path">node_modules/one-time</property>
       </properties>
     </component>
     <component type="library" bom-ref="opentype.js@0.7.3">
@@ -23513,7 +23513,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/opentype.js</property>
+        <property name="cdx:npm:package:path">node_modules/opentype.js</property>
       </properties>
     </component>
     <component type="library" bom-ref="optionator@0.8.3">
@@ -23549,7 +23549,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/optionator</property>
+        <property name="cdx:npm:package:path">node_modules/optionator</property>
       </properties>
     </component>
     <component type="library" bom-ref="os-homedir@1.0.2">
@@ -23577,7 +23577,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/os-homedir</property>
+        <property name="cdx:npm:package:path">node_modules/os-homedir</property>
       </properties>
     </component>
     <component type="library" bom-ref="os-tmpdir@1.0.2">
@@ -23605,7 +23605,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/os-tmpdir</property>
+        <property name="cdx:npm:package:path">node_modules/os-tmpdir</property>
       </properties>
     </component>
     <component type="library" bom-ref="osenv@0.1.5">
@@ -23633,7 +23633,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/osenv</property>
+        <property name="cdx:npm:package:path">node_modules/osenv</property>
       </properties>
     </component>
     <component type="library" bom-ref="otplib@12.0.1">
@@ -23665,7 +23665,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/otplib</property>
+        <property name="cdx:npm:package:path">node_modules/otplib</property>
       </properties>
     </component>
     <component type="library" bom-ref="p-cancelable@0.4.1">
@@ -23693,7 +23693,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/p-cancelable</property>
+        <property name="cdx:npm:package:path">node_modules/p-cancelable</property>
       </properties>
     </component>
     <component type="library" bom-ref="p-event@2.3.1">
@@ -23721,7 +23721,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/p-event</property>
+        <property name="cdx:npm:package:path">node_modules/p-event</property>
       </properties>
     </component>
     <component type="library" bom-ref="p-finally@1.0.0">
@@ -23749,7 +23749,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/p-finally</property>
+        <property name="cdx:npm:package:path">node_modules/p-finally</property>
       </properties>
     </component>
     <component type="library" bom-ref="p-is-promise@1.1.0">
@@ -23777,7 +23777,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/p-is-promise</property>
+        <property name="cdx:npm:package:path">node_modules/p-is-promise</property>
       </properties>
     </component>
     <component type="library" bom-ref="p-limit@2.3.0">
@@ -23805,7 +23805,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/p-limit</property>
+        <property name="cdx:npm:package:path">node_modules/p-limit</property>
       </properties>
     </component>
     <component type="library" bom-ref="p-locate@3.0.0">
@@ -23833,7 +23833,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/p-locate</property>
+        <property name="cdx:npm:package:path">node_modules/p-locate</property>
       </properties>
     </component>
     <component type="library" bom-ref="p-map@4.0.0">
@@ -23861,7 +23861,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/p-map</property>
+        <property name="cdx:npm:package:path">node_modules/p-map</property>
       </properties>
     </component>
     <component type="library" bom-ref="p-timeout@2.0.1">
@@ -23889,7 +23889,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/p-timeout</property>
+        <property name="cdx:npm:package:path">node_modules/p-timeout</property>
       </properties>
     </component>
     <component type="library" bom-ref="p-try@2.2.0">
@@ -23917,7 +23917,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/p-try</property>
+        <property name="cdx:npm:package:path">node_modules/p-try</property>
       </properties>
     </component>
     <component type="library" bom-ref="pako@0.2.9">
@@ -23948,7 +23948,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/pako</property>
+        <property name="cdx:npm:package:path">node_modules/pako</property>
       </properties>
     </component>
     <component type="library" bom-ref="parse-filepath@1.0.2">
@@ -23984,7 +23984,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/parse-filepath</property>
+        <property name="cdx:npm:package:path">node_modules/parse-filepath</property>
       </properties>
     </component>
     <component type="library" bom-ref="parse-json@4.0.0">
@@ -24012,7 +24012,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/parse-json</property>
+        <property name="cdx:npm:package:path">node_modules/parse-json</property>
       </properties>
     </component>
     <component type="library" bom-ref="parse-passwd@1.0.0">
@@ -24048,7 +24048,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/parse-passwd</property>
+        <property name="cdx:npm:package:path">node_modules/parse-passwd</property>
       </properties>
     </component>
     <component type="library" bom-ref="parseurl@1.3.3">
@@ -24075,7 +24075,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/parseurl</property>
+        <property name="cdx:npm:package:path">node_modules/parseurl</property>
       </properties>
     </component>
     <component type="library" bom-ref="pascalcase@0.1.1">
@@ -24111,7 +24111,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/pascalcase</property>
+        <property name="cdx:npm:package:path">node_modules/pascalcase</property>
       </properties>
     </component>
     <component type="library" bom-ref="path-exists@3.0.0">
@@ -24139,7 +24139,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/path-exists</property>
+        <property name="cdx:npm:package:path">node_modules/path-exists</property>
       </properties>
     </component>
     <component type="library" bom-ref="path-is-absolute@1.0.1">
@@ -24167,7 +24167,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/path-is-absolute</property>
+        <property name="cdx:npm:package:path">node_modules/path-is-absolute</property>
       </properties>
     </component>
     <component type="library" bom-ref="path-parse@1.0.7">
@@ -24203,7 +24203,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/path-parse</property>
+        <property name="cdx:npm:package:path">node_modules/path-parse</property>
       </properties>
     </component>
     <component type="library" bom-ref="path-root-regex@0.1.2">
@@ -24239,7 +24239,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/path-root-regex</property>
+        <property name="cdx:npm:package:path">node_modules/path-root-regex</property>
       </properties>
     </component>
     <component type="library" bom-ref="path-root@0.1.1">
@@ -24275,7 +24275,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/path-root</property>
+        <property name="cdx:npm:package:path">node_modules/path-root</property>
       </properties>
     </component>
     <component type="library" bom-ref="path-to-regexp@0.1.7">
@@ -24302,7 +24302,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/path-to-regexp</property>
+        <property name="cdx:npm:package:path">node_modules/path-to-regexp</property>
       </properties>
     </component>
     <component type="library" bom-ref="pdfkit@0.11.0">
@@ -24338,7 +24338,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/pdfkit</property>
+        <property name="cdx:npm:package:path">node_modules/pdfkit</property>
       </properties>
     </component>
     <component type="library" bom-ref="peek-readable@4.1.0">
@@ -24370,7 +24370,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/peek-readable</property>
+        <property name="cdx:npm:package:path">node_modules/peek-readable</property>
       </properties>
     </component>
     <component type="library" bom-ref="pend@1.2.0">
@@ -24402,7 +24402,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/pend</property>
+        <property name="cdx:npm:package:path">node_modules/pend</property>
       </properties>
     </component>
     <component type="library" bom-ref="performance-now@2.1.0">
@@ -24438,7 +24438,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/performance-now</property>
+        <property name="cdx:npm:package:path">node_modules/performance-now</property>
       </properties>
     </component>
     <component type="library" bom-ref="pg-connection-string@2.5.0">
@@ -24474,7 +24474,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/pg-connection-string</property>
+        <property name="cdx:npm:package:path">node_modules/pg-connection-string</property>
       </properties>
     </component>
     <component type="library" bom-ref="picomatch@2.3.1">
@@ -24510,7 +24510,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/picomatch</property>
+        <property name="cdx:npm:package:path">node_modules/picomatch</property>
       </properties>
     </component>
     <component type="library" bom-ref="pify@4.0.1">
@@ -24538,7 +24538,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/pify</property>
+        <property name="cdx:npm:package:path">node_modules/pify</property>
       </properties>
     </component>
     <component type="library" bom-ref="pinkie-promise@2.0.1">
@@ -24566,7 +24566,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/pinkie-promise</property>
+        <property name="cdx:npm:package:path">node_modules/pinkie-promise</property>
       </properties>
     </component>
     <component type="library" bom-ref="pinkie@2.0.4">
@@ -24594,7 +24594,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/pinkie</property>
+        <property name="cdx:npm:package:path">node_modules/pinkie</property>
       </properties>
     </component>
     <component type="library" bom-ref="png-js@1.0.0">
@@ -24621,7 +24621,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/png-js</property>
+        <property name="cdx:npm:package:path">node_modules/png-js</property>
       </properties>
     </component>
     <component type="library" bom-ref="portscanner@2.2.0">
@@ -24656,7 +24656,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/portscanner</property>
+        <property name="cdx:npm:package:path">node_modules/portscanner</property>
       </properties>
     </component>
     <component type="library" bom-ref="posix-character-classes@0.1.1">
@@ -24692,7 +24692,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/posix-character-classes</property>
+        <property name="cdx:npm:package:path">node_modules/posix-character-classes</property>
       </properties>
     </component>
     <component type="library" bom-ref="prebuild-install@5.3.6">
@@ -24728,7 +24728,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/prebuild-install</property>
+        <property name="cdx:npm:package:path">node_modules/prebuild-install</property>
       </properties>
     </component>
     <component type="library" bom-ref="prelude-ls@1.1.2">
@@ -24765,7 +24765,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/prelude-ls</property>
+        <property name="cdx:npm:package:path">node_modules/prelude-ls</property>
       </properties>
     </component>
     <component type="library" bom-ref="prepend-http@2.0.0">
@@ -24793,7 +24793,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/prepend-http</property>
+        <property name="cdx:npm:package:path">node_modules/prepend-http</property>
       </properties>
     </component>
     <component type="library" bom-ref="pretty-bytes@4.0.2">
@@ -24821,7 +24821,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/pretty-bytes</property>
+        <property name="cdx:npm:package:path">node_modules/pretty-bytes</property>
       </properties>
     </component>
     <component type="library" bom-ref="process-nextick-args@2.0.1">
@@ -24856,7 +24856,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/process-nextick-args</property>
+        <property name="cdx:npm:package:path">node_modules/process-nextick-args</property>
       </properties>
     </component>
     <component type="library" bom-ref="prom-client@12.0.0">
@@ -24884,7 +24884,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/prom-client</property>
+        <property name="cdx:npm:package:path">node_modules/prom-client</property>
       </properties>
     </component>
     <component type="library" bom-ref="promise-inflight@1.0.1">
@@ -24920,7 +24920,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/promise-inflight</property>
+        <property name="cdx:npm:package:path">node_modules/promise-inflight</property>
       </properties>
     </component>
     <component type="library" bom-ref="promise-retry@2.0.1">
@@ -24952,7 +24952,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/promise-retry</property>
+        <property name="cdx:npm:package:path">node_modules/promise-retry</property>
       </properties>
       <components>
         <component type="library" bom-ref="promise-retry@2.0.1|err-code@2.0.3">
@@ -24984,7 +24984,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/promise-retry/node_modules/err-code</property>
+            <property name="cdx:npm:package:path">node_modules/promise-retry/node_modules/err-code</property>
           </properties>
         </component>
         <component type="library" bom-ref="promise-retry@2.0.1|retry@0.12.0">
@@ -25016,7 +25016,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/promise-retry/node_modules/retry</property>
+            <property name="cdx:npm:package:path">node_modules/promise-retry/node_modules/retry</property>
           </properties>
         </component>
       </components>
@@ -25046,7 +25046,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/promise</property>
+        <property name="cdx:npm:package:path">node_modules/promise</property>
       </properties>
     </component>
     <component type="library" bom-ref="proper-lockfile@1.2.0">
@@ -25078,7 +25078,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/proper-lockfile</property>
+        <property name="cdx:npm:package:path">node_modules/proper-lockfile</property>
       </properties>
     </component>
     <component type="library" bom-ref="proxy-addr@2.0.7">
@@ -25106,7 +25106,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/proxy-addr</property>
+        <property name="cdx:npm:package:path">node_modules/proxy-addr</property>
       </properties>
     </component>
     <component type="library" bom-ref="psl@1.9.0">
@@ -25130,7 +25130,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/psl</property>
+        <property name="cdx:npm:package:path">node_modules/psl</property>
       </properties>
     </component>
     <component type="library" bom-ref="pug-attrs@3.0.0">
@@ -25158,7 +25158,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/pug-attrs</property>
+        <property name="cdx:npm:package:path">node_modules/pug-attrs</property>
       </properties>
     </component>
     <component type="library" bom-ref="pug-code-gen@3.0.2">
@@ -25186,7 +25186,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/pug-code-gen</property>
+        <property name="cdx:npm:package:path">node_modules/pug-code-gen</property>
       </properties>
     </component>
     <component type="library" bom-ref="pug-error@2.0.0">
@@ -25214,7 +25214,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/pug-error</property>
+        <property name="cdx:npm:package:path">node_modules/pug-error</property>
       </properties>
     </component>
     <component type="library" bom-ref="pug-filters@4.0.0">
@@ -25242,7 +25242,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/pug-filters</property>
+        <property name="cdx:npm:package:path">node_modules/pug-filters</property>
       </properties>
     </component>
     <component type="library" bom-ref="pug-lexer@5.0.1">
@@ -25270,7 +25270,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/pug-lexer</property>
+        <property name="cdx:npm:package:path">node_modules/pug-lexer</property>
       </properties>
     </component>
     <component type="library" bom-ref="pug-linker@4.0.0">
@@ -25298,7 +25298,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/pug-linker</property>
+        <property name="cdx:npm:package:path">node_modules/pug-linker</property>
       </properties>
     </component>
     <component type="library" bom-ref="pug-load@3.0.0">
@@ -25326,7 +25326,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/pug-load</property>
+        <property name="cdx:npm:package:path">node_modules/pug-load</property>
       </properties>
     </component>
     <component type="library" bom-ref="pug-parser@6.0.0">
@@ -25354,7 +25354,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/pug-parser</property>
+        <property name="cdx:npm:package:path">node_modules/pug-parser</property>
       </properties>
     </component>
     <component type="library" bom-ref="pug-runtime@3.0.1">
@@ -25382,7 +25382,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/pug-runtime</property>
+        <property name="cdx:npm:package:path">node_modules/pug-runtime</property>
       </properties>
     </component>
     <component type="library" bom-ref="pug-strip-comments@2.0.0">
@@ -25410,7 +25410,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/pug-strip-comments</property>
+        <property name="cdx:npm:package:path">node_modules/pug-strip-comments</property>
       </properties>
     </component>
     <component type="library" bom-ref="pug-walk@2.0.0">
@@ -25438,7 +25438,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/pug-walk</property>
+        <property name="cdx:npm:package:path">node_modules/pug-walk</property>
       </properties>
     </component>
     <component type="library" bom-ref="pug@3.0.2">
@@ -25470,7 +25470,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/pug</property>
+        <property name="cdx:npm:package:path">node_modules/pug</property>
       </properties>
     </component>
     <component type="library" bom-ref="pump@3.0.0">
@@ -25498,7 +25498,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/pump</property>
+        <property name="cdx:npm:package:path">node_modules/pump</property>
       </properties>
     </component>
     <component type="library" bom-ref="punycode@2.1.1">
@@ -25534,7 +25534,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/punycode</property>
+        <property name="cdx:npm:package:path">node_modules/punycode</property>
       </properties>
     </component>
     <component type="library" bom-ref="qs@6.11.0">
@@ -25565,7 +25565,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/qs</property>
+        <property name="cdx:npm:package:path">node_modules/qs</property>
       </properties>
     </component>
     <component type="library" bom-ref="query-string@5.1.1">
@@ -25593,7 +25593,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/query-string</property>
+        <property name="cdx:npm:package:path">node_modules/query-string</property>
       </properties>
     </component>
     <component type="library" bom-ref="range_check@2.0.4">
@@ -25621,7 +25621,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/range_check</property>
+        <property name="cdx:npm:package:path">node_modules/range_check</property>
       </properties>
     </component>
     <component type="library" bom-ref="range-parser@1.2.1">
@@ -25649,7 +25649,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/range-parser</property>
+        <property name="cdx:npm:package:path">node_modules/range-parser</property>
       </properties>
     </component>
     <component type="library" bom-ref="raw-body@2.5.1">
@@ -25677,7 +25677,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/raw-body</property>
+        <property name="cdx:npm:package:path">node_modules/raw-body</property>
       </properties>
     </component>
     <component type="library" bom-ref="rc@1.2.8">
@@ -25703,7 +25703,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/rc</property>
+        <property name="cdx:npm:package:path">node_modules/rc</property>
       </properties>
     </component>
     <component type="library" bom-ref="read-pkg@4.0.1">
@@ -25731,7 +25731,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/read-pkg</property>
+        <property name="cdx:npm:package:path">node_modules/read-pkg</property>
       </properties>
       <components>
         <component type="library" bom-ref="read-pkg@4.0.1|pify@3.0.0">
@@ -25759,7 +25759,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/read-pkg/node_modules/pify</property>
+            <property name="cdx:npm:package:path">node_modules/read-pkg/node_modules/pify</property>
           </properties>
         </component>
       </components>
@@ -25788,7 +25788,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/readable-stream</property>
+        <property name="cdx:npm:package:path">node_modules/readable-stream</property>
       </properties>
       <components>
         <component type="library" bom-ref="readable-stream@2.3.7|isarray@1.0.0">
@@ -25820,7 +25820,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/readable-stream/node_modules/isarray</property>
+            <property name="cdx:npm:package:path">node_modules/readable-stream/node_modules/isarray</property>
           </properties>
         </component>
       </components>
@@ -25854,7 +25854,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/readable-web-to-node-stream</property>
+        <property name="cdx:npm:package:path">node_modules/readable-web-to-node-stream</property>
       </properties>
       <components>
         <component type="library" bom-ref="readable-web-to-node-stream@3.0.2|readable-stream@3.6.0">
@@ -25881,7 +25881,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/readable-web-to-node-stream/node_modules/readable-stream</property>
+            <property name="cdx:npm:package:path">node_modules/readable-web-to-node-stream/node_modules/readable-stream</property>
           </properties>
         </component>
       </components>
@@ -25919,7 +25919,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/readdirp</property>
+        <property name="cdx:npm:package:path">node_modules/readdirp</property>
       </properties>
     </component>
     <component type="library" bom-ref="rechoir@0.7.1">
@@ -25947,7 +25947,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/rechoir</property>
+        <property name="cdx:npm:package:path">node_modules/rechoir</property>
       </properties>
     </component>
     <component type="library" bom-ref="regex-not@1.0.2">
@@ -25983,7 +25983,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/regex-not</property>
+        <property name="cdx:npm:package:path">node_modules/regex-not</property>
       </properties>
     </component>
     <component type="library" bom-ref="regexp.prototype.flags@1.4.3">
@@ -26011,7 +26011,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/regexp.prototype.flags</property>
+        <property name="cdx:npm:package:path">node_modules/regexp.prototype.flags</property>
       </properties>
     </component>
     <component type="library" bom-ref="remove-trailing-separator@1.1.0">
@@ -26047,7 +26047,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/remove-trailing-separator</property>
+        <property name="cdx:npm:package:path">node_modules/remove-trailing-separator</property>
       </properties>
     </component>
     <component type="library" bom-ref="repeat-element@1.1.4">
@@ -26083,7 +26083,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/repeat-element</property>
+        <property name="cdx:npm:package:path">node_modules/repeat-element</property>
       </properties>
     </component>
     <component type="library" bom-ref="repeat-string@1.6.1">
@@ -26119,7 +26119,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/repeat-string</property>
+        <property name="cdx:npm:package:path">node_modules/repeat-string</property>
       </properties>
     </component>
     <component type="library" bom-ref="replace@1.2.2">
@@ -26147,7 +26147,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/replace</property>
+        <property name="cdx:npm:package:path">node_modules/replace</property>
       </properties>
       <components>
         <component type="library" bom-ref="replace@1.2.2|ansi-regex@5.0.1">
@@ -26175,7 +26175,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/replace/node_modules/ansi-regex</property>
+            <property name="cdx:npm:package:path">node_modules/replace/node_modules/ansi-regex</property>
           </properties>
         </component>
         <component type="library" bom-ref="replace@1.2.2|ansi-styles@4.3.0">
@@ -26203,7 +26203,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/replace/node_modules/ansi-styles</property>
+            <property name="cdx:npm:package:path">node_modules/replace/node_modules/ansi-styles</property>
           </properties>
         </component>
         <component type="library" bom-ref="replace@1.2.2|brace-expansion@1.1.11">
@@ -26235,7 +26235,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/replace/node_modules/brace-expansion</property>
+            <property name="cdx:npm:package:path">node_modules/replace/node_modules/brace-expansion</property>
           </properties>
         </component>
         <component type="library" bom-ref="replace@1.2.2|cliui@6.0.0">
@@ -26263,7 +26263,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/replace/node_modules/cliui</property>
+            <property name="cdx:npm:package:path">node_modules/replace/node_modules/cliui</property>
           </properties>
         </component>
         <component type="library" bom-ref="replace@1.2.2|color-convert@2.0.1">
@@ -26291,7 +26291,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/replace/node_modules/color-convert</property>
+            <property name="cdx:npm:package:path">node_modules/replace/node_modules/color-convert</property>
           </properties>
         </component>
         <component type="library" bom-ref="replace@1.2.2|color-name@1.1.4">
@@ -26323,7 +26323,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/replace/node_modules/color-name</property>
+            <property name="cdx:npm:package:path">node_modules/replace/node_modules/color-name</property>
           </properties>
         </component>
         <component type="library" bom-ref="replace@1.2.2|find-up@4.1.0">
@@ -26351,7 +26351,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/replace/node_modules/find-up</property>
+            <property name="cdx:npm:package:path">node_modules/replace/node_modules/find-up</property>
           </properties>
         </component>
         <component type="library" bom-ref="replace@1.2.2|is-fullwidth-code-point@3.0.0">
@@ -26379,7 +26379,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/replace/node_modules/is-fullwidth-code-point</property>
+            <property name="cdx:npm:package:path">node_modules/replace/node_modules/is-fullwidth-code-point</property>
           </properties>
         </component>
         <component type="library" bom-ref="replace@1.2.2|locate-path@5.0.0">
@@ -26407,7 +26407,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/replace/node_modules/locate-path</property>
+            <property name="cdx:npm:package:path">node_modules/replace/node_modules/locate-path</property>
           </properties>
         </component>
         <component type="library" bom-ref="replace@1.2.2|minimatch@3.0.5">
@@ -26435,7 +26435,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/replace/node_modules/minimatch</property>
+            <property name="cdx:npm:package:path">node_modules/replace/node_modules/minimatch</property>
           </properties>
         </component>
         <component type="library" bom-ref="replace@1.2.2|p-locate@4.1.0">
@@ -26463,7 +26463,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/replace/node_modules/p-locate</property>
+            <property name="cdx:npm:package:path">node_modules/replace/node_modules/p-locate</property>
           </properties>
         </component>
         <component type="library" bom-ref="replace@1.2.2|path-exists@4.0.0">
@@ -26491,7 +26491,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/replace/node_modules/path-exists</property>
+            <property name="cdx:npm:package:path">node_modules/replace/node_modules/path-exists</property>
           </properties>
         </component>
         <component type="library" bom-ref="replace@1.2.2|string-width@4.2.3">
@@ -26519,7 +26519,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/replace/node_modules/string-width</property>
+            <property name="cdx:npm:package:path">node_modules/replace/node_modules/string-width</property>
           </properties>
         </component>
         <component type="library" bom-ref="replace@1.2.2|strip-ansi@6.0.1">
@@ -26547,7 +26547,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/replace/node_modules/strip-ansi</property>
+            <property name="cdx:npm:package:path">node_modules/replace/node_modules/strip-ansi</property>
           </properties>
         </component>
         <component type="library" bom-ref="replace@1.2.2|wrap-ansi@6.2.0">
@@ -26575,7 +26575,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/replace/node_modules/wrap-ansi</property>
+            <property name="cdx:npm:package:path">node_modules/replace/node_modules/wrap-ansi</property>
           </properties>
         </component>
         <component type="library" bom-ref="replace@1.2.2|yargs-parser@18.1.3">
@@ -26603,7 +26603,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/replace/node_modules/yargs-parser</property>
+            <property name="cdx:npm:package:path">node_modules/replace/node_modules/yargs-parser</property>
           </properties>
         </component>
         <component type="library" bom-ref="replace@1.2.2|yargs@15.4.1">
@@ -26634,7 +26634,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/replace/node_modules/yargs</property>
+            <property name="cdx:npm:package:path">node_modules/replace/node_modules/yargs</property>
           </properties>
         </component>
       </components>
@@ -26668,7 +26668,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/request</property>
+        <property name="cdx:npm:package:path">node_modules/request</property>
       </properties>
       <components>
         <component type="library" bom-ref="request@2.88.2|qs@6.5.3">
@@ -26699,7 +26699,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/request/node_modules/qs</property>
+            <property name="cdx:npm:package:path">node_modules/request/node_modules/qs</property>
           </properties>
         </component>
       </components>
@@ -26737,7 +26737,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/require-directory</property>
+        <property name="cdx:npm:package:path">node_modules/require-directory</property>
       </properties>
     </component>
     <component type="library" bom-ref="require-main-filename@2.0.0">
@@ -26773,7 +26773,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/require-main-filename</property>
+        <property name="cdx:npm:package:path">node_modules/require-main-filename</property>
       </properties>
     </component>
     <component type="library" bom-ref="resolve-dir@1.0.1">
@@ -26809,7 +26809,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/resolve-dir</property>
+        <property name="cdx:npm:package:path">node_modules/resolve-dir</property>
       </properties>
     </component>
     <component type="library" bom-ref="resolve-url@0.2.1">
@@ -26837,7 +26837,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/resolve-url</property>
+        <property name="cdx:npm:package:path">node_modules/resolve-url</property>
       </properties>
     </component>
     <component type="library" bom-ref="resolve@1.22.1">
@@ -26865,7 +26865,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/resolve</property>
+        <property name="cdx:npm:package:path">node_modules/resolve</property>
       </properties>
     </component>
     <component type="library" bom-ref="responselike@1.0.2">
@@ -26893,7 +26893,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/responselike</property>
+        <property name="cdx:npm:package:path">node_modules/responselike</property>
       </properties>
     </component>
     <component type="library" bom-ref="restructure@2.0.1">
@@ -26929,7 +26929,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/restructure</property>
+        <property name="cdx:npm:package:path">node_modules/restructure</property>
       </properties>
     </component>
     <component type="library" bom-ref="ret@0.1.15">
@@ -26957,7 +26957,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/ret</property>
+        <property name="cdx:npm:package:path">node_modules/ret</property>
       </properties>
     </component>
     <component type="library" bom-ref="retry-as-promised@6.1.0">
@@ -26993,7 +26993,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/retry-as-promised</property>
+        <property name="cdx:npm:package:path">node_modules/retry-as-promised</property>
       </properties>
     </component>
     <component type="library" bom-ref="retry@0.10.1">
@@ -27025,7 +27025,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/retry</property>
+        <property name="cdx:npm:package:path">node_modules/retry</property>
       </properties>
     </component>
     <component type="library" bom-ref="rimraf@3.0.2">
@@ -27053,7 +27053,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/rimraf</property>
+        <property name="cdx:npm:package:path">node_modules/rimraf</property>
       </properties>
     </component>
     <component type="library" bom-ref="rxjs@6.6.7">
@@ -27089,7 +27089,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/rxjs</property>
+        <property name="cdx:npm:package:path">node_modules/rxjs</property>
       </properties>
       <components>
         <component type="library" bom-ref="rxjs@6.6.7|tslib@1.14.1">
@@ -27125,7 +27125,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/rxjs/node_modules/tslib</property>
+            <property name="cdx:npm:package:path">node_modules/rxjs/node_modules/tslib</property>
           </properties>
         </component>
       </components>
@@ -27163,7 +27163,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/safe-buffer</property>
+        <property name="cdx:npm:package:path">node_modules/safe-buffer</property>
       </properties>
     </component>
     <component type="library" bom-ref="safe-regex@1.1.0">
@@ -27195,7 +27195,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/safe-regex</property>
+        <property name="cdx:npm:package:path">node_modules/safe-regex</property>
       </properties>
     </component>
     <component type="library" bom-ref="safe-stable-stringify@2.4.1">
@@ -27231,7 +27231,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/safe-stable-stringify</property>
+        <property name="cdx:npm:package:path">node_modules/safe-stable-stringify</property>
       </properties>
     </component>
     <component type="library" bom-ref="safer-buffer@2.1.2">
@@ -27263,7 +27263,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/safer-buffer</property>
+        <property name="cdx:npm:package:path">node_modules/safer-buffer</property>
       </properties>
     </component>
     <component type="library" bom-ref="samsam@1.1.2">
@@ -27290,7 +27290,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/samsam</property>
+        <property name="cdx:npm:package:path">node_modules/samsam</property>
       </properties>
     </component>
     <component type="library" bom-ref="sanitize-filename@1.6.3">
@@ -27314,7 +27314,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/sanitize-filename</property>
+        <property name="cdx:npm:package:path">node_modules/sanitize-filename</property>
       </properties>
     </component>
     <component type="library" bom-ref="sanitize-html@1.4.2">
@@ -27342,7 +27342,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/sanitize-html</property>
+        <property name="cdx:npm:package:path">node_modules/sanitize-html</property>
       </properties>
       <components>
         <component type="library" bom-ref="sanitize-html@1.4.2|lodash@2.4.2">
@@ -27378,7 +27378,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/sanitize-html/node_modules/lodash</property>
+            <property name="cdx:npm:package:path">node_modules/sanitize-html/node_modules/lodash</property>
           </properties>
         </component>
       </components>
@@ -27408,7 +27408,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/sax</property>
+        <property name="cdx:npm:package:path">node_modules/sax</property>
       </properties>
     </component>
     <component type="library" bom-ref="seek-bzip@1.0.6">
@@ -27435,7 +27435,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/seek-bzip</property>
+        <property name="cdx:npm:package:path">node_modules/seek-bzip</property>
       </properties>
     </component>
     <component type="library" bom-ref="semver@7.3.8">
@@ -27463,7 +27463,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/semver</property>
+        <property name="cdx:npm:package:path">node_modules/semver</property>
       </properties>
     </component>
     <component type="library" bom-ref="send@0.18.0">
@@ -27491,7 +27491,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/send</property>
+        <property name="cdx:npm:package:path">node_modules/send</property>
       </properties>
       <components>
         <component type="library" bom-ref="send@0.18.0|ms@2.1.3">
@@ -27518,7 +27518,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/send/node_modules/ms</property>
+            <property name="cdx:npm:package:path">node_modules/send/node_modules/ms</property>
           </properties>
         </component>
       </components>
@@ -27548,7 +27548,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/sequelize-pool</property>
+        <property name="cdx:npm:package:path">node_modules/sequelize-pool</property>
       </properties>
     </component>
     <component type="library" bom-ref="sequelize@6.25.3">
@@ -27583,7 +27583,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/sequelize</property>
+        <property name="cdx:npm:package:path">node_modules/sequelize</property>
       </properties>
       <components>
         <component type="library" bom-ref="sequelize@6.25.3|debug@4.3.4">
@@ -27611,7 +27611,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/sequelize/node_modules/debug</property>
+            <property name="cdx:npm:package:path">node_modules/sequelize/node_modules/debug</property>
           </properties>
         </component>
         <component type="library" bom-ref="sequelize@6.25.3|ms@2.1.2">
@@ -27638,7 +27638,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/sequelize/node_modules/ms</property>
+            <property name="cdx:npm:package:path">node_modules/sequelize/node_modules/ms</property>
           </properties>
         </component>
         <component type="library" bom-ref="sequelize@6.25.3|uuid@8.3.2">
@@ -27665,7 +27665,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/sequelize/node_modules/uuid</property>
+            <property name="cdx:npm:package:path">node_modules/sequelize/node_modules/uuid</property>
           </properties>
         </component>
       </components>
@@ -27695,7 +27695,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/serve-index</property>
+        <property name="cdx:npm:package:path">node_modules/serve-index</property>
       </properties>
       <components>
         <component type="library" bom-ref="serve-index@1.9.1|depd@1.1.2">
@@ -27723,7 +27723,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/serve-index/node_modules/depd</property>
+            <property name="cdx:npm:package:path">node_modules/serve-index/node_modules/depd</property>
           </properties>
         </component>
         <component type="library" bom-ref="serve-index@1.9.1|http-errors@1.6.3">
@@ -27751,7 +27751,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/serve-index/node_modules/http-errors</property>
+            <property name="cdx:npm:package:path">node_modules/serve-index/node_modules/http-errors</property>
           </properties>
         </component>
         <component type="library" bom-ref="serve-index@1.9.1|inherits@2.0.3">
@@ -27778,7 +27778,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/serve-index/node_modules/inherits</property>
+            <property name="cdx:npm:package:path">node_modules/serve-index/node_modules/inherits</property>
           </properties>
         </component>
         <component type="library" bom-ref="serve-index@1.9.1|setprototypeof@1.1.0">
@@ -27814,7 +27814,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/serve-index/node_modules/setprototypeof</property>
+            <property name="cdx:npm:package:path">node_modules/serve-index/node_modules/setprototypeof</property>
           </properties>
         </component>
         <component type="library" bom-ref="serve-index@1.9.1|statuses@1.5.0">
@@ -27841,7 +27841,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/serve-index/node_modules/statuses</property>
+            <property name="cdx:npm:package:path">node_modules/serve-index/node_modules/statuses</property>
           </properties>
         </component>
       </components>
@@ -27871,7 +27871,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/serve-static</property>
+        <property name="cdx:npm:package:path">node_modules/serve-static</property>
       </properties>
     </component>
     <component type="library" bom-ref="set-blocking@2.0.0">
@@ -27907,7 +27907,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/set-blocking</property>
+        <property name="cdx:npm:package:path">node_modules/set-blocking</property>
       </properties>
     </component>
     <component type="library" bom-ref="set-value@2.0.1">
@@ -27943,7 +27943,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/set-value</property>
+        <property name="cdx:npm:package:path">node_modules/set-value</property>
       </properties>
       <components>
         <component type="library" bom-ref="set-value@2.0.1|extend-shallow@2.0.1">
@@ -27979,7 +27979,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/set-value/node_modules/extend-shallow</property>
+            <property name="cdx:npm:package:path">node_modules/set-value/node_modules/extend-shallow</property>
           </properties>
         </component>
         <component type="library" bom-ref="set-value@2.0.1|is-extendable@0.1.1">
@@ -28015,7 +28015,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/set-value/node_modules/is-extendable</property>
+            <property name="cdx:npm:package:path">node_modules/set-value/node_modules/is-extendable</property>
           </properties>
         </component>
       </components>
@@ -28045,7 +28045,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/setimmediate</property>
+        <property name="cdx:npm:package:path">node_modules/setimmediate</property>
       </properties>
     </component>
     <component type="library" bom-ref="setprototypeof@1.2.0">
@@ -28081,7 +28081,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/setprototypeof</property>
+        <property name="cdx:npm:package:path">node_modules/setprototypeof</property>
       </properties>
     </component>
     <component type="library" bom-ref="side-channel@1.0.4">
@@ -28117,7 +28117,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/side-channel</property>
+        <property name="cdx:npm:package:path">node_modules/side-channel</property>
       </properties>
     </component>
     <component type="library" bom-ref="signal-exit@3.0.7">
@@ -28153,7 +28153,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/signal-exit</property>
+        <property name="cdx:npm:package:path">node_modules/signal-exit</property>
       </properties>
     </component>
     <component type="library" bom-ref="simple-concat@1.0.1">
@@ -28189,7 +28189,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/simple-concat</property>
+        <property name="cdx:npm:package:path">node_modules/simple-concat</property>
       </properties>
     </component>
     <component type="library" bom-ref="simple-get@3.1.1">
@@ -28225,7 +28225,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/simple-get</property>
+        <property name="cdx:npm:package:path">node_modules/simple-get</property>
       </properties>
       <components>
         <component type="library" bom-ref="simple-get@3.1.1|decompress-response@4.2.1">
@@ -28253,7 +28253,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/simple-get/node_modules/decompress-response</property>
+            <property name="cdx:npm:package:path">node_modules/simple-get/node_modules/decompress-response</property>
           </properties>
         </component>
         <component type="library" bom-ref="simple-get@3.1.1|mimic-response@2.1.0">
@@ -28281,7 +28281,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/simple-get/node_modules/mimic-response</property>
+            <property name="cdx:npm:package:path">node_modules/simple-get/node_modules/mimic-response</property>
           </properties>
         </component>
       </components>
@@ -28311,7 +28311,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/simple-swizzle</property>
+        <property name="cdx:npm:package:path">node_modules/simple-swizzle</property>
       </properties>
       <components>
         <component type="library" bom-ref="simple-swizzle@0.2.2|is-arrayish@0.3.2">
@@ -28339,7 +28339,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/simple-swizzle/node_modules/is-arrayish</property>
+            <property name="cdx:npm:package:path">node_modules/simple-swizzle/node_modules/is-arrayish</property>
           </properties>
         </component>
       </components>
@@ -28377,7 +28377,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/sinon</property>
+        <property name="cdx:npm:package:path">node_modules/sinon</property>
       </properties>
     </component>
     <component type="library" bom-ref="smart-buffer@4.2.0">
@@ -28413,7 +28413,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/smart-buffer</property>
+        <property name="cdx:npm:package:path">node_modules/smart-buffer</property>
       </properties>
     </component>
     <component type="library" bom-ref="snapdragon-node@2.1.1">
@@ -28449,7 +28449,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/snapdragon-node</property>
+        <property name="cdx:npm:package:path">node_modules/snapdragon-node</property>
       </properties>
       <components>
         <component type="library" bom-ref="snapdragon-node@2.1.1|define-property@1.0.0">
@@ -28485,7 +28485,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/snapdragon-node/node_modules/define-property</property>
+            <property name="cdx:npm:package:path">node_modules/snapdragon-node/node_modules/define-property</property>
           </properties>
         </component>
       </components>
@@ -28523,7 +28523,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/snapdragon-util</property>
+        <property name="cdx:npm:package:path">node_modules/snapdragon-util</property>
       </properties>
       <components>
         <component type="library" bom-ref="snapdragon-util@3.0.1|kind-of@3.2.2">
@@ -28559,7 +28559,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/snapdragon-util/node_modules/kind-of</property>
+            <property name="cdx:npm:package:path">node_modules/snapdragon-util/node_modules/kind-of</property>
           </properties>
         </component>
       </components>
@@ -28597,7 +28597,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/snapdragon</property>
+        <property name="cdx:npm:package:path">node_modules/snapdragon</property>
       </properties>
       <components>
         <component type="library" bom-ref="snapdragon@0.8.2|define-property@0.2.5">
@@ -28633,7 +28633,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/snapdragon/node_modules/define-property</property>
+            <property name="cdx:npm:package:path">node_modules/snapdragon/node_modules/define-property</property>
           </properties>
         </component>
         <component type="library" bom-ref="snapdragon@0.8.2|extend-shallow@2.0.1">
@@ -28669,7 +28669,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/snapdragon/node_modules/extend-shallow</property>
+            <property name="cdx:npm:package:path">node_modules/snapdragon/node_modules/extend-shallow</property>
           </properties>
         </component>
         <component type="library" bom-ref="snapdragon@0.8.2|is-accessor-descriptor@0.1.6">
@@ -28705,7 +28705,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/snapdragon/node_modules/is-accessor-descriptor</property>
+            <property name="cdx:npm:package:path">node_modules/snapdragon/node_modules/is-accessor-descriptor</property>
           </properties>
           <components>
             <component type="library" bom-ref="snapdragon@0.8.2|is-accessor-descriptor@0.1.6|kind-of@3.2.2">
@@ -28741,7 +28741,7 @@
                 </reference>
               </externalReferences>
               <properties>
-                <property name="cdx:npm:package:installPath">node_modules/snapdragon/node_modules/is-accessor-descriptor/node_modules/kind-of</property>
+                <property name="cdx:npm:package:path">node_modules/snapdragon/node_modules/is-accessor-descriptor/node_modules/kind-of</property>
               </properties>
             </component>
           </components>
@@ -28779,7 +28779,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/snapdragon/node_modules/is-data-descriptor</property>
+            <property name="cdx:npm:package:path">node_modules/snapdragon/node_modules/is-data-descriptor</property>
           </properties>
           <components>
             <component type="library" bom-ref="snapdragon@0.8.2|is-data-descriptor@0.1.4|kind-of@3.2.2">
@@ -28815,7 +28815,7 @@
                 </reference>
               </externalReferences>
               <properties>
-                <property name="cdx:npm:package:installPath">node_modules/snapdragon/node_modules/is-data-descriptor/node_modules/kind-of</property>
+                <property name="cdx:npm:package:path">node_modules/snapdragon/node_modules/is-data-descriptor/node_modules/kind-of</property>
               </properties>
             </component>
           </components>
@@ -28853,7 +28853,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/snapdragon/node_modules/is-descriptor</property>
+            <property name="cdx:npm:package:path">node_modules/snapdragon/node_modules/is-descriptor</property>
           </properties>
         </component>
         <component type="library" bom-ref="snapdragon@0.8.2|is-extendable@0.1.1">
@@ -28889,7 +28889,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/snapdragon/node_modules/is-extendable</property>
+            <property name="cdx:npm:package:path">node_modules/snapdragon/node_modules/is-extendable</property>
           </properties>
         </component>
         <component type="library" bom-ref="snapdragon@0.8.2|kind-of@5.1.0">
@@ -28925,7 +28925,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/snapdragon/node_modules/kind-of</property>
+            <property name="cdx:npm:package:path">node_modules/snapdragon/node_modules/kind-of</property>
           </properties>
         </component>
         <component type="library" bom-ref="snapdragon@0.8.2|source-map@0.5.7">
@@ -28957,7 +28957,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/snapdragon/node_modules/source-map</property>
+            <property name="cdx:npm:package:path">node_modules/snapdragon/node_modules/source-map</property>
           </properties>
         </component>
       </components>
@@ -28986,7 +28986,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/socket.io-adapter</property>
+        <property name="cdx:npm:package:path">node_modules/socket.io-adapter</property>
       </properties>
     </component>
     <component type="library" bom-ref="socket.io-parser@4.0.5">
@@ -29013,7 +29013,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/socket.io-parser</property>
+        <property name="cdx:npm:package:path">node_modules/socket.io-parser</property>
       </properties>
       <components>
         <component type="library" bom-ref="socket.io-parser@4.0.5|debug@4.3.4">
@@ -29041,7 +29041,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/socket.io-parser/node_modules/debug</property>
+            <property name="cdx:npm:package:path">node_modules/socket.io-parser/node_modules/debug</property>
           </properties>
         </component>
         <component type="library" bom-ref="socket.io-parser@4.0.5|ms@2.1.2">
@@ -29068,7 +29068,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/socket.io-parser/node_modules/ms</property>
+            <property name="cdx:npm:package:path">node_modules/socket.io-parser/node_modules/ms</property>
           </properties>
         </component>
       </components>
@@ -29097,7 +29097,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/socket.io</property>
+        <property name="cdx:npm:package:path">node_modules/socket.io</property>
       </properties>
       <components>
         <component type="library" bom-ref="socket.io@3.1.2|debug@4.3.4">
@@ -29125,7 +29125,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/socket.io/node_modules/debug</property>
+            <property name="cdx:npm:package:path">node_modules/socket.io/node_modules/debug</property>
           </properties>
         </component>
         <component type="library" bom-ref="socket.io@3.1.2|ms@2.1.2">
@@ -29152,7 +29152,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/socket.io/node_modules/ms</property>
+            <property name="cdx:npm:package:path">node_modules/socket.io/node_modules/ms</property>
           </properties>
         </component>
       </components>
@@ -29190,7 +29190,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/socks-proxy-agent</property>
+        <property name="cdx:npm:package:path">node_modules/socks-proxy-agent</property>
       </properties>
       <components>
         <component type="library" bom-ref="socks-proxy-agent@6.2.1|debug@4.3.4">
@@ -29218,7 +29218,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/socks-proxy-agent/node_modules/debug</property>
+            <property name="cdx:npm:package:path">node_modules/socks-proxy-agent/node_modules/debug</property>
           </properties>
         </component>
         <component type="library" bom-ref="socks-proxy-agent@6.2.1|ms@2.1.2">
@@ -29245,7 +29245,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/socks-proxy-agent/node_modules/ms</property>
+            <property name="cdx:npm:package:path">node_modules/socks-proxy-agent/node_modules/ms</property>
           </properties>
         </component>
       </components>
@@ -29283,7 +29283,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/socks</property>
+        <property name="cdx:npm:package:path">node_modules/socks</property>
       </properties>
       <components>
         <component type="library" bom-ref="socks@2.7.1|ip@2.0.0">
@@ -29314,7 +29314,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/socks/node_modules/ip</property>
+            <property name="cdx:npm:package:path">node_modules/socks/node_modules/ip</property>
           </properties>
         </component>
       </components>
@@ -29344,7 +29344,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/sort-keys-length</property>
+        <property name="cdx:npm:package:path">node_modules/sort-keys-length</property>
       </properties>
       <components>
         <component type="library" bom-ref="sort-keys-length@1.0.1|sort-keys@1.1.2">
@@ -29372,7 +29372,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/sort-keys-length/node_modules/sort-keys</property>
+            <property name="cdx:npm:package:path">node_modules/sort-keys-length/node_modules/sort-keys</property>
           </properties>
         </component>
       </components>
@@ -29402,7 +29402,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/sort-keys</property>
+        <property name="cdx:npm:package:path">node_modules/sort-keys</property>
       </properties>
     </component>
     <component type="library" bom-ref="source-map-resolve@0.5.3">
@@ -29430,7 +29430,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/source-map-resolve</property>
+        <property name="cdx:npm:package:path">node_modules/source-map-resolve</property>
       </properties>
     </component>
     <component type="library" bom-ref="source-map-support@0.5.21">
@@ -29461,7 +29461,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/source-map-support</property>
+        <property name="cdx:npm:package:path">node_modules/source-map-support</property>
       </properties>
     </component>
     <component type="library" bom-ref="source-map-url@0.4.1">
@@ -29489,7 +29489,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/source-map-url</property>
+        <property name="cdx:npm:package:path">node_modules/source-map-url</property>
       </properties>
     </component>
     <component type="library" bom-ref="source-map@0.6.1">
@@ -29521,7 +29521,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/source-map</property>
+        <property name="cdx:npm:package:path">node_modules/source-map</property>
       </properties>
     </component>
     <component type="library" bom-ref="spawn-command@0.0.2-1">
@@ -29549,7 +29549,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/spawn-command</property>
+        <property name="cdx:npm:package:path">node_modules/spawn-command</property>
       </properties>
     </component>
     <component type="library" bom-ref="spdx-correct@3.1.1">
@@ -29577,7 +29577,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/spdx-correct</property>
+        <property name="cdx:npm:package:path">node_modules/spdx-correct</property>
       </properties>
     </component>
     <component type="library" bom-ref="spdx-exceptions@2.3.0">
@@ -29605,7 +29605,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/spdx-exceptions</property>
+        <property name="cdx:npm:package:path">node_modules/spdx-exceptions</property>
       </properties>
     </component>
     <component type="library" bom-ref="spdx-expression-parse@3.0.1">
@@ -29633,7 +29633,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/spdx-expression-parse</property>
+        <property name="cdx:npm:package:path">node_modules/spdx-expression-parse</property>
       </properties>
     </component>
     <component type="library" bom-ref="spdx-license-ids@3.0.12">
@@ -29661,7 +29661,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/spdx-license-ids</property>
+        <property name="cdx:npm:package:path">node_modules/spdx-license-ids</property>
       </properties>
     </component>
     <component type="library" bom-ref="split-string@3.1.0">
@@ -29697,7 +29697,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/split-string</property>
+        <property name="cdx:npm:package:path">node_modules/split-string</property>
       </properties>
     </component>
     <component type="library" bom-ref="sprintf-js@1.1.2">
@@ -29725,7 +29725,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/sprintf-js</property>
+        <property name="cdx:npm:package:path">node_modules/sprintf-js</property>
       </properties>
     </component>
     <component type="library" bom-ref="sqlite3@5.1.2">
@@ -29757,7 +29757,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/sqlite3</property>
+        <property name="cdx:npm:package:path">node_modules/sqlite3</property>
       </properties>
     </component>
     <component type="library" bom-ref="sshpk@1.17.0">
@@ -29793,7 +29793,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/sshpk</property>
+        <property name="cdx:npm:package:path">node_modules/sshpk</property>
       </properties>
     </component>
     <component type="library" bom-ref="ssri@8.0.1">
@@ -29821,7 +29821,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/ssri</property>
+        <property name="cdx:npm:package:path">node_modules/ssri</property>
       </properties>
     </component>
     <component type="library" bom-ref="stack-trace@0.0.10">
@@ -29853,7 +29853,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/stack-trace</property>
+        <property name="cdx:npm:package:path">node_modules/stack-trace</property>
       </properties>
     </component>
     <component type="library" bom-ref="static-extend@0.1.2">
@@ -29889,7 +29889,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/static-extend</property>
+        <property name="cdx:npm:package:path">node_modules/static-extend</property>
       </properties>
       <components>
         <component type="library" bom-ref="static-extend@0.1.2|define-property@0.2.5">
@@ -29925,7 +29925,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/static-extend/node_modules/define-property</property>
+            <property name="cdx:npm:package:path">node_modules/static-extend/node_modules/define-property</property>
           </properties>
         </component>
         <component type="library" bom-ref="static-extend@0.1.2|is-accessor-descriptor@0.1.6">
@@ -29961,7 +29961,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/static-extend/node_modules/is-accessor-descriptor</property>
+            <property name="cdx:npm:package:path">node_modules/static-extend/node_modules/is-accessor-descriptor</property>
           </properties>
           <components>
             <component type="library" bom-ref="static-extend@0.1.2|is-accessor-descriptor@0.1.6|kind-of@3.2.2">
@@ -29997,7 +29997,7 @@
                 </reference>
               </externalReferences>
               <properties>
-                <property name="cdx:npm:package:installPath">node_modules/static-extend/node_modules/is-accessor-descriptor/node_modules/kind-of</property>
+                <property name="cdx:npm:package:path">node_modules/static-extend/node_modules/is-accessor-descriptor/node_modules/kind-of</property>
               </properties>
             </component>
           </components>
@@ -30035,7 +30035,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/static-extend/node_modules/is-data-descriptor</property>
+            <property name="cdx:npm:package:path">node_modules/static-extend/node_modules/is-data-descriptor</property>
           </properties>
           <components>
             <component type="library" bom-ref="static-extend@0.1.2|is-data-descriptor@0.1.4|kind-of@3.2.2">
@@ -30071,7 +30071,7 @@
                 </reference>
               </externalReferences>
               <properties>
-                <property name="cdx:npm:package:installPath">node_modules/static-extend/node_modules/is-data-descriptor/node_modules/kind-of</property>
+                <property name="cdx:npm:package:path">node_modules/static-extend/node_modules/is-data-descriptor/node_modules/kind-of</property>
               </properties>
             </component>
           </components>
@@ -30109,7 +30109,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/static-extend/node_modules/is-descriptor</property>
+            <property name="cdx:npm:package:path">node_modules/static-extend/node_modules/is-descriptor</property>
           </properties>
         </component>
         <component type="library" bom-ref="static-extend@0.1.2|kind-of@5.1.0">
@@ -30145,7 +30145,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/static-extend/node_modules/kind-of</property>
+            <property name="cdx:npm:package:path">node_modules/static-extend/node_modules/kind-of</property>
           </properties>
         </component>
       </components>
@@ -30174,7 +30174,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/statuses</property>
+        <property name="cdx:npm:package:path">node_modules/statuses</property>
       </properties>
     </component>
     <component type="library" bom-ref="stream-buffers@2.2.0">
@@ -30202,7 +30202,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/stream-buffers</property>
+        <property name="cdx:npm:package:path">node_modules/stream-buffers</property>
       </properties>
     </component>
     <component type="library" bom-ref="streamsearch@0.1.2">
@@ -30231,7 +30231,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/streamsearch</property>
+        <property name="cdx:npm:package:path">node_modules/streamsearch</property>
       </properties>
     </component>
     <component type="library" bom-ref="strict-uri-encode@1.1.0">
@@ -30259,7 +30259,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/strict-uri-encode</property>
+        <property name="cdx:npm:package:path">node_modules/strict-uri-encode</property>
       </properties>
     </component>
     <component type="library" bom-ref="string_decoder@1.1.1">
@@ -30290,7 +30290,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/string_decoder</property>
+        <property name="cdx:npm:package:path">node_modules/string_decoder</property>
       </properties>
     </component>
     <component type="library" bom-ref="string-width@1.0.2">
@@ -30318,7 +30318,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/string-width</property>
+        <property name="cdx:npm:package:path">node_modules/string-width</property>
       </properties>
     </component>
     <component type="library" bom-ref="string.fromcodepoint@0.2.1">
@@ -30355,7 +30355,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/string.fromcodepoint</property>
+        <property name="cdx:npm:package:path">node_modules/string.fromcodepoint</property>
       </properties>
     </component>
     <component type="library" bom-ref="string.prototype.codepointat@0.2.1">
@@ -30391,7 +30391,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/string.prototype.codepointat</property>
+        <property name="cdx:npm:package:path">node_modules/string.prototype.codepointat</property>
       </properties>
     </component>
     <component type="library" bom-ref="strip-ansi@3.0.1">
@@ -30419,7 +30419,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/strip-ansi</property>
+        <property name="cdx:npm:package:path">node_modules/strip-ansi</property>
       </properties>
     </component>
     <component type="library" bom-ref="strip-bom@3.0.0">
@@ -30447,7 +30447,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/strip-bom</property>
+        <property name="cdx:npm:package:path">node_modules/strip-bom</property>
       </properties>
     </component>
     <component type="library" bom-ref="strip-dirs@2.1.0">
@@ -30475,7 +30475,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/strip-dirs</property>
+        <property name="cdx:npm:package:path">node_modules/strip-dirs</property>
       </properties>
     </component>
     <component type="library" bom-ref="strip-json-comments@2.0.1">
@@ -30503,7 +30503,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/strip-json-comments</property>
+        <property name="cdx:npm:package:path">node_modules/strip-json-comments</property>
       </properties>
     </component>
     <component type="library" bom-ref="strip-outer@1.0.1">
@@ -30531,7 +30531,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/strip-outer</property>
+        <property name="cdx:npm:package:path">node_modules/strip-outer</property>
       </properties>
     </component>
     <component type="library" bom-ref="strtok3@6.3.0">
@@ -30563,7 +30563,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/strtok3</property>
+        <property name="cdx:npm:package:path">node_modules/strtok3</property>
       </properties>
     </component>
     <component type="library" bom-ref="supports-color@5.5.0">
@@ -30591,7 +30591,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/supports-color</property>
+        <property name="cdx:npm:package:path">node_modules/supports-color</property>
       </properties>
     </component>
     <component type="library" bom-ref="supports-preserve-symlinks-flag@1.0.0">
@@ -30627,7 +30627,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/supports-preserve-symlinks-flag</property>
+        <property name="cdx:npm:package:path">node_modules/supports-preserve-symlinks-flag</property>
       </properties>
     </component>
     <component type="library" bom-ref="svg-captcha@1.4.0">
@@ -30663,7 +30663,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/svg-captcha</property>
+        <property name="cdx:npm:package:path">node_modules/svg-captcha</property>
       </properties>
     </component>
     <component type="library" bom-ref="swagger-ui-dist@4.15.2">
@@ -30685,7 +30685,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/swagger-ui-dist</property>
+        <property name="cdx:npm:package:path">node_modules/swagger-ui-dist</property>
       </properties>
     </component>
     <component type="library" bom-ref="swagger-ui-express@4.5.0">
@@ -30717,7 +30717,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/swagger-ui-express</property>
+        <property name="cdx:npm:package:path">node_modules/swagger-ui-express</property>
       </properties>
     </component>
     <component type="library" bom-ref="tar-fs@2.1.1">
@@ -30753,7 +30753,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/tar-fs</property>
+        <property name="cdx:npm:package:path">node_modules/tar-fs</property>
       </properties>
       <components>
         <component type="library" bom-ref="tar-fs@2.1.1|bl@4.1.0">
@@ -30784,7 +30784,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/tar-fs/node_modules/bl</property>
+            <property name="cdx:npm:package:path">node_modules/tar-fs/node_modules/bl</property>
           </properties>
         </component>
         <component type="library" bom-ref="tar-fs@2.1.1|chownr@1.1.4">
@@ -30812,7 +30812,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/tar-fs/node_modules/chownr</property>
+            <property name="cdx:npm:package:path">node_modules/tar-fs/node_modules/chownr</property>
           </properties>
         </component>
         <component type="library" bom-ref="tar-fs@2.1.1|readable-stream@3.6.0">
@@ -30839,7 +30839,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/tar-fs/node_modules/readable-stream</property>
+            <property name="cdx:npm:package:path">node_modules/tar-fs/node_modules/readable-stream</property>
           </properties>
         </component>
         <component type="library" bom-ref="tar-fs@2.1.1|tar-stream@2.2.0">
@@ -30875,7 +30875,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/tar-fs/node_modules/tar-stream</property>
+            <property name="cdx:npm:package:path">node_modules/tar-fs/node_modules/tar-stream</property>
           </properties>
         </component>
       </components>
@@ -30913,7 +30913,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/tar-stream</property>
+        <property name="cdx:npm:package:path">node_modules/tar-stream</property>
       </properties>
     </component>
     <component type="library" bom-ref="tar@6.1.12">
@@ -30941,7 +30941,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/tar</property>
+        <property name="cdx:npm:package:path">node_modules/tar</property>
       </properties>
     </component>
     <component type="library" bom-ref="tdigest@0.1.2">
@@ -30977,7 +30977,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/tdigest</property>
+        <property name="cdx:npm:package:path">node_modules/tdigest</property>
       </properties>
     </component>
     <component type="library" bom-ref="text-hex@1.0.0">
@@ -31013,7 +31013,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/text-hex</property>
+        <property name="cdx:npm:package:path">node_modules/text-hex</property>
       </properties>
     </component>
     <component type="library" bom-ref="thirty-two@1.0.2">
@@ -31036,7 +31036,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/thirty-two</property>
+        <property name="cdx:npm:package:path">node_modules/thirty-two</property>
       </properties>
     </component>
     <component type="library" bom-ref="through@2.3.8">
@@ -31068,7 +31068,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/through</property>
+        <property name="cdx:npm:package:path">node_modules/through</property>
       </properties>
     </component>
     <component type="library" bom-ref="timed-out@4.0.1">
@@ -31096,7 +31096,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/timed-out</property>
+        <property name="cdx:npm:package:path">node_modules/timed-out</property>
       </properties>
     </component>
     <component type="library" bom-ref="tiny-inflate@1.0.3">
@@ -31132,7 +31132,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/tiny-inflate</property>
+        <property name="cdx:npm:package:path">node_modules/tiny-inflate</property>
       </properties>
     </component>
     <component type="library" bom-ref="to-buffer@1.1.1">
@@ -31168,7 +31168,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/to-buffer</property>
+        <property name="cdx:npm:package:path">node_modules/to-buffer</property>
       </properties>
     </component>
     <component type="library" bom-ref="to-fast-properties@2.0.0">
@@ -31196,7 +31196,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/to-fast-properties</property>
+        <property name="cdx:npm:package:path">node_modules/to-fast-properties</property>
       </properties>
     </component>
     <component type="library" bom-ref="to-object-path@0.3.0">
@@ -31232,7 +31232,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/to-object-path</property>
+        <property name="cdx:npm:package:path">node_modules/to-object-path</property>
       </properties>
       <components>
         <component type="library" bom-ref="to-object-path@0.3.0|kind-of@3.2.2">
@@ -31268,7 +31268,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/to-object-path/node_modules/kind-of</property>
+            <property name="cdx:npm:package:path">node_modules/to-object-path/node_modules/kind-of</property>
           </properties>
         </component>
       </components>
@@ -31306,7 +31306,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/to-regex-range</property>
+        <property name="cdx:npm:package:path">node_modules/to-regex-range</property>
       </properties>
     </component>
     <component type="library" bom-ref="to-regex@3.0.2">
@@ -31342,7 +31342,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/to-regex</property>
+        <property name="cdx:npm:package:path">node_modules/to-regex</property>
       </properties>
     </component>
     <component type="library" bom-ref="toidentifier@1.0.1">
@@ -31370,7 +31370,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/toidentifier</property>
+        <property name="cdx:npm:package:path">node_modules/toidentifier</property>
       </properties>
     </component>
     <component type="library" bom-ref="token-stream@1.0.0">
@@ -31398,7 +31398,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/token-stream</property>
+        <property name="cdx:npm:package:path">node_modules/token-stream</property>
       </properties>
     </component>
     <component type="library" bom-ref="token-types@4.2.1">
@@ -31430,7 +31430,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/token-types</property>
+        <property name="cdx:npm:package:path">node_modules/token-types</property>
       </properties>
     </component>
     <component type="library" bom-ref="toposort-class@1.0.1">
@@ -31457,7 +31457,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/toposort-class</property>
+        <property name="cdx:npm:package:path">node_modules/toposort-class</property>
       </properties>
     </component>
     <component type="library" bom-ref="tough-cookie@2.5.0">
@@ -31493,7 +31493,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/tough-cookie</property>
+        <property name="cdx:npm:package:path">node_modules/tough-cookie</property>
       </properties>
     </component>
     <component type="library" bom-ref="tr46@0.0.3">
@@ -31529,7 +31529,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/tr46</property>
+        <property name="cdx:npm:package:path">node_modules/tr46</property>
       </properties>
     </component>
     <component type="library" bom-ref="traverse@0.3.9">
@@ -31557,7 +31557,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/traverse</property>
+        <property name="cdx:npm:package:path">node_modules/traverse</property>
       </properties>
     </component>
     <component type="library" bom-ref="tree-kill@1.2.2">
@@ -31589,7 +31589,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/tree-kill</property>
+        <property name="cdx:npm:package:path">node_modules/tree-kill</property>
       </properties>
     </component>
     <component type="library" bom-ref="trim-repeated@1.0.0">
@@ -31617,7 +31617,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/trim-repeated</property>
+        <property name="cdx:npm:package:path">node_modules/trim-repeated</property>
       </properties>
     </component>
     <component type="library" bom-ref="triple-beam@1.3.0">
@@ -31653,7 +31653,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/triple-beam</property>
+        <property name="cdx:npm:package:path">node_modules/triple-beam</property>
       </properties>
     </component>
     <component type="library" bom-ref="truncate-utf8-bytes@1.0.2">
@@ -31689,7 +31689,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/truncate-utf8-bytes</property>
+        <property name="cdx:npm:package:path">node_modules/truncate-utf8-bytes</property>
       </properties>
     </component>
     <component type="library" bom-ref="ts-node-dev@1.1.8">
@@ -31716,7 +31716,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/ts-node-dev</property>
+        <property name="cdx:npm:package:path">node_modules/ts-node-dev</property>
       </properties>
       <components>
         <component type="library" bom-ref="ts-node-dev@1.1.8|rimraf@2.7.1">
@@ -31744,7 +31744,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/ts-node-dev/node_modules/rimraf</property>
+            <property name="cdx:npm:package:path">node_modules/ts-node-dev/node_modules/rimraf</property>
           </properties>
         </component>
       </components>
@@ -31782,7 +31782,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/ts-node</property>
+        <property name="cdx:npm:package:path">node_modules/ts-node</property>
       </properties>
     </component>
     <component type="library" bom-ref="tsconfig@7.0.0">
@@ -31818,7 +31818,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/tsconfig</property>
+        <property name="cdx:npm:package:path">node_modules/tsconfig</property>
       </properties>
     </component>
     <component type="library" bom-ref="tslib@2.4.1">
@@ -31854,7 +31854,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/tslib</property>
+        <property name="cdx:npm:package:path">node_modules/tslib</property>
       </properties>
     </component>
     <component type="library" bom-ref="tunnel-agent@0.6.0">
@@ -31882,7 +31882,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/tunnel-agent</property>
+        <property name="cdx:npm:package:path">node_modules/tunnel-agent</property>
       </properties>
     </component>
     <component type="library" bom-ref="tweetnacl@0.14.5">
@@ -31918,7 +31918,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/tweetnacl</property>
+        <property name="cdx:npm:package:path">node_modules/tweetnacl</property>
       </properties>
     </component>
     <component type="library" bom-ref="type-check@0.3.2">
@@ -31954,7 +31954,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/type-check</property>
+        <property name="cdx:npm:package:path">node_modules/type-check</property>
       </properties>
     </component>
     <component type="library" bom-ref="type-is@1.6.18">
@@ -31981,7 +31981,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/type-is</property>
+        <property name="cdx:npm:package:path">node_modules/type-is</property>
       </properties>
     </component>
     <component type="library" bom-ref="typecast@0.0.1">
@@ -32008,7 +32008,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/typecast</property>
+        <property name="cdx:npm:package:path">node_modules/typecast</property>
       </properties>
     </component>
     <component type="library" bom-ref="typedarray@0.0.6">
@@ -32040,7 +32040,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/typedarray</property>
+        <property name="cdx:npm:package:path">node_modules/typedarray</property>
       </properties>
     </component>
     <component type="library" bom-ref="typescript@4.8.4">
@@ -32076,7 +32076,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/typescript</property>
+        <property name="cdx:npm:package:path">node_modules/typescript</property>
       </properties>
     </component>
     <component type="library" bom-ref="uglify-js@3.17.4">
@@ -32104,7 +32104,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/uglify-js</property>
+        <property name="cdx:npm:package:path">node_modules/uglify-js</property>
       </properties>
     </component>
     <component type="library" bom-ref="unbzip2-stream@1.4.3">
@@ -32136,7 +32136,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/unbzip2-stream</property>
+        <property name="cdx:npm:package:path">node_modules/unbzip2-stream</property>
       </properties>
     </component>
     <component type="library" bom-ref="unc-path-regex@0.1.2">
@@ -32172,7 +32172,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/unc-path-regex</property>
+        <property name="cdx:npm:package:path">node_modules/unc-path-regex</property>
       </properties>
     </component>
     <component type="library" bom-ref="underscore.string@3.3.6">
@@ -32207,7 +32207,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/underscore.string</property>
+        <property name="cdx:npm:package:path">node_modules/underscore.string</property>
       </properties>
     </component>
     <component type="library" bom-ref="unicode-properties@1.4.1">
@@ -32243,7 +32243,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/unicode-properties</property>
+        <property name="cdx:npm:package:path">node_modules/unicode-properties</property>
       </properties>
     </component>
     <component type="library" bom-ref="unicode-trie@2.0.0">
@@ -32279,7 +32279,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/unicode-trie</property>
+        <property name="cdx:npm:package:path">node_modules/unicode-trie</property>
       </properties>
     </component>
     <component type="library" bom-ref="union-value@1.0.1">
@@ -32315,7 +32315,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/union-value</property>
+        <property name="cdx:npm:package:path">node_modules/union-value</property>
       </properties>
       <components>
         <component type="library" bom-ref="union-value@1.0.1|is-extendable@0.1.1">
@@ -32351,7 +32351,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/union-value/node_modules/is-extendable</property>
+            <property name="cdx:npm:package:path">node_modules/union-value/node_modules/is-extendable</property>
           </properties>
         </component>
       </components>
@@ -32389,7 +32389,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/unique-filename</property>
+        <property name="cdx:npm:package:path">node_modules/unique-filename</property>
       </properties>
     </component>
     <component type="library" bom-ref="unique-slug@2.0.2">
@@ -32417,7 +32417,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/unique-slug</property>
+        <property name="cdx:npm:package:path">node_modules/unique-slug</property>
       </properties>
     </component>
     <component type="library" bom-ref="unit-compare@1.0.1">
@@ -32453,7 +32453,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/unit-compare</property>
+        <property name="cdx:npm:package:path">node_modules/unit-compare</property>
       </properties>
     </component>
     <component type="library" bom-ref="universalify@2.0.0">
@@ -32489,7 +32489,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/universalify</property>
+        <property name="cdx:npm:package:path">node_modules/universalify</property>
       </properties>
     </component>
     <component type="library" bom-ref="unpipe@1.0.0">
@@ -32517,7 +32517,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/unpipe</property>
+        <property name="cdx:npm:package:path">node_modules/unpipe</property>
       </properties>
     </component>
     <component type="library" bom-ref="unset-value@1.0.0">
@@ -32553,7 +32553,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/unset-value</property>
+        <property name="cdx:npm:package:path">node_modules/unset-value</property>
       </properties>
       <components>
         <component type="library" bom-ref="unset-value@1.0.0|has-value@0.3.1">
@@ -32589,7 +32589,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/unset-value/node_modules/has-value</property>
+            <property name="cdx:npm:package:path">node_modules/unset-value/node_modules/has-value</property>
           </properties>
           <components>
             <component type="library" bom-ref="unset-value@1.0.0|has-value@0.3.1|isobject@2.1.0">
@@ -32625,7 +32625,7 @@
                 </reference>
               </externalReferences>
               <properties>
-                <property name="cdx:npm:package:installPath">node_modules/unset-value/node_modules/has-value/node_modules/isobject</property>
+                <property name="cdx:npm:package:path">node_modules/unset-value/node_modules/has-value/node_modules/isobject</property>
               </properties>
             </component>
           </components>
@@ -32663,7 +32663,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/unset-value/node_modules/has-values</property>
+            <property name="cdx:npm:package:path">node_modules/unset-value/node_modules/has-values</property>
           </properties>
         </component>
         <component type="library" bom-ref="unset-value@1.0.0|isarray@1.0.0">
@@ -32695,7 +32695,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/unset-value/node_modules/isarray</property>
+            <property name="cdx:npm:package:path">node_modules/unset-value/node_modules/isarray</property>
           </properties>
         </component>
       </components>
@@ -32725,7 +32725,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/untildify</property>
+        <property name="cdx:npm:package:path">node_modules/untildify</property>
       </properties>
     </component>
     <component type="library" bom-ref="unzipper@0.9.15">
@@ -32753,7 +32753,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/unzipper</property>
+        <property name="cdx:npm:package:path">node_modules/unzipper</property>
       </properties>
       <components>
         <component type="library" bom-ref="unzipper@0.9.15|bluebird@3.4.7">
@@ -32789,7 +32789,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/unzipper/node_modules/bluebird</property>
+            <property name="cdx:npm:package:path">node_modules/unzipper/node_modules/bluebird</property>
           </properties>
         </component>
       </components>
@@ -32827,7 +32827,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/uri-js</property>
+        <property name="cdx:npm:package:path">node_modules/uri-js</property>
       </properties>
     </component>
     <component type="library" bom-ref="urix@0.1.0">
@@ -32855,7 +32855,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/urix</property>
+        <property name="cdx:npm:package:path">node_modules/urix</property>
       </properties>
     </component>
     <component type="library" bom-ref="url-parse-lax@3.0.0">
@@ -32883,7 +32883,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/url-parse-lax</property>
+        <property name="cdx:npm:package:path">node_modules/url-parse-lax</property>
       </properties>
     </component>
     <component type="library" bom-ref="url-to-options@1.0.1">
@@ -32911,7 +32911,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/url-to-options</property>
+        <property name="cdx:npm:package:path">node_modules/url-to-options</property>
       </properties>
     </component>
     <component type="library" bom-ref="use@3.1.1">
@@ -32947,7 +32947,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/use</property>
+        <property name="cdx:npm:package:path">node_modules/use</property>
       </properties>
     </component>
     <component type="library" bom-ref="utf8-byte-length@1.0.4">
@@ -32983,7 +32983,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/utf8-byte-length</property>
+        <property name="cdx:npm:package:path">node_modules/utf8-byte-length</property>
       </properties>
     </component>
     <component type="library" bom-ref="util-deprecate@1.0.2">
@@ -33019,7 +33019,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/util-deprecate</property>
+        <property name="cdx:npm:package:path">node_modules/util-deprecate</property>
       </properties>
     </component>
     <component type="library" bom-ref="util@0.12.5">
@@ -33051,7 +33051,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/util</property>
+        <property name="cdx:npm:package:path">node_modules/util</property>
       </properties>
     </component>
     <component type="library" bom-ref="utils-merge@1.0.1">
@@ -33087,7 +33087,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/utils-merge</property>
+        <property name="cdx:npm:package:path">node_modules/utils-merge</property>
       </properties>
     </component>
     <component type="library" bom-ref="uuid@3.4.0">
@@ -33114,7 +33114,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/uuid</property>
+        <property name="cdx:npm:package:path">node_modules/uuid</property>
       </properties>
     </component>
     <component type="library" bom-ref="v8flags@3.2.0">
@@ -33142,7 +33142,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/v8flags</property>
+        <property name="cdx:npm:package:path">node_modules/v8flags</property>
       </properties>
     </component>
     <component type="library" bom-ref="validate-npm-package-license@3.0.4">
@@ -33170,7 +33170,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/validate-npm-package-license</property>
+        <property name="cdx:npm:package:path">node_modules/validate-npm-package-license</property>
       </properties>
     </component>
     <component type="library" bom-ref="validate@4.5.1">
@@ -33198,7 +33198,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/validate</property>
+        <property name="cdx:npm:package:path">node_modules/validate</property>
       </properties>
     </component>
     <component type="library" bom-ref="validator@13.7.0">
@@ -33234,7 +33234,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/validator</property>
+        <property name="cdx:npm:package:path">node_modules/validator</property>
       </properties>
     </component>
     <component type="library" bom-ref="vary@1.1.2">
@@ -33262,7 +33262,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/vary</property>
+        <property name="cdx:npm:package:path">node_modules/vary</property>
       </properties>
     </component>
     <component type="library" bom-ref="verror@1.10.0">
@@ -33289,7 +33289,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/verror</property>
+        <property name="cdx:npm:package:path">node_modules/verror</property>
       </properties>
       <components>
         <component type="library" bom-ref="verror@1.10.0|core-util-is@1.0.2">
@@ -33321,7 +33321,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/verror/node_modules/core-util-is</property>
+            <property name="cdx:npm:package:path">node_modules/verror/node_modules/core-util-is</property>
           </properties>
         </component>
       </components>
@@ -33351,7 +33351,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/vm2</property>
+        <property name="cdx:npm:package:path">node_modules/vm2</property>
       </properties>
       <components>
         <component type="library" bom-ref="vm2@3.9.11|acorn@8.8.1">
@@ -33382,7 +33382,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/vm2/node_modules/acorn</property>
+            <property name="cdx:npm:package:path">node_modules/vm2/node_modules/acorn</property>
           </properties>
         </component>
       </components>
@@ -33420,7 +33420,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/void-elements</property>
+        <property name="cdx:npm:package:path">node_modules/void-elements</property>
       </properties>
     </component>
     <component type="library" bom-ref="walk@2.3.15">
@@ -33454,7 +33454,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/walk</property>
+        <property name="cdx:npm:package:path">node_modules/walk</property>
       </properties>
     </component>
     <component type="library" bom-ref="walkdir@0.0.11">
@@ -33486,7 +33486,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/walkdir</property>
+        <property name="cdx:npm:package:path">node_modules/walkdir</property>
       </properties>
     </component>
     <component type="library" bom-ref="webidl-conversions@3.0.1">
@@ -33514,7 +33514,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/webidl-conversions</property>
+        <property name="cdx:npm:package:path">node_modules/webidl-conversions</property>
       </properties>
     </component>
     <component type="library" bom-ref="whatwg-url@5.0.0">
@@ -33542,7 +33542,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/whatwg-url</property>
+        <property name="cdx:npm:package:path">node_modules/whatwg-url</property>
       </properties>
     </component>
     <component type="library" bom-ref="which-boxed-primitive@1.0.2">
@@ -33578,7 +33578,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/which-boxed-primitive</property>
+        <property name="cdx:npm:package:path">node_modules/which-boxed-primitive</property>
       </properties>
     </component>
     <component type="library" bom-ref="which-collection@1.0.1">
@@ -33614,7 +33614,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/which-collection</property>
+        <property name="cdx:npm:package:path">node_modules/which-collection</property>
       </properties>
     </component>
     <component type="library" bom-ref="which-module@2.0.0">
@@ -33650,7 +33650,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/which-module</property>
+        <property name="cdx:npm:package:path">node_modules/which-module</property>
       </properties>
     </component>
     <component type="library" bom-ref="which-pm-runs@1.1.0">
@@ -33686,7 +33686,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/which-pm-runs</property>
+        <property name="cdx:npm:package:path">node_modules/which-pm-runs</property>
       </properties>
     </component>
     <component type="library" bom-ref="which-typed-array@1.1.9">
@@ -33714,7 +33714,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/which-typed-array</property>
+        <property name="cdx:npm:package:path">node_modules/which-typed-array</property>
       </properties>
     </component>
     <component type="library" bom-ref="which@2.0.2">
@@ -33742,7 +33742,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/which</property>
+        <property name="cdx:npm:package:path">node_modules/which</property>
       </properties>
     </component>
     <component type="library" bom-ref="wide-align@1.1.5">
@@ -33770,7 +33770,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/wide-align</property>
+        <property name="cdx:npm:package:path">node_modules/wide-align</property>
       </properties>
     </component>
     <component type="library" bom-ref="winston-transport@4.5.0">
@@ -33802,7 +33802,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/winston-transport</property>
+        <property name="cdx:npm:package:path">node_modules/winston-transport</property>
       </properties>
       <components>
         <component type="library" bom-ref="winston-transport@4.5.0|readable-stream@3.6.0">
@@ -33829,7 +33829,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/winston-transport/node_modules/readable-stream</property>
+            <property name="cdx:npm:package:path">node_modules/winston-transport/node_modules/readable-stream</property>
           </properties>
         </component>
       </components>
@@ -33859,7 +33859,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/winston</property>
+        <property name="cdx:npm:package:path">node_modules/winston</property>
       </properties>
       <components>
         <component type="library" bom-ref="winston@3.8.2|async@3.2.4">
@@ -33895,7 +33895,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/winston/node_modules/async</property>
+            <property name="cdx:npm:package:path">node_modules/winston/node_modules/async</property>
           </properties>
         </component>
         <component type="library" bom-ref="winston@3.8.2|is-stream@2.0.1">
@@ -33923,7 +33923,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/winston/node_modules/is-stream</property>
+            <property name="cdx:npm:package:path">node_modules/winston/node_modules/is-stream</property>
           </properties>
         </component>
         <component type="library" bom-ref="winston@3.8.2|readable-stream@3.6.0">
@@ -33950,7 +33950,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/winston/node_modules/readable-stream</property>
+            <property name="cdx:npm:package:path">node_modules/winston/node_modules/readable-stream</property>
           </properties>
         </component>
       </components>
@@ -33980,7 +33980,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/with</property>
+        <property name="cdx:npm:package:path">node_modules/with</property>
       </properties>
     </component>
     <component type="library" bom-ref="wkx@0.5.0">
@@ -34008,7 +34008,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/wkx</property>
+        <property name="cdx:npm:package:path">node_modules/wkx</property>
       </properties>
     </component>
     <component type="library" bom-ref="word-wrap@1.2.3">
@@ -34044,7 +34044,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/word-wrap</property>
+        <property name="cdx:npm:package:path">node_modules/word-wrap</property>
       </properties>
     </component>
     <component type="library" bom-ref="wordwrap@0.0.3">
@@ -34072,7 +34072,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/wordwrap</property>
+        <property name="cdx:npm:package:path">node_modules/wordwrap</property>
       </properties>
     </component>
     <component type="library" bom-ref="wrap-ansi@5.1.0">
@@ -34100,7 +34100,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/wrap-ansi</property>
+        <property name="cdx:npm:package:path">node_modules/wrap-ansi</property>
       </properties>
       <components>
         <component type="library" bom-ref="wrap-ansi@5.1.0|ansi-regex@4.1.1">
@@ -34128,7 +34128,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/wrap-ansi/node_modules/ansi-regex</property>
+            <property name="cdx:npm:package:path">node_modules/wrap-ansi/node_modules/ansi-regex</property>
           </properties>
         </component>
         <component type="library" bom-ref="wrap-ansi@5.1.0|emoji-regex@7.0.3">
@@ -34164,7 +34164,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/wrap-ansi/node_modules/emoji-regex</property>
+            <property name="cdx:npm:package:path">node_modules/wrap-ansi/node_modules/emoji-regex</property>
           </properties>
         </component>
         <component type="library" bom-ref="wrap-ansi@5.1.0|is-fullwidth-code-point@2.0.0">
@@ -34192,7 +34192,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/wrap-ansi/node_modules/is-fullwidth-code-point</property>
+            <property name="cdx:npm:package:path">node_modules/wrap-ansi/node_modules/is-fullwidth-code-point</property>
           </properties>
         </component>
         <component type="library" bom-ref="wrap-ansi@5.1.0|string-width@3.1.0">
@@ -34220,7 +34220,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/wrap-ansi/node_modules/string-width</property>
+            <property name="cdx:npm:package:path">node_modules/wrap-ansi/node_modules/string-width</property>
           </properties>
         </component>
         <component type="library" bom-ref="wrap-ansi@5.1.0|strip-ansi@5.2.0">
@@ -34248,7 +34248,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/wrap-ansi/node_modules/strip-ansi</property>
+            <property name="cdx:npm:package:path">node_modules/wrap-ansi/node_modules/strip-ansi</property>
           </properties>
         </component>
       </components>
@@ -34286,7 +34286,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/wrappy</property>
+        <property name="cdx:npm:package:path">node_modules/wrappy</property>
       </properties>
     </component>
     <component type="library" bom-ref="ws@7.4.6">
@@ -34322,7 +34322,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/ws</property>
+        <property name="cdx:npm:package:path">node_modules/ws</property>
       </properties>
     </component>
     <component type="library" bom-ref="xtend@4.0.2">
@@ -34358,7 +34358,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/xtend</property>
+        <property name="cdx:npm:package:path">node_modules/xtend</property>
       </properties>
     </component>
     <component type="library" bom-ref="y18n@4.0.3">
@@ -34390,7 +34390,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/y18n</property>
+        <property name="cdx:npm:package:path">node_modules/y18n</property>
       </properties>
     </component>
     <component type="library" bom-ref="yallist@4.0.0">
@@ -34418,7 +34418,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/yallist</property>
+        <property name="cdx:npm:package:path">node_modules/yallist</property>
       </properties>
     </component>
     <component type="library" bom-ref="yaml-schema-validator@1.2.3">
@@ -34446,7 +34446,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/yaml-schema-validator</property>
+        <property name="cdx:npm:package:path">node_modules/yaml-schema-validator</property>
       </properties>
     </component>
     <component type="library" bom-ref="yargs-parser@13.1.2">
@@ -34470,7 +34470,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/yargs-parser</property>
+        <property name="cdx:npm:package:path">node_modules/yargs-parser</property>
       </properties>
     </component>
     <component type="library" bom-ref="yargs@13.3.2">
@@ -34501,7 +34501,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/yargs</property>
+        <property name="cdx:npm:package:path">node_modules/yargs</property>
       </properties>
       <components>
         <component type="library" bom-ref="yargs@13.3.2|ansi-regex@4.1.1">
@@ -34529,7 +34529,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/yargs/node_modules/ansi-regex</property>
+            <property name="cdx:npm:package:path">node_modules/yargs/node_modules/ansi-regex</property>
           </properties>
         </component>
         <component type="library" bom-ref="yargs@13.3.2|emoji-regex@7.0.3">
@@ -34565,7 +34565,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/yargs/node_modules/emoji-regex</property>
+            <property name="cdx:npm:package:path">node_modules/yargs/node_modules/emoji-regex</property>
           </properties>
         </component>
         <component type="library" bom-ref="yargs@13.3.2|is-fullwidth-code-point@2.0.0">
@@ -34593,7 +34593,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/yargs/node_modules/is-fullwidth-code-point</property>
+            <property name="cdx:npm:package:path">node_modules/yargs/node_modules/is-fullwidth-code-point</property>
           </properties>
         </component>
         <component type="library" bom-ref="yargs@13.3.2|string-width@3.1.0">
@@ -34621,7 +34621,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/yargs/node_modules/string-width</property>
+            <property name="cdx:npm:package:path">node_modules/yargs/node_modules/string-width</property>
           </properties>
         </component>
         <component type="library" bom-ref="yargs@13.3.2|strip-ansi@5.2.0">
@@ -34649,7 +34649,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/yargs/node_modules/strip-ansi</property>
+            <property name="cdx:npm:package:path">node_modules/yargs/node_modules/strip-ansi</property>
           </properties>
         </component>
       </components>
@@ -34687,7 +34687,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/yauzl</property>
+        <property name="cdx:npm:package:path">node_modules/yauzl</property>
       </properties>
     </component>
     <component type="library" bom-ref="yn@3.1.1">
@@ -34715,7 +34715,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/yn</property>
+        <property name="cdx:npm:package:path">node_modules/yn</property>
       </properties>
     </component>
     <component type="library" bom-ref="z85@0.0.2">
@@ -34751,7 +34751,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/z85</property>
+        <property name="cdx:npm:package:path">node_modules/z85</property>
       </properties>
     </component>
     <component type="library" bom-ref="zip-stream@1.2.0">
@@ -34787,7 +34787,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/zip-stream</property>
+        <property name="cdx:npm:package:path">node_modules/zip-stream</property>
       </properties>
     </component>
     <component type="library" bom-ref="zlibjs@0.3.1">
@@ -34819,7 +34819,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/zlibjs</property>
+        <property name="cdx:npm:package:path">node_modules/zlibjs</property>
       </properties>
     </component>
   </components>

--- a/demo/juice-shop/example-results/bom.1.4.json
+++ b/demo/juice-shop/example-results/bom.1.4.json
@@ -8,7 +8,7 @@
       {
         "vendor": "@cyclonedx",
         "name": "cyclonedx-npm",
-        "version": "1.4.0",
+        "version": "1.4.1",
         "externalReferences": [
           {
             "url": "https://github.com/CycloneDX/cyclonedx-node-npm/issues",
@@ -62,6 +62,10 @@
       ],
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -107,6 +111,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@babel/helper-string-parser"
+        }
       ]
     },
     {
@@ -141,6 +151,12 @@
           "url": "https://github.com/babel/babel.git#packages/babel-helper-validator-identifier",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\" and \"repository.directory\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@babel/helper-validator-identifier"
         }
       ]
     },
@@ -187,6 +203,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@babel/parser"
+        }
       ]
     },
     {
@@ -231,6 +253,12 @@
           "url": "https://babel.dev/docs/en/next/babel-types",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@babel/types"
         }
       ]
     },
@@ -277,6 +305,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@colors/colors"
+        }
       ]
     },
     {
@@ -322,6 +356,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@dabh/diagnostics"
+        }
       ]
     },
     {
@@ -356,6 +396,12 @@
           "url": "https://github.com/wraithgar/gar-promisify.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@gar/promisify"
         }
       ]
     },
@@ -393,6 +439,12 @@
           "comment": "as detected from PackageJson property \"repository.url\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@mapbox/node-pre-gyp"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -425,6 +477,12 @@
               "url": "chalk/ansi-regex",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/ansi-regex"
             }
           ]
         },
@@ -470,6 +528,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/are-we-there-yet"
+            }
           ]
         },
         {
@@ -503,6 +567,12 @@
               "url": "git://github.com/lovell/detect-libc",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/detect-libc"
             }
           ]
         },
@@ -548,6 +618,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/gauge"
+            }
           ]
         },
         {
@@ -581,6 +657,12 @@
               "url": "sindresorhus/is-fullwidth-code-point",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/is-fullwidth-code-point"
             }
           ]
         },
@@ -617,6 +699,12 @@
               "comment": "as detected from PackageJson property \"repository\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/make-dir"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -648,6 +736,12 @@
                   "url": "https://github.com/npm/node-semver",
                   "type": "vcs",
                   "comment": "as detected from PackageJson property \"repository\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/@mapbox/node-pre-gyp/node_modules/make-dir/node_modules/semver"
                 }
               ]
             }
@@ -685,6 +779,12 @@
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/nopt"
+            }
           ]
         },
         {
@@ -719,6 +819,12 @@
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/npmlog"
+            }
           ]
         },
         {
@@ -751,6 +857,12 @@
               "url": "git://github.com/nodejs/readable-stream",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/readable-stream"
             }
           ]
         },
@@ -786,6 +898,12 @@
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/string-width"
+            }
           ]
         },
         {
@@ -819,6 +937,12 @@
               "url": "chalk/strip-ansi",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/strip-ansi"
             }
           ]
         }
@@ -862,6 +986,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/core-loader"
+        }
       ]
     },
     {
@@ -901,6 +1031,12 @@
           "url": "git+https://github.com/axa-group/nlp.js.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/core"
         }
       ]
     },
@@ -942,6 +1078,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/evaluator"
+        }
       ]
     },
     {
@@ -981,6 +1123,12 @@
           "url": "git+https://github.com/axa-group/nlp.js.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-all"
         }
       ]
     },
@@ -1022,6 +1170,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ar"
+        }
       ]
     },
     {
@@ -1061,6 +1215,12 @@
           "url": "git+https://github.com/axa-group/nlp.js.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-bn"
         }
       ]
     },
@@ -1102,6 +1262,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ca"
+        }
       ]
     },
     {
@@ -1141,6 +1307,12 @@
           "url": "git+https://github.com/axa-group/nlp.js.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-cs"
         }
       ]
     },
@@ -1182,6 +1354,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-da"
+        }
       ]
     },
     {
@@ -1221,6 +1399,12 @@
           "url": "git+https://github.com/axa-group/nlp.js.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-de"
         }
       ]
     },
@@ -1262,6 +1446,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-el"
+        }
       ]
     },
     {
@@ -1301,6 +1491,12 @@
           "url": "git+https://github.com/axa-group/nlp.js.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-en-min"
         }
       ]
     },
@@ -1342,6 +1538,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-en"
+        }
       ]
     },
     {
@@ -1381,6 +1583,12 @@
           "url": "git+https://github.com/axa-group/nlp.js.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-es"
         }
       ]
     },
@@ -1422,6 +1630,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-eu"
+        }
       ]
     },
     {
@@ -1461,6 +1675,12 @@
           "url": "git+https://github.com/axa-group/nlp.js.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-fa"
         }
       ]
     },
@@ -1502,6 +1722,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-fi"
+        }
       ]
     },
     {
@@ -1541,6 +1767,12 @@
           "url": "git+https://github.com/axa-group/nlp.js.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-fr"
         }
       ]
     },
@@ -1582,6 +1814,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ga"
+        }
       ]
     },
     {
@@ -1621,6 +1859,12 @@
           "url": "git+https://github.com/axa-group/nlp.js.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-gl"
         }
       ]
     },
@@ -1662,6 +1906,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-hi"
+        }
       ]
     },
     {
@@ -1701,6 +1951,12 @@
           "url": "git+https://github.com/axa-group/nlp.js.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-hu"
         }
       ]
     },
@@ -1742,6 +1998,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-hy"
+        }
       ]
     },
     {
@@ -1781,6 +2043,12 @@
           "url": "git+https://github.com/axa-group/nlp.js.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-id"
         }
       ]
     },
@@ -1822,6 +2090,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-it"
+        }
       ]
     },
     {
@@ -1861,6 +2135,12 @@
           "url": "git+https://github.com/axa-group/nlp.js.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ja"
         }
       ]
     },
@@ -1902,6 +2182,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ko"
+        }
       ]
     },
     {
@@ -1941,6 +2227,12 @@
           "url": "git+https://github.com/axa-group/nlp.js.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-lt"
         }
       ]
     },
@@ -1982,6 +2274,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ms"
+        }
       ]
     },
     {
@@ -2021,6 +2319,12 @@
           "url": "git+https://github.com/axa-group/nlp.js.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ne"
         }
       ]
     },
@@ -2062,6 +2366,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-nl"
+        }
       ]
     },
     {
@@ -2101,6 +2411,12 @@
           "url": "git+https://github.com/axa-group/nlp.js.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-no"
         }
       ]
     },
@@ -2142,6 +2458,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-pl"
+        }
       ]
     },
     {
@@ -2181,6 +2503,12 @@
           "url": "git+https://github.com/axa-group/nlp.js.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-pt"
         }
       ]
     },
@@ -2222,6 +2550,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ro"
+        }
       ]
     },
     {
@@ -2261,6 +2595,12 @@
           "url": "git+https://github.com/axa-group/nlp.js.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ru"
         }
       ]
     },
@@ -2302,6 +2642,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-sl"
+        }
       ]
     },
     {
@@ -2341,6 +2687,12 @@
           "url": "git+https://github.com/axa-group/nlp.js.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-sr"
         }
       ]
     },
@@ -2382,6 +2734,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-sv"
+        }
       ]
     },
     {
@@ -2421,6 +2779,12 @@
           "url": "git+https://github.com/axa-group/nlp.js.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ta"
         }
       ]
     },
@@ -2462,6 +2826,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-th"
+        }
       ]
     },
     {
@@ -2501,6 +2871,12 @@
           "url": "git+https://github.com/axa-group/nlp.js.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-tl"
         }
       ]
     },
@@ -2542,6 +2918,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-tr"
+        }
       ]
     },
     {
@@ -2581,6 +2963,12 @@
           "url": "git+https://github.com/axa-group/nlp.js.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-uk"
         }
       ]
     },
@@ -2622,6 +3010,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-zh"
+        }
       ]
     },
     {
@@ -2661,6 +3055,12 @@
           "url": "git+https://github.com/axa-group/nlp.js.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/language-min"
         }
       ]
     },
@@ -2702,6 +3102,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/language"
+        }
       ]
     },
     {
@@ -2741,6 +3147,12 @@
           "url": "git+https://github.com/axa-group/nlp.js.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/ner"
         }
       ]
     },
@@ -2782,6 +3194,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/neural"
+        }
       ]
     },
     {
@@ -2821,6 +3239,12 @@
           "url": "git+https://github.com/axa-group/nlp.js.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/nlg"
         }
       ]
     },
@@ -2862,6 +3286,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/nlp"
+        }
       ]
     },
     {
@@ -2901,6 +3331,12 @@
           "url": "git+https://github.com/axa-group/nlp.js.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/nlu"
         }
       ]
     },
@@ -2942,6 +3378,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/request"
+        }
       ]
     },
     {
@@ -2981,6 +3423,12 @@
           "url": "git+https://github.com/axa-group/nlp.js.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/sentiment"
         }
       ]
     },
@@ -3022,6 +3470,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/similarity"
+        }
       ]
     },
     {
@@ -3062,6 +3516,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/slot"
+        }
       ]
     },
     {
@@ -3091,6 +3551,12 @@
           "url": "https://registry.npmjs.org/@npmcli/fs/-/fs-1.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@npmcli/fs"
         }
       ]
     },
@@ -3125,6 +3591,12 @@
           "url": "git+https://github.com/npm/move-file",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@npmcli/move-file"
         }
       ]
     },
@@ -3166,6 +3638,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib/core"
+        }
       ]
     },
     {
@@ -3205,6 +3683,12 @@
           "url": "https://yeojz.otplib.dev",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib/plugin-crypto"
         }
       ]
     },
@@ -3246,6 +3730,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib/plugin-thirty-two"
+        }
       ]
     },
     {
@@ -3285,6 +3775,12 @@
           "url": "https://yeojz.otplib.dev",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib/preset-default"
         }
       ]
     },
@@ -3326,6 +3822,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib/preset-v11"
+        }
       ]
     },
     {
@@ -3360,6 +3862,12 @@
           "url": "sindresorhus/is",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@sindresorhus/is"
         }
       ]
     },
@@ -3406,6 +3914,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@swc/helpers"
+        }
       ]
     },
     {
@@ -3445,6 +3959,12 @@
           "url": "https://github.com/Borewit/tokenizer-token.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@tokenizer/token"
         }
       ]
     },
@@ -3486,6 +4006,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@tootallnate/once"
+        }
       ]
     },
     {
@@ -3524,6 +4050,12 @@
           "url": "https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/component-emitter",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/component-emitter"
         }
       ]
     },
@@ -3564,6 +4096,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/cookie"
+        }
       ]
     },
     {
@@ -3602,6 +4140,12 @@
           "url": "https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/cors",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/cors"
         }
       ]
     },
@@ -3642,6 +4186,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/debug"
+        }
       ]
     },
     {
@@ -3675,6 +4225,12 @@
           "url": "https://github.com/DefinitelyTyped/DefinitelyTyped.git#types/ms",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\" and \"repository.directory\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/ms"
         }
       ]
     },
@@ -3715,6 +4271,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/node"
+        }
       ]
     },
     {
@@ -3750,6 +4312,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/strip-bom"
+        }
       ]
     },
     {
@@ -3783,6 +4351,12 @@
           "url": "https://www.github.com/DefinitelyTyped/DefinitelyTyped.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/strip-json-comments"
         }
       ]
     },
@@ -3823,6 +4397,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/validator"
+        }
       ]
     },
     {
@@ -3857,6 +4437,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/abbrev"
+        }
       ]
     },
     {
@@ -3889,6 +4475,12 @@
           "url": "jshttp/accepts",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/accepts"
         }
       ]
     },
@@ -3928,6 +4520,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/acorn-walk"
+        }
       ]
     },
     {
@@ -3965,6 +4563,12 @@
           "url": "https://github.com/acornjs/acorn",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/acorn"
         }
       ]
     },
@@ -4006,6 +4610,12 @@
           "comment": "as detected from PackageJson property \"repository.url\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/agent-base"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4039,6 +4649,12 @@
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agent-base/node_modules/debug"
+            }
           ]
         },
         {
@@ -4071,6 +4687,12 @@
               "url": "zeit/ms",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agent-base/node_modules/ms"
             }
           ]
         }
@@ -4114,6 +4736,12 @@
           "comment": "as detected from PackageJson property \"repository.url\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/agentkeepalive"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4146,6 +4774,12 @@
               "url": "git://github.com/debug-js/debug.git",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agentkeepalive/node_modules/debug"
             }
           ]
         },
@@ -4181,6 +4815,12 @@
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agentkeepalive/node_modules/depd"
+            }
           ]
         },
         {
@@ -4213,6 +4853,12 @@
               "url": "zeit/ms",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agentkeepalive/node_modules/ms"
             }
           ]
         }
@@ -4249,6 +4895,12 @@
           "url": "sindresorhus/aggregate-error",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/aggregate-error"
         }
       ]
     },
@@ -4294,6 +4946,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ajv"
+        }
       ]
     },
     {
@@ -4328,6 +4986,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ansi-regex"
+        }
       ]
     },
     {
@@ -4361,6 +5025,12 @@
           "url": "chalk/ansi-styles",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ansi-styles"
         }
       ]
     },
@@ -4400,6 +5070,12 @@
           "url": "https://github.com/micromatch/anymatch",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/anymatch"
         }
       ],
       "components": [
@@ -4445,6 +5121,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/anymatch/node_modules/normalize-path"
+            }
           ]
         }
       ]
@@ -4479,6 +5161,12 @@
           "url": "http://github.com/LinusU/node-append-field.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/append-field"
         }
       ]
     },
@@ -4524,6 +5212,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/aproba"
+        }
       ]
     },
     {
@@ -4559,6 +5253,12 @@
           "comment": "as detected from PackageJson property \"repository\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/archive-type"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4591,6 +5291,12 @@
               "url": "sindresorhus/file-type",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/archive-type/node_modules/file-type"
             }
           ]
         }
@@ -4638,6 +5344,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/archiver-utils"
+        }
       ]
     },
     {
@@ -4681,6 +5393,12 @@
           "url": "https://github.com/archiverjs/node-archiver",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/archiver"
         }
       ]
     },
@@ -4726,6 +5444,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/are-we-there-yet"
+        }
       ]
     },
     {
@@ -4759,6 +5483,12 @@
           "url": "zeit/arg",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/arg"
         }
       ]
     },
@@ -4794,6 +5524,12 @@
           "comment": "as detected from PackageJson property \"repository\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/argparse"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4826,6 +5562,12 @@
               "url": "https://github.com/alexei/sprintf.js.git",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/argparse/node_modules/sprintf-js"
             }
           ]
         }
@@ -4873,6 +5615,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/arr-diff"
+        }
       ]
     },
     {
@@ -4916,6 +5664,12 @@
           "url": "https://github.com/jonschlinkert/arr-flatten",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/arr-flatten"
         }
       ]
     },
@@ -4961,6 +5715,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/arr-union"
+        }
       ]
     },
     {
@@ -5004,6 +5764,12 @@
           "url": "https://github.com/jonschlinkert/array-each",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/array-each"
         }
       ]
     },
@@ -5049,6 +5815,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/array-flatten"
+        }
       ]
     },
     {
@@ -5092,6 +5864,12 @@
           "url": "https://github.com/jonschlinkert/array-slice",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/array-slice"
         }
       ]
     },
@@ -5137,6 +5915,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/array-unique"
+        }
       ]
     },
     {
@@ -5169,6 +5953,12 @@
           "url": "https://github.com/kriskowal/asap.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/asap"
         }
       ]
     },
@@ -5204,6 +5994,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/asn1"
+        }
       ]
     },
     {
@@ -5238,6 +6034,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/assert-never"
+        }
       ]
     },
     {
@@ -5271,6 +6073,12 @@
           "url": "https://github.com/mcavage/node-assert-plus.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/assert-plus"
         }
       ]
     },
@@ -5316,6 +6124,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/assign-symbols"
+        }
       ]
     },
     {
@@ -5359,6 +6173,12 @@
           "url": "https://caolan.github.io/async/",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/async"
         }
       ]
     },
@@ -5404,6 +6224,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/asynckit"
+        }
       ]
     },
     {
@@ -5448,6 +6274,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/at-least-node"
+        }
       ]
     },
     {
@@ -5484,6 +6316,12 @@
           "url": "https://git.coolaj86.com/coolaj86/atob.js.git",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/atob"
         }
       ]
     },
@@ -5529,6 +6367,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/available-typed-arrays"
+        }
       ]
     },
     {
@@ -5562,6 +6406,12 @@
           "url": "https://github.com/mikeal/aws-sign",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/aws-sign2"
         }
       ]
     },
@@ -5597,6 +6447,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/aws4"
+        }
       ]
     },
     {
@@ -5630,6 +6486,12 @@
           "url": "https://github.com/pugjs/babel-walk.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/babel-walk"
         }
       ]
     },
@@ -5669,6 +6531,12 @@
           "url": "https://github.com/juliangruber/balanced-match",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/balanced-match"
         }
       ]
     },
@@ -5715,6 +6583,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5758,6 +6632,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/base/node_modules/define-property"
+            }
           ]
         }
       ]
@@ -5773,6 +6653,14 @@
         {
           "alg": "SHA-512",
           "content": "6b5788162e11f724ab6e232ec931b1e5ef76b911f9b5063a900acd70568a05495e2282e3763060ed9c66dccaa6dca9a47f6ec72d1ff57e7c57f6af0643b21abe"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://github.com/niklasvh/base64-arraybuffer/blob/master/LICENSE-MIT"
+          }
         }
       ],
       "purl": "pkg:npm/base64-arraybuffer@0.1.4",
@@ -5796,6 +6684,12 @@
           "url": "https://github.com/niklasvh/base64-arraybuffer",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base64-arraybuffer"
         }
       ]
     },
@@ -5841,6 +6735,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base64-js"
+        }
       ]
     },
     {
@@ -5874,6 +6774,12 @@
           "url": "https://github.com/faeldt/base64id.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base64id"
         }
       ]
     },
@@ -5909,6 +6815,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base64url"
+        }
       ]
     },
     {
@@ -5941,6 +6853,12 @@
           "url": "jshttp/basic-auth",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/basic-auth"
         }
       ]
     },
@@ -5976,6 +6894,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/batch"
+        }
       ]
     },
     {
@@ -6008,6 +6932,12 @@
           "url": "git://github.com/joyent/node-bcrypt-pbkdf.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bcrypt-pbkdf"
         }
       ]
     },
@@ -6043,6 +6973,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/big-integer"
+        }
       ]
     },
     {
@@ -6077,6 +7013,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/binary-extensions"
+        }
       ]
     },
     {
@@ -6110,6 +7052,12 @@
           "url": "http://github.com/substack/node-binary.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/binary"
         }
       ]
     },
@@ -6155,6 +7103,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bindings"
+        }
       ]
     },
     {
@@ -6188,6 +7142,12 @@
           "url": "git://github.com/vadimg/js_bintrees.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bintrees"
         }
       ]
     },
@@ -6226,6 +7186,12 @@
           "url": "https://github.com/rvagg/bl",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bl"
         }
       ]
     },
@@ -6271,6 +7237,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bluebird"
+        }
       ]
     },
     {
@@ -6303,6 +7275,12 @@
           "url": "expressjs/body-parser",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/body-parser"
         }
       ]
     },
@@ -6344,6 +7322,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bower-config"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -6381,6 +7365,12 @@
               "url": "https://github.com/minimistjs/minimist",
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bower-config/node_modules/minimist"
             }
           ]
         }
@@ -6422,6 +7412,12 @@
           "url": "https://github.com/juliangruber/brace-expansion",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/brace-expansion"
         }
       ]
     },
@@ -6468,6 +7464,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/braces"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -6510,6 +7512,12 @@
               "url": "https://github.com/jonschlinkert/extend-shallow",
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/braces/node_modules/extend-shallow"
             }
           ]
         },
@@ -6554,6 +7562,12 @@
               "url": "https://github.com/jonschlinkert/is-extendable",
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/braces/node_modules/is-extendable"
             }
           ]
         }
@@ -6601,6 +7615,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/brotli"
+        }
       ]
     },
     {
@@ -6632,6 +7652,12 @@
           "url": "LinusU/buffer-alloc-unsafe",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-alloc-unsafe"
         }
       ]
     },
@@ -6665,6 +7691,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-alloc"
+        }
       ]
     },
     {
@@ -6685,6 +7717,12 @@
           "license": {
             "id": "MIT"
           }
+        },
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://github.com/brianloveswords/buffer-crc32/raw/master/LICENSE"
+          }
         }
       ],
       "purl": "pkg:npm/buffer-crc32@0.2.13",
@@ -6703,6 +7741,12 @@
           "url": "https://github.com/brianloveswords/buffer-crc32",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-crc32"
         }
       ]
     },
@@ -6736,6 +7780,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-fill"
+        }
       ]
     },
     {
@@ -6767,6 +7817,12 @@
           "url": "LinusU/buffer-from",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-from"
         }
       ]
     },
@@ -6812,6 +7868,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-indexof-polyfill"
+        }
       ]
     },
     {
@@ -6856,6 +7918,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer"
+        }
       ]
     },
     {
@@ -6883,6 +7951,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffers"
+        }
       ]
     },
     {
@@ -6898,6 +7972,14 @@
           "content": "2275850e89af964123fb158b05f53702f9db558a9e4d6990a29896d2d596132e727a1626d9890611ce7db149b0ff8b72e598ff6f45871acd4b81e72e052046ae"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "http://github.com/mscdex/busboy/raw/master/LICENSE"
+          }
+        }
+      ],
       "purl": "pkg:npm/busboy@0.2.14",
       "externalReferences": [
         {
@@ -6909,6 +7991,12 @@
           "url": "http://github.com/mscdex/busboy.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/busboy"
         }
       ],
       "components": [
@@ -6949,6 +8037,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/busboy/node_modules/isarray"
+            }
           ]
         },
         {
@@ -6982,6 +8076,12 @@
               "url": "git://github.com/isaacs/readable-stream",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/busboy/node_modules/readable-stream"
             }
           ]
         },
@@ -7020,6 +8120,12 @@
               "url": "https://github.com/rvagg/string_decoder",
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/busboy/node_modules/string_decoder"
             }
           ]
         }
@@ -7067,6 +8173,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/byline"
+        }
       ]
     },
     {
@@ -7101,6 +8213,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bytes"
+        }
       ]
     },
     {
@@ -7133,6 +8251,12 @@
           "url": "https://github.com/npm/cacache",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cacache"
         }
       ]
     },
@@ -7177,6 +8301,12 @@
           "url": "https://github.com/jonschlinkert/cache-base",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cache-base"
         }
       ]
     },
@@ -7223,6 +8353,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cacheable-request"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7255,6 +8391,12 @@
               "url": "sindresorhus/get-stream",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cacheable-request/node_modules/get-stream"
             }
           ]
         },
@@ -7289,6 +8431,12 @@
               "url": "sindresorhus/lowercase-keys",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cacheable-request/node_modules/lowercase-keys"
             }
           ]
         }
@@ -7336,6 +8484,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/call-bind"
+        }
       ]
     },
     {
@@ -7369,6 +8523,12 @@
           "url": "sindresorhus/camelcase",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/camelcase"
         }
       ]
     },
@@ -7409,6 +8569,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/caseless"
+        }
       ]
     },
     {
@@ -7443,6 +8609,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/chainsaw"
+        }
       ]
     },
     {
@@ -7475,6 +8647,12 @@
           "url": "chalk/chalk",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/chalk"
         }
       ]
     },
@@ -7509,6 +8687,12 @@
           "url": "https://github.com/ForbesLindesay/character-parser.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/character-parser"
         }
       ]
     },
@@ -7555,6 +8739,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/check-dependencies"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7586,6 +8776,12 @@
               "url": "https://github.com/npm/node-semver",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/check-dependencies/node_modules/semver"
             }
           ]
         }
@@ -7633,6 +8829,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/check-types"
+        }
       ]
     },
     {
@@ -7678,6 +8880,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/chokidar"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7720,6 +8928,12 @@
               "url": "https://github.com/micromatch/braces",
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar/node_modules/braces"
             }
           ]
         },
@@ -7765,6 +8979,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar/node_modules/fill-range"
+            }
           ]
         },
         {
@@ -7808,6 +9028,12 @@
               "url": "https://github.com/micromatch/is-glob",
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar/node_modules/is-glob"
             }
           ]
         },
@@ -7853,6 +9079,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar/node_modules/is-number"
+            }
           ]
         },
         {
@@ -7896,6 +9128,12 @@
               "url": "https://github.com/jonschlinkert/normalize-path",
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar/node_modules/normalize-path"
             }
           ]
         },
@@ -7941,6 +9179,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar/node_modules/to-regex-range"
+            }
           ]
         }
       ]
@@ -7976,6 +9220,12 @@
           "url": "git://github.com/isaacs/chownr.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/chownr"
         }
       ]
     },
@@ -8020,6 +9270,12 @@
           "url": "https://github.com/dscape/clarinet",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/clarinet"
         }
       ]
     },
@@ -8066,6 +9322,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/class-utils"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -8108,6 +9370,12 @@
               "url": "https://github.com/jonschlinkert/define-property",
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils/node_modules/define-property"
             }
           ]
         },
@@ -8154,6 +9422,12 @@
               "comment": "as detected from PackageJson property \"homepage\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils/node_modules/is-accessor-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -8196,6 +9470,12 @@
                   "url": "https://github.com/jonschlinkert/kind-of",
                   "type": "website",
                   "comment": "as detected from PackageJson property \"homepage\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/class-utils/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -8244,6 +9524,12 @@
               "comment": "as detected from PackageJson property \"homepage\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils/node_modules/is-data-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -8286,6 +9572,12 @@
                   "url": "https://github.com/jonschlinkert/kind-of",
                   "type": "website",
                   "comment": "as detected from PackageJson property \"homepage\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/class-utils/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -8333,6 +9625,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils/node_modules/is-descriptor"
+            }
           ]
         },
         {
@@ -8377,6 +9675,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils/node_modules/kind-of"
+            }
           ]
         }
       ]
@@ -8413,6 +9717,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/clean-stack"
+        }
       ]
     },
     {
@@ -8448,6 +9758,12 @@
           "comment": "as detected from PackageJson property \"repository.url\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cliui"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -8480,6 +9796,12 @@
               "url": "chalk/ansi-regex",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui/node_modules/ansi-regex"
             }
           ]
         },
@@ -8525,6 +9847,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui/node_modules/emoji-regex"
+            }
           ]
         },
         {
@@ -8558,6 +9886,12 @@
               "url": "sindresorhus/is-fullwidth-code-point",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui/node_modules/is-fullwidth-code-point"
             }
           ]
         },
@@ -8593,6 +9927,12 @@
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui/node_modules/string-width"
+            }
           ]
         },
         {
@@ -8626,6 +9966,12 @@
               "url": "chalk/strip-ansi",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui/node_modules/strip-ansi"
             }
           ]
         }
@@ -8673,6 +10019,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/clone-response"
+        }
       ]
     },
     {
@@ -8712,6 +10064,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/clone"
+        }
       ]
     },
     {
@@ -8745,6 +10103,12 @@
           "url": "sindresorhus/code-point-at",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/code-point-at"
         }
       ]
     },
@@ -8790,6 +10154,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/collection-visit"
+        }
       ]
     },
     {
@@ -8823,6 +10193,12 @@
           "url": "Qix-/color-convert",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color-convert"
         }
       ]
     },
@@ -8868,6 +10244,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color-name"
+        }
       ]
     },
     {
@@ -8901,6 +10283,12 @@
           "url": "Qix-/color-string",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color-string"
         }
       ]
     },
@@ -8936,6 +10324,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color-support"
+        }
       ]
     },
     {
@@ -8968,6 +10362,12 @@
           "url": "Qix-/color",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color"
         }
       ]
     },
@@ -9013,6 +10413,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/colors"
+        }
       ]
     },
     {
@@ -9057,6 +10463,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/colorspace"
+        }
       ]
     },
     {
@@ -9096,6 +10508,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/combined-stream"
+        }
       ]
     },
     {
@@ -9130,6 +10548,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/commander"
+        }
       ]
     },
     {
@@ -9163,6 +10587,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/component-emitter"
+        }
       ]
     },
     {
@@ -9195,6 +10625,12 @@
           "url": "https://github.com/component/type.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/component-type"
         }
       ]
     },
@@ -9240,6 +10676,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/compress-commons"
+        }
       ]
     },
     {
@@ -9272,6 +10714,12 @@
           "url": "jshttp/compressible",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/compressible"
         }
       ]
     },
@@ -9307,6 +10755,12 @@
           "comment": "as detected from PackageJson property \"repository\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/compression"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9339,6 +10793,12 @@
               "url": "visionmedia/bytes.js",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/compression/node_modules/bytes"
             }
           ]
         }
@@ -9375,6 +10835,12 @@
           "url": "git://github.com/substack/node-concat-map.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/concat-map"
         }
       ]
     },
@@ -9415,6 +10881,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/concat-stream"
+        }
       ]
     },
     {
@@ -9450,6 +10922,12 @@
           "comment": "as detected from PackageJson property \"repository.url\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/concurrently"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9482,6 +10960,12 @@
               "url": "chalk/supports-color",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/concurrently/node_modules/supports-color"
             }
           ]
         }
@@ -9524,6 +11008,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/config"
+        }
       ]
     },
     {
@@ -9557,6 +11047,12 @@
           "url": "https://github.com/iarna/console-control-strings",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/console-control-strings"
         }
       ]
     },
@@ -9592,6 +11088,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/constantinople"
+        }
       ]
     },
     {
@@ -9625,6 +11127,12 @@
           "url": "jshttp/content-disposition",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/content-disposition"
         }
       ],
       "components": [
@@ -9670,6 +11178,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/content-disposition/node_modules/safe-buffer"
+            }
           ]
         }
       ]
@@ -9706,6 +11220,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/content-type"
+        }
       ]
     },
     {
@@ -9739,6 +11259,12 @@
           "url": "expressjs/cookie-parser",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cookie-parser"
         }
       ]
     },
@@ -9774,6 +11300,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cookie-signature"
+        }
       ]
     },
     {
@@ -9807,6 +11339,12 @@
           "url": "jshttp/cookie",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cookie"
         }
       ]
     },
@@ -9852,6 +11390,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/copy-descriptor"
+        }
       ]
     },
     {
@@ -9891,6 +11435,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/core-util-is"
+        }
       ]
     },
     {
@@ -9924,6 +11474,12 @@
           "url": "expressjs/cors",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cors"
         }
       ]
     },
@@ -9969,6 +11525,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/crc"
+        }
       ]
     },
     {
@@ -10013,6 +11575,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/crc32-stream"
+        }
       ]
     },
     {
@@ -10045,6 +11613,12 @@
           "url": "nuxt-contrib/create-require",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/create-require"
         }
       ]
     },
@@ -10085,6 +11659,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/crypto-js"
+        }
       ]
     },
     {
@@ -10119,6 +11699,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dashdash"
+        }
       ]
     },
     {
@@ -10151,6 +11737,12 @@
           "url": "https://github.com/date-fns/date-fns",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/date-fns"
         }
       ]
     },
@@ -10191,6 +11783,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dateformat"
+        }
       ]
     },
     {
@@ -10224,6 +11822,12 @@
           "url": "git://github.com/visionmedia/debug.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/debug"
         }
       ]
     },
@@ -10259,6 +11863,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decamelize"
+        }
       ]
     },
     {
@@ -10293,6 +11903,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decode-uri-component"
+        }
       ]
     },
     {
@@ -10325,6 +11941,12 @@
           "url": "sindresorhus/decompress-response",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-response"
         }
       ]
     },
@@ -10361,6 +11983,12 @@
           "comment": "as detected from PackageJson property \"repository\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-tar"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -10393,6 +12021,12 @@
               "url": "sindresorhus/file-type",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-tar/node_modules/file-type"
             }
           ]
         }
@@ -10431,6 +12065,12 @@
           "comment": "as detected from PackageJson property \"repository\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-tarbz2"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -10463,6 +12103,12 @@
               "url": "sindresorhus/file-type",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-tarbz2/node_modules/file-type"
             }
           ]
         }
@@ -10501,6 +12147,12 @@
           "comment": "as detected from PackageJson property \"repository\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-targz"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -10533,6 +12185,12 @@
               "url": "sindresorhus/file-type",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-targz/node_modules/file-type"
             }
           ]
         }
@@ -10571,6 +12229,12 @@
           "comment": "as detected from PackageJson property \"repository\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-unzip"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -10603,6 +12267,12 @@
               "url": "sindresorhus/file-type",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-unzip/node_modules/file-type"
             }
           ]
         },
@@ -10638,6 +12308,12 @@
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-unzip/node_modules/get-stream"
+            }
           ]
         },
         {
@@ -10671,6 +12347,12 @@
               "url": "sindresorhus/pify",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-unzip/node_modules/pify"
             }
           ]
         }
@@ -10709,6 +12391,12 @@
           "comment": "as detected from PackageJson property \"repository\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -10743,6 +12431,12 @@
               "comment": "as detected from PackageJson property \"repository\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress/node_modules/make-dir"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -10775,6 +12469,12 @@
                   "url": "sindresorhus/pify",
                   "type": "vcs",
                   "comment": "as detected from PackageJson property \"repository\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/decompress/node_modules/make-dir/node_modules/pify"
                 }
               ]
             }
@@ -10812,6 +12512,12 @@
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress/node_modules/pify"
+            }
           ]
         }
       ]
@@ -10848,6 +12554,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/deep-equal"
+        }
       ]
     },
     {
@@ -10867,6 +12579,12 @@
         {
           "license": {
             "id": "MIT"
+          }
+        },
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://raw.githubusercontent.com/unclechu/node-deep-extend/master/LICENSE"
           }
         }
       ],
@@ -10891,6 +12609,12 @@
           "url": "https://github.com/unclechu/node-deep-extend",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/deep-extend"
         }
       ]
     },
@@ -10926,6 +12650,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/deep-is"
+        }
       ]
     },
     {
@@ -10959,6 +12689,12 @@
           "url": "git://github.com/ljharb/define-properties.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/define-properties"
         }
       ]
     },
@@ -11004,6 +12740,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/define-property"
+        }
       ]
     },
     {
@@ -11043,6 +12785,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/delayed-stream"
+        }
       ]
     },
     {
@@ -11075,6 +12823,12 @@
           "url": "visionmedia/node-delegates",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/delegates"
         }
       ]
     },
@@ -11110,6 +12864,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/depd"
+        }
       ]
     },
     {
@@ -11143,6 +12903,12 @@
           "url": "stream-utils/destroy",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/destroy"
         }
       ]
     },
@@ -11188,6 +12954,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/detect-file"
+        }
       ]
     },
     {
@@ -11221,6 +12993,12 @@
           "url": "git://github.com/lovell/detect-libc",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/detect-libc"
         }
       ]
     },
@@ -11266,6 +13044,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dfa"
+        }
       ]
     },
     {
@@ -11281,6 +13065,14 @@
           "content": "143bdbb67abb77394fcf4c32625384c627c311972ef21fab12b11781fc6a98b7d17c2fe4262744161e3e79f7c944edcfd3199fab23db48c1b42ef78d45f4ca56"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "http://github.com/mscdex/dicer/raw/master/LICENSE"
+          }
+        }
+      ],
       "purl": "pkg:npm/dicer@0.2.5",
       "externalReferences": [
         {
@@ -11292,6 +13084,12 @@
           "url": "http://github.com/mscdex/dicer.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dicer"
         }
       ],
       "components": [
@@ -11332,6 +13130,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/dicer/node_modules/isarray"
+            }
           ]
         },
         {
@@ -11365,6 +13169,12 @@
               "url": "git://github.com/isaacs/readable-stream",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/dicer/node_modules/readable-stream"
             }
           ]
         },
@@ -11403,6 +13213,12 @@
               "url": "https://github.com/rvagg/string_decoder",
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/dicer/node_modules/string_decoder"
             }
           ]
         }
@@ -11444,6 +13260,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/diff"
+        }
       ]
     },
     {
@@ -11477,6 +13299,12 @@
           "url": "https://github.com/pugjs/doctypes.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/doctypes"
         }
       ]
     },
@@ -11512,6 +13340,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/domelementtype"
+        }
       ]
     },
     {
@@ -11539,6 +13373,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/domhandler"
+        }
       ]
     },
     {
@@ -11565,6 +13405,12 @@
           "url": "git://github.com/FB55/domutils.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/domutils"
         }
       ]
     },
@@ -11599,6 +13445,12 @@
           "url": "git://github.com/mickhansen/dottie.js.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dottie"
         }
       ]
     },
@@ -11644,6 +13496,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/double-ended-queue"
+        }
       ]
     },
     {
@@ -11688,6 +13546,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/doublearray"
+        }
       ]
     },
     {
@@ -11723,6 +13587,12 @@
           "comment": "as detected from PackageJson property \"repository\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/download"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -11755,6 +13625,12 @@
               "url": "sindresorhus/file-type",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/download/node_modules/file-type"
             }
           ]
         }
@@ -11792,6 +13668,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/duplexer2"
+        }
       ]
     },
     {
@@ -11825,6 +13707,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/duplexer3"
+        }
       ]
     },
     {
@@ -11856,6 +13744,12 @@
           "url": "https://github.com/thlorenz/dynamic-dedupe",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dynamic-dedupe"
         }
       ]
     },
@@ -11901,6 +13795,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ecc-jsbn"
+        }
       ]
     },
     {
@@ -11934,6 +13834,12 @@
           "url": "jonathanong/ee-first",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ee-first"
         }
       ]
     },
@@ -11977,6 +13883,12 @@
           "url": "https://github.com/eivindfjeldstad/dot",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/eivindfjeldstad-dot"
         }
       ]
     },
@@ -12022,6 +13934,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/emoji-regex"
+        }
       ]
     },
     {
@@ -12056,6 +13974,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/enabled"
+        }
       ]
     },
     {
@@ -12088,6 +14012,12 @@
           "url": "pillarjs/encodeurl",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/encodeurl"
         }
       ]
     },
@@ -12122,6 +14052,12 @@
           "url": "https://github.com/andris9/encoding.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/encoding"
         }
       ],
       "components": [
@@ -12166,6 +14102,12 @@
               "url": "https://github.com/ashtuchkin/iconv-lite",
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/encoding/node_modules/iconv-lite"
             }
           ]
         }
@@ -12213,6 +14155,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/end-of-stream"
+        }
       ]
     },
     {
@@ -12250,6 +14198,12 @@
           "url": "https://github.com/socketio/engine.io-parser",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/engine.io-parser"
         }
       ]
     },
@@ -12291,6 +14245,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/engine.io"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12324,6 +14284,12 @@
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/engine.io/node_modules/debug"
+            }
           ]
         },
         {
@@ -12356,6 +14322,12 @@
               "url": "zeit/ms",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/engine.io/node_modules/ms"
             }
           ]
         }
@@ -12392,6 +14364,12 @@
           "url": "sindresorhus/env-paths",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/env-paths"
         }
       ]
     },
@@ -12432,6 +14410,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/err-code"
+        }
       ]
     },
     {
@@ -12465,6 +14449,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/error-ex"
+        }
       ]
     },
     {
@@ -12497,6 +14487,12 @@
           "url": "expressjs/errorhandler",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/errorhandler"
         }
       ]
     },
@@ -12542,6 +14538,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/es-get-iterator"
+        }
       ]
     },
     {
@@ -12574,6 +14576,12 @@
           "url": "component/escape-html",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/escape-html"
         }
       ]
     },
@@ -12608,6 +14616,12 @@
           "url": "sindresorhus/escape-string-regexp",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/escape-string-regexp"
         }
       ]
     },
@@ -12646,6 +14660,12 @@
           "url": "http://github.com/estools/escodegen",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/escodegen"
         }
       ]
     },
@@ -12691,6 +14711,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/esprima"
+        }
       ]
     },
     {
@@ -12728,6 +14754,12 @@
           "url": "https://github.com/estools/estraverse",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/estraverse"
         }
       ]
     },
@@ -12767,6 +14799,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/esutils"
+        }
       ]
     },
     {
@@ -12799,6 +14837,12 @@
           "url": "jshttp/etag",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/etag"
         }
       ]
     },
@@ -12833,6 +14877,12 @@
           "url": "git://github.com/hij1nx/EventEmitter2.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/eventemitter2"
         }
       ]
     },
@@ -12873,6 +14923,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/eventemitter3"
+        }
       ]
     },
     {
@@ -12899,6 +14955,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/exif"
+        }
       ]
     },
     {
@@ -12912,6 +14974,14 @@
         {
           "alg": "SHA-512",
           "content": "664fde34a576cdb8e92b3aec43e9f51baa6855b12b4312742c13895da299d445622f31fe86b2eef5c757238cf0f5d05026c970044a5b4363f5a12ee70f1b3a8d"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://github.com/cowboy/node-exit/blob/master/LICENSE-MIT"
+          }
         }
       ],
       "purl": "pkg:npm/exit@0.1.2",
@@ -12935,6 +15005,12 @@
           "url": "https://github.com/cowboy/node-exit",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/exit"
         }
       ]
     },
@@ -12981,6 +15057,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/expand-brackets"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -13023,6 +15105,12 @@
               "url": "https://github.com/jonschlinkert/define-property",
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/define-property"
             }
           ]
         },
@@ -13067,6 +15155,12 @@
               "url": "https://github.com/jonschlinkert/extend-shallow",
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/extend-shallow"
             }
           ]
         },
@@ -13113,6 +15207,12 @@
               "comment": "as detected from PackageJson property \"homepage\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/is-accessor-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -13155,6 +15255,12 @@
                   "url": "https://github.com/jonschlinkert/kind-of",
                   "type": "website",
                   "comment": "as detected from PackageJson property \"homepage\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/expand-brackets/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -13203,6 +15309,12 @@
               "comment": "as detected from PackageJson property \"homepage\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/is-data-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -13245,6 +15357,12 @@
                   "url": "https://github.com/jonschlinkert/kind-of",
                   "type": "website",
                   "comment": "as detected from PackageJson property \"homepage\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/expand-brackets/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -13292,6 +15410,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/is-descriptor"
+            }
           ]
         },
         {
@@ -13335,6 +15459,12 @@
               "url": "https://github.com/jonschlinkert/is-extendable",
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/is-extendable"
             }
           ]
         },
@@ -13380,6 +15510,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/kind-of"
+            }
           ]
         }
       ]
@@ -13418,6 +15554,12 @@
           "url": "https://github.com/ralphtheninja/expand-template",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/expand-template"
         }
       ]
     },
@@ -13463,6 +15605,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/expand-tilde"
+        }
       ]
     },
     {
@@ -13497,6 +15645,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-ipfilter"
+        }
       ]
     },
     {
@@ -13510,6 +15664,14 @@
         {
           "alg": "SHA-512",
           "content": "086481d1bddb3555c8e93d021797ffe7964a62b220fdbd3ad7b10f99728af44e32d6ad96d70f494e08cf7e1b16c2e3e20ad939b280609b966482ac6086c7da1e"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "http://www.opensource.org/licenses/MIT"
+          }
         }
       ],
       "purl": "pkg:npm/express-jwt@0.1.3",
@@ -13528,6 +15690,12 @@
           "url": "git://github.com/auth0/express-jwt.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-jwt"
         }
       ],
       "components": [
@@ -13568,6 +15736,12 @@
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/express-jwt/node_modules/jsonwebtoken"
+            }
           ]
         },
         {
@@ -13581,6 +15755,13 @@
             {
               "alg": "SHA-512",
               "content": "9778c28c225f0baa48b9c6b5dc6329094e2588462f624d7b5e9160a494b22e9f115fe770760ad906fb646a87e622282995ecdb1b55591548106c315149ddfb60"
+            }
+          ],
+          "licenses": [
+            {
+              "license": {
+                "id": "MIT"
+              }
             }
           ],
           "purl": "pkg:npm/moment@2.0.0",
@@ -13604,6 +15785,12 @@
               "url": "http://momentjs.com",
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/express-jwt/node_modules/moment"
             }
           ]
         }
@@ -13645,6 +15832,12 @@
           "url": "https://github.com/nfriedly/express-rate-limit",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-rate-limit"
         }
       ]
     },
@@ -13690,6 +15883,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-robots-txt"
+        }
       ]
     },
     {
@@ -13732,6 +15931,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-security.txt"
+        }
       ]
     },
     {
@@ -13772,6 +15977,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -13804,6 +16015,12 @@
               "url": "jshttp/cookie",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/express/node_modules/cookie"
             }
           ]
         },
@@ -13849,6 +16066,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/express/node_modules/safe-buffer"
+            }
           ]
         }
       ]
@@ -13885,6 +16108,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ext-list"
+        }
       ]
     },
     {
@@ -13918,6 +16147,12 @@
           "url": "kevva/ext-name",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ext-name"
         }
       ]
     },
@@ -13963,6 +16198,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/extend-shallow"
+        }
       ]
     },
     {
@@ -13996,6 +16237,12 @@
           "url": "https://github.com/justmoon/node-extend.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/extend"
         }
       ]
     },
@@ -14042,6 +16289,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/extglob"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14084,6 +16337,12 @@
               "url": "https://github.com/jonschlinkert/define-property",
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/extglob/node_modules/define-property"
             }
           ]
         },
@@ -14129,6 +16388,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/extglob/node_modules/extend-shallow"
+            }
           ]
         },
         {
@@ -14173,6 +16438,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/extglob/node_modules/is-extendable"
+            }
           ]
         }
       ]
@@ -14207,6 +16478,12 @@
           "url": "git://github.com/davepacheco/node-extsprintf.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/extsprintf"
         }
       ]
     },
@@ -14252,6 +16529,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fast-deep-equal"
+        }
       ]
     },
     {
@@ -14291,6 +16574,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fast-json-stable-stringify"
+        }
       ]
     },
     {
@@ -14324,6 +16613,12 @@
           "url": "https://github.com/hiddentao/fast-levenshtein.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fast-levenshtein"
         }
       ]
     },
@@ -14369,6 +16664,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fast.js"
+        }
       ]
     },
     {
@@ -14407,6 +16708,12 @@
           "url": "git://github.com/andrewrk/node-fd-slicer.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fd-slicer"
         }
       ]
     },
@@ -14452,6 +16759,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/feature-policy"
+        }
       ]
     },
     {
@@ -14495,6 +16808,12 @@
           "url": "https://github.com/taylorhakes/fecha",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fecha"
         }
       ]
     },
@@ -14541,6 +16860,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/file-js"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14579,6 +16904,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/file-js/node_modules/brace-expansion"
+            }
           ]
         },
         {
@@ -14612,6 +16943,12 @@
               "url": "git://github.com/isaacs/minimatch.git",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/file-js/node_modules/minimatch"
             }
           ]
         }
@@ -14649,6 +16986,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/file-stream-rotator"
+        }
       ]
     },
     {
@@ -14682,6 +17025,12 @@
           "url": "sindresorhus/file-type",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/file-type"
         }
       ]
     },
@@ -14727,6 +17076,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/file-uri-to-path"
+        }
       ]
     },
     {
@@ -14770,6 +17125,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/filehound"
+        }
       ]
     },
     {
@@ -14804,6 +17165,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/filename-reserved-regex"
+        }
       ]
     },
     {
@@ -14837,6 +17204,12 @@
           "url": "sindresorhus/filenamify",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/filenamify"
         }
       ]
     },
@@ -14880,6 +17253,12 @@
           "url": "https://github.com/nspragg/filesniffer",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/filesniffer"
         }
       ]
     },
@@ -14926,6 +17305,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fill-range"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14968,6 +17353,12 @@
               "url": "https://github.com/jonschlinkert/extend-shallow",
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/fill-range/node_modules/extend-shallow"
             }
           ]
         },
@@ -15013,6 +17404,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/fill-range/node_modules/is-extendable"
+            }
           ]
         }
       ]
@@ -15054,6 +17451,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/finale-rest"
+        }
       ]
     },
     {
@@ -15087,6 +17490,12 @@
           "url": "pillarjs/finalhandler",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/finalhandler"
         }
       ]
     },
@@ -15122,6 +17531,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/find-up"
+        }
       ]
     },
     {
@@ -15155,6 +17570,12 @@
           "url": "js-cli/node-findup-sync",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/findup-sync"
         }
       ]
     },
@@ -15190,6 +17611,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fined"
+        }
       ]
     },
     {
@@ -15223,6 +17650,12 @@
           "url": "gulpjs/flagged-respawn",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/flagged-respawn"
         }
       ]
     },
@@ -15268,6 +17701,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fn.name"
+        }
       ]
     },
     {
@@ -15302,6 +17741,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fontkit"
+        }
       ]
     },
     {
@@ -15321,6 +17766,12 @@
         {
           "license": {
             "id": "MIT"
+          }
+        },
+        {
+          "license": {
+            "id": "MIT",
+            "url": "http://github.com/Raynos/for-each/raw/master/LICENSE"
           }
         }
       ],
@@ -15345,6 +17796,12 @@
           "url": "https://github.com/Raynos/for-each",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/for-each"
         }
       ]
     },
@@ -15390,6 +17847,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/for-in"
+        }
       ]
     },
     {
@@ -15433,6 +17896,12 @@
           "url": "https://github.com/jonschlinkert/for-own",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/for-own"
         }
       ]
     },
@@ -15478,6 +17947,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/foreachasync"
+        }
       ]
     },
     {
@@ -15511,6 +17986,12 @@
           "url": "https://github.com/mikeal/forever-agent",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/forever-agent"
         }
       ]
     },
@@ -15546,6 +18027,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/form-data"
+        }
       ]
     },
     {
@@ -15577,6 +18064,12 @@
           "url": "http://busterjs.org/docs/formatio/",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/formatio"
         }
       ]
     },
@@ -15610,6 +18103,12 @@
           "url": "jshttp/forwarded",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/forwarded"
         }
       ]
     },
@@ -15655,6 +18154,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fragment-cache"
+        }
       ]
     },
     {
@@ -15688,6 +18193,12 @@
           "url": "jshttp/fresh",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fresh"
         }
       ]
     },
@@ -15733,6 +18244,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/from2"
+        }
       ]
     },
     {
@@ -15777,6 +18294,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fs-constants"
+        }
       ]
     },
     {
@@ -15815,6 +18338,12 @@
           "url": "https://github.com/jprichardson/node-fs-extra",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fs-extra"
         }
       ]
     },
@@ -15860,6 +18389,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fs-minipass"
+        }
       ]
     },
     {
@@ -15893,6 +18428,12 @@
           "url": "git+https://github.com/isaacs/fs.realpath.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fs.realpath"
         }
       ]
     },
@@ -15929,6 +18470,12 @@
           "comment": "as detected from PackageJson property \"repository.url\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fstream"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -15961,6 +18508,12 @@
               "url": "https://github.com/substack/node-mkdirp.git",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/fstream/node_modules/mkdirp"
             }
           ]
         },
@@ -15995,6 +18548,12 @@
               "url": "git://github.com/isaacs/rimraf.git",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/fstream/node_modules/rimraf"
             }
           ]
         }
@@ -16042,6 +18601,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/function-bind"
+        }
       ]
     },
     {
@@ -16086,6 +18651,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/functions-have-names"
+        }
       ]
     },
     {
@@ -16119,6 +18690,12 @@
           "url": "https://github.com/nol13/fuzzball.js.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fuzzball"
         }
       ]
     },
@@ -16164,6 +18741,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/gauge"
+        }
       ]
     },
     {
@@ -16197,6 +18780,12 @@
           "url": "git://github.com/maxogden/geojson-js-utils.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/geojson-utils"
         }
       ]
     },
@@ -16240,6 +18829,12 @@
           "url": "https://github.com/stefanpenner/get-caller-file#readme",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-caller-file"
         }
       ]
     },
@@ -16285,6 +18880,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-intrinsic"
+        }
       ]
     },
     {
@@ -16318,6 +18919,12 @@
           "url": "sindresorhus/get-stream",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-stream"
         }
       ]
     },
@@ -16363,6 +18970,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-value"
+        }
       ]
     },
     {
@@ -16376,6 +18989,14 @@
         {
           "alg": "SHA-512",
           "content": "db36e50c168571bdeb078ac5efb5d59ee20d384da1da4fce9ea5c08b2d08ad3c547d5d62169de56b7de8010558f690a9594dbaf1615856ddadef586532e2ec3a"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://github.com/cowboy/node-getobject/blob/master/LICENSE-MIT"
+          }
         }
       ],
       "purl": "pkg:npm/getobject@1.0.2",
@@ -16399,6 +19020,12 @@
           "url": "https://github.com/cowboy/node-getobject",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/getobject"
         }
       ]
     },
@@ -16433,6 +19060,12 @@
           "url": "https://github.com/arekinath/node-getpass.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/getpass"
         }
       ]
     },
@@ -16473,6 +19106,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/github-from-package"
+        }
       ]
     },
     {
@@ -16506,6 +19145,12 @@
           "url": "gulpjs/glob-parent",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/glob-parent"
         }
       ],
       "components": [
@@ -16551,6 +19196,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/glob-parent/node_modules/is-glob"
+            }
           ]
         }
       ]
@@ -16586,6 +19237,12 @@
           "url": "git://github.com/isaacs/node-glob.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/glob"
         }
       ],
       "components": [
@@ -16626,6 +19283,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/glob/node_modules/brace-expansion"
+            }
           ]
         },
         {
@@ -16659,6 +19322,12 @@
               "url": "git://github.com/isaacs/minimatch.git",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/glob/node_modules/minimatch"
             }
           ]
         }
@@ -16706,6 +19375,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/global-modules"
+        }
       ]
     },
     {
@@ -16751,6 +19426,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/global-prefix"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -16783,6 +19464,12 @@
               "url": "git://github.com/isaacs/node-which.git",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/global-prefix/node_modules/which"
             }
           ]
         }
@@ -16830,6 +19517,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/gopd"
+        }
       ]
     },
     {
@@ -16862,6 +19555,12 @@
           "url": "sindresorhus/got",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/got"
         }
       ],
       "components": [
@@ -16897,6 +19596,12 @@
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/got/node_modules/get-stream"
+            }
           ]
         },
         {
@@ -16930,6 +19635,12 @@
               "url": "sindresorhus/pify",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/got/node_modules/pify"
             }
           ]
         }
@@ -16966,6 +19677,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/graceful-fs"
+        }
       ]
     },
     {
@@ -17001,6 +19718,12 @@
           "comment": "as detected from PackageJson property \"repository\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-cli"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17033,6 +19756,12 @@
               "url": "https://github.com/npm/nopt.git",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-cli/node_modules/nopt"
             }
           ]
         }
@@ -17071,6 +19800,12 @@
           "comment": "as detected from PackageJson property \"repository\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-contrib-compress"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17103,6 +19838,12 @@
               "url": "chalk/ansi-styles",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-contrib-compress/node_modules/ansi-styles"
             }
           ]
         },
@@ -17137,6 +19878,12 @@
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-contrib-compress/node_modules/chalk"
+            }
           ]
         },
         {
@@ -17170,6 +19917,12 @@
               "url": "chalk/supports-color",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-contrib-compress/node_modules/supports-color"
             }
           ]
         }
@@ -17211,6 +19964,12 @@
           "url": "http://gruntjs.com/",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-known-options"
         }
       ]
     },
@@ -17257,6 +20016,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-legacy-log-utils"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17289,6 +20054,12 @@
               "url": "chalk/ansi-styles",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils/node_modules/ansi-styles"
             }
           ]
         },
@@ -17323,6 +20094,12 @@
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils/node_modules/chalk"
+            }
           ]
         },
         {
@@ -17356,6 +20133,12 @@
               "url": "Qix-/color-convert",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils/node_modules/color-convert"
             }
           ]
         },
@@ -17401,6 +20184,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils/node_modules/color-name"
+            }
           ]
         },
         {
@@ -17435,6 +20224,12 @@
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils/node_modules/has-flag"
+            }
           ]
         },
         {
@@ -17468,6 +20263,12 @@
               "url": "chalk/supports-color",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils/node_modules/supports-color"
             }
           ]
         }
@@ -17516,6 +20317,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-legacy-log"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17558,6 +20365,12 @@
               "url": "https://github.com/Marak/colors.js",
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log/node_modules/colors"
             }
           ]
         }
@@ -17606,6 +20419,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-legacy-util"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17649,6 +20468,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-util/node_modules/async"
+            }
           ]
         }
       ]
@@ -17664,6 +20489,14 @@
         {
           "alg": "SHA-512",
           "content": "60b88341ab38e198a5fdb3648561423fade923291348ce1368dcd73e257b9e23241d179f9a9c857b96968919f80ace6e24c2e15da77ca63ac08b604e9a44e465"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://github.com/exo-dev/grunt-replace-json/blob/master/LICENCE.md"
+          }
         }
       ],
       "purl": "pkg:npm/grunt-replace-json@0.1.0",
@@ -17687,6 +20520,12 @@
           "url": "https://github.com/exo-dev/grunt-replace-json",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-replace-json"
         }
       ]
     },
@@ -17728,6 +20567,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17766,6 +20611,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt/node_modules/brace-expansion"
+            }
           ]
         },
         {
@@ -17779,6 +20630,14 @@
             {
               "alg": "SHA-512",
               "content": "cfc36bc218bac33c4d3086f196b4f3b945ba296b8a928819ffb39d0d5abed3e9319fbeca507d678a9c7c894eacbaa907a9ce32ea7edaf40f08a66c58fe94e35a"
+            }
+          ],
+          "licenses": [
+            {
+              "license": {
+                "id": "MIT",
+                "url": "https://github.com/cowboy/node-findup-sync/blob/master/LICENSE-MIT"
+              }
             }
           ],
           "purl": "pkg:npm/findup-sync@0.3.0",
@@ -17802,6 +20661,12 @@
               "url": "https://github.com/cowboy/node-findup-sync",
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt/node_modules/findup-sync"
             }
           ],
           "components": [
@@ -17836,6 +20701,12 @@
                   "url": "git://github.com/isaacs/node-glob.git",
                   "type": "vcs",
                   "comment": "as detected from PackageJson property \"repository.url\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/grunt/node_modules/findup-sync/node_modules/glob"
                 }
               ]
             }
@@ -17873,6 +20744,12 @@
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt/node_modules/glob"
+            }
           ]
         },
         {
@@ -17906,6 +20783,12 @@
               "url": "git://github.com/isaacs/minimatch.git",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt/node_modules/minimatch"
             }
           ]
         }
@@ -17949,6 +20832,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/handlebars"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17981,6 +20870,12 @@
               "url": "git://github.com/substack/node-wordwrap.git",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/handlebars/node_modules/wordwrap"
             }
           ]
         }
@@ -18028,6 +20923,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/har-schema"
+        }
       ]
     },
     {
@@ -18072,6 +20973,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/har-validator"
+        }
       ]
     },
     {
@@ -18105,6 +21012,12 @@
           "url": "sindresorhus/has-ansi",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-ansi"
         }
       ]
     },
@@ -18150,6 +21063,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-bigints"
+        }
       ]
     },
     {
@@ -18183,6 +21102,12 @@
           "url": "sindresorhus/has-flag",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-flag"
         }
       ]
     },
@@ -18228,6 +21153,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-property-descriptors"
+        }
       ]
     },
     {
@@ -18271,6 +21202,12 @@
           "url": "https://github.com/Xotic750/has-symbol-support-x",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-symbol-support-x"
         }
       ]
     },
@@ -18316,6 +21253,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-symbols"
+        }
       ]
     },
     {
@@ -18359,6 +21302,12 @@
           "url": "https://github.com/Xotic750/has-to-string-tag-x",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-to-string-tag-x"
         }
       ]
     },
@@ -18404,6 +21353,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-tostringtag"
+        }
       ]
     },
     {
@@ -18448,6 +21403,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-unicode"
+        }
       ]
     },
     {
@@ -18491,6 +21452,12 @@
           "url": "https://github.com/jonschlinkert/has-value",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-value"
         }
       ]
     },
@@ -18537,6 +21504,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-values"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18580,6 +21553,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/has-values/node_modules/kind-of"
+            }
           ]
         }
       ]
@@ -18601,6 +21580,12 @@
         {
           "license": {
             "id": "MIT"
+          }
+        },
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://github.com/tarruda/has/blob/master/LICENSE-MIT"
           }
         }
       ],
@@ -18625,6 +21610,12 @@
           "url": "https://github.com/tarruda/has",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has"
         }
       ]
     },
@@ -18670,6 +21661,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hashids"
+        }
       ]
     },
     {
@@ -18704,6 +21701,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hbs"
+        }
       ]
     },
     {
@@ -18717,6 +21720,14 @@
         {
           "alg": "SHA-512",
           "content": "c059f526572c81b71611ac10e80d46ced80d45197a53212d6804480e901e1f7737e53ffd89dfd040abdaa75340cfa624da82ab2b05d0659144452d2d97d13426"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "http://mths.be/mit"
+          }
         }
       ],
       "purl": "pkg:npm/he@0.4.1",
@@ -18740,6 +21751,12 @@
           "url": "http://mths.be/he",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/he"
         }
       ]
     },
@@ -18779,6 +21796,12 @@
           "url": "https://github.com/qiao/heap.js",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/heap"
         }
       ]
     },
@@ -18824,6 +21847,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/helmet"
+        }
       ]
     },
     {
@@ -18862,6 +21891,12 @@
           "url": "https://github.com/mmckegg/hoister.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hoister"
         }
       ]
     },
@@ -18907,6 +21942,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/homedir-polyfill"
+        }
       ]
     },
     {
@@ -18920,6 +21961,14 @@
         {
           "alg": "SHA-512",
           "content": "b7e51eac2b10be24b29802270f4d4fc3e0e7feeb26cf5b113bedd9935fa5c7c7a0f962a90f6ba57305aa1c72f4f9ab1e441afedfebc88621b52b5253c1a21c4c"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://github.com/cowboy/javascript-hooker/blob/master/LICENSE-MIT"
+          }
         }
       ],
       "purl": "pkg:npm/hooker@0.2.3",
@@ -18943,6 +21992,12 @@
           "url": "http://github.com/cowboy/javascript-hooker",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hooker"
         }
       ]
     },
@@ -18988,6 +22043,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hosted-git-info"
+        }
       ]
     },
     {
@@ -19022,6 +22083,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/html-entities"
+        }
       ]
     },
     {
@@ -19035,6 +22102,14 @@
         {
           "alg": "SHA-512",
           "content": "67c8bade7eec7ae3ef45ed4f432ae39a8552b6fedb8cc6b4b24ace97f93ab674ffe56a4f36bcd62c1d4783f749c415c7fcce8a66f9b6e494065428901b15112d"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "http://github.com/fb55/htmlparser2/raw/master/LICENSE"
+          }
         }
       ],
       "purl": "pkg:npm/htmlparser2@3.3.0",
@@ -19053,6 +22128,12 @@
           "url": "git://github.com/fb55/htmlparser2.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/htmlparser2"
         }
       ],
       "components": [
@@ -19093,6 +22174,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/htmlparser2/node_modules/isarray"
+            }
           ]
         },
         {
@@ -19126,6 +22213,12 @@
               "url": "git://github.com/isaacs/readable-stream",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/htmlparser2/node_modules/readable-stream"
             }
           ]
         },
@@ -19165,6 +22258,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/htmlparser2/node_modules/string_decoder"
+            }
           ]
         }
       ]
@@ -19201,6 +22300,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/http-cache-semantics"
+        }
       ]
     },
     {
@@ -19234,6 +22339,12 @@
           "url": "jshttp/http-errors",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/http-errors"
         }
       ]
     },
@@ -19275,6 +22386,12 @@
           "comment": "as detected from PackageJson property \"repository.url\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/http-proxy-agent"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -19308,6 +22425,12 @@
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/http-proxy-agent/node_modules/debug"
+            }
           ]
         },
         {
@@ -19340,6 +22463,12 @@
               "url": "zeit/ms",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/http-proxy-agent/node_modules/ms"
             }
           ]
         }
@@ -19387,6 +22516,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/http-signature"
+        }
       ]
     },
     {
@@ -19427,6 +22562,12 @@
           "comment": "as detected from PackageJson property \"repository.url\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/https-proxy-agent"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -19460,6 +22601,12 @@
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/https-proxy-agent/node_modules/debug"
+            }
           ]
         },
         {
@@ -19492,6 +22639,12 @@
               "url": "zeit/ms",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/https-proxy-agent/node_modules/ms"
             }
           ]
         }
@@ -19528,6 +22681,12 @@
           "url": "https://github.com/node-modules/humanize-ms",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/humanize-ms"
         }
       ]
     },
@@ -19567,6 +22726,12 @@
           "url": "http://github.com/mashpie/i18n-node",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/i18n"
         }
       ]
     },
@@ -19612,6 +22777,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/iconv-lite"
+        }
       ]
     },
     {
@@ -19646,6 +22817,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ieee754"
+        }
       ]
     },
     {
@@ -19679,6 +22856,12 @@
           "url": "git+https://github.com/isaacs/ignore-walk.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ignore-walk"
         }
       ],
       "components": [
@@ -19719,6 +22902,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/ignore-walk/node_modules/brace-expansion"
+            }
           ]
         },
         {
@@ -19752,6 +22941,12 @@
               "url": "git://github.com/isaacs/minimatch.git",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/ignore-walk/node_modules/minimatch"
             }
           ]
         }
@@ -19798,6 +22993,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/iltorb"
+        }
       ]
     },
     {
@@ -19842,6 +23043,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/imurmurhash"
+        }
       ]
     },
     {
@@ -19875,6 +23082,12 @@
           "url": "sindresorhus/indent-string",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/indent-string"
         }
       ]
     },
@@ -19910,6 +23123,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/infer-owner"
+        }
       ]
     },
     {
@@ -19943,6 +23162,12 @@
           "url": "https://github.com/dreamerslab/node.inflection.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/inflection"
         }
       ]
     },
@@ -19988,6 +23213,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/inflight"
+        }
       ]
     },
     {
@@ -20020,6 +23251,12 @@
           "url": "git://github.com/isaacs/inherits",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/inherits"
         }
       ]
     },
@@ -20054,6 +23291,12 @@
           "url": "git://github.com/isaacs/ini.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ini"
         }
       ]
     },
@@ -20099,6 +23342,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/interpret"
+        }
       ]
     },
     {
@@ -20133,6 +23382,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/into-stream"
+        }
       ]
     },
     {
@@ -20166,6 +23421,12 @@
           "url": "https://github.com/zertosh/invariant",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/invariant"
         }
       ]
     },
@@ -20204,6 +23465,12 @@
           "url": "https://github.com/indutny/node-ip",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ip"
         }
       ]
     },
@@ -20249,6 +23516,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ip6"
+        }
       ]
     },
     {
@@ -20282,6 +23555,12 @@
           "url": "git://github.com/whitequark/ipaddr.js",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ipaddr.js"
         }
       ]
     },
@@ -20327,6 +23606,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-absolute"
+        }
       ]
     },
     {
@@ -20370,6 +23655,12 @@
           "url": "https://github.com/jonschlinkert/is-accessor-descriptor",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-accessor-descriptor"
         }
       ]
     },
@@ -20415,6 +23706,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-arguments"
+        }
       ]
     },
     {
@@ -20448,6 +23745,12 @@
           "url": "https://github.com/qix-/node-is-arrayish.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-arrayish"
         }
       ]
     },
@@ -20493,6 +23796,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-bigint"
+        }
       ]
     },
     {
@@ -20527,6 +23836,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-binary-path"
+        }
       ]
     },
     {
@@ -20560,6 +23875,12 @@
           "url": "git://github.com/inspect-js/is-boolean-object.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-boolean-object"
         }
       ]
     },
@@ -20600,6 +23921,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-buffer"
+        }
       ]
     },
     {
@@ -20633,6 +23960,12 @@
           "url": "git://github.com/inspect-js/is-callable.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-callable"
         }
       ]
     },
@@ -20678,6 +24011,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-core-module"
+        }
       ]
     },
     {
@@ -20722,6 +24061,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-data-descriptor"
+        }
       ]
     },
     {
@@ -20755,6 +24100,12 @@
           "url": "git://github.com/inspect-js/is-date-object.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-date-object"
         }
       ]
     },
@@ -20800,6 +24151,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-descriptor"
+        }
       ]
     },
     {
@@ -20834,6 +24191,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-docker"
+        }
       ]
     },
     {
@@ -20867,6 +24230,12 @@
           "url": "https://github.com/pugjs/is-expression.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-expression"
         }
       ]
     },
@@ -20912,6 +24281,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-extendable"
+        }
       ]
     },
     {
@@ -20956,6 +24331,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-extglob"
+        }
       ]
     },
     {
@@ -20989,6 +24370,12 @@
           "url": "sindresorhus/is-fullwidth-code-point",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-fullwidth-code-point"
         }
       ]
     },
@@ -21028,6 +24415,12 @@
           "url": "git://github.com/inspect-js/is-generator-function.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-generator-function"
         }
       ]
     },
@@ -21073,6 +24466,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-glob"
+        }
       ]
     },
     {
@@ -21106,6 +24505,12 @@
           "url": "sindresorhus/is-heroku",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-heroku"
         }
       ]
     },
@@ -21151,6 +24556,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-lambda"
+        }
       ]
     },
     {
@@ -21195,6 +24606,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-map"
+        }
       ]
     },
     {
@@ -21228,6 +24645,12 @@
           "url": "shinnn/is-natural-number.js",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-natural-number"
         }
       ]
     },
@@ -21273,6 +24696,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-number-like"
+        }
       ]
     },
     {
@@ -21316,6 +24745,12 @@
           "url": "https://github.com/inspect-js/is-number-object#readme",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-number-object"
         }
       ]
     },
@@ -21362,6 +24797,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-number"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21405,6 +24846,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/is-number/node_modules/kind-of"
+            }
           ]
         }
       ]
@@ -21426,6 +24873,12 @@
         {
           "license": {
             "id": "MIT"
+          }
+        },
+        {
+          "license": {
+            "id": "MIT",
+            "url": "http://github.com/inspect-js/is-object/raw/master/LICENSE"
           }
         }
       ],
@@ -21450,6 +24903,12 @@
           "url": "https://github.com/inspect-js/is-object",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-object"
         }
       ]
     },
@@ -21484,6 +24943,12 @@
           "url": "sindresorhus/is-plain-obj",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-plain-obj"
         }
       ]
     },
@@ -21529,6 +24994,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-plain-object"
+        }
       ]
     },
     {
@@ -21562,6 +25033,12 @@
           "url": "https://github.com/then/is-promise.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-promise"
         }
       ]
     },
@@ -21607,6 +25084,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-regex"
+        }
       ]
     },
     {
@@ -21651,6 +25134,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-relative"
+        }
       ]
     },
     {
@@ -21684,6 +25173,12 @@
           "url": "floatdrop/is-retry-allowed",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-retry-allowed"
         }
       ]
     },
@@ -21729,6 +25224,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-set"
+        }
       ]
     },
     {
@@ -21763,6 +25264,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-stream"
+        }
       ]
     },
     {
@@ -21796,6 +25303,12 @@
           "url": "git://github.com/ljharb/is-string.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-string"
         }
       ]
     },
@@ -21836,6 +25349,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-symbol"
+        }
       ]
     },
     {
@@ -21869,6 +25388,12 @@
           "url": "git://github.com/inspect-js/is-typed-array.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-typed-array"
         }
       ]
     },
@@ -21914,6 +25439,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-typedarray"
+        }
       ]
     },
     {
@@ -21957,6 +25488,12 @@
           "url": "https://github.com/jonschlinkert/is-unc-path",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-unc-path"
         }
       ]
     },
@@ -22002,6 +25539,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-weakmap"
+        }
       ]
     },
     {
@@ -22045,6 +25588,12 @@
           "url": "https://github.com/inspect-js/is-weakset#readme",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-weakset"
         }
       ]
     },
@@ -22090,6 +25639,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-windows"
+        }
       ]
     },
     {
@@ -22128,6 +25683,12 @@
           "url": "https://github.com/juliangruber/isarray",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isarray"
         }
       ]
     },
@@ -22173,6 +25734,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isexe"
+        }
       ]
     },
     {
@@ -22216,6 +25783,12 @@
           "url": "https://github.com/jonschlinkert/isobject",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isobject"
         }
       ]
     },
@@ -22261,6 +25834,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isstream"
+        }
       ]
     },
     {
@@ -22294,6 +25873,12 @@
           "url": "stevenvachon/isurl",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isurl"
         }
       ]
     },
@@ -22329,6 +25914,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/js-stringify"
+        }
       ]
     },
     {
@@ -22362,6 +25953,12 @@
           "url": "lydell/js-tokens",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/js-tokens"
         }
       ]
     },
@@ -22402,6 +25999,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/js-yaml"
+        }
       ]
     },
     {
@@ -22435,6 +26038,12 @@
           "url": "https://github.com/andyperlitch/jsbn.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jsbn"
         }
       ]
     },
@@ -22475,6 +26084,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-buffer"
+        }
       ]
     },
     {
@@ -22508,6 +26123,12 @@
           "url": "https://github.com/zkat/json-parse-better-errors",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-parse-better-errors"
         }
       ]
     },
@@ -22553,6 +26174,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-schema-traverse"
+        }
       ]
     },
     {
@@ -22584,6 +26211,12 @@
           "url": "http://github.com/kriszyp/json-schema",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-schema"
         }
       ]
     },
@@ -22629,6 +26262,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-stringify-safe"
+        }
       ]
     },
     {
@@ -22673,6 +26312,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json5"
+        }
       ]
     },
     {
@@ -22706,6 +26351,12 @@
           "url": "git@github.com:jprichardson/node-jsonfile.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jsonfile"
         }
       ]
     },
@@ -22746,6 +26397,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jsonwebtoken"
+        }
       ]
     },
     {
@@ -22778,6 +26435,12 @@
           "url": "git://github.com/joyent/node-jsprim.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jsprim"
         }
       ]
     },
@@ -22823,6 +26486,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jssha"
+        }
       ]
     },
     {
@@ -22856,6 +26525,12 @@
           "url": "https://github.com/jstransformers/jstransformer.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jstransformer"
         }
       ]
     },
@@ -22901,6 +26576,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/juicy-chat-bot"
+        }
       ]
     },
     {
@@ -22935,6 +26616,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jwa"
+        }
       ]
     },
     {
@@ -22968,6 +26655,12 @@
           "url": "git://github.com/brianloveswords/node-jws.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jws"
         }
       ]
     },
@@ -23013,6 +26706,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/keyv"
+        }
       ]
     },
     {
@@ -23056,6 +26755,12 @@
           "url": "https://github.com/jonschlinkert/kind-of",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/kind-of"
         }
       ]
     },
@@ -23101,6 +26806,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/kuler"
+        }
       ]
     },
     {
@@ -23144,6 +26855,12 @@
           "url": "https://github.com/takuyaa/kuromoji.js",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/kuromoji"
         }
       ]
     },
@@ -23189,6 +26906,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lazystream"
+        }
       ]
     },
     {
@@ -23233,6 +26956,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/levn"
+        }
       ]
     },
     {
@@ -23273,6 +27002,12 @@
           "comment": "as detected from PackageJson property \"repository.url\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/libxmljs2"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -23304,6 +27039,12 @@
               "url": "git://github.com/nodejs/nan.git",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/libxmljs2/node_modules/nan"
             }
           ]
         }
@@ -23340,6 +27081,12 @@
           "url": "gruntjs/js-liftup",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/liftup"
         }
       ],
       "components": [
@@ -23385,6 +27132,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/braces"
+            }
           ]
         },
         {
@@ -23429,6 +27182,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/fill-range"
+            }
           ]
         },
         {
@@ -23462,6 +27221,12 @@
               "url": "gulpjs/findup-sync",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/findup-sync"
             }
           ]
         },
@@ -23507,6 +27272,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/is-glob"
+            }
           ]
         },
         {
@@ -23550,6 +27321,12 @@
               "url": "https://github.com/jonschlinkert/is-number",
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/is-number"
             }
           ]
         },
@@ -23595,6 +27372,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/micromatch"
+            }
           ]
         },
         {
@@ -23638,6 +27421,12 @@
               "url": "https://github.com/micromatch/to-regex-range",
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/to-regex-range"
             }
           ]
         }
@@ -23686,6 +27475,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/linebreak"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -23718,6 +27513,12 @@
               "url": "git://github.com/beatgammit/base64-js.git",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/linebreak/node_modules/base64-js"
             }
           ]
         }
@@ -23755,6 +27556,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/listenercount"
+        }
       ]
     },
     {
@@ -23788,6 +27595,12 @@
           "url": "sindresorhus/locate-path",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/locate-path"
         }
       ]
     },
@@ -23828,6 +27641,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lodash.camelcase"
+        }
       ]
     },
     {
@@ -23866,6 +27685,12 @@
           "url": "https://lodash.com/",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lodash.isfinite"
         }
       ]
     },
@@ -23906,6 +27731,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lodash.set"
+        }
       ]
     },
     {
@@ -23944,6 +27775,12 @@
           "url": "https://lodash.com/",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lodash"
         }
       ]
     },
@@ -23990,6 +27827,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/logform"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -24021,6 +27864,12 @@
               "url": "vercel/ms",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/logform/node_modules/ms"
             }
           ]
         }
@@ -24068,6 +27917,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lolex"
+        }
       ]
     },
     {
@@ -24107,6 +27962,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/loose-envify"
+        }
       ]
     },
     {
@@ -24141,6 +28002,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lowercase-keys"
+        }
       ]
     },
     {
@@ -24174,6 +28041,12 @@
           "url": "git://github.com/isaacs/node-lru-cache.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lru-cache"
         }
       ]
     },
@@ -24210,6 +28083,12 @@
           "comment": "as detected from PackageJson property \"repository\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-dir"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -24241,6 +28120,12 @@
               "url": "https://github.com/npm/node-semver",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-dir/node_modules/semver"
             }
           ]
         }
@@ -24288,6 +28173,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-error"
+        }
       ]
     },
     {
@@ -24321,6 +28212,12 @@
           "url": "https://github.com/npm/make-fetch-happen",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-fetch-happen"
         }
       ],
       "components": [
@@ -24362,6 +28259,12 @@
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen/node_modules/@tootallnate/once"
+            }
           ]
         },
         {
@@ -24396,6 +28299,12 @@
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen/node_modules/debug"
+            }
           ]
         },
         {
@@ -24429,6 +28338,12 @@
               "url": "https://github.com/kornelski/http-cache-semantics.git",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen/node_modules/http-cache-semantics"
             }
           ]
         },
@@ -24469,6 +28384,12 @@
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen/node_modules/http-proxy-agent"
+            }
           ]
         },
         {
@@ -24501,6 +28422,12 @@
               "url": "zeit/ms",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen/node_modules/ms"
             }
           ]
         }
@@ -24548,6 +28475,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-iterator"
+        }
       ]
     },
     {
@@ -24591,6 +28524,12 @@
           "url": "https://github.com/eemeli/make-plural#readme",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-plural"
         }
       ]
     },
@@ -24636,6 +28575,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/map-cache"
+        }
       ]
     },
     {
@@ -24680,6 +28625,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/map-visit"
+        }
       ]
     },
     {
@@ -24719,6 +28670,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/marsdb"
+        }
       ]
     },
     {
@@ -24752,6 +28709,12 @@
           "url": "Semigradsky/math-interval-parser",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/math-interval-parser"
         }
       ]
     },
@@ -24787,6 +28750,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/media-typer"
+        }
       ]
     },
     {
@@ -24820,6 +28789,12 @@
           "url": "component/merge-descriptors",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/merge-descriptors"
         }
       ]
     },
@@ -24860,6 +28835,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/messageformat-formatters"
+        }
       ]
     },
     {
@@ -24897,6 +28878,12 @@
           "url": "https://messageformat.github.io/",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/messageformat-parser"
         }
       ]
     },
@@ -24936,6 +28923,12 @@
           "url": "https://messageformat.github.io/messageformat/",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/messageformat"
         }
       ],
       "components": [
@@ -24981,6 +28974,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/messageformat/node_modules/make-plural"
+            }
           ]
         }
       ]
@@ -25015,6 +29014,12 @@
           "url": "jshttp/methods",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/methods"
         }
       ]
     },
@@ -25060,6 +29065,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/micromatch"
+        }
       ]
     },
     {
@@ -25093,6 +29104,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mime-db"
+        }
       ]
     },
     {
@@ -25125,6 +29142,12 @@
           "url": "jshttp/mime-types",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mime-types"
         }
       ]
     },
@@ -25160,6 +29183,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mime"
+        }
       ]
     },
     {
@@ -25194,6 +29223,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mimic-response"
+        }
       ]
     },
     {
@@ -25227,6 +29262,12 @@
           "url": "git://github.com/isaacs/minimatch.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minimatch"
         }
       ]
     },
@@ -25267,6 +29308,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minimist"
+        }
       ]
     },
     {
@@ -25295,6 +29342,12 @@
           "url": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-collect"
         }
       ]
     },
@@ -25328,6 +29381,12 @@
           "url": "git+https://github.com/npm/minipass-fetch.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-fetch"
         }
       ]
     },
@@ -25363,6 +29422,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-flush"
+        }
       ]
     },
     {
@@ -25391,6 +29456,12 @@
           "url": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-pipeline"
         }
       ]
     },
@@ -25426,6 +29497,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-sized"
+        }
       ]
     },
     {
@@ -25460,6 +29537,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass"
+        }
       ]
     },
     {
@@ -25493,6 +29576,12 @@
           "url": "git+https://github.com/isaacs/minizlib.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minizlib"
         }
       ]
     },
@@ -25538,6 +29627,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mixin-deep"
+        }
       ]
     },
     {
@@ -25582,6 +29677,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mkdirp-classic"
+        }
       ]
     },
     {
@@ -25614,6 +29715,12 @@
           "url": "https://github.com/isaacs/node-mkdirp.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mkdirp"
         }
       ]
     },
@@ -25659,6 +29766,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/moment-timezone"
+        }
       ]
     },
     {
@@ -25703,6 +29816,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/moment"
+        }
       ]
     },
     {
@@ -25737,6 +29856,12 @@
           "comment": "as detected from PackageJson property \"repository\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/morgan"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -25768,6 +29893,12 @@
               "url": "jshttp/on-finished",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/morgan/node_modules/on-finished"
             }
           ]
         }
@@ -25815,6 +29946,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mout"
+        }
       ]
     },
     {
@@ -25847,6 +29984,12 @@
           "url": "zeit/ms",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ms"
         }
       ]
     },
@@ -25882,6 +30025,12 @@
           "comment": "as detected from PackageJson property \"repository\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/multer"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -25914,6 +30063,12 @@
               "url": "https://github.com/substack/node-mkdirp.git",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/multer/node_modules/mkdirp"
             }
           ]
         }
@@ -25956,6 +30111,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mustache"
+        }
       ]
     },
     {
@@ -25988,6 +30149,12 @@
           "url": "git://github.com/nodejs/nan.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/nan"
         }
       ]
     },
@@ -26033,6 +30200,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/nanomatch"
+        }
       ]
     },
     {
@@ -26077,6 +30250,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/napi-build-utils"
+        }
       ]
     },
     {
@@ -26112,6 +30291,12 @@
           "comment": "as detected from PackageJson property \"repository.url\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/needle"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -26145,6 +30330,12 @@
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/needle/node_modules/debug"
+            }
           ]
         },
         {
@@ -26177,6 +30368,12 @@
               "url": "vercel/ms",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/needle/node_modules/ms"
             }
           ]
         }
@@ -26212,6 +30409,12 @@
           "url": "jshttp/negotiator",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/negotiator"
         }
       ]
     },
@@ -26250,6 +30453,12 @@
           "url": "https://github.com/suguru03/neo-async",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/neo-async"
         }
       ]
     },
@@ -26296,6 +30505,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-abi"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -26327,6 +30542,12 @@
               "url": "https://github.com/npm/node-semver",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-abi/node_modules/semver"
             }
           ]
         }
@@ -26373,6 +30594,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-addon-api"
+        }
       ]
     },
     {
@@ -26417,6 +30644,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-fetch"
+        }
       ]
     },
     {
@@ -26452,6 +30685,12 @@
           "comment": "as detected from PackageJson property \"repository.url\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-gyp"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -26484,6 +30723,12 @@
               "url": "chalk/ansi-regex",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/ansi-regex"
             }
           ]
         },
@@ -26529,6 +30774,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/are-we-there-yet"
+            }
           ]
         },
         {
@@ -26573,6 +30824,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/gauge"
+            }
           ]
         },
         {
@@ -26606,6 +30863,12 @@
               "url": "sindresorhus/is-fullwidth-code-point",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/is-fullwidth-code-point"
             }
           ]
         },
@@ -26641,6 +30904,12 @@
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/nopt"
+            }
           ]
         },
         {
@@ -26675,6 +30944,12 @@
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/npmlog"
+            }
           ]
         },
         {
@@ -26707,6 +30982,12 @@
               "url": "git://github.com/nodejs/readable-stream",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/readable-stream"
             }
           ]
         },
@@ -26742,6 +31023,12 @@
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/string-width"
+            }
           ]
         },
         {
@@ -26775,6 +31062,12 @@
               "url": "chalk/strip-ansi",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/strip-ansi"
             }
           ]
         }
@@ -26813,6 +31106,12 @@
           "comment": "as detected from PackageJson property \"repository.url\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-pre-gyp"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -26845,6 +31144,12 @@
               "url": "git://github.com/isaacs/chownr.git",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/chownr"
             }
           ]
         },
@@ -26890,6 +31195,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/fs-minipass"
+            }
           ]
         },
         {
@@ -26923,6 +31234,12 @@
               "url": "git+https://github.com/isaacs/minipass.git",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/minipass"
             }
           ]
         },
@@ -26958,6 +31275,12 @@
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/minizlib"
+            }
           ]
         },
         {
@@ -26991,6 +31314,12 @@
               "url": "https://github.com/substack/node-mkdirp.git",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/mkdirp"
             }
           ]
         },
@@ -27026,6 +31355,12 @@
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/nopt"
+            }
           ]
         },
         {
@@ -27059,6 +31394,12 @@
               "url": "git://github.com/isaacs/rimraf.git",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/rimraf"
             }
           ]
         },
@@ -27104,6 +31445,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/safe-buffer"
+            }
           ]
         },
         {
@@ -27136,6 +31483,12 @@
               "url": "https://github.com/npm/node-semver",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/semver"
             }
           ]
         },
@@ -27171,6 +31524,12 @@
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/tar"
+            }
           ]
         },
         {
@@ -27204,6 +31563,12 @@
               "url": "git+https://github.com/isaacs/yallist.git",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/yallist"
             }
           ]
         }
@@ -27240,6 +31605,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/noop-logger"
+        }
       ]
     },
     {
@@ -27273,6 +31644,12 @@
           "url": "https://github.com/npm/nopt.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/nopt"
         }
       ]
     },
@@ -27309,6 +31686,12 @@
           "comment": "as detected from PackageJson property \"repository.url\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/normalize-package-data"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -27340,6 +31723,12 @@
               "url": "https://github.com/npm/node-semver",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/normalize-package-data/node_modules/semver"
             }
           ]
         }
@@ -27387,6 +31776,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/normalize-path"
+        }
       ]
     },
     {
@@ -27420,6 +31815,12 @@
           "url": "sindresorhus/normalize-url",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/normalize-url"
         }
       ]
     },
@@ -27461,6 +31862,12 @@
           "comment": "as detected from PackageJson property \"repository.url\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/notevil"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -27472,6 +31879,14 @@
             {
               "alg": "SHA-512",
               "content": "ae9e5d30a37ccc4b3d75f8bd8345f50a52e657ffd647293f475e66a6914d202205446e4ff7654fed9d38a7ca64fbe800068f56dad63e907caee8fd661078264c"
+            }
+          ],
+          "licenses": [
+            {
+              "license": {
+                "name": "BSD",
+                "url": "http://github.com/ariya/esprima/raw/master/LICENSE.BSD"
+              }
             }
           ],
           "purl": "pkg:npm/esprima@1.0.4",
@@ -27490,6 +31905,12 @@
               "url": "http://esprima.org",
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/notevil/node_modules/esprima"
             }
           ]
         }
@@ -27527,6 +31948,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/npm-bundled"
+        }
       ]
     },
     {
@@ -27560,6 +31987,12 @@
           "url": "git+https://github.com/npm/npm-normalize-package-bin",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/npm-normalize-package-bin"
         }
       ]
     },
@@ -27605,6 +32038,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/npm-packlist"
+        }
       ]
     },
     {
@@ -27638,6 +32077,12 @@
           "url": "https://github.com/npm/npmlog.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/npmlog"
         }
       ]
     },
@@ -27673,6 +32118,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/number-is-nan"
+        }
       ]
     },
     {
@@ -27707,6 +32158,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/oauth-sign"
+        }
       ]
     },
     {
@@ -27740,6 +32197,12 @@
           "url": "sindresorhus/object-assign",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-assign"
         }
       ]
     },
@@ -27786,6 +32249,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-copy"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -27828,6 +32297,12 @@
               "url": "https://github.com/jonschlinkert/define-property",
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy/node_modules/define-property"
             }
           ]
         },
@@ -27873,6 +32348,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy/node_modules/is-accessor-descriptor"
+            }
           ]
         },
         {
@@ -27916,6 +32397,12 @@
               "url": "https://github.com/jonschlinkert/is-data-descriptor",
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy/node_modules/is-data-descriptor"
             }
           ]
         },
@@ -27962,6 +32449,12 @@
               "comment": "as detected from PackageJson property \"homepage\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy/node_modules/is-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -28004,6 +32497,12 @@
                   "url": "https://github.com/jonschlinkert/kind-of",
                   "type": "website",
                   "comment": "as detected from PackageJson property \"homepage\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/object-copy/node_modules/is-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -28051,6 +32550,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy/node_modules/kind-of"
+            }
           ]
         }
       ]
@@ -28091,6 +32596,12 @@
           "url": "https://github.com/inspect-js/object-inspect",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-inspect"
         }
       ]
     },
@@ -28136,6 +32647,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-is"
+        }
       ]
     },
     {
@@ -28169,6 +32686,12 @@
           "url": "git://github.com/ljharb/object-keys.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-keys"
         }
       ]
     },
@@ -28214,6 +32737,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-visit"
+        }
       ]
     },
     {
@@ -28247,6 +32776,12 @@
           "url": "git://github.com/ljharb/object.assign.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object.assign"
         }
       ]
     },
@@ -28292,6 +32827,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object.defaults"
+        }
       ]
     },
     {
@@ -28335,6 +32876,12 @@
           "url": "https://github.com/jonschlinkert/object.map",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object.map"
         }
       ]
     },
@@ -28380,6 +32927,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object.pick"
+        }
       ]
     },
     {
@@ -28412,6 +32965,12 @@
           "url": "jshttp/on-finished",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/on-finished"
         }
       ]
     },
@@ -28447,6 +33006,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/on-headers"
+        }
       ]
     },
     {
@@ -28480,6 +33045,12 @@
           "url": "git://github.com/isaacs/once",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/once"
         }
       ]
     },
@@ -28515,6 +33086,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/one-time"
+        }
       ]
     },
     {
@@ -28548,6 +33125,12 @@
           "url": "git://github.com/nodebox/opentype.js.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/opentype.js"
         }
       ]
     },
@@ -28593,6 +33176,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/optionator"
+        }
       ]
     },
     {
@@ -28626,6 +33215,12 @@
           "url": "sindresorhus/os-homedir",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/os-homedir"
         }
       ]
     },
@@ -28661,6 +33256,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/os-tmpdir"
+        }
       ]
     },
     {
@@ -28694,6 +33295,12 @@
           "url": "https://github.com/npm/osenv",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/osenv"
         }
       ]
     },
@@ -28734,6 +33341,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/otplib"
+        }
       ]
     },
     {
@@ -28767,6 +33380,12 @@
           "url": "sindresorhus/p-cancelable",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-cancelable"
         }
       ]
     },
@@ -28802,6 +33421,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-event"
+        }
       ]
     },
     {
@@ -28835,6 +33460,12 @@
           "url": "sindresorhus/p-finally",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-finally"
         }
       ]
     },
@@ -28870,6 +33501,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-is-promise"
+        }
       ]
     },
     {
@@ -28903,6 +33540,12 @@
           "url": "sindresorhus/p-limit",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-limit"
         }
       ]
     },
@@ -28938,6 +33581,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-locate"
+        }
       ]
     },
     {
@@ -28971,6 +33620,12 @@
           "url": "sindresorhus/p-map",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-map"
         }
       ]
     },
@@ -29006,6 +33661,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-timeout"
+        }
       ]
     },
     {
@@ -29039,6 +33700,12 @@
           "url": "sindresorhus/p-try",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-try"
         }
       ]
     },
@@ -29077,6 +33744,12 @@
           "url": "https://github.com/nodeca/pako",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pako"
         }
       ]
     },
@@ -29122,6 +33795,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/parse-filepath"
+        }
       ]
     },
     {
@@ -29155,6 +33834,12 @@
           "url": "sindresorhus/parse-json",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/parse-json"
         }
       ]
     },
@@ -29200,6 +33885,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/parse-passwd"
+        }
       ]
     },
     {
@@ -29232,6 +33923,12 @@
           "url": "pillarjs/parseurl",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/parseurl"
         }
       ]
     },
@@ -29277,6 +33974,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pascalcase"
+        }
       ]
     },
     {
@@ -29311,6 +34014,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-exists"
+        }
       ]
     },
     {
@@ -29344,6 +34053,12 @@
           "url": "sindresorhus/path-is-absolute",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-is-absolute"
         }
       ]
     },
@@ -29389,6 +34104,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-parse"
+        }
       ]
     },
     {
@@ -29432,6 +34153,12 @@
           "url": "https://github.com/regexhq/path-root-regex",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-root-regex"
         }
       ]
     },
@@ -29477,6 +34204,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-root"
+        }
       ]
     },
     {
@@ -29509,6 +34242,12 @@
           "url": "https://github.com/component/path-to-regexp.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-to-regexp"
         }
       ]
     },
@@ -29554,6 +34293,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pdfkit"
+        }
       ]
     },
     {
@@ -29593,6 +34338,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/peek-readable"
+        }
       ]
     },
     {
@@ -29631,6 +34382,12 @@
           "url": "git://github.com/andrewrk/node-pend.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pend"
         }
       ]
     },
@@ -29676,6 +34433,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/performance-now"
+        }
       ]
     },
     {
@@ -29719,6 +34482,12 @@
           "url": "https://github.com/brianc/node-postgres/tree/master/packages/pg-connection-string",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pg-connection-string"
         }
       ]
     },
@@ -29764,6 +34533,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/picomatch"
+        }
       ]
     },
     {
@@ -29797,6 +34572,12 @@
           "url": "sindresorhus/pify",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pify"
         }
       ]
     },
@@ -29832,6 +34613,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pinkie-promise"
+        }
       ]
     },
     {
@@ -29866,6 +34653,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pinkie"
+        }
       ]
     },
     {
@@ -29897,6 +34690,12 @@
           "url": "https://github.com/devongovett/png.js.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/png-js"
         }
       ]
     },
@@ -29940,6 +34739,12 @@
           "url": "https://github.com/baalexander/node-portscanner",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/portscanner"
         }
       ]
     },
@@ -29985,6 +34790,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/posix-character-classes"
+        }
       ]
     },
     {
@@ -30029,6 +34840,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/prebuild-install"
+        }
       ]
     },
     {
@@ -30042,6 +34859,14 @@
         {
           "alg": "SHA-512",
           "content": "112176dd5e12286ea55521998183696ec89a02475a6fa6603b17b9da9efe2a27775b7bb76f147855f77fa36d5d98dee34add08c20678bf9314776e8512d5c4f7"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://raw.github.com/gkz/prelude-ls/master/LICENSE"
+          }
         }
       ],
       "purl": "pkg:npm/prelude-ls@1.1.2",
@@ -30065,6 +34890,12 @@
           "url": "http://preludels.com",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/prelude-ls"
         }
       ]
     },
@@ -30100,6 +34931,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/prepend-http"
+        }
       ]
     },
     {
@@ -30133,6 +34970,12 @@
           "url": "sindresorhus/pretty-bytes",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pretty-bytes"
         }
       ]
     },
@@ -30177,6 +35020,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/process-nextick-args"
+        }
       ]
     },
     {
@@ -30215,6 +35064,12 @@
           "url": "https://github.com/siimon/prom-client",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/prom-client"
         }
       ]
     },
@@ -30260,6 +35115,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/promise-inflight"
+        }
       ]
     },
     {
@@ -30300,6 +35161,12 @@
           "comment": "as detected from PackageJson property \"repository.url\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/promise-retry"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -30337,6 +35204,12 @@
               "url": "git://github.com/IndigoUnited/js-err-code.git",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/promise-retry/node_modules/err-code"
             }
           ]
         },
@@ -30377,6 +35250,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/promise-retry/node_modules/retry"
+            }
           ]
         }
       ]
@@ -30412,6 +35291,12 @@
           "url": "https://github.com/then/promise.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/promise"
         }
       ]
     },
@@ -30452,6 +35337,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/proper-lockfile"
+        }
       ]
     },
     {
@@ -30485,6 +35376,12 @@
           "url": "jshttp/proxy-addr",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/proxy-addr"
         }
       ]
     },
@@ -30520,6 +35417,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/psl"
+        }
       ]
     },
     {
@@ -30553,6 +35456,12 @@
           "url": "https://github.com/pugjs/pug/tree/master/packages/pug-attrs",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-attrs"
         }
       ]
     },
@@ -30588,6 +35497,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-code-gen"
+        }
       ]
     },
     {
@@ -30621,6 +35536,12 @@
           "url": "https://github.com/pugjs/pug/tree/master/packages/pug-error",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-error"
         }
       ]
     },
@@ -30656,6 +35577,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-filters"
+        }
       ]
     },
     {
@@ -30689,6 +35616,12 @@
           "url": "https://github.com/pugjs/pug/tree/master/packages/pug-lexer",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-lexer"
         }
       ]
     },
@@ -30724,6 +35657,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-linker"
+        }
       ]
     },
     {
@@ -30757,6 +35696,12 @@
           "url": "https://github.com/pugjs/pug/tree/master/packages/pug-load",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-load"
         }
       ]
     },
@@ -30792,6 +35737,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-parser"
+        }
       ]
     },
     {
@@ -30825,6 +35776,12 @@
           "url": "https://github.com/pugjs/pug/tree/master/packages/pug-runtime",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-runtime"
         }
       ]
     },
@@ -30860,6 +35817,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-strip-comments"
+        }
       ]
     },
     {
@@ -30893,6 +35856,12 @@
           "url": "https://github.com/pugjs/pug/tree/master/packages/pug-walk",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-walk"
         }
       ]
     },
@@ -30933,6 +35902,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug"
+        }
       ]
     },
     {
@@ -30966,6 +35941,12 @@
           "url": "git://github.com/mafintosh/pump.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pump"
         }
       ]
     },
@@ -31011,6 +35992,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/punycode"
+        }
       ]
     },
     {
@@ -31049,6 +36036,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/qs"
+        }
       ]
     },
     {
@@ -31082,6 +36075,12 @@
           "url": "sindresorhus/query-string",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/query-string"
         }
       ]
     },
@@ -31117,6 +36116,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/range_check"
+        }
       ]
     },
     {
@@ -31150,6 +36155,12 @@
           "url": "jshttp/range-parser",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/range-parser"
         }
       ]
     },
@@ -31185,6 +36196,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/raw-body"
+        }
       ]
     },
     {
@@ -31216,6 +36233,12 @@
           "url": "https://github.com/dominictarr/rc.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/rc"
         }
       ]
     },
@@ -31252,6 +36275,12 @@
           "comment": "as detected from PackageJson property \"repository\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/read-pkg"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -31284,6 +36313,12 @@
               "url": "sindresorhus/pify",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/read-pkg/node_modules/pify"
             }
           ]
         }
@@ -31319,6 +36354,12 @@
           "url": "git://github.com/nodejs/readable-stream",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/readable-stream"
         }
       ],
       "components": [
@@ -31358,6 +36399,12 @@
               "url": "https://github.com/juliangruber/isarray",
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/readable-stream/node_modules/isarray"
             }
           ]
         }
@@ -31401,6 +36448,12 @@
           "comment": "as detected from PackageJson property \"repository\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/readable-web-to-node-stream"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -31432,6 +36485,12 @@
               "url": "git://github.com/nodejs/readable-stream",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/readable-web-to-node-stream/node_modules/readable-stream"
             }
           ]
         }
@@ -31479,6 +36538,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/readdirp"
+        }
       ]
     },
     {
@@ -31512,6 +36577,12 @@
           "url": "gulpjs/rechoir",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/rechoir"
         }
       ]
     },
@@ -31557,6 +36628,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/regex-not"
+        }
       ]
     },
     {
@@ -31590,6 +36667,12 @@
           "url": "git://github.com/es-shims/RegExp.prototype.flags.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/regexp.prototype.flags"
         }
       ]
     },
@@ -31635,6 +36718,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/remove-trailing-separator"
+        }
       ]
     },
     {
@@ -31678,6 +36767,12 @@
           "url": "https://github.com/jonschlinkert/repeat-element",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/repeat-element"
         }
       ]
     },
@@ -31723,6 +36818,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/repeat-string"
+        }
       ]
     },
     {
@@ -31758,6 +36859,12 @@
           "comment": "as detected from PackageJson property \"repository.url\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/replace"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -31790,6 +36897,12 @@
               "url": "chalk/ansi-regex",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/ansi-regex"
             }
           ]
         },
@@ -31824,6 +36937,12 @@
               "url": "chalk/ansi-styles",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/ansi-styles"
             }
           ]
         },
@@ -31864,6 +36983,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/brace-expansion"
+            }
           ]
         },
         {
@@ -31898,6 +37023,12 @@
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/cliui"
+            }
           ]
         },
         {
@@ -31931,6 +37062,12 @@
               "url": "Qix-/color-convert",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/color-convert"
             }
           ]
         },
@@ -31976,6 +37113,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/color-name"
+            }
           ]
         },
         {
@@ -32009,6 +37152,12 @@
               "url": "sindresorhus/find-up",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/find-up"
             }
           ]
         },
@@ -32044,6 +37193,12 @@
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/is-fullwidth-code-point"
+            }
           ]
         },
         {
@@ -32077,6 +37232,12 @@
               "url": "sindresorhus/locate-path",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/locate-path"
             }
           ]
         },
@@ -32112,6 +37273,12 @@
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/minimatch"
+            }
           ]
         },
         {
@@ -32145,6 +37312,12 @@
               "url": "sindresorhus/p-locate",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/p-locate"
             }
           ]
         },
@@ -32180,6 +37353,12 @@
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/path-exists"
+            }
           ]
         },
         {
@@ -32213,6 +37392,12 @@
               "url": "sindresorhus/string-width",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/string-width"
             }
           ]
         },
@@ -32248,6 +37433,12 @@
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/strip-ansi"
+            }
           ]
         },
         {
@@ -32282,6 +37473,12 @@
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/wrap-ansi"
+            }
           ]
         },
         {
@@ -32315,6 +37512,12 @@
               "url": "https://github.com/yargs/yargs-parser.git",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/yargs-parser"
             }
           ]
         },
@@ -32353,6 +37556,12 @@
               "url": "https://yargs.js.org/",
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/yargs"
             }
           ]
         }
@@ -32396,6 +37605,12 @@
           "comment": "as detected from PackageJson property \"repository.url\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/request"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -32432,6 +37647,12 @@
               "url": "https://github.com/ljharb/qs",
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/request/node_modules/qs"
             }
           ]
         }
@@ -32479,6 +37700,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/require-directory"
+        }
       ]
     },
     {
@@ -32522,6 +37749,12 @@
           "url": "https://github.com/yargs/require-main-filename#readme",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/require-main-filename"
         }
       ]
     },
@@ -32567,6 +37800,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/resolve-dir"
+        }
       ]
     },
     {
@@ -32600,6 +37839,12 @@
           "url": "lydell/resolve-url",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/resolve-url"
         }
       ]
     },
@@ -32635,6 +37880,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/resolve"
+        }
       ]
     },
     {
@@ -32668,6 +37919,12 @@
           "url": "https://github.com/lukechilds/responselike.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/responselike"
         }
       ]
     },
@@ -32713,6 +37970,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/restructure"
+        }
       ]
     },
     {
@@ -32746,6 +38009,12 @@
           "url": "git://github.com/fent/ret.js.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ret"
         }
       ]
     },
@@ -32791,6 +38060,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/retry-as-promised"
+        }
       ]
     },
     {
@@ -32830,6 +38105,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/retry"
+        }
       ]
     },
     {
@@ -32863,6 +38144,12 @@
           "url": "git://github.com/isaacs/rimraf.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/rimraf"
         }
       ]
     },
@@ -32909,6 +38196,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/rxjs"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -32951,6 +38244,12 @@
               "url": "https://www.typescriptlang.org/",
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/rxjs/node_modules/tslib"
             }
           ]
         }
@@ -32998,6 +38297,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safe-buffer"
+        }
       ]
     },
     {
@@ -33036,6 +38341,12 @@
           "url": "https://github.com/substack/safe-regex",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safe-regex"
         }
       ]
     },
@@ -33081,6 +38392,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safe-stable-stringify"
+        }
       ]
     },
     {
@@ -33120,6 +38437,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safer-buffer"
+        }
       ]
     },
     {
@@ -33151,6 +38474,12 @@
           "url": "http://busterjs.org/docs/buster-assertions",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/samsam"
         }
       ]
     },
@@ -33186,6 +38515,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sanitize-filename"
+        }
       ]
     },
     {
@@ -33219,6 +38554,12 @@
           "url": "https://github.com/punkave/sanitize-html.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sanitize-html"
         }
       ],
       "components": [
@@ -33264,6 +38605,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sanitize-html/node_modules/lodash"
+            }
           ]
         }
       ]
@@ -33300,6 +38647,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sax"
+        }
       ]
     },
     {
@@ -33332,6 +38685,12 @@
           "url": "https://github.com/cscott/seek-bzip.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/seek-bzip"
         }
       ]
     },
@@ -33366,6 +38725,12 @@
           "url": "https://github.com/npm/node-semver.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/semver"
         }
       ]
     },
@@ -33402,6 +38767,12 @@
           "comment": "as detected from PackageJson property \"repository\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/send"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -33433,6 +38804,12 @@
               "url": "vercel/ms",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/send/node_modules/ms"
             }
           ]
         }
@@ -33469,6 +38846,12 @@
           "url": "http://github.com/sushantdhiman/sequelize-pool.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sequelize-pool"
         }
       ]
     },
@@ -33514,6 +38897,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sequelize"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -33546,6 +38935,12 @@
               "url": "git://github.com/debug-js/debug.git",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sequelize/node_modules/debug"
             }
           ]
         },
@@ -33580,6 +38975,12 @@
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sequelize/node_modules/ms"
+            }
           ]
         },
         {
@@ -33612,6 +39013,12 @@
               "url": "https://github.com/uuidjs/uuid.git",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sequelize/node_modules/uuid"
             }
           ]
         }
@@ -33650,6 +39057,12 @@
           "comment": "as detected from PackageJson property \"repository\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/serve-index"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -33682,6 +39095,12 @@
               "url": "dougwilson/nodejs-depd",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index/node_modules/depd"
             }
           ]
         },
@@ -33717,6 +39136,12 @@
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index/node_modules/http-errors"
+            }
           ]
         },
         {
@@ -33749,6 +39174,12 @@
               "url": "git://github.com/isaacs/inherits",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index/node_modules/inherits"
             }
           ]
         },
@@ -33794,6 +39225,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index/node_modules/setprototypeof"
+            }
           ]
         },
         {
@@ -33826,6 +39263,12 @@
               "url": "jshttp/statuses",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index/node_modules/statuses"
             }
           ]
         }
@@ -33862,6 +39305,12 @@
           "url": "expressjs/serve-static",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/serve-static"
         }
       ]
     },
@@ -33906,6 +39355,12 @@
           "url": "https://github.com/yargs/set-blocking#readme",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/set-blocking"
         }
       ]
     },
@@ -33952,6 +39407,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/set-value"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -33994,6 +39455,12 @@
               "url": "https://github.com/jonschlinkert/extend-shallow",
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/set-value/node_modules/extend-shallow"
             }
           ]
         },
@@ -34039,6 +39506,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/set-value/node_modules/is-extendable"
+            }
           ]
         }
       ]
@@ -34074,6 +39547,12 @@
           "url": "YuzuJS/setImmediate",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/setimmediate"
         }
       ]
     },
@@ -34119,6 +39598,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/setprototypeof"
+        }
       ]
     },
     {
@@ -34162,6 +39647,12 @@
           "url": "https://github.com/ljharb/side-channel#readme",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/side-channel"
         }
       ]
     },
@@ -34207,6 +39698,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/signal-exit"
+        }
       ]
     },
     {
@@ -34250,6 +39747,12 @@
           "url": "https://github.com/feross/simple-concat",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/simple-concat"
         }
       ]
     },
@@ -34296,6 +39799,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/simple-get"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -34328,6 +39837,12 @@
               "url": "sindresorhus/decompress-response",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/simple-get/node_modules/decompress-response"
             }
           ]
         },
@@ -34362,6 +39877,12 @@
               "url": "sindresorhus/mimic-response",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/simple-get/node_modules/mimic-response"
             }
           ]
         }
@@ -34400,6 +39921,12 @@
           "comment": "as detected from PackageJson property \"repository\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/simple-swizzle"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -34432,6 +39959,12 @@
               "url": "https://github.com/qix-/node-is-arrayish.git",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/simple-swizzle/node_modules/is-arrayish"
             }
           ]
         }
@@ -34479,6 +40012,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sinon"
+        }
       ]
     },
     {
@@ -34522,6 +40061,12 @@
           "url": "https://github.com/JoshGlazebrook/smart-buffer/",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/smart-buffer"
         }
       ]
     },
@@ -34568,6 +40113,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/snapdragon-node"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -34610,6 +40161,12 @@
               "url": "https://github.com/jonschlinkert/define-property",
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon-node/node_modules/define-property"
             }
           ]
         }
@@ -34658,6 +40215,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/snapdragon-util"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -34700,6 +40263,12 @@
               "url": "https://github.com/jonschlinkert/kind-of",
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon-util/node_modules/kind-of"
             }
           ]
         }
@@ -34748,6 +40317,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/snapdragon"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -34790,6 +40365,12 @@
               "url": "https://github.com/jonschlinkert/define-property",
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/define-property"
             }
           ]
         },
@@ -34834,6 +40415,12 @@
               "url": "https://github.com/jonschlinkert/extend-shallow",
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/extend-shallow"
             }
           ]
         },
@@ -34880,6 +40467,12 @@
               "comment": "as detected from PackageJson property \"homepage\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/is-accessor-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -34922,6 +40515,12 @@
                   "url": "https://github.com/jonschlinkert/kind-of",
                   "type": "website",
                   "comment": "as detected from PackageJson property \"homepage\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/snapdragon/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -34970,6 +40569,12 @@
               "comment": "as detected from PackageJson property \"homepage\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/is-data-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -35012,6 +40617,12 @@
                   "url": "https://github.com/jonschlinkert/kind-of",
                   "type": "website",
                   "comment": "as detected from PackageJson property \"homepage\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/snapdragon/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -35059,6 +40670,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/is-descriptor"
+            }
           ]
         },
         {
@@ -35102,6 +40719,12 @@
               "url": "https://github.com/jonschlinkert/is-extendable",
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/is-extendable"
             }
           ]
         },
@@ -35147,6 +40770,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/kind-of"
+            }
           ]
         },
         {
@@ -35186,6 +40815,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/source-map"
+            }
           ]
         }
       ]
@@ -35221,6 +40856,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socket.io-adapter"
+        }
       ]
     },
     {
@@ -35253,6 +40894,12 @@
           "url": "https://github.com/socketio/socket.io-parser.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socket.io-parser"
         }
       ],
       "components": [
@@ -35288,6 +40935,12 @@
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socket.io-parser/node_modules/debug"
+            }
           ]
         },
         {
@@ -35320,6 +40973,12 @@
               "url": "zeit/ms",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socket.io-parser/node_modules/ms"
             }
           ]
         }
@@ -35357,6 +41016,12 @@
           "comment": "as detected from PackageJson property \"repository.url\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socket.io"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -35390,6 +41055,12 @@
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socket.io/node_modules/debug"
+            }
           ]
         },
         {
@@ -35422,6 +41093,12 @@
               "url": "zeit/ms",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socket.io/node_modules/ms"
             }
           ]
         }
@@ -35470,6 +41147,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socks-proxy-agent"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -35503,6 +41186,12 @@
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socks-proxy-agent/node_modules/debug"
+            }
           ]
         },
         {
@@ -35535,6 +41224,12 @@
               "url": "zeit/ms",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socks-proxy-agent/node_modules/ms"
             }
           ]
         }
@@ -35583,6 +41278,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socks"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -35619,6 +41320,12 @@
               "url": "https://github.com/indutny/node-ip",
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socks/node_modules/ip"
             }
           ]
         }
@@ -35657,6 +41364,12 @@
           "comment": "as detected from PackageJson property \"repository\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sort-keys-length"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -35689,6 +41402,12 @@
               "url": "sindresorhus/sort-keys",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sort-keys-length/node_modules/sort-keys"
             }
           ]
         }
@@ -35726,6 +41445,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sort-keys"
+        }
       ]
     },
     {
@@ -35759,6 +41484,12 @@
           "url": "lydell/source-map-resolve",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/source-map-resolve"
         }
       ]
     },
@@ -35798,6 +41529,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/source-map-support"
+        }
       ]
     },
     {
@@ -35831,6 +41568,12 @@
           "url": "lydell/source-map-url",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/source-map-url"
         }
       ]
     },
@@ -35871,6 +41614,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/source-map"
+        }
       ]
     },
     {
@@ -35904,6 +41653,12 @@
           "url": "https://github.com/mmalecki/spawn-command",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spawn-command"
         }
       ]
     },
@@ -35939,6 +41694,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spdx-correct"
+        }
       ]
     },
     {
@@ -35972,6 +41733,12 @@
           "url": "kemitchell/spdx-exceptions.json",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spdx-exceptions"
         }
       ]
     },
@@ -36007,6 +41774,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spdx-expression-parse"
+        }
       ]
     },
     {
@@ -36040,6 +41813,12 @@
           "url": "jslicense/spdx-license-ids",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spdx-license-ids"
         }
       ]
     },
@@ -36085,6 +41864,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/split-string"
+        }
       ]
     },
     {
@@ -36118,6 +41903,12 @@
           "url": "https://github.com/alexei/sprintf.js.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sprintf-js"
         }
       ]
     },
@@ -36157,6 +41948,12 @@
           "url": "https://github.com/TryGhost/node-sqlite3",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sqlite3"
         }
       ]
     },
@@ -36202,6 +41999,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sshpk"
+        }
       ]
     },
     {
@@ -36235,6 +42038,12 @@
           "url": "https://github.com/npm/ssri",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ssri"
         }
       ]
     },
@@ -36274,6 +42083,12 @@
           "url": "https://github.com/felixge/node-stack-trace",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/stack-trace"
         }
       ]
     },
@@ -36320,6 +42135,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/static-extend"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -36362,6 +42183,12 @@
               "url": "https://github.com/jonschlinkert/define-property",
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend/node_modules/define-property"
             }
           ]
         },
@@ -36408,6 +42235,12 @@
               "comment": "as detected from PackageJson property \"homepage\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend/node_modules/is-accessor-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -36450,6 +42283,12 @@
                   "url": "https://github.com/jonschlinkert/kind-of",
                   "type": "website",
                   "comment": "as detected from PackageJson property \"homepage\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/static-extend/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -36498,6 +42337,12 @@
               "comment": "as detected from PackageJson property \"homepage\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend/node_modules/is-data-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -36540,6 +42385,12 @@
                   "url": "https://github.com/jonschlinkert/kind-of",
                   "type": "website",
                   "comment": "as detected from PackageJson property \"homepage\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/static-extend/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -36587,6 +42438,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend/node_modules/is-descriptor"
+            }
           ]
         },
         {
@@ -36631,6 +42488,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend/node_modules/kind-of"
+            }
           ]
         }
       ]
@@ -36666,6 +42529,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/statuses"
+        }
       ]
     },
     {
@@ -36700,6 +42569,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/stream-buffers"
+        }
       ]
     },
     {
@@ -36715,6 +42590,14 @@
           "content": "8e8b3cbbef892a6d0045c4944c06573950b4992a31ec1867eac060b72ef73f57f72467fbc86d9c9536c134751d75efe476f3f614449a9bebccea5f2306b3711c"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "http://github.com/mscdex/streamsearch/raw/master/LICENSE"
+          }
+        }
+      ],
       "purl": "pkg:npm/streamsearch@0.1.2",
       "externalReferences": [
         {
@@ -36726,6 +42609,12 @@
           "url": "http://github.com/mscdex/streamsearch.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/streamsearch"
         }
       ]
     },
@@ -36760,6 +42649,12 @@
           "url": "kevva/strict-uri-encode",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strict-uri-encode"
         }
       ]
     },
@@ -36799,6 +42694,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string_decoder"
+        }
       ]
     },
     {
@@ -36833,6 +42734,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string-width"
+        }
       ]
     },
     {
@@ -36846,6 +42753,14 @@
         {
           "alg": "SHA-512",
           "content": "9faf47df53a7c5219267265b80196f6085e5acc849434750017d63b354038696941face6537418963d3b6c2c023653cebb7a115c8b9b18f9768031a71ec882aa"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "http://mths.be/mit"
+          }
         }
       ],
       "purl": "pkg:npm/string.fromcodepoint@0.2.1",
@@ -36869,6 +42784,12 @@
           "url": "http://mths.be/fromcodepoint",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string.fromcodepoint"
         }
       ]
     },
@@ -36914,6 +42835,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string.prototype.codepointat"
+        }
       ]
     },
     {
@@ -36947,6 +42874,12 @@
           "url": "chalk/strip-ansi",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-ansi"
         }
       ]
     },
@@ -36982,6 +42915,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-bom"
+        }
       ]
     },
     {
@@ -37015,6 +42954,12 @@
           "url": "shinnn/node-strip-dirs",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-dirs"
         }
       ]
     },
@@ -37050,6 +42995,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-json-comments"
+        }
       ]
     },
     {
@@ -37083,6 +43034,12 @@
           "url": "sindresorhus/strip-outer",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-outer"
         }
       ]
     },
@@ -37123,6 +43080,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strtok3"
+        }
       ]
     },
     {
@@ -37156,6 +43119,12 @@
           "url": "chalk/supports-color",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/supports-color"
         }
       ]
     },
@@ -37201,6 +43170,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/supports-preserve-symlinks-flag"
+        }
       ]
     },
     {
@@ -37245,6 +43220,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/svg-captcha"
+        }
       ]
     },
     {
@@ -37276,6 +43257,12 @@
           "url": "git@github.com:swagger-api/swagger-ui.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/swagger-ui-dist"
         }
       ]
     },
@@ -37320,6 +43307,12 @@
           "url": "https://github.com/scottie1984/swagger-ui-express",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/swagger-ui-express"
         }
       ]
     },
@@ -37366,6 +43359,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tar-fs"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -37403,6 +43402,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/tar-fs/node_modules/bl"
+            }
           ]
         },
         {
@@ -37437,6 +43442,12 @@
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/tar-fs/node_modules/chownr"
+            }
           ]
         },
         {
@@ -37469,6 +43480,12 @@
               "url": "git://github.com/nodejs/readable-stream",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/tar-fs/node_modules/readable-stream"
             }
           ]
         },
@@ -37513,6 +43530,12 @@
               "url": "https://github.com/mafintosh/tar-stream",
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/tar-fs/node_modules/tar-stream"
             }
           ]
         }
@@ -37560,6 +43583,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tar-stream"
+        }
       ]
     },
     {
@@ -37593,6 +43622,12 @@
           "url": "https://github.com/npm/node-tar.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tar"
         }
       ]
     },
@@ -37638,6 +43673,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tdigest"
+        }
       ]
     },
     {
@@ -37682,6 +43723,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/text-hex"
+        }
       ]
     },
     {
@@ -37708,6 +43755,12 @@
           "url": "git://github.com/chrisumbel/thirty-two.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/thirty-two"
         }
       ]
     },
@@ -37748,6 +43801,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/through"
+        }
       ]
     },
     {
@@ -37781,6 +43840,12 @@
           "url": "floatdrop/timed-out",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/timed-out"
         }
       ]
     },
@@ -37826,6 +43891,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tiny-inflate"
+        }
       ]
     },
     {
@@ -37870,6 +43941,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-buffer"
+        }
       ]
     },
     {
@@ -37903,6 +43980,12 @@
           "url": "sindresorhus/to-fast-properties",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-fast-properties"
         }
       ]
     },
@@ -37949,6 +44032,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-object-path"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -37991,6 +44080,12 @@
               "url": "https://github.com/jonschlinkert/kind-of",
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/to-object-path/node_modules/kind-of"
             }
           ]
         }
@@ -38038,6 +44133,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-regex-range"
+        }
       ]
     },
     {
@@ -38082,6 +44183,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-regex"
+        }
       ]
     },
     {
@@ -38116,6 +44223,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/toidentifier"
+        }
       ]
     },
     {
@@ -38149,6 +44262,12 @@
           "url": "https://github.com/pugjs/token-stream.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/token-stream"
         }
       ]
     },
@@ -38189,6 +44308,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/token-types"
+        }
       ]
     },
     {
@@ -38221,6 +44346,12 @@
           "url": "https://github.com/gustavohenke/toposort.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/toposort-class"
         }
       ]
     },
@@ -38266,6 +44397,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tough-cookie"
+        }
       ]
     },
     {
@@ -38310,6 +44447,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tr46"
+        }
       ]
     },
     {
@@ -38343,6 +44486,12 @@
           "url": "http://github.com/substack/js-traverse.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/traverse"
         }
       ]
     },
@@ -38383,6 +44532,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tree-kill"
+        }
       ]
     },
     {
@@ -38416,6 +44571,12 @@
           "url": "sindresorhus/trim-repeated",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/trim-repeated"
         }
       ]
     },
@@ -38461,6 +44622,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/triple-beam"
+        }
       ]
     },
     {
@@ -38505,6 +44672,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/truncate-utf8-bytes"
+        }
       ]
     },
     {
@@ -38539,6 +44712,12 @@
           "comment": "as detected from PackageJson property \"repository.url\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ts-node-dev"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -38571,6 +44750,12 @@
               "url": "git://github.com/isaacs/rimraf.git",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/ts-node-dev/node_modules/rimraf"
             }
           ]
         }
@@ -38618,6 +44803,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ts-node"
+        }
       ]
     },
     {
@@ -38661,6 +44852,12 @@
           "url": "https://github.com/TypeStrong/tsconfig",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tsconfig"
         }
       ]
     },
@@ -38706,6 +44903,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tslib"
+        }
       ]
     },
     {
@@ -38739,6 +44942,12 @@
           "url": "https://github.com/mikeal/tunnel-agent",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tunnel-agent"
         }
       ]
     },
@@ -38784,6 +44993,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tweetnacl"
+        }
       ]
     },
     {
@@ -38828,6 +45043,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/type-check"
+        }
       ]
     },
     {
@@ -38861,6 +45082,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/type-is"
+        }
       ]
     },
     {
@@ -38893,6 +45120,12 @@
           "url": "https://github.com/eivindfjeldstad/typecast.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/typecast"
         }
       ]
     },
@@ -38932,6 +45165,12 @@
           "url": "https://github.com/substack/typedarray",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/typedarray"
         }
       ]
     },
@@ -38977,6 +45216,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/typescript"
+        }
       ]
     },
     {
@@ -39010,6 +45255,12 @@
           "url": "mishoo/UglifyJS",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/uglify-js"
         }
       ]
     },
@@ -39049,6 +45300,12 @@
           "url": "https://github.com/regular/unbzip2-stream.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unbzip2-stream"
         }
       ]
     },
@@ -39094,6 +45351,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unc-path-regex"
+        }
       ]
     },
     {
@@ -39136,6 +45399,12 @@
           "url": "http://epeli.github.com/underscore.string/",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/underscore.string"
         }
       ]
     },
@@ -39181,6 +45450,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unicode-properties"
+        }
       ]
     },
     {
@@ -39224,6 +45499,12 @@
           "url": "https://github.com/devongovett/unicode-trie",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unicode-trie"
         }
       ]
     },
@@ -39270,6 +45551,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/union-value"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -39312,6 +45599,12 @@
               "url": "https://github.com/jonschlinkert/is-extendable",
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/union-value/node_modules/is-extendable"
             }
           ]
         }
@@ -39359,6 +45652,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unique-filename"
+        }
       ]
     },
     {
@@ -39392,6 +45691,12 @@
           "url": "git://github.com/iarna/unique-slug.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unique-slug"
         }
       ]
     },
@@ -39437,6 +45742,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unit-compare"
+        }
       ]
     },
     {
@@ -39481,6 +45792,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/universalify"
+        }
       ]
     },
     {
@@ -39514,6 +45831,12 @@
           "url": "stream-utils/unpipe",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unpipe"
         }
       ]
     },
@@ -39560,6 +45883,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unset-value"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -39604,6 +45933,12 @@
               "comment": "as detected from PackageJson property \"homepage\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/unset-value/node_modules/has-value"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -39646,6 +45981,12 @@
                   "url": "https://github.com/jonschlinkert/isobject",
                   "type": "website",
                   "comment": "as detected from PackageJson property \"homepage\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/unset-value/node_modules/has-value/node_modules/isobject"
                 }
               ]
             }
@@ -39693,6 +46034,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/unset-value/node_modules/has-values"
+            }
           ]
         },
         {
@@ -39732,6 +46079,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/unset-value/node_modules/isarray"
+            }
           ]
         }
       ]
@@ -39768,6 +46121,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/untildify"
+        }
       ]
     },
     {
@@ -39801,6 +46160,12 @@
           "url": "https://github.com/ZJONSSON/node-unzipper.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unzipper"
         }
       ],
       "components": [
@@ -39845,6 +46210,12 @@
               "url": "https://github.com/petkaantonov/bluebird",
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/unzipper/node_modules/bluebird"
             }
           ]
         }
@@ -39892,6 +46263,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/uri-js"
+        }
       ]
     },
     {
@@ -39925,6 +46302,12 @@
           "url": "lydell/urix",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/urix"
         }
       ]
     },
@@ -39960,6 +46343,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/url-parse-lax"
+        }
       ]
     },
     {
@@ -39993,6 +46382,12 @@
           "url": "stevenvachon/url-to-options",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/url-to-options"
         }
       ]
     },
@@ -40038,6 +46433,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/use"
+        }
       ]
     },
     {
@@ -40081,6 +46482,12 @@
           "url": "https://github.com/parshap/utf8-byte-length#readme",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/utf8-byte-length"
         }
       ]
     },
@@ -40126,6 +46533,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/util-deprecate"
+        }
       ]
     },
     {
@@ -40165,6 +46578,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/util"
+        }
       ]
     },
     {
@@ -40185,6 +46604,12 @@
           "license": {
             "id": "MIT"
           }
+        },
+        {
+          "license": {
+            "id": "MIT",
+            "url": "http://opensource.org/licenses/MIT"
+          }
         }
       ],
       "purl": "pkg:npm/utils-merge@1.0.1",
@@ -40203,6 +46628,12 @@
           "url": "git://github.com/jaredhanson/utils-merge.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/utils-merge"
         }
       ]
     },
@@ -40236,6 +46667,12 @@
           "url": "https://github.com/uuidjs/uuid.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/uuid"
         }
       ]
     },
@@ -40271,6 +46708,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/v8flags"
+        }
       ]
     },
     {
@@ -40305,6 +46748,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/validate-npm-package-license"
+        }
       ]
     },
     {
@@ -40338,6 +46787,12 @@
           "url": "eivindfjeldstad/validate",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/validate"
         }
       ]
     },
@@ -40383,6 +46838,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/validator"
+        }
       ]
     },
     {
@@ -40417,6 +46878,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/vary"
+        }
       ]
     },
     {
@@ -40449,6 +46916,12 @@
           "url": "git://github.com/davepacheco/node-verror.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/verror"
         }
       ],
       "components": [
@@ -40489,6 +46962,12 @@
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/verror/node_modules/core-util-is"
+            }
           ]
         }
       ]
@@ -40524,6 +47003,12 @@
           "url": "github:patriksimek/vm2",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/vm2"
         }
       ],
       "components": [
@@ -40562,6 +47047,12 @@
               "url": "https://github.com/acornjs/acorn",
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/vm2/node_modules/acorn"
             }
           ]
         }
@@ -40609,6 +47100,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/void-elements"
+        }
       ]
     },
     {
@@ -40651,6 +47148,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/walk"
+        }
       ]
     },
     {
@@ -40690,6 +47193,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/walkdir"
+        }
       ]
     },
     {
@@ -40724,6 +47233,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/webidl-conversions"
+        }
       ]
     },
     {
@@ -40757,6 +47272,12 @@
           "url": "jsdom/whatwg-url",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/whatwg-url"
         }
       ]
     },
@@ -40802,6 +47323,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-boxed-primitive"
+        }
       ]
     },
     {
@@ -40845,6 +47372,12 @@
           "url": "https://github.com/inspect-js/which-collection#readme",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-collection"
         }
       ]
     },
@@ -40890,6 +47423,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-module"
+        }
       ]
     },
     {
@@ -40934,6 +47473,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-pm-runs"
+        }
       ]
     },
     {
@@ -40967,6 +47512,12 @@
           "url": "git://github.com/inspect-js/which-typed-array.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-typed-array"
         }
       ]
     },
@@ -41002,6 +47553,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which"
+        }
       ]
     },
     {
@@ -41035,6 +47592,12 @@
           "url": "https://github.com/iarna/wide-align",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wide-align"
         }
       ]
     },
@@ -41081,6 +47644,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/winston-transport"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -41112,6 +47681,12 @@
               "url": "git://github.com/nodejs/readable-stream",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/winston-transport/node_modules/readable-stream"
             }
           ]
         }
@@ -41148,6 +47723,12 @@
           "url": "https://github.com/winstonjs/winston.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/winston"
         }
       ],
       "components": [
@@ -41193,6 +47774,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/winston/node_modules/async"
+            }
           ]
         },
         {
@@ -41227,6 +47814,12 @@
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/winston/node_modules/is-stream"
+            }
           ]
         },
         {
@@ -41259,6 +47852,12 @@
               "url": "git://github.com/nodejs/readable-stream",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository.url\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/winston/node_modules/readable-stream"
             }
           ]
         }
@@ -41296,6 +47895,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/with"
+        }
       ]
     },
     {
@@ -41329,6 +47934,12 @@
           "url": "http://github.com/cschwarz/wkx.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wkx"
         }
       ]
     },
@@ -41374,6 +47985,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/word-wrap"
+        }
       ]
     },
     {
@@ -41407,6 +48024,12 @@
           "url": "git://github.com/substack/node-wordwrap.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wordwrap"
         }
       ]
     },
@@ -41443,6 +48066,12 @@
           "comment": "as detected from PackageJson property \"repository\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wrap-ansi"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -41475,6 +48104,12 @@
               "url": "chalk/ansi-regex",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi/node_modules/ansi-regex"
             }
           ]
         },
@@ -41520,6 +48155,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi/node_modules/emoji-regex"
+            }
           ]
         },
         {
@@ -41553,6 +48194,12 @@
               "url": "sindresorhus/is-fullwidth-code-point",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi/node_modules/is-fullwidth-code-point"
             }
           ]
         },
@@ -41588,6 +48235,12 @@
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi/node_modules/string-width"
+            }
           ]
         },
         {
@@ -41621,6 +48274,12 @@
               "url": "chalk/strip-ansi",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi/node_modules/strip-ansi"
             }
           ]
         }
@@ -41668,6 +48327,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wrappy"
+        }
       ]
     },
     {
@@ -41711,6 +48376,12 @@
           "url": "https://github.com/websockets/ws",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ws"
         }
       ]
     },
@@ -41756,6 +48427,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/xtend"
+        }
       ]
     },
     {
@@ -41800,6 +48477,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/y18n"
+        }
       ]
     },
     {
@@ -41833,6 +48516,12 @@
           "url": "git+https://github.com/isaacs/yallist.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yallist"
         }
       ]
     },
@@ -41868,6 +48557,12 @@
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yaml-schema-validator"
+        }
       ]
     },
     {
@@ -41901,6 +48596,12 @@
           "url": "git@github.com:yargs/yargs-parser.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository.url\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yargs-parser"
         }
       ]
     },
@@ -41941,6 +48642,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yargs"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -41973,6 +48680,12 @@
               "url": "chalk/ansi-regex",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs/node_modules/ansi-regex"
             }
           ]
         },
@@ -42018,6 +48731,12 @@
               "type": "website",
               "comment": "as detected from PackageJson property \"homepage\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs/node_modules/emoji-regex"
+            }
           ]
         },
         {
@@ -42051,6 +48770,12 @@
               "url": "sindresorhus/is-fullwidth-code-point",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs/node_modules/is-fullwidth-code-point"
             }
           ]
         },
@@ -42086,6 +48811,12 @@
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs/node_modules/string-width"
+            }
           ]
         },
         {
@@ -42119,6 +48850,12 @@
               "url": "chalk/strip-ansi",
               "type": "vcs",
               "comment": "as detected from PackageJson property \"repository\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs/node_modules/strip-ansi"
             }
           ]
         }
@@ -42166,6 +48903,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yauzl"
+        }
       ]
     },
     {
@@ -42199,6 +48942,12 @@
           "url": "sindresorhus/yn",
           "type": "vcs",
           "comment": "as detected from PackageJson property \"repository\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yn"
         }
       ]
     },
@@ -42244,6 +48993,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/z85"
+        }
       ]
     },
     {
@@ -42288,6 +49043,12 @@
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/zip-stream"
+        }
       ]
     },
     {
@@ -42326,6 +49087,12 @@
           "url": "https://github.com/imaya/zlib.js",
           "type": "website",
           "comment": "as detected from PackageJson property \"homepage\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/zlibjs"
         }
       ]
     }

--- a/demo/juice-shop/example-results/bom.1.4.json
+++ b/demo/juice-shop/example-results/bom.1.4.json
@@ -62,7 +62,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -114,7 +114,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@babel/helper-string-parser"
         }
       ]
@@ -155,7 +155,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@babel/helper-validator-identifier"
         }
       ]
@@ -206,7 +206,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@babel/parser"
         }
       ]
@@ -257,7 +257,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@babel/types"
         }
       ]
@@ -308,7 +308,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@colors/colors"
         }
       ]
@@ -359,7 +359,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@dabh/diagnostics"
         }
       ]
@@ -400,7 +400,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@gar/promisify"
         }
       ]
@@ -441,7 +441,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@mapbox/node-pre-gyp"
         }
       ],
@@ -481,7 +481,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/ansi-regex"
             }
           ]
@@ -531,7 +531,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/are-we-there-yet"
             }
           ]
@@ -571,7 +571,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/detect-libc"
             }
           ]
@@ -621,7 +621,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/gauge"
             }
           ]
@@ -661,7 +661,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -701,7 +701,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/make-dir"
             }
           ],
@@ -740,7 +740,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/@mapbox/node-pre-gyp/node_modules/make-dir/node_modules/semver"
                 }
               ]
@@ -782,7 +782,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/nopt"
             }
           ]
@@ -822,7 +822,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/npmlog"
             }
           ]
@@ -861,7 +861,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/readable-stream"
             }
           ]
@@ -901,7 +901,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/string-width"
             }
           ]
@@ -941,7 +941,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/strip-ansi"
             }
           ]
@@ -989,7 +989,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/core-loader"
         }
       ]
@@ -1035,7 +1035,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/core"
         }
       ]
@@ -1081,7 +1081,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/evaluator"
         }
       ]
@@ -1127,7 +1127,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-all"
         }
       ]
@@ -1173,7 +1173,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ar"
         }
       ]
@@ -1219,7 +1219,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-bn"
         }
       ]
@@ -1265,7 +1265,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ca"
         }
       ]
@@ -1311,7 +1311,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-cs"
         }
       ]
@@ -1357,7 +1357,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-da"
         }
       ]
@@ -1403,7 +1403,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-de"
         }
       ]
@@ -1449,7 +1449,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-el"
         }
       ]
@@ -1495,7 +1495,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-en-min"
         }
       ]
@@ -1541,7 +1541,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-en"
         }
       ]
@@ -1587,7 +1587,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-es"
         }
       ]
@@ -1633,7 +1633,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-eu"
         }
       ]
@@ -1679,7 +1679,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-fa"
         }
       ]
@@ -1725,7 +1725,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-fi"
         }
       ]
@@ -1771,7 +1771,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-fr"
         }
       ]
@@ -1817,7 +1817,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ga"
         }
       ]
@@ -1863,7 +1863,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-gl"
         }
       ]
@@ -1909,7 +1909,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-hi"
         }
       ]
@@ -1955,7 +1955,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-hu"
         }
       ]
@@ -2001,7 +2001,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-hy"
         }
       ]
@@ -2047,7 +2047,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-id"
         }
       ]
@@ -2093,7 +2093,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-it"
         }
       ]
@@ -2139,7 +2139,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ja"
         }
       ]
@@ -2185,7 +2185,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ko"
         }
       ]
@@ -2231,7 +2231,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-lt"
         }
       ]
@@ -2277,7 +2277,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ms"
         }
       ]
@@ -2323,7 +2323,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ne"
         }
       ]
@@ -2369,7 +2369,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-nl"
         }
       ]
@@ -2415,7 +2415,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-no"
         }
       ]
@@ -2461,7 +2461,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-pl"
         }
       ]
@@ -2507,7 +2507,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-pt"
         }
       ]
@@ -2553,7 +2553,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ro"
         }
       ]
@@ -2599,7 +2599,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ru"
         }
       ]
@@ -2645,7 +2645,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-sl"
         }
       ]
@@ -2691,7 +2691,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-sr"
         }
       ]
@@ -2737,7 +2737,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-sv"
         }
       ]
@@ -2783,7 +2783,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ta"
         }
       ]
@@ -2829,7 +2829,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-th"
         }
       ]
@@ -2875,7 +2875,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-tl"
         }
       ]
@@ -2921,7 +2921,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-tr"
         }
       ]
@@ -2967,7 +2967,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-uk"
         }
       ]
@@ -3013,7 +3013,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-zh"
         }
       ]
@@ -3059,7 +3059,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/language-min"
         }
       ]
@@ -3105,7 +3105,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/language"
         }
       ]
@@ -3151,7 +3151,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/ner"
         }
       ]
@@ -3197,7 +3197,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/neural"
         }
       ]
@@ -3243,7 +3243,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/nlg"
         }
       ]
@@ -3289,7 +3289,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/nlp"
         }
       ]
@@ -3335,7 +3335,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/nlu"
         }
       ]
@@ -3381,7 +3381,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/request"
         }
       ]
@@ -3427,7 +3427,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/sentiment"
         }
       ]
@@ -3473,7 +3473,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/similarity"
         }
       ]
@@ -3519,7 +3519,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/slot"
         }
       ]
@@ -3555,7 +3555,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@npmcli/fs"
         }
       ]
@@ -3595,7 +3595,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@npmcli/move-file"
         }
       ]
@@ -3641,7 +3641,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib/core"
         }
       ]
@@ -3687,7 +3687,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib/plugin-crypto"
         }
       ]
@@ -3733,7 +3733,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib/plugin-thirty-two"
         }
       ]
@@ -3779,7 +3779,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib/preset-default"
         }
       ]
@@ -3825,7 +3825,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib/preset-v11"
         }
       ]
@@ -3866,7 +3866,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@sindresorhus/is"
         }
       ]
@@ -3917,7 +3917,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@swc/helpers"
         }
       ]
@@ -3963,7 +3963,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@tokenizer/token"
         }
       ]
@@ -4009,7 +4009,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@tootallnate/once"
         }
       ]
@@ -4054,7 +4054,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/component-emitter"
         }
       ]
@@ -4099,7 +4099,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/cookie"
         }
       ]
@@ -4144,7 +4144,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/cors"
         }
       ]
@@ -4189,7 +4189,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/debug"
         }
       ]
@@ -4229,7 +4229,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/ms"
         }
       ]
@@ -4274,7 +4274,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/node"
         }
       ]
@@ -4315,7 +4315,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/strip-bom"
         }
       ]
@@ -4355,7 +4355,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/strip-json-comments"
         }
       ]
@@ -4400,7 +4400,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/validator"
         }
       ]
@@ -4440,7 +4440,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/abbrev"
         }
       ]
@@ -4479,7 +4479,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/accepts"
         }
       ]
@@ -4523,7 +4523,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/acorn-walk"
         }
       ]
@@ -4567,7 +4567,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/acorn"
         }
       ]
@@ -4612,7 +4612,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/agent-base"
         }
       ],
@@ -4652,7 +4652,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agent-base/node_modules/debug"
             }
           ]
@@ -4691,7 +4691,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agent-base/node_modules/ms"
             }
           ]
@@ -4738,7 +4738,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/agentkeepalive"
         }
       ],
@@ -4778,7 +4778,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agentkeepalive/node_modules/debug"
             }
           ]
@@ -4818,7 +4818,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agentkeepalive/node_modules/depd"
             }
           ]
@@ -4857,7 +4857,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agentkeepalive/node_modules/ms"
             }
           ]
@@ -4899,7 +4899,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/aggregate-error"
         }
       ]
@@ -4949,7 +4949,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ajv"
         }
       ]
@@ -4989,7 +4989,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ansi-regex"
         }
       ]
@@ -5029,7 +5029,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ansi-styles"
         }
       ]
@@ -5074,7 +5074,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/anymatch"
         }
       ],
@@ -5124,7 +5124,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/anymatch/node_modules/normalize-path"
             }
           ]
@@ -5165,7 +5165,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/append-field"
         }
       ]
@@ -5215,7 +5215,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/aproba"
         }
       ]
@@ -5255,7 +5255,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/archive-type"
         }
       ],
@@ -5295,7 +5295,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/archive-type/node_modules/file-type"
             }
           ]
@@ -5347,7 +5347,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/archiver-utils"
         }
       ]
@@ -5397,7 +5397,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/archiver"
         }
       ]
@@ -5447,7 +5447,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/are-we-there-yet"
         }
       ]
@@ -5487,7 +5487,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/arg"
         }
       ]
@@ -5526,7 +5526,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/argparse"
         }
       ],
@@ -5566,7 +5566,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/argparse/node_modules/sprintf-js"
             }
           ]
@@ -5618,7 +5618,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/arr-diff"
         }
       ]
@@ -5668,7 +5668,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/arr-flatten"
         }
       ]
@@ -5718,7 +5718,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/arr-union"
         }
       ]
@@ -5768,7 +5768,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/array-each"
         }
       ]
@@ -5818,7 +5818,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/array-flatten"
         }
       ]
@@ -5868,7 +5868,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/array-slice"
         }
       ]
@@ -5918,7 +5918,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/array-unique"
         }
       ]
@@ -5957,7 +5957,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/asap"
         }
       ]
@@ -5997,7 +5997,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/asn1"
         }
       ]
@@ -6037,7 +6037,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/assert-never"
         }
       ]
@@ -6077,7 +6077,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/assert-plus"
         }
       ]
@@ -6127,7 +6127,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/assign-symbols"
         }
       ]
@@ -6177,7 +6177,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/async"
         }
       ]
@@ -6227,7 +6227,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/asynckit"
         }
       ]
@@ -6277,7 +6277,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/at-least-node"
         }
       ]
@@ -6320,7 +6320,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/atob"
         }
       ]
@@ -6370,7 +6370,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/available-typed-arrays"
         }
       ]
@@ -6410,7 +6410,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/aws-sign2"
         }
       ]
@@ -6450,7 +6450,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/aws4"
         }
       ]
@@ -6490,7 +6490,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/babel-walk"
         }
       ]
@@ -6535,7 +6535,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/balanced-match"
         }
       ]
@@ -6585,7 +6585,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base"
         }
       ],
@@ -6635,7 +6635,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/base/node_modules/define-property"
             }
           ]
@@ -6688,7 +6688,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base64-arraybuffer"
         }
       ]
@@ -6738,7 +6738,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base64-js"
         }
       ]
@@ -6778,7 +6778,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base64id"
         }
       ]
@@ -6818,7 +6818,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base64url"
         }
       ]
@@ -6857,7 +6857,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/basic-auth"
         }
       ]
@@ -6897,7 +6897,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/batch"
         }
       ]
@@ -6936,7 +6936,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bcrypt-pbkdf"
         }
       ]
@@ -6976,7 +6976,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/big-integer"
         }
       ]
@@ -7016,7 +7016,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/binary-extensions"
         }
       ]
@@ -7056,7 +7056,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/binary"
         }
       ]
@@ -7106,7 +7106,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bindings"
         }
       ]
@@ -7146,7 +7146,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bintrees"
         }
       ]
@@ -7190,7 +7190,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bl"
         }
       ]
@@ -7240,7 +7240,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bluebird"
         }
       ]
@@ -7279,7 +7279,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/body-parser"
         }
       ]
@@ -7324,7 +7324,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bower-config"
         }
       ],
@@ -7369,7 +7369,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bower-config/node_modules/minimist"
             }
           ]
@@ -7416,7 +7416,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/brace-expansion"
         }
       ]
@@ -7466,7 +7466,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/braces"
         }
       ],
@@ -7516,7 +7516,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/braces/node_modules/extend-shallow"
             }
           ]
@@ -7566,7 +7566,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/braces/node_modules/is-extendable"
             }
           ]
@@ -7618,7 +7618,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/brotli"
         }
       ]
@@ -7656,7 +7656,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-alloc-unsafe"
         }
       ]
@@ -7694,7 +7694,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-alloc"
         }
       ]
@@ -7745,7 +7745,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-crc32"
         }
       ]
@@ -7783,7 +7783,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-fill"
         }
       ]
@@ -7821,7 +7821,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-from"
         }
       ]
@@ -7871,7 +7871,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-indexof-polyfill"
         }
       ]
@@ -7921,7 +7921,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer"
         }
       ]
@@ -7954,7 +7954,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffers"
         }
       ]
@@ -7995,7 +7995,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/busboy"
         }
       ],
@@ -8040,7 +8040,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/busboy/node_modules/isarray"
             }
           ]
@@ -8080,7 +8080,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/busboy/node_modules/readable-stream"
             }
           ]
@@ -8124,7 +8124,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/busboy/node_modules/string_decoder"
             }
           ]
@@ -8176,7 +8176,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/byline"
         }
       ]
@@ -8216,7 +8216,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bytes"
         }
       ]
@@ -8255,7 +8255,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cacache"
         }
       ]
@@ -8305,7 +8305,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cache-base"
         }
       ]
@@ -8355,7 +8355,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cacheable-request"
         }
       ],
@@ -8395,7 +8395,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cacheable-request/node_modules/get-stream"
             }
           ]
@@ -8435,7 +8435,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cacheable-request/node_modules/lowercase-keys"
             }
           ]
@@ -8487,7 +8487,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/call-bind"
         }
       ]
@@ -8527,7 +8527,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/camelcase"
         }
       ]
@@ -8572,7 +8572,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/caseless"
         }
       ]
@@ -8612,7 +8612,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/chainsaw"
         }
       ]
@@ -8651,7 +8651,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/chalk"
         }
       ]
@@ -8691,7 +8691,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/character-parser"
         }
       ]
@@ -8741,7 +8741,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/check-dependencies"
         }
       ],
@@ -8780,7 +8780,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/check-dependencies/node_modules/semver"
             }
           ]
@@ -8832,7 +8832,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/check-types"
         }
       ]
@@ -8882,7 +8882,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/chokidar"
         }
       ],
@@ -8932,7 +8932,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar/node_modules/braces"
             }
           ]
@@ -8982,7 +8982,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar/node_modules/fill-range"
             }
           ]
@@ -9032,7 +9032,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar/node_modules/is-glob"
             }
           ]
@@ -9082,7 +9082,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar/node_modules/is-number"
             }
           ]
@@ -9132,7 +9132,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar/node_modules/normalize-path"
             }
           ]
@@ -9182,7 +9182,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar/node_modules/to-regex-range"
             }
           ]
@@ -9224,7 +9224,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/chownr"
         }
       ]
@@ -9274,7 +9274,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/clarinet"
         }
       ]
@@ -9324,7 +9324,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/class-utils"
         }
       ],
@@ -9374,7 +9374,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils/node_modules/define-property"
             }
           ]
@@ -9424,7 +9424,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils/node_modules/is-accessor-descriptor"
             }
           ],
@@ -9474,7 +9474,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/class-utils/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
@@ -9526,7 +9526,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils/node_modules/is-data-descriptor"
             }
           ],
@@ -9576,7 +9576,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/class-utils/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
@@ -9628,7 +9628,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils/node_modules/is-descriptor"
             }
           ]
@@ -9678,7 +9678,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils/node_modules/kind-of"
             }
           ]
@@ -9720,7 +9720,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/clean-stack"
         }
       ]
@@ -9760,7 +9760,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cliui"
         }
       ],
@@ -9800,7 +9800,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui/node_modules/ansi-regex"
             }
           ]
@@ -9850,7 +9850,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui/node_modules/emoji-regex"
             }
           ]
@@ -9890,7 +9890,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -9930,7 +9930,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui/node_modules/string-width"
             }
           ]
@@ -9970,7 +9970,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui/node_modules/strip-ansi"
             }
           ]
@@ -10022,7 +10022,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/clone-response"
         }
       ]
@@ -10067,7 +10067,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/clone"
         }
       ]
@@ -10107,7 +10107,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/code-point-at"
         }
       ]
@@ -10157,7 +10157,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/collection-visit"
         }
       ]
@@ -10197,7 +10197,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color-convert"
         }
       ]
@@ -10247,7 +10247,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color-name"
         }
       ]
@@ -10287,7 +10287,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color-string"
         }
       ]
@@ -10327,7 +10327,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color-support"
         }
       ]
@@ -10366,7 +10366,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color"
         }
       ]
@@ -10416,7 +10416,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/colors"
         }
       ]
@@ -10466,7 +10466,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/colorspace"
         }
       ]
@@ -10511,7 +10511,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/combined-stream"
         }
       ]
@@ -10551,7 +10551,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/commander"
         }
       ]
@@ -10590,7 +10590,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/component-emitter"
         }
       ]
@@ -10629,7 +10629,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/component-type"
         }
       ]
@@ -10679,7 +10679,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/compress-commons"
         }
       ]
@@ -10718,7 +10718,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/compressible"
         }
       ]
@@ -10757,7 +10757,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/compression"
         }
       ],
@@ -10797,7 +10797,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/compression/node_modules/bytes"
             }
           ]
@@ -10839,7 +10839,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/concat-map"
         }
       ]
@@ -10884,7 +10884,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/concat-stream"
         }
       ]
@@ -10924,7 +10924,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/concurrently"
         }
       ],
@@ -10964,7 +10964,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/concurrently/node_modules/supports-color"
             }
           ]
@@ -11011,7 +11011,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/config"
         }
       ]
@@ -11051,7 +11051,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/console-control-strings"
         }
       ]
@@ -11091,7 +11091,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/constantinople"
         }
       ]
@@ -11131,7 +11131,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/content-disposition"
         }
       ],
@@ -11181,7 +11181,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/content-disposition/node_modules/safe-buffer"
             }
           ]
@@ -11223,7 +11223,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/content-type"
         }
       ]
@@ -11263,7 +11263,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cookie-parser"
         }
       ]
@@ -11303,7 +11303,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cookie-signature"
         }
       ]
@@ -11343,7 +11343,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cookie"
         }
       ]
@@ -11393,7 +11393,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/copy-descriptor"
         }
       ]
@@ -11438,7 +11438,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/core-util-is"
         }
       ]
@@ -11478,7 +11478,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cors"
         }
       ]
@@ -11528,7 +11528,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/crc"
         }
       ]
@@ -11578,7 +11578,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/crc32-stream"
         }
       ]
@@ -11617,7 +11617,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/create-require"
         }
       ]
@@ -11662,7 +11662,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/crypto-js"
         }
       ]
@@ -11702,7 +11702,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dashdash"
         }
       ]
@@ -11741,7 +11741,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/date-fns"
         }
       ]
@@ -11786,7 +11786,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dateformat"
         }
       ]
@@ -11826,7 +11826,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/debug"
         }
       ]
@@ -11866,7 +11866,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decamelize"
         }
       ]
@@ -11906,7 +11906,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decode-uri-component"
         }
       ]
@@ -11945,7 +11945,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-response"
         }
       ]
@@ -11985,7 +11985,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-tar"
         }
       ],
@@ -12025,7 +12025,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-tar/node_modules/file-type"
             }
           ]
@@ -12067,7 +12067,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-tarbz2"
         }
       ],
@@ -12107,7 +12107,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-tarbz2/node_modules/file-type"
             }
           ]
@@ -12149,7 +12149,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-targz"
         }
       ],
@@ -12189,7 +12189,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-targz/node_modules/file-type"
             }
           ]
@@ -12231,7 +12231,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-unzip"
         }
       ],
@@ -12271,7 +12271,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-unzip/node_modules/file-type"
             }
           ]
@@ -12311,7 +12311,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-unzip/node_modules/get-stream"
             }
           ]
@@ -12351,7 +12351,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-unzip/node_modules/pify"
             }
           ]
@@ -12393,7 +12393,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress"
         }
       ],
@@ -12433,7 +12433,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress/node_modules/make-dir"
             }
           ],
@@ -12473,7 +12473,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/decompress/node_modules/make-dir/node_modules/pify"
                 }
               ]
@@ -12515,7 +12515,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress/node_modules/pify"
             }
           ]
@@ -12557,7 +12557,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/deep-equal"
         }
       ]
@@ -12613,7 +12613,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/deep-extend"
         }
       ]
@@ -12653,7 +12653,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/deep-is"
         }
       ]
@@ -12693,7 +12693,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/define-properties"
         }
       ]
@@ -12743,7 +12743,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/define-property"
         }
       ]
@@ -12788,7 +12788,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/delayed-stream"
         }
       ]
@@ -12827,7 +12827,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/delegates"
         }
       ]
@@ -12867,7 +12867,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/depd"
         }
       ]
@@ -12907,7 +12907,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/destroy"
         }
       ]
@@ -12957,7 +12957,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/detect-file"
         }
       ]
@@ -12997,7 +12997,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/detect-libc"
         }
       ]
@@ -13047,7 +13047,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dfa"
         }
       ]
@@ -13088,7 +13088,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dicer"
         }
       ],
@@ -13133,7 +13133,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/dicer/node_modules/isarray"
             }
           ]
@@ -13173,7 +13173,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/dicer/node_modules/readable-stream"
             }
           ]
@@ -13217,7 +13217,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/dicer/node_modules/string_decoder"
             }
           ]
@@ -13263,7 +13263,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/diff"
         }
       ]
@@ -13303,7 +13303,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/doctypes"
         }
       ]
@@ -13343,7 +13343,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/domelementtype"
         }
       ]
@@ -13376,7 +13376,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/domhandler"
         }
       ]
@@ -13409,7 +13409,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/domutils"
         }
       ]
@@ -13449,7 +13449,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dottie"
         }
       ]
@@ -13499,7 +13499,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/double-ended-queue"
         }
       ]
@@ -13549,7 +13549,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/doublearray"
         }
       ]
@@ -13589,7 +13589,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/download"
         }
       ],
@@ -13629,7 +13629,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/download/node_modules/file-type"
             }
           ]
@@ -13671,7 +13671,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/duplexer2"
         }
       ]
@@ -13710,7 +13710,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/duplexer3"
         }
       ]
@@ -13748,7 +13748,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dynamic-dedupe"
         }
       ]
@@ -13798,7 +13798,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ecc-jsbn"
         }
       ]
@@ -13838,7 +13838,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ee-first"
         }
       ]
@@ -13887,7 +13887,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/eivindfjeldstad-dot"
         }
       ]
@@ -13937,7 +13937,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/emoji-regex"
         }
       ]
@@ -13977,7 +13977,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/enabled"
         }
       ]
@@ -14016,7 +14016,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/encodeurl"
         }
       ]
@@ -14056,7 +14056,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/encoding"
         }
       ],
@@ -14106,7 +14106,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/encoding/node_modules/iconv-lite"
             }
           ]
@@ -14158,7 +14158,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/end-of-stream"
         }
       ]
@@ -14202,7 +14202,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/engine.io-parser"
         }
       ]
@@ -14247,7 +14247,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/engine.io"
         }
       ],
@@ -14287,7 +14287,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/engine.io/node_modules/debug"
             }
           ]
@@ -14326,7 +14326,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/engine.io/node_modules/ms"
             }
           ]
@@ -14368,7 +14368,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/env-paths"
         }
       ]
@@ -14413,7 +14413,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/err-code"
         }
       ]
@@ -14452,7 +14452,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/error-ex"
         }
       ]
@@ -14491,7 +14491,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/errorhandler"
         }
       ]
@@ -14541,7 +14541,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/es-get-iterator"
         }
       ]
@@ -14580,7 +14580,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/escape-html"
         }
       ]
@@ -14620,7 +14620,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/escape-string-regexp"
         }
       ]
@@ -14664,7 +14664,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/escodegen"
         }
       ]
@@ -14714,7 +14714,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/esprima"
         }
       ]
@@ -14758,7 +14758,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/estraverse"
         }
       ]
@@ -14802,7 +14802,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/esutils"
         }
       ]
@@ -14841,7 +14841,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/etag"
         }
       ]
@@ -14881,7 +14881,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/eventemitter2"
         }
       ]
@@ -14926,7 +14926,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/eventemitter3"
         }
       ]
@@ -14958,7 +14958,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/exif"
         }
       ]
@@ -15009,7 +15009,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/exit"
         }
       ]
@@ -15059,7 +15059,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/expand-brackets"
         }
       ],
@@ -15109,7 +15109,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/define-property"
             }
           ]
@@ -15159,7 +15159,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/extend-shallow"
             }
           ]
@@ -15209,7 +15209,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/is-accessor-descriptor"
             }
           ],
@@ -15259,7 +15259,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/expand-brackets/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
@@ -15311,7 +15311,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/is-data-descriptor"
             }
           ],
@@ -15361,7 +15361,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/expand-brackets/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
@@ -15413,7 +15413,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/is-descriptor"
             }
           ]
@@ -15463,7 +15463,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/is-extendable"
             }
           ]
@@ -15513,7 +15513,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/kind-of"
             }
           ]
@@ -15558,7 +15558,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/expand-template"
         }
       ]
@@ -15608,7 +15608,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/expand-tilde"
         }
       ]
@@ -15648,7 +15648,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-ipfilter"
         }
       ]
@@ -15694,7 +15694,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-jwt"
         }
       ],
@@ -15739,7 +15739,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/express-jwt/node_modules/jsonwebtoken"
             }
           ]
@@ -15789,7 +15789,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/express-jwt/node_modules/moment"
             }
           ]
@@ -15836,7 +15836,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-rate-limit"
         }
       ]
@@ -15886,7 +15886,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-robots-txt"
         }
       ]
@@ -15934,7 +15934,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-security.txt"
         }
       ]
@@ -15979,7 +15979,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express"
         }
       ],
@@ -16019,7 +16019,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/express/node_modules/cookie"
             }
           ]
@@ -16069,7 +16069,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/express/node_modules/safe-buffer"
             }
           ]
@@ -16111,7 +16111,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ext-list"
         }
       ]
@@ -16151,7 +16151,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ext-name"
         }
       ]
@@ -16201,7 +16201,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/extend-shallow"
         }
       ]
@@ -16241,7 +16241,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/extend"
         }
       ]
@@ -16291,7 +16291,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/extglob"
         }
       ],
@@ -16341,7 +16341,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/extglob/node_modules/define-property"
             }
           ]
@@ -16391,7 +16391,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/extglob/node_modules/extend-shallow"
             }
           ]
@@ -16441,7 +16441,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/extglob/node_modules/is-extendable"
             }
           ]
@@ -16482,7 +16482,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/extsprintf"
         }
       ]
@@ -16532,7 +16532,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fast-deep-equal"
         }
       ]
@@ -16577,7 +16577,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fast-json-stable-stringify"
         }
       ]
@@ -16617,7 +16617,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fast-levenshtein"
         }
       ]
@@ -16667,7 +16667,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fast.js"
         }
       ]
@@ -16712,7 +16712,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fd-slicer"
         }
       ]
@@ -16762,7 +16762,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/feature-policy"
         }
       ]
@@ -16812,7 +16812,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fecha"
         }
       ]
@@ -16862,7 +16862,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/file-js"
         }
       ],
@@ -16907,7 +16907,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/file-js/node_modules/brace-expansion"
             }
           ]
@@ -16947,7 +16947,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/file-js/node_modules/minimatch"
             }
           ]
@@ -16989,7 +16989,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/file-stream-rotator"
         }
       ]
@@ -17029,7 +17029,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/file-type"
         }
       ]
@@ -17079,7 +17079,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/file-uri-to-path"
         }
       ]
@@ -17128,7 +17128,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/filehound"
         }
       ]
@@ -17168,7 +17168,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/filename-reserved-regex"
         }
       ]
@@ -17208,7 +17208,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/filenamify"
         }
       ]
@@ -17257,7 +17257,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/filesniffer"
         }
       ]
@@ -17307,7 +17307,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fill-range"
         }
       ],
@@ -17357,7 +17357,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/fill-range/node_modules/extend-shallow"
             }
           ]
@@ -17407,7 +17407,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/fill-range/node_modules/is-extendable"
             }
           ]
@@ -17454,7 +17454,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/finale-rest"
         }
       ]
@@ -17494,7 +17494,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/finalhandler"
         }
       ]
@@ -17534,7 +17534,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/find-up"
         }
       ]
@@ -17574,7 +17574,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/findup-sync"
         }
       ]
@@ -17614,7 +17614,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fined"
         }
       ]
@@ -17654,7 +17654,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/flagged-respawn"
         }
       ]
@@ -17704,7 +17704,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fn.name"
         }
       ]
@@ -17744,7 +17744,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fontkit"
         }
       ]
@@ -17800,7 +17800,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/for-each"
         }
       ]
@@ -17850,7 +17850,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/for-in"
         }
       ]
@@ -17900,7 +17900,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/for-own"
         }
       ]
@@ -17950,7 +17950,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/foreachasync"
         }
       ]
@@ -17990,7 +17990,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/forever-agent"
         }
       ]
@@ -18030,7 +18030,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/form-data"
         }
       ]
@@ -18068,7 +18068,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/formatio"
         }
       ]
@@ -18107,7 +18107,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/forwarded"
         }
       ]
@@ -18157,7 +18157,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fragment-cache"
         }
       ]
@@ -18197,7 +18197,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fresh"
         }
       ]
@@ -18247,7 +18247,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/from2"
         }
       ]
@@ -18297,7 +18297,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fs-constants"
         }
       ]
@@ -18342,7 +18342,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fs-extra"
         }
       ]
@@ -18392,7 +18392,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fs-minipass"
         }
       ]
@@ -18432,7 +18432,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fs.realpath"
         }
       ]
@@ -18472,7 +18472,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fstream"
         }
       ],
@@ -18512,7 +18512,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/fstream/node_modules/mkdirp"
             }
           ]
@@ -18552,7 +18552,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/fstream/node_modules/rimraf"
             }
           ]
@@ -18604,7 +18604,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/function-bind"
         }
       ]
@@ -18654,7 +18654,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/functions-have-names"
         }
       ]
@@ -18694,7 +18694,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fuzzball"
         }
       ]
@@ -18744,7 +18744,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/gauge"
         }
       ]
@@ -18784,7 +18784,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/geojson-utils"
         }
       ]
@@ -18833,7 +18833,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-caller-file"
         }
       ]
@@ -18883,7 +18883,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-intrinsic"
         }
       ]
@@ -18923,7 +18923,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-stream"
         }
       ]
@@ -18973,7 +18973,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-value"
         }
       ]
@@ -19024,7 +19024,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/getobject"
         }
       ]
@@ -19064,7 +19064,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/getpass"
         }
       ]
@@ -19109,7 +19109,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/github-from-package"
         }
       ]
@@ -19149,7 +19149,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/glob-parent"
         }
       ],
@@ -19199,7 +19199,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/glob-parent/node_modules/is-glob"
             }
           ]
@@ -19241,7 +19241,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/glob"
         }
       ],
@@ -19286,7 +19286,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/glob/node_modules/brace-expansion"
             }
           ]
@@ -19326,7 +19326,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/glob/node_modules/minimatch"
             }
           ]
@@ -19378,7 +19378,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/global-modules"
         }
       ]
@@ -19428,7 +19428,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/global-prefix"
         }
       ],
@@ -19468,7 +19468,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/global-prefix/node_modules/which"
             }
           ]
@@ -19520,7 +19520,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/gopd"
         }
       ]
@@ -19559,7 +19559,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/got"
         }
       ],
@@ -19599,7 +19599,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/got/node_modules/get-stream"
             }
           ]
@@ -19639,7 +19639,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/got/node_modules/pify"
             }
           ]
@@ -19680,7 +19680,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/graceful-fs"
         }
       ]
@@ -19720,7 +19720,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-cli"
         }
       ],
@@ -19760,7 +19760,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-cli/node_modules/nopt"
             }
           ]
@@ -19802,7 +19802,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-contrib-compress"
         }
       ],
@@ -19842,7 +19842,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-contrib-compress/node_modules/ansi-styles"
             }
           ]
@@ -19881,7 +19881,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-contrib-compress/node_modules/chalk"
             }
           ]
@@ -19921,7 +19921,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-contrib-compress/node_modules/supports-color"
             }
           ]
@@ -19968,7 +19968,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-known-options"
         }
       ]
@@ -20018,7 +20018,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-legacy-log-utils"
         }
       ],
@@ -20058,7 +20058,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils/node_modules/ansi-styles"
             }
           ]
@@ -20097,7 +20097,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils/node_modules/chalk"
             }
           ]
@@ -20137,7 +20137,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils/node_modules/color-convert"
             }
           ]
@@ -20187,7 +20187,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils/node_modules/color-name"
             }
           ]
@@ -20227,7 +20227,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils/node_modules/has-flag"
             }
           ]
@@ -20267,7 +20267,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils/node_modules/supports-color"
             }
           ]
@@ -20319,7 +20319,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-legacy-log"
         }
       ],
@@ -20369,7 +20369,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log/node_modules/colors"
             }
           ]
@@ -20421,7 +20421,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-legacy-util"
         }
       ],
@@ -20471,7 +20471,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-util/node_modules/async"
             }
           ]
@@ -20524,7 +20524,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-replace-json"
         }
       ]
@@ -20569,7 +20569,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt"
         }
       ],
@@ -20614,7 +20614,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt/node_modules/brace-expansion"
             }
           ]
@@ -20665,7 +20665,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt/node_modules/findup-sync"
             }
           ],
@@ -20705,7 +20705,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/grunt/node_modules/findup-sync/node_modules/glob"
                 }
               ]
@@ -20747,7 +20747,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt/node_modules/glob"
             }
           ]
@@ -20787,7 +20787,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt/node_modules/minimatch"
             }
           ]
@@ -20834,7 +20834,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/handlebars"
         }
       ],
@@ -20874,7 +20874,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/handlebars/node_modules/wordwrap"
             }
           ]
@@ -20926,7 +20926,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/har-schema"
         }
       ]
@@ -20976,7 +20976,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/har-validator"
         }
       ]
@@ -21016,7 +21016,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-ansi"
         }
       ]
@@ -21066,7 +21066,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-bigints"
         }
       ]
@@ -21106,7 +21106,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-flag"
         }
       ]
@@ -21156,7 +21156,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-property-descriptors"
         }
       ]
@@ -21206,7 +21206,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-symbol-support-x"
         }
       ]
@@ -21256,7 +21256,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-symbols"
         }
       ]
@@ -21306,7 +21306,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-to-string-tag-x"
         }
       ]
@@ -21356,7 +21356,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-tostringtag"
         }
       ]
@@ -21406,7 +21406,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-unicode"
         }
       ]
@@ -21456,7 +21456,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-value"
         }
       ]
@@ -21506,7 +21506,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-values"
         }
       ],
@@ -21556,7 +21556,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/has-values/node_modules/kind-of"
             }
           ]
@@ -21614,7 +21614,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has"
         }
       ]
@@ -21664,7 +21664,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hashids"
         }
       ]
@@ -21704,7 +21704,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hbs"
         }
       ]
@@ -21755,7 +21755,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/he"
         }
       ]
@@ -21800,7 +21800,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/heap"
         }
       ]
@@ -21850,7 +21850,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/helmet"
         }
       ]
@@ -21895,7 +21895,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hoister"
         }
       ]
@@ -21945,7 +21945,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/homedir-polyfill"
         }
       ]
@@ -21996,7 +21996,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hooker"
         }
       ]
@@ -22046,7 +22046,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hosted-git-info"
         }
       ]
@@ -22086,7 +22086,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/html-entities"
         }
       ]
@@ -22132,7 +22132,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/htmlparser2"
         }
       ],
@@ -22177,7 +22177,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/htmlparser2/node_modules/isarray"
             }
           ]
@@ -22217,7 +22217,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/htmlparser2/node_modules/readable-stream"
             }
           ]
@@ -22261,7 +22261,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/htmlparser2/node_modules/string_decoder"
             }
           ]
@@ -22303,7 +22303,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/http-cache-semantics"
         }
       ]
@@ -22343,7 +22343,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/http-errors"
         }
       ]
@@ -22388,7 +22388,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/http-proxy-agent"
         }
       ],
@@ -22428,7 +22428,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/http-proxy-agent/node_modules/debug"
             }
           ]
@@ -22467,7 +22467,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/http-proxy-agent/node_modules/ms"
             }
           ]
@@ -22519,7 +22519,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/http-signature"
         }
       ]
@@ -22564,7 +22564,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/https-proxy-agent"
         }
       ],
@@ -22604,7 +22604,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/https-proxy-agent/node_modules/debug"
             }
           ]
@@ -22643,7 +22643,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/https-proxy-agent/node_modules/ms"
             }
           ]
@@ -22685,7 +22685,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/humanize-ms"
         }
       ]
@@ -22730,7 +22730,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/i18n"
         }
       ]
@@ -22780,7 +22780,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/iconv-lite"
         }
       ]
@@ -22820,7 +22820,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ieee754"
         }
       ]
@@ -22860,7 +22860,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ignore-walk"
         }
       ],
@@ -22905,7 +22905,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/ignore-walk/node_modules/brace-expansion"
             }
           ]
@@ -22945,7 +22945,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/ignore-walk/node_modules/minimatch"
             }
           ]
@@ -22996,7 +22996,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/iltorb"
         }
       ]
@@ -23046,7 +23046,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/imurmurhash"
         }
       ]
@@ -23086,7 +23086,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/indent-string"
         }
       ]
@@ -23126,7 +23126,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/infer-owner"
         }
       ]
@@ -23166,7 +23166,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/inflection"
         }
       ]
@@ -23216,7 +23216,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/inflight"
         }
       ]
@@ -23255,7 +23255,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/inherits"
         }
       ]
@@ -23295,7 +23295,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ini"
         }
       ]
@@ -23345,7 +23345,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/interpret"
         }
       ]
@@ -23385,7 +23385,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/into-stream"
         }
       ]
@@ -23425,7 +23425,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/invariant"
         }
       ]
@@ -23469,7 +23469,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ip"
         }
       ]
@@ -23519,7 +23519,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ip6"
         }
       ]
@@ -23559,7 +23559,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ipaddr.js"
         }
       ]
@@ -23609,7 +23609,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-absolute"
         }
       ]
@@ -23659,7 +23659,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-accessor-descriptor"
         }
       ]
@@ -23709,7 +23709,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-arguments"
         }
       ]
@@ -23749,7 +23749,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-arrayish"
         }
       ]
@@ -23799,7 +23799,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-bigint"
         }
       ]
@@ -23839,7 +23839,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-binary-path"
         }
       ]
@@ -23879,7 +23879,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-boolean-object"
         }
       ]
@@ -23924,7 +23924,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-buffer"
         }
       ]
@@ -23964,7 +23964,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-callable"
         }
       ]
@@ -24014,7 +24014,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-core-module"
         }
       ]
@@ -24064,7 +24064,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-data-descriptor"
         }
       ]
@@ -24104,7 +24104,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-date-object"
         }
       ]
@@ -24154,7 +24154,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-descriptor"
         }
       ]
@@ -24194,7 +24194,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-docker"
         }
       ]
@@ -24234,7 +24234,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-expression"
         }
       ]
@@ -24284,7 +24284,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-extendable"
         }
       ]
@@ -24334,7 +24334,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-extglob"
         }
       ]
@@ -24374,7 +24374,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-fullwidth-code-point"
         }
       ]
@@ -24419,7 +24419,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-generator-function"
         }
       ]
@@ -24469,7 +24469,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-glob"
         }
       ]
@@ -24509,7 +24509,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-heroku"
         }
       ]
@@ -24559,7 +24559,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-lambda"
         }
       ]
@@ -24609,7 +24609,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-map"
         }
       ]
@@ -24649,7 +24649,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-natural-number"
         }
       ]
@@ -24699,7 +24699,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-number-like"
         }
       ]
@@ -24749,7 +24749,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-number-object"
         }
       ]
@@ -24799,7 +24799,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-number"
         }
       ],
@@ -24849,7 +24849,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/is-number/node_modules/kind-of"
             }
           ]
@@ -24907,7 +24907,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-object"
         }
       ]
@@ -24947,7 +24947,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-plain-obj"
         }
       ]
@@ -24997,7 +24997,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-plain-object"
         }
       ]
@@ -25037,7 +25037,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-promise"
         }
       ]
@@ -25087,7 +25087,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-regex"
         }
       ]
@@ -25137,7 +25137,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-relative"
         }
       ]
@@ -25177,7 +25177,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-retry-allowed"
         }
       ]
@@ -25227,7 +25227,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-set"
         }
       ]
@@ -25267,7 +25267,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-stream"
         }
       ]
@@ -25307,7 +25307,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-string"
         }
       ]
@@ -25352,7 +25352,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-symbol"
         }
       ]
@@ -25392,7 +25392,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-typed-array"
         }
       ]
@@ -25442,7 +25442,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-typedarray"
         }
       ]
@@ -25492,7 +25492,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-unc-path"
         }
       ]
@@ -25542,7 +25542,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-weakmap"
         }
       ]
@@ -25592,7 +25592,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-weakset"
         }
       ]
@@ -25642,7 +25642,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-windows"
         }
       ]
@@ -25687,7 +25687,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isarray"
         }
       ]
@@ -25737,7 +25737,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isexe"
         }
       ]
@@ -25787,7 +25787,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isobject"
         }
       ]
@@ -25837,7 +25837,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isstream"
         }
       ]
@@ -25877,7 +25877,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isurl"
         }
       ]
@@ -25917,7 +25917,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/js-stringify"
         }
       ]
@@ -25957,7 +25957,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/js-tokens"
         }
       ]
@@ -26002,7 +26002,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/js-yaml"
         }
       ]
@@ -26042,7 +26042,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jsbn"
         }
       ]
@@ -26087,7 +26087,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-buffer"
         }
       ]
@@ -26127,7 +26127,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-parse-better-errors"
         }
       ]
@@ -26177,7 +26177,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-schema-traverse"
         }
       ]
@@ -26215,7 +26215,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-schema"
         }
       ]
@@ -26265,7 +26265,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-stringify-safe"
         }
       ]
@@ -26315,7 +26315,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json5"
         }
       ]
@@ -26355,7 +26355,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jsonfile"
         }
       ]
@@ -26400,7 +26400,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jsonwebtoken"
         }
       ]
@@ -26439,7 +26439,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jsprim"
         }
       ]
@@ -26489,7 +26489,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jssha"
         }
       ]
@@ -26529,7 +26529,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jstransformer"
         }
       ]
@@ -26579,7 +26579,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/juicy-chat-bot"
         }
       ]
@@ -26619,7 +26619,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jwa"
         }
       ]
@@ -26659,7 +26659,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jws"
         }
       ]
@@ -26709,7 +26709,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/keyv"
         }
       ]
@@ -26759,7 +26759,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/kind-of"
         }
       ]
@@ -26809,7 +26809,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/kuler"
         }
       ]
@@ -26859,7 +26859,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/kuromoji"
         }
       ]
@@ -26909,7 +26909,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lazystream"
         }
       ]
@@ -26959,7 +26959,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/levn"
         }
       ]
@@ -27004,7 +27004,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/libxmljs2"
         }
       ],
@@ -27043,7 +27043,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/libxmljs2/node_modules/nan"
             }
           ]
@@ -27085,7 +27085,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/liftup"
         }
       ],
@@ -27135,7 +27135,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/braces"
             }
           ]
@@ -27185,7 +27185,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/fill-range"
             }
           ]
@@ -27225,7 +27225,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/findup-sync"
             }
           ]
@@ -27275,7 +27275,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/is-glob"
             }
           ]
@@ -27325,7 +27325,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/is-number"
             }
           ]
@@ -27375,7 +27375,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/micromatch"
             }
           ]
@@ -27425,7 +27425,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/to-regex-range"
             }
           ]
@@ -27477,7 +27477,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/linebreak"
         }
       ],
@@ -27517,7 +27517,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/linebreak/node_modules/base64-js"
             }
           ]
@@ -27559,7 +27559,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/listenercount"
         }
       ]
@@ -27599,7 +27599,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/locate-path"
         }
       ]
@@ -27644,7 +27644,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lodash.camelcase"
         }
       ]
@@ -27689,7 +27689,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lodash.isfinite"
         }
       ]
@@ -27734,7 +27734,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lodash.set"
         }
       ]
@@ -27779,7 +27779,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lodash"
         }
       ]
@@ -27829,7 +27829,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/logform"
         }
       ],
@@ -27868,7 +27868,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/logform/node_modules/ms"
             }
           ]
@@ -27920,7 +27920,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lolex"
         }
       ]
@@ -27965,7 +27965,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/loose-envify"
         }
       ]
@@ -28005,7 +28005,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lowercase-keys"
         }
       ]
@@ -28045,7 +28045,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lru-cache"
         }
       ]
@@ -28085,7 +28085,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-dir"
         }
       ],
@@ -28124,7 +28124,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-dir/node_modules/semver"
             }
           ]
@@ -28176,7 +28176,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-error"
         }
       ]
@@ -28216,7 +28216,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-fetch-happen"
         }
       ],
@@ -28262,7 +28262,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen/node_modules/@tootallnate/once"
             }
           ]
@@ -28302,7 +28302,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen/node_modules/debug"
             }
           ]
@@ -28342,7 +28342,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen/node_modules/http-cache-semantics"
             }
           ]
@@ -28387,7 +28387,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen/node_modules/http-proxy-agent"
             }
           ]
@@ -28426,7 +28426,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen/node_modules/ms"
             }
           ]
@@ -28478,7 +28478,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-iterator"
         }
       ]
@@ -28528,7 +28528,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-plural"
         }
       ]
@@ -28578,7 +28578,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/map-cache"
         }
       ]
@@ -28628,7 +28628,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/map-visit"
         }
       ]
@@ -28673,7 +28673,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/marsdb"
         }
       ]
@@ -28713,7 +28713,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/math-interval-parser"
         }
       ]
@@ -28753,7 +28753,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/media-typer"
         }
       ]
@@ -28793,7 +28793,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/merge-descriptors"
         }
       ]
@@ -28838,7 +28838,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/messageformat-formatters"
         }
       ]
@@ -28882,7 +28882,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/messageformat-parser"
         }
       ]
@@ -28927,7 +28927,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/messageformat"
         }
       ],
@@ -28977,7 +28977,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/messageformat/node_modules/make-plural"
             }
           ]
@@ -29018,7 +29018,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/methods"
         }
       ]
@@ -29068,7 +29068,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/micromatch"
         }
       ]
@@ -29107,7 +29107,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mime-db"
         }
       ]
@@ -29146,7 +29146,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mime-types"
         }
       ]
@@ -29186,7 +29186,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mime"
         }
       ]
@@ -29226,7 +29226,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mimic-response"
         }
       ]
@@ -29266,7 +29266,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minimatch"
         }
       ]
@@ -29311,7 +29311,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minimist"
         }
       ]
@@ -29346,7 +29346,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-collect"
         }
       ]
@@ -29385,7 +29385,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-fetch"
         }
       ]
@@ -29425,7 +29425,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-flush"
         }
       ]
@@ -29460,7 +29460,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-pipeline"
         }
       ]
@@ -29500,7 +29500,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-sized"
         }
       ]
@@ -29540,7 +29540,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass"
         }
       ]
@@ -29580,7 +29580,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minizlib"
         }
       ]
@@ -29630,7 +29630,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mixin-deep"
         }
       ]
@@ -29680,7 +29680,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mkdirp-classic"
         }
       ]
@@ -29719,7 +29719,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mkdirp"
         }
       ]
@@ -29769,7 +29769,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/moment-timezone"
         }
       ]
@@ -29819,7 +29819,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/moment"
         }
       ]
@@ -29858,7 +29858,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/morgan"
         }
       ],
@@ -29897,7 +29897,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/morgan/node_modules/on-finished"
             }
           ]
@@ -29949,7 +29949,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mout"
         }
       ]
@@ -29988,7 +29988,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ms"
         }
       ]
@@ -30027,7 +30027,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/multer"
         }
       ],
@@ -30067,7 +30067,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/multer/node_modules/mkdirp"
             }
           ]
@@ -30114,7 +30114,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mustache"
         }
       ]
@@ -30153,7 +30153,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/nan"
         }
       ]
@@ -30203,7 +30203,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/nanomatch"
         }
       ]
@@ -30253,7 +30253,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/napi-build-utils"
         }
       ]
@@ -30293,7 +30293,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/needle"
         }
       ],
@@ -30333,7 +30333,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/needle/node_modules/debug"
             }
           ]
@@ -30372,7 +30372,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/needle/node_modules/ms"
             }
           ]
@@ -30413,7 +30413,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/negotiator"
         }
       ]
@@ -30457,7 +30457,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/neo-async"
         }
       ]
@@ -30507,7 +30507,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-abi"
         }
       ],
@@ -30546,7 +30546,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-abi/node_modules/semver"
             }
           ]
@@ -30597,7 +30597,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-addon-api"
         }
       ]
@@ -30647,7 +30647,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-fetch"
         }
       ]
@@ -30687,7 +30687,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-gyp"
         }
       ],
@@ -30727,7 +30727,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/ansi-regex"
             }
           ]
@@ -30777,7 +30777,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/are-we-there-yet"
             }
           ]
@@ -30827,7 +30827,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/gauge"
             }
           ]
@@ -30867,7 +30867,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -30907,7 +30907,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/nopt"
             }
           ]
@@ -30947,7 +30947,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/npmlog"
             }
           ]
@@ -30986,7 +30986,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/readable-stream"
             }
           ]
@@ -31026,7 +31026,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/string-width"
             }
           ]
@@ -31066,7 +31066,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/strip-ansi"
             }
           ]
@@ -31108,7 +31108,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-pre-gyp"
         }
       ],
@@ -31148,7 +31148,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/chownr"
             }
           ]
@@ -31198,7 +31198,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/fs-minipass"
             }
           ]
@@ -31238,7 +31238,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/minipass"
             }
           ]
@@ -31278,7 +31278,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/minizlib"
             }
           ]
@@ -31318,7 +31318,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/mkdirp"
             }
           ]
@@ -31358,7 +31358,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/nopt"
             }
           ]
@@ -31398,7 +31398,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/rimraf"
             }
           ]
@@ -31448,7 +31448,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/safe-buffer"
             }
           ]
@@ -31487,7 +31487,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/semver"
             }
           ]
@@ -31527,7 +31527,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/tar"
             }
           ]
@@ -31567,7 +31567,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/yallist"
             }
           ]
@@ -31608,7 +31608,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/noop-logger"
         }
       ]
@@ -31648,7 +31648,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/nopt"
         }
       ]
@@ -31688,7 +31688,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/normalize-package-data"
         }
       ],
@@ -31727,7 +31727,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/normalize-package-data/node_modules/semver"
             }
           ]
@@ -31779,7 +31779,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/normalize-path"
         }
       ]
@@ -31819,7 +31819,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/normalize-url"
         }
       ]
@@ -31864,7 +31864,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/notevil"
         }
       ],
@@ -31909,7 +31909,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/notevil/node_modules/esprima"
             }
           ]
@@ -31951,7 +31951,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/npm-bundled"
         }
       ]
@@ -31991,7 +31991,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/npm-normalize-package-bin"
         }
       ]
@@ -32041,7 +32041,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/npm-packlist"
         }
       ]
@@ -32081,7 +32081,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/npmlog"
         }
       ]
@@ -32121,7 +32121,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/number-is-nan"
         }
       ]
@@ -32161,7 +32161,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/oauth-sign"
         }
       ]
@@ -32201,7 +32201,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-assign"
         }
       ]
@@ -32251,7 +32251,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-copy"
         }
       ],
@@ -32301,7 +32301,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy/node_modules/define-property"
             }
           ]
@@ -32351,7 +32351,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy/node_modules/is-accessor-descriptor"
             }
           ]
@@ -32401,7 +32401,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy/node_modules/is-data-descriptor"
             }
           ]
@@ -32451,7 +32451,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy/node_modules/is-descriptor"
             }
           ],
@@ -32501,7 +32501,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/object-copy/node_modules/is-descriptor/node_modules/kind-of"
                 }
               ]
@@ -32553,7 +32553,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy/node_modules/kind-of"
             }
           ]
@@ -32600,7 +32600,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-inspect"
         }
       ]
@@ -32650,7 +32650,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-is"
         }
       ]
@@ -32690,7 +32690,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-keys"
         }
       ]
@@ -32740,7 +32740,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-visit"
         }
       ]
@@ -32780,7 +32780,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object.assign"
         }
       ]
@@ -32830,7 +32830,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object.defaults"
         }
       ]
@@ -32880,7 +32880,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object.map"
         }
       ]
@@ -32930,7 +32930,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object.pick"
         }
       ]
@@ -32969,7 +32969,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/on-finished"
         }
       ]
@@ -33009,7 +33009,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/on-headers"
         }
       ]
@@ -33049,7 +33049,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/once"
         }
       ]
@@ -33089,7 +33089,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/one-time"
         }
       ]
@@ -33129,7 +33129,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/opentype.js"
         }
       ]
@@ -33179,7 +33179,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/optionator"
         }
       ]
@@ -33219,7 +33219,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/os-homedir"
         }
       ]
@@ -33259,7 +33259,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/os-tmpdir"
         }
       ]
@@ -33299,7 +33299,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/osenv"
         }
       ]
@@ -33344,7 +33344,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/otplib"
         }
       ]
@@ -33384,7 +33384,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-cancelable"
         }
       ]
@@ -33424,7 +33424,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-event"
         }
       ]
@@ -33464,7 +33464,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-finally"
         }
       ]
@@ -33504,7 +33504,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-is-promise"
         }
       ]
@@ -33544,7 +33544,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-limit"
         }
       ]
@@ -33584,7 +33584,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-locate"
         }
       ]
@@ -33624,7 +33624,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-map"
         }
       ]
@@ -33664,7 +33664,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-timeout"
         }
       ]
@@ -33704,7 +33704,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-try"
         }
       ]
@@ -33748,7 +33748,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pako"
         }
       ]
@@ -33798,7 +33798,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/parse-filepath"
         }
       ]
@@ -33838,7 +33838,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/parse-json"
         }
       ]
@@ -33888,7 +33888,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/parse-passwd"
         }
       ]
@@ -33927,7 +33927,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/parseurl"
         }
       ]
@@ -33977,7 +33977,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pascalcase"
         }
       ]
@@ -34017,7 +34017,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-exists"
         }
       ]
@@ -34057,7 +34057,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-is-absolute"
         }
       ]
@@ -34107,7 +34107,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-parse"
         }
       ]
@@ -34157,7 +34157,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-root-regex"
         }
       ]
@@ -34207,7 +34207,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-root"
         }
       ]
@@ -34246,7 +34246,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-to-regexp"
         }
       ]
@@ -34296,7 +34296,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pdfkit"
         }
       ]
@@ -34341,7 +34341,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/peek-readable"
         }
       ]
@@ -34386,7 +34386,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pend"
         }
       ]
@@ -34436,7 +34436,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/performance-now"
         }
       ]
@@ -34486,7 +34486,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pg-connection-string"
         }
       ]
@@ -34536,7 +34536,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/picomatch"
         }
       ]
@@ -34576,7 +34576,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pify"
         }
       ]
@@ -34616,7 +34616,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pinkie-promise"
         }
       ]
@@ -34656,7 +34656,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pinkie"
         }
       ]
@@ -34694,7 +34694,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/png-js"
         }
       ]
@@ -34743,7 +34743,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/portscanner"
         }
       ]
@@ -34793,7 +34793,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/posix-character-classes"
         }
       ]
@@ -34843,7 +34843,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/prebuild-install"
         }
       ]
@@ -34894,7 +34894,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/prelude-ls"
         }
       ]
@@ -34934,7 +34934,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/prepend-http"
         }
       ]
@@ -34974,7 +34974,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pretty-bytes"
         }
       ]
@@ -35023,7 +35023,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/process-nextick-args"
         }
       ]
@@ -35068,7 +35068,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/prom-client"
         }
       ]
@@ -35118,7 +35118,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/promise-inflight"
         }
       ]
@@ -35163,7 +35163,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/promise-retry"
         }
       ],
@@ -35208,7 +35208,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/promise-retry/node_modules/err-code"
             }
           ]
@@ -35253,7 +35253,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/promise-retry/node_modules/retry"
             }
           ]
@@ -35295,7 +35295,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/promise"
         }
       ]
@@ -35340,7 +35340,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/proper-lockfile"
         }
       ]
@@ -35380,7 +35380,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/proxy-addr"
         }
       ]
@@ -35420,7 +35420,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/psl"
         }
       ]
@@ -35460,7 +35460,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-attrs"
         }
       ]
@@ -35500,7 +35500,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-code-gen"
         }
       ]
@@ -35540,7 +35540,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-error"
         }
       ]
@@ -35580,7 +35580,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-filters"
         }
       ]
@@ -35620,7 +35620,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-lexer"
         }
       ]
@@ -35660,7 +35660,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-linker"
         }
       ]
@@ -35700,7 +35700,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-load"
         }
       ]
@@ -35740,7 +35740,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-parser"
         }
       ]
@@ -35780,7 +35780,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-runtime"
         }
       ]
@@ -35820,7 +35820,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-strip-comments"
         }
       ]
@@ -35860,7 +35860,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-walk"
         }
       ]
@@ -35905,7 +35905,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug"
         }
       ]
@@ -35945,7 +35945,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pump"
         }
       ]
@@ -35995,7 +35995,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/punycode"
         }
       ]
@@ -36039,7 +36039,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/qs"
         }
       ]
@@ -36079,7 +36079,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/query-string"
         }
       ]
@@ -36119,7 +36119,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/range_check"
         }
       ]
@@ -36159,7 +36159,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/range-parser"
         }
       ]
@@ -36199,7 +36199,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/raw-body"
         }
       ]
@@ -36237,7 +36237,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/rc"
         }
       ]
@@ -36277,7 +36277,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/read-pkg"
         }
       ],
@@ -36317,7 +36317,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/read-pkg/node_modules/pify"
             }
           ]
@@ -36358,7 +36358,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/readable-stream"
         }
       ],
@@ -36403,7 +36403,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/readable-stream/node_modules/isarray"
             }
           ]
@@ -36450,7 +36450,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/readable-web-to-node-stream"
         }
       ],
@@ -36489,7 +36489,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/readable-web-to-node-stream/node_modules/readable-stream"
             }
           ]
@@ -36541,7 +36541,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/readdirp"
         }
       ]
@@ -36581,7 +36581,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/rechoir"
         }
       ]
@@ -36631,7 +36631,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/regex-not"
         }
       ]
@@ -36671,7 +36671,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/regexp.prototype.flags"
         }
       ]
@@ -36721,7 +36721,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/remove-trailing-separator"
         }
       ]
@@ -36771,7 +36771,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/repeat-element"
         }
       ]
@@ -36821,7 +36821,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/repeat-string"
         }
       ]
@@ -36861,7 +36861,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/replace"
         }
       ],
@@ -36901,7 +36901,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/ansi-regex"
             }
           ]
@@ -36941,7 +36941,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/ansi-styles"
             }
           ]
@@ -36986,7 +36986,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/brace-expansion"
             }
           ]
@@ -37026,7 +37026,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/cliui"
             }
           ]
@@ -37066,7 +37066,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/color-convert"
             }
           ]
@@ -37116,7 +37116,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/color-name"
             }
           ]
@@ -37156,7 +37156,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/find-up"
             }
           ]
@@ -37196,7 +37196,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -37236,7 +37236,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/locate-path"
             }
           ]
@@ -37276,7 +37276,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/minimatch"
             }
           ]
@@ -37316,7 +37316,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/p-locate"
             }
           ]
@@ -37356,7 +37356,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/path-exists"
             }
           ]
@@ -37396,7 +37396,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/string-width"
             }
           ]
@@ -37436,7 +37436,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/strip-ansi"
             }
           ]
@@ -37476,7 +37476,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/wrap-ansi"
             }
           ]
@@ -37516,7 +37516,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/yargs-parser"
             }
           ]
@@ -37560,7 +37560,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/yargs"
             }
           ]
@@ -37607,7 +37607,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/request"
         }
       ],
@@ -37651,7 +37651,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/request/node_modules/qs"
             }
           ]
@@ -37703,7 +37703,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/require-directory"
         }
       ]
@@ -37753,7 +37753,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/require-main-filename"
         }
       ]
@@ -37803,7 +37803,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/resolve-dir"
         }
       ]
@@ -37843,7 +37843,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/resolve-url"
         }
       ]
@@ -37883,7 +37883,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/resolve"
         }
       ]
@@ -37923,7 +37923,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/responselike"
         }
       ]
@@ -37973,7 +37973,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/restructure"
         }
       ]
@@ -38013,7 +38013,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ret"
         }
       ]
@@ -38063,7 +38063,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/retry-as-promised"
         }
       ]
@@ -38108,7 +38108,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/retry"
         }
       ]
@@ -38148,7 +38148,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/rimraf"
         }
       ]
@@ -38198,7 +38198,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/rxjs"
         }
       ],
@@ -38248,7 +38248,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/rxjs/node_modules/tslib"
             }
           ]
@@ -38300,7 +38300,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safe-buffer"
         }
       ]
@@ -38345,7 +38345,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safe-regex"
         }
       ]
@@ -38395,7 +38395,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safe-stable-stringify"
         }
       ]
@@ -38440,7 +38440,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safer-buffer"
         }
       ]
@@ -38478,7 +38478,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/samsam"
         }
       ]
@@ -38518,7 +38518,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sanitize-filename"
         }
       ]
@@ -38558,7 +38558,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sanitize-html"
         }
       ],
@@ -38608,7 +38608,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sanitize-html/node_modules/lodash"
             }
           ]
@@ -38650,7 +38650,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sax"
         }
       ]
@@ -38689,7 +38689,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/seek-bzip"
         }
       ]
@@ -38729,7 +38729,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/semver"
         }
       ]
@@ -38769,7 +38769,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/send"
         }
       ],
@@ -38808,7 +38808,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/send/node_modules/ms"
             }
           ]
@@ -38850,7 +38850,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sequelize-pool"
         }
       ]
@@ -38899,7 +38899,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sequelize"
         }
       ],
@@ -38939,7 +38939,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sequelize/node_modules/debug"
             }
           ]
@@ -38978,7 +38978,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sequelize/node_modules/ms"
             }
           ]
@@ -39017,7 +39017,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sequelize/node_modules/uuid"
             }
           ]
@@ -39059,7 +39059,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/serve-index"
         }
       ],
@@ -39099,7 +39099,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index/node_modules/depd"
             }
           ]
@@ -39139,7 +39139,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index/node_modules/http-errors"
             }
           ]
@@ -39178,7 +39178,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index/node_modules/inherits"
             }
           ]
@@ -39228,7 +39228,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index/node_modules/setprototypeof"
             }
           ]
@@ -39267,7 +39267,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index/node_modules/statuses"
             }
           ]
@@ -39309,7 +39309,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/serve-static"
         }
       ]
@@ -39359,7 +39359,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/set-blocking"
         }
       ]
@@ -39409,7 +39409,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/set-value"
         }
       ],
@@ -39459,7 +39459,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/set-value/node_modules/extend-shallow"
             }
           ]
@@ -39509,7 +39509,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/set-value/node_modules/is-extendable"
             }
           ]
@@ -39551,7 +39551,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/setimmediate"
         }
       ]
@@ -39601,7 +39601,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/setprototypeof"
         }
       ]
@@ -39651,7 +39651,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/side-channel"
         }
       ]
@@ -39701,7 +39701,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/signal-exit"
         }
       ]
@@ -39751,7 +39751,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/simple-concat"
         }
       ]
@@ -39801,7 +39801,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/simple-get"
         }
       ],
@@ -39841,7 +39841,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/simple-get/node_modules/decompress-response"
             }
           ]
@@ -39881,7 +39881,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/simple-get/node_modules/mimic-response"
             }
           ]
@@ -39923,7 +39923,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/simple-swizzle"
         }
       ],
@@ -39963,7 +39963,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/simple-swizzle/node_modules/is-arrayish"
             }
           ]
@@ -40015,7 +40015,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sinon"
         }
       ]
@@ -40065,7 +40065,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/smart-buffer"
         }
       ]
@@ -40115,7 +40115,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/snapdragon-node"
         }
       ],
@@ -40165,7 +40165,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon-node/node_modules/define-property"
             }
           ]
@@ -40217,7 +40217,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/snapdragon-util"
         }
       ],
@@ -40267,7 +40267,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon-util/node_modules/kind-of"
             }
           ]
@@ -40319,7 +40319,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/snapdragon"
         }
       ],
@@ -40369,7 +40369,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/define-property"
             }
           ]
@@ -40419,7 +40419,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/extend-shallow"
             }
           ]
@@ -40469,7 +40469,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/is-accessor-descriptor"
             }
           ],
@@ -40519,7 +40519,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/snapdragon/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
@@ -40571,7 +40571,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/is-data-descriptor"
             }
           ],
@@ -40621,7 +40621,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/snapdragon/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
@@ -40673,7 +40673,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/is-descriptor"
             }
           ]
@@ -40723,7 +40723,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/is-extendable"
             }
           ]
@@ -40773,7 +40773,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/kind-of"
             }
           ]
@@ -40818,7 +40818,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/source-map"
             }
           ]
@@ -40859,7 +40859,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socket.io-adapter"
         }
       ]
@@ -40898,7 +40898,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socket.io-parser"
         }
       ],
@@ -40938,7 +40938,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socket.io-parser/node_modules/debug"
             }
           ]
@@ -40977,7 +40977,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socket.io-parser/node_modules/ms"
             }
           ]
@@ -41018,7 +41018,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socket.io"
         }
       ],
@@ -41058,7 +41058,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socket.io/node_modules/debug"
             }
           ]
@@ -41097,7 +41097,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socket.io/node_modules/ms"
             }
           ]
@@ -41149,7 +41149,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socks-proxy-agent"
         }
       ],
@@ -41189,7 +41189,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socks-proxy-agent/node_modules/debug"
             }
           ]
@@ -41228,7 +41228,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socks-proxy-agent/node_modules/ms"
             }
           ]
@@ -41280,7 +41280,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socks"
         }
       ],
@@ -41324,7 +41324,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socks/node_modules/ip"
             }
           ]
@@ -41366,7 +41366,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sort-keys-length"
         }
       ],
@@ -41406,7 +41406,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sort-keys-length/node_modules/sort-keys"
             }
           ]
@@ -41448,7 +41448,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sort-keys"
         }
       ]
@@ -41488,7 +41488,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/source-map-resolve"
         }
       ]
@@ -41532,7 +41532,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/source-map-support"
         }
       ]
@@ -41572,7 +41572,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/source-map-url"
         }
       ]
@@ -41617,7 +41617,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/source-map"
         }
       ]
@@ -41657,7 +41657,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spawn-command"
         }
       ]
@@ -41697,7 +41697,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spdx-correct"
         }
       ]
@@ -41737,7 +41737,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spdx-exceptions"
         }
       ]
@@ -41777,7 +41777,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spdx-expression-parse"
         }
       ]
@@ -41817,7 +41817,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spdx-license-ids"
         }
       ]
@@ -41867,7 +41867,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/split-string"
         }
       ]
@@ -41907,7 +41907,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sprintf-js"
         }
       ]
@@ -41952,7 +41952,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sqlite3"
         }
       ]
@@ -42002,7 +42002,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sshpk"
         }
       ]
@@ -42042,7 +42042,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ssri"
         }
       ]
@@ -42087,7 +42087,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/stack-trace"
         }
       ]
@@ -42137,7 +42137,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/static-extend"
         }
       ],
@@ -42187,7 +42187,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend/node_modules/define-property"
             }
           ]
@@ -42237,7 +42237,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend/node_modules/is-accessor-descriptor"
             }
           ],
@@ -42287,7 +42287,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/static-extend/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
@@ -42339,7 +42339,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend/node_modules/is-data-descriptor"
             }
           ],
@@ -42389,7 +42389,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/static-extend/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
@@ -42441,7 +42441,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend/node_modules/is-descriptor"
             }
           ]
@@ -42491,7 +42491,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend/node_modules/kind-of"
             }
           ]
@@ -42532,7 +42532,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/statuses"
         }
       ]
@@ -42572,7 +42572,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/stream-buffers"
         }
       ]
@@ -42613,7 +42613,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/streamsearch"
         }
       ]
@@ -42653,7 +42653,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strict-uri-encode"
         }
       ]
@@ -42697,7 +42697,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string_decoder"
         }
       ]
@@ -42737,7 +42737,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string-width"
         }
       ]
@@ -42788,7 +42788,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string.fromcodepoint"
         }
       ]
@@ -42838,7 +42838,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string.prototype.codepointat"
         }
       ]
@@ -42878,7 +42878,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-ansi"
         }
       ]
@@ -42918,7 +42918,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-bom"
         }
       ]
@@ -42958,7 +42958,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-dirs"
         }
       ]
@@ -42998,7 +42998,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-json-comments"
         }
       ]
@@ -43038,7 +43038,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-outer"
         }
       ]
@@ -43083,7 +43083,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strtok3"
         }
       ]
@@ -43123,7 +43123,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/supports-color"
         }
       ]
@@ -43173,7 +43173,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/supports-preserve-symlinks-flag"
         }
       ]
@@ -43223,7 +43223,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/svg-captcha"
         }
       ]
@@ -43261,7 +43261,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/swagger-ui-dist"
         }
       ]
@@ -43311,7 +43311,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/swagger-ui-express"
         }
       ]
@@ -43361,7 +43361,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tar-fs"
         }
       ],
@@ -43405,7 +43405,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/tar-fs/node_modules/bl"
             }
           ]
@@ -43445,7 +43445,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/tar-fs/node_modules/chownr"
             }
           ]
@@ -43484,7 +43484,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/tar-fs/node_modules/readable-stream"
             }
           ]
@@ -43534,7 +43534,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/tar-fs/node_modules/tar-stream"
             }
           ]
@@ -43586,7 +43586,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tar-stream"
         }
       ]
@@ -43626,7 +43626,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tar"
         }
       ]
@@ -43676,7 +43676,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tdigest"
         }
       ]
@@ -43726,7 +43726,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/text-hex"
         }
       ]
@@ -43759,7 +43759,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/thirty-two"
         }
       ]
@@ -43804,7 +43804,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/through"
         }
       ]
@@ -43844,7 +43844,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/timed-out"
         }
       ]
@@ -43894,7 +43894,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tiny-inflate"
         }
       ]
@@ -43944,7 +43944,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-buffer"
         }
       ]
@@ -43984,7 +43984,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-fast-properties"
         }
       ]
@@ -44034,7 +44034,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-object-path"
         }
       ],
@@ -44084,7 +44084,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/to-object-path/node_modules/kind-of"
             }
           ]
@@ -44136,7 +44136,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-regex-range"
         }
       ]
@@ -44186,7 +44186,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-regex"
         }
       ]
@@ -44226,7 +44226,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/toidentifier"
         }
       ]
@@ -44266,7 +44266,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/token-stream"
         }
       ]
@@ -44311,7 +44311,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/token-types"
         }
       ]
@@ -44350,7 +44350,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/toposort-class"
         }
       ]
@@ -44400,7 +44400,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tough-cookie"
         }
       ]
@@ -44450,7 +44450,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tr46"
         }
       ]
@@ -44490,7 +44490,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/traverse"
         }
       ]
@@ -44535,7 +44535,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tree-kill"
         }
       ]
@@ -44575,7 +44575,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/trim-repeated"
         }
       ]
@@ -44625,7 +44625,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/triple-beam"
         }
       ]
@@ -44675,7 +44675,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/truncate-utf8-bytes"
         }
       ]
@@ -44714,7 +44714,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ts-node-dev"
         }
       ],
@@ -44754,7 +44754,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/ts-node-dev/node_modules/rimraf"
             }
           ]
@@ -44806,7 +44806,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ts-node"
         }
       ]
@@ -44856,7 +44856,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tsconfig"
         }
       ]
@@ -44906,7 +44906,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tslib"
         }
       ]
@@ -44946,7 +44946,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tunnel-agent"
         }
       ]
@@ -44996,7 +44996,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tweetnacl"
         }
       ]
@@ -45046,7 +45046,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/type-check"
         }
       ]
@@ -45085,7 +45085,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/type-is"
         }
       ]
@@ -45124,7 +45124,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/typecast"
         }
       ]
@@ -45169,7 +45169,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/typedarray"
         }
       ]
@@ -45219,7 +45219,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/typescript"
         }
       ]
@@ -45259,7 +45259,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/uglify-js"
         }
       ]
@@ -45304,7 +45304,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unbzip2-stream"
         }
       ]
@@ -45354,7 +45354,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unc-path-regex"
         }
       ]
@@ -45403,7 +45403,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/underscore.string"
         }
       ]
@@ -45453,7 +45453,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unicode-properties"
         }
       ]
@@ -45503,7 +45503,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unicode-trie"
         }
       ]
@@ -45553,7 +45553,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/union-value"
         }
       ],
@@ -45603,7 +45603,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/union-value/node_modules/is-extendable"
             }
           ]
@@ -45655,7 +45655,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unique-filename"
         }
       ]
@@ -45695,7 +45695,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unique-slug"
         }
       ]
@@ -45745,7 +45745,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unit-compare"
         }
       ]
@@ -45795,7 +45795,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/universalify"
         }
       ]
@@ -45835,7 +45835,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unpipe"
         }
       ]
@@ -45885,7 +45885,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unset-value"
         }
       ],
@@ -45935,7 +45935,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/unset-value/node_modules/has-value"
             }
           ],
@@ -45985,7 +45985,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/unset-value/node_modules/has-value/node_modules/isobject"
                 }
               ]
@@ -46037,7 +46037,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/unset-value/node_modules/has-values"
             }
           ]
@@ -46082,7 +46082,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/unset-value/node_modules/isarray"
             }
           ]
@@ -46124,7 +46124,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/untildify"
         }
       ]
@@ -46164,7 +46164,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unzipper"
         }
       ],
@@ -46214,7 +46214,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/unzipper/node_modules/bluebird"
             }
           ]
@@ -46266,7 +46266,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/uri-js"
         }
       ]
@@ -46306,7 +46306,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/urix"
         }
       ]
@@ -46346,7 +46346,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/url-parse-lax"
         }
       ]
@@ -46386,7 +46386,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/url-to-options"
         }
       ]
@@ -46436,7 +46436,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/use"
         }
       ]
@@ -46486,7 +46486,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/utf8-byte-length"
         }
       ]
@@ -46536,7 +46536,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/util-deprecate"
         }
       ]
@@ -46581,7 +46581,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/util"
         }
       ]
@@ -46632,7 +46632,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/utils-merge"
         }
       ]
@@ -46671,7 +46671,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/uuid"
         }
       ]
@@ -46711,7 +46711,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/v8flags"
         }
       ]
@@ -46751,7 +46751,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/validate-npm-package-license"
         }
       ]
@@ -46791,7 +46791,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/validate"
         }
       ]
@@ -46841,7 +46841,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/validator"
         }
       ]
@@ -46881,7 +46881,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/vary"
         }
       ]
@@ -46920,7 +46920,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/verror"
         }
       ],
@@ -46965,7 +46965,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/verror/node_modules/core-util-is"
             }
           ]
@@ -47007,7 +47007,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/vm2"
         }
       ],
@@ -47051,7 +47051,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/vm2/node_modules/acorn"
             }
           ]
@@ -47103,7 +47103,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/void-elements"
         }
       ]
@@ -47151,7 +47151,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/walk"
         }
       ]
@@ -47196,7 +47196,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/walkdir"
         }
       ]
@@ -47236,7 +47236,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/webidl-conversions"
         }
       ]
@@ -47276,7 +47276,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/whatwg-url"
         }
       ]
@@ -47326,7 +47326,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-boxed-primitive"
         }
       ]
@@ -47376,7 +47376,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-collection"
         }
       ]
@@ -47426,7 +47426,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-module"
         }
       ]
@@ -47476,7 +47476,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-pm-runs"
         }
       ]
@@ -47516,7 +47516,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-typed-array"
         }
       ]
@@ -47556,7 +47556,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which"
         }
       ]
@@ -47596,7 +47596,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wide-align"
         }
       ]
@@ -47646,7 +47646,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/winston-transport"
         }
       ],
@@ -47685,7 +47685,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/winston-transport/node_modules/readable-stream"
             }
           ]
@@ -47727,7 +47727,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/winston"
         }
       ],
@@ -47777,7 +47777,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/winston/node_modules/async"
             }
           ]
@@ -47817,7 +47817,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/winston/node_modules/is-stream"
             }
           ]
@@ -47856,7 +47856,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/winston/node_modules/readable-stream"
             }
           ]
@@ -47898,7 +47898,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/with"
         }
       ]
@@ -47938,7 +47938,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wkx"
         }
       ]
@@ -47988,7 +47988,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/word-wrap"
         }
       ]
@@ -48028,7 +48028,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wordwrap"
         }
       ]
@@ -48068,7 +48068,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wrap-ansi"
         }
       ],
@@ -48108,7 +48108,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi/node_modules/ansi-regex"
             }
           ]
@@ -48158,7 +48158,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi/node_modules/emoji-regex"
             }
           ]
@@ -48198,7 +48198,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -48238,7 +48238,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi/node_modules/string-width"
             }
           ]
@@ -48278,7 +48278,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi/node_modules/strip-ansi"
             }
           ]
@@ -48330,7 +48330,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wrappy"
         }
       ]
@@ -48380,7 +48380,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ws"
         }
       ]
@@ -48430,7 +48430,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/xtend"
         }
       ]
@@ -48480,7 +48480,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/y18n"
         }
       ]
@@ -48520,7 +48520,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yallist"
         }
       ]
@@ -48560,7 +48560,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yaml-schema-validator"
         }
       ]
@@ -48600,7 +48600,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yargs-parser"
         }
       ]
@@ -48644,7 +48644,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yargs"
         }
       ],
@@ -48684,7 +48684,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs/node_modules/ansi-regex"
             }
           ]
@@ -48734,7 +48734,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs/node_modules/emoji-regex"
             }
           ]
@@ -48774,7 +48774,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -48814,7 +48814,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs/node_modules/string-width"
             }
           ]
@@ -48854,7 +48854,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs/node_modules/strip-ansi"
             }
           ]
@@ -48906,7 +48906,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yauzl"
         }
       ]
@@ -48946,7 +48946,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yn"
         }
       ]
@@ -48996,7 +48996,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/z85"
         }
       ]
@@ -49046,7 +49046,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/zip-stream"
         }
       ]
@@ -49091,7 +49091,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/zlibjs"
         }
       ]

--- a/demo/juice-shop/example-results/bom.1.4.xml
+++ b/demo/juice-shop/example-results/bom.1.4.xml
@@ -5,7 +5,7 @@
       <tool>
         <vendor>@cyclonedx</vendor>
         <name>cyclonedx-npm</name>
-        <version>1.4.0</version>
+        <version>1.4.1</version>
         <externalReferences>
           <reference type="issue-tracker">
             <url>https://github.com/CycloneDX/cyclonedx-node-npm/issues</url>
@@ -48,6 +48,7 @@
         </reference>
       </externalReferences>
       <properties>
+        <property name="cdx:npm:package:installPath"/>
         <property name="cdx:npm:package:private">true</property>
       </properties>
     </component>
@@ -82,6 +83,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@babel/helper-string-parser</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@babel/helper-validator-identifier@7.19.1">
       <author>The Babel Team (https://babel.dev/team)</author>
@@ -108,6 +112,9 @@
           <comment>as detected from PackageJson property "repository.url" and "repository.directory"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@babel/helper-validator-identifier</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@babel/parser@7.20.2">
       <author>The Babel Team (https://babel.dev/team)</author>
@@ -142,6 +149,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@babel/parser</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@babel/types@7.20.2">
       <author>The Babel Team (https://babel.dev/team)</author>
@@ -176,6 +186,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@babel/types</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@colors/colors@1.5.0">
       <author>DABH</author>
@@ -210,6 +223,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@colors/colors</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@dabh/diagnostics@2.0.3">
       <author>Arnout Kazemier</author>
@@ -244,6 +260,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@dabh/diagnostics</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@gar/promisify@1.1.3">
       <author>Gar &lt;gar+npm@danger.computer&gt;</author>
@@ -270,6 +289,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@gar/promisify</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@mapbox/node-pre-gyp@1.0.10">
       <author>Dane Springmeyer &lt;dane@mapbox.com&gt;</author>
@@ -296,6 +318,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@mapbox/node-pre-gyp</property>
+      </properties>
       <components>
         <component type="library" bom-ref="@mapbox/node-pre-gyp@1.0.10|ansi-regex@5.0.1">
           <author>Sindre Sorhus</author>
@@ -321,6 +346,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/@mapbox/node-pre-gyp/node_modules/ansi-regex</property>
+          </properties>
         </component>
         <component type="library" bom-ref="@mapbox/node-pre-gyp@1.0.10|are-we-there-yet@2.0.0">
           <author>GitHub Inc.</author>
@@ -354,6 +382,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/@mapbox/node-pre-gyp/node_modules/are-we-there-yet</property>
+          </properties>
         </component>
         <component type="library" bom-ref="@mapbox/node-pre-gyp@1.0.10|detect-libc@2.0.1">
           <author>Lovell Fuller &lt;npm@lovell.info&gt;</author>
@@ -379,6 +410,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/@mapbox/node-pre-gyp/node_modules/detect-libc</property>
+          </properties>
         </component>
         <component type="library" bom-ref="@mapbox/node-pre-gyp@1.0.10|gauge@3.0.2">
           <author>Rebecca Turner &lt;me@re-becca.org&gt;</author>
@@ -412,6 +446,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/@mapbox/node-pre-gyp/node_modules/gauge</property>
+          </properties>
         </component>
         <component type="library" bom-ref="@mapbox/node-pre-gyp@1.0.10|is-fullwidth-code-point@3.0.0">
           <author>Sindre Sorhus</author>
@@ -437,6 +474,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/@mapbox/node-pre-gyp/node_modules/is-fullwidth-code-point</property>
+          </properties>
         </component>
         <component type="library" bom-ref="@mapbox/node-pre-gyp@1.0.10|make-dir@3.1.0">
           <author>Sindre Sorhus</author>
@@ -462,6 +502,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/@mapbox/node-pre-gyp/node_modules/make-dir</property>
+          </properties>
           <components>
             <component type="library" bom-ref="@mapbox/node-pre-gyp@1.0.10|make-dir@3.1.0|semver@6.3.0">
               <name>semver</name>
@@ -486,6 +529,9 @@
                   <comment>as detected from PackageJson property "repository"</comment>
                 </reference>
               </externalReferences>
+              <properties>
+                <property name="cdx:npm:package:installPath">node_modules/@mapbox/node-pre-gyp/node_modules/make-dir/node_modules/semver</property>
+              </properties>
             </component>
           </components>
         </component>
@@ -513,6 +559,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/@mapbox/node-pre-gyp/node_modules/nopt</property>
+          </properties>
         </component>
         <component type="library" bom-ref="@mapbox/node-pre-gyp@1.0.10|npmlog@5.0.1">
           <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me/)</author>
@@ -538,6 +587,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/@mapbox/node-pre-gyp/node_modules/npmlog</property>
+          </properties>
         </component>
         <component type="library" bom-ref="@mapbox/node-pre-gyp@1.0.10|readable-stream@3.6.0">
           <name>readable-stream</name>
@@ -562,6 +614,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/@mapbox/node-pre-gyp/node_modules/readable-stream</property>
+          </properties>
         </component>
         <component type="library" bom-ref="@mapbox/node-pre-gyp@1.0.10|string-width@4.2.3">
           <author>Sindre Sorhus</author>
@@ -587,6 +642,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/@mapbox/node-pre-gyp/node_modules/string-width</property>
+          </properties>
         </component>
         <component type="library" bom-ref="@mapbox/node-pre-gyp@1.0.10|strip-ansi@6.0.1">
           <author>Sindre Sorhus</author>
@@ -612,6 +670,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/@mapbox/node-pre-gyp/node_modules/strip-ansi</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -644,6 +705,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/core-loader</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/core@4.23.4">
       <author>Jesus Seijas</author>
@@ -674,6 +738,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/core</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/evaluator@4.22.7">
       <author>Jesus Seijas</author>
@@ -704,6 +771,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/evaluator</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-all@4.24.0">
       <author>Jesus Seijas</author>
@@ -734,6 +804,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-all</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-ar@4.23.4">
       <author>Jesus Seijas</author>
@@ -764,6 +837,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-ar</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-bn@4.23.4">
       <author>Jesus Seijas</author>
@@ -794,6 +870,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-bn</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-ca@4.23.4">
       <author>Jesus Seijas</author>
@@ -824,6 +903,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-ca</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-cs@4.23.4">
       <author>Jesus Seijas</author>
@@ -854,6 +936,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-cs</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-da@4.23.4">
       <author>Jesus Seijas</author>
@@ -884,6 +969,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-da</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-de@4.23.4">
       <author>Jesus Seijas</author>
@@ -914,6 +1002,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-de</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-el@4.23.4">
       <author>Jesus Seijas</author>
@@ -944,6 +1035,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-el</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-en-min@4.23.4">
       <author>Jesus Seijas</author>
@@ -974,6 +1068,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-en-min</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-en@4.23.4">
       <author>Jesus Seijas</author>
@@ -1004,6 +1101,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-en</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-es@4.23.4">
       <author>Jesus Seijas</author>
@@ -1034,6 +1134,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-es</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-eu@4.23.4">
       <author>Jesus Seijas</author>
@@ -1064,6 +1167,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-eu</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-fa@4.23.4">
       <author>Jesus Seijas</author>
@@ -1094,6 +1200,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-fa</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-fi@4.23.4">
       <author>Jesus Seijas</author>
@@ -1124,6 +1233,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-fi</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-fr@4.23.4">
       <author>Jesus Seijas</author>
@@ -1154,6 +1266,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-fr</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-ga@4.23.4">
       <author>Jesus Seijas</author>
@@ -1184,6 +1299,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-ga</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-gl@4.23.4">
       <author>Jesus Seijas</author>
@@ -1214,6 +1332,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-gl</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-hi@4.23.4">
       <author>Jesus Seijas</author>
@@ -1244,6 +1365,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-hi</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-hu@4.23.4">
       <author>Jesus Seijas</author>
@@ -1274,6 +1398,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-hu</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-hy@4.23.4">
       <author>Jesus Seijas</author>
@@ -1304,6 +1431,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-hy</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-id@4.23.4">
       <author>Jesus Seijas</author>
@@ -1334,6 +1464,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-id</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-it@4.23.4">
       <author>Jesus Seijas</author>
@@ -1364,6 +1497,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-it</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-ja@4.24.0">
       <author>Jesus Seijas</author>
@@ -1394,6 +1530,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-ja</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-ko@4.23.4">
       <author>Jesus Seijas</author>
@@ -1424,6 +1563,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-ko</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-lt@4.23.4">
       <author>Jesus Seijas</author>
@@ -1454,6 +1596,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-lt</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-ms@4.23.4">
       <author>Jesus Seijas</author>
@@ -1484,6 +1629,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-ms</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-ne@4.23.4">
       <author>Jesus Seijas</author>
@@ -1514,6 +1662,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-ne</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-nl@4.23.4">
       <author>Jesus Seijas</author>
@@ -1544,6 +1695,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-nl</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-no@4.23.4">
       <author>Jesus Seijas</author>
@@ -1574,6 +1728,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-no</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-pl@4.23.4">
       <author>Jesus Seijas</author>
@@ -1604,6 +1761,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-pl</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-pt@4.23.4">
       <author>Jesus Seijas</author>
@@ -1634,6 +1794,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-pt</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-ro@4.23.4">
       <author>Jesus Seijas</author>
@@ -1664,6 +1827,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-ro</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-ru@4.23.4">
       <author>Jesus Seijas</author>
@@ -1694,6 +1860,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-ru</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-sl@4.23.4">
       <author>Jesus Seijas</author>
@@ -1724,6 +1893,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-sl</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-sr@4.23.4">
       <author>Jesus Seijas</author>
@@ -1754,6 +1926,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-sr</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-sv@4.23.4">
       <author>Jesus Seijas</author>
@@ -1784,6 +1959,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-sv</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-ta@4.23.4">
       <author>Jesus Seijas</author>
@@ -1814,6 +1992,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-ta</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-th@4.23.4">
       <author>Jesus Seijas</author>
@@ -1844,6 +2025,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-th</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-tl@4.23.4">
       <author>Jesus Seijas</author>
@@ -1874,6 +2058,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-tl</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-tr@4.23.4">
       <author>Jesus Seijas</author>
@@ -1904,6 +2091,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-tr</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-uk@4.23.4">
       <author>Jesus Seijas</author>
@@ -1934,6 +2124,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-uk</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-zh@4.23.4">
       <author>Jesus Seijas</author>
@@ -1964,6 +2157,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-zh</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/language-min@4.22.7">
       <author>Jesus Seijas</author>
@@ -1994,6 +2190,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/language-min</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/language@4.22.7">
       <author>Jesus Seijas</author>
@@ -2024,6 +2223,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/language</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/ner@4.23.4">
       <author>Jesus Seijas</author>
@@ -2054,6 +2256,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/ner</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/neural@4.22.7">
       <author>Jesus Seijas</author>
@@ -2084,6 +2289,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/neural</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/nlg@4.23.4">
       <author>Jesus Seijas</author>
@@ -2114,6 +2322,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/nlg</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/nlp@4.23.5">
       <author>Jesus Seijas</author>
@@ -2144,6 +2355,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/nlp</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/nlu@4.23.5">
       <author>Jesus Seijas</author>
@@ -2174,6 +2388,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/nlu</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/request@4.22.7">
       <author>Jesus Seijas</author>
@@ -2204,6 +2421,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/request</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/sentiment@4.23.4">
       <author>Jesus Seijas</author>
@@ -2234,6 +2454,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/sentiment</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/similarity@4.22.7">
       <author>Jesus Seijas</author>
@@ -2264,6 +2487,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/similarity</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/slot@4.22.17">
       <author>Jesus Seijas</author>
@@ -2294,6 +2520,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/slot</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@npmcli/fs@1.1.1">
       <author>GitHub Inc.</author>
@@ -2316,6 +2545,9 @@
           <comment>as detected from npm-ls property "resolved"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@npmcli/fs</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@npmcli/move-file@1.1.2">
       <group>@npmcli</group>
@@ -2341,6 +2573,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@npmcli/move-file</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@otplib/core@12.0.1">
       <author>Gerald Yeo &lt;contact@fusedthought.com&gt;</author>
@@ -2371,6 +2606,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@otplib/core</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@otplib/plugin-crypto@12.0.1">
       <author>Gerald Yeo &lt;contact@fusedthought.com&gt;</author>
@@ -2401,6 +2639,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@otplib/plugin-crypto</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@otplib/plugin-thirty-two@12.0.1">
       <author>Gerald Yeo &lt;contact@fusedthought.com&gt;</author>
@@ -2431,6 +2672,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@otplib/plugin-thirty-two</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@otplib/preset-default@12.0.1">
       <author>Gerald Yeo &lt;contact@fusedthought.com&gt;</author>
@@ -2461,6 +2705,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@otplib/preset-default</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@otplib/preset-v11@12.0.1">
       <author>Gerald Yeo &lt;contact@fusedthought.com&gt;</author>
@@ -2491,6 +2738,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@otplib/preset-v11</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@sindresorhus/is@0.7.0">
       <author>Sindre Sorhus</author>
@@ -2517,6 +2767,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@sindresorhus/is</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@swc/helpers@0.3.17">
       <author>강동윤 &lt;kdy1997.dev@gmail.com&gt;</author>
@@ -2551,6 +2804,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@swc/helpers</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@tokenizer/token@0.3.0">
       <author>Borewit</author>
@@ -2581,6 +2837,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@tokenizer/token</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@tootallnate/once@2.0.0">
       <author>Nathan Rajlich &lt;nathan@tootallnate.net&gt; (http://n8.io/)</author>
@@ -2611,6 +2870,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@tootallnate/once</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@types/component-emitter@1.2.11">
       <group>@types</group>
@@ -2640,6 +2902,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@types/component-emitter</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@types/cookie@0.4.1">
       <group>@types</group>
@@ -2669,6 +2934,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@types/cookie</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@types/cors@2.8.12">
       <group>@types</group>
@@ -2698,6 +2966,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@types/cors</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@types/debug@4.1.7">
       <group>@types</group>
@@ -2727,6 +2998,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@types/debug</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@types/ms@0.7.31">
       <group>@types</group>
@@ -2752,6 +3026,9 @@
           <comment>as detected from PackageJson property "repository.url" and "repository.directory"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@types/ms</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@types/node@18.11.9">
       <group>@types</group>
@@ -2781,6 +3058,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@types/node</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@types/strip-bom@3.0.0">
       <author>Mohamed Hegazy &lt;https://github.com/mhegazy&gt;</author>
@@ -2807,6 +3087,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@types/strip-bom</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@types/strip-json-comments@0.0.30">
       <group>@types</group>
@@ -2832,6 +3115,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@types/strip-json-comments</property>
+      </properties>
     </component>
     <component type="library" bom-ref="@types/validator@13.7.10">
       <group>@types</group>
@@ -2861,6 +3147,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/@types/validator</property>
+      </properties>
     </component>
     <component type="library" bom-ref="abbrev@1.1.1">
       <author>Isaac Z. Schlueter &lt;i@izs.me&gt;</author>
@@ -2886,6 +3175,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/abbrev</property>
+      </properties>
     </component>
     <component type="library" bom-ref="accepts@1.3.8">
       <name>accepts</name>
@@ -2910,6 +3202,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/accepts</property>
+      </properties>
     </component>
     <component type="library" bom-ref="acorn-walk@8.2.0">
       <name>acorn-walk</name>
@@ -2938,6 +3233,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/acorn-walk</property>
+      </properties>
     </component>
     <component type="library" bom-ref="acorn@7.4.1">
       <name>acorn</name>
@@ -2966,6 +3264,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/acorn</property>
+      </properties>
     </component>
     <component type="library" bom-ref="agent-base@6.0.2">
       <author>Nathan Rajlich &lt;nathan@tootallnate.net&gt; (http://n8.io/)</author>
@@ -2995,6 +3296,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/agent-base</property>
+      </properties>
       <components>
         <component type="library" bom-ref="agent-base@6.0.2|debug@4.3.4">
           <author>Josh Junon &lt;josh.junon@protonmail.com&gt;</author>
@@ -3020,6 +3324,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/agent-base/node_modules/debug</property>
+          </properties>
         </component>
         <component type="library" bom-ref="agent-base@6.0.2|ms@2.1.2">
           <name>ms</name>
@@ -3044,6 +3351,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/agent-base/node_modules/ms</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -3075,6 +3385,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/agentkeepalive</property>
+      </properties>
       <components>
         <component type="library" bom-ref="agentkeepalive@4.2.1|debug@4.3.4">
           <author>Josh Junon &lt;josh.junon@protonmail.com&gt;</author>
@@ -3100,6 +3413,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/agentkeepalive/node_modules/debug</property>
+          </properties>
         </component>
         <component type="library" bom-ref="agentkeepalive@4.2.1|depd@1.1.2">
           <author>Douglas Christopher Wilson &lt;doug@somethingdoug.com&gt;</author>
@@ -3125,6 +3441,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/agentkeepalive/node_modules/depd</property>
+          </properties>
         </component>
         <component type="library" bom-ref="agentkeepalive@4.2.1|ms@2.1.2">
           <name>ms</name>
@@ -3149,6 +3468,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/agentkeepalive/node_modules/ms</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -3176,6 +3498,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/aggregate-error</property>
+      </properties>
     </component>
     <component type="library" bom-ref="ajv@6.12.6">
       <author>Evgeny Poberezkin</author>
@@ -3209,6 +3534,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/ajv</property>
+      </properties>
     </component>
     <component type="library" bom-ref="ansi-regex@2.1.1">
       <author>Sindre Sorhus</author>
@@ -3234,6 +3562,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/ansi-regex</property>
+      </properties>
     </component>
     <component type="library" bom-ref="ansi-styles@3.2.1">
       <author>Sindre Sorhus</author>
@@ -3259,6 +3590,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/ansi-styles</property>
+      </properties>
     </component>
     <component type="library" bom-ref="anymatch@3.1.2">
       <author>Elan Shanker</author>
@@ -3288,6 +3622,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/anymatch</property>
+      </properties>
       <components>
         <component type="library" bom-ref="anymatch@3.1.2|normalize-path@3.0.0">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -3321,6 +3658,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/anymatch/node_modules/normalize-path</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -3347,6 +3687,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/append-field</property>
+      </properties>
     </component>
     <component type="library" bom-ref="aproba@1.2.0">
       <author>Rebecca Turner &lt;me@re-becca.org&gt;</author>
@@ -3380,6 +3723,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/aproba</property>
+      </properties>
     </component>
     <component type="library" bom-ref="archive-type@4.0.0">
       <author>Kevin Mårtensson</author>
@@ -3405,6 +3751,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/archive-type</property>
+      </properties>
       <components>
         <component type="library" bom-ref="archive-type@4.0.0|file-type@4.4.0">
           <author>Sindre Sorhus</author>
@@ -3430,6 +3779,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/archive-type/node_modules/file-type</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -3465,6 +3817,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/archiver-utils</property>
+      </properties>
     </component>
     <component type="library" bom-ref="archiver@1.3.0">
       <author>Chris Talkington</author>
@@ -3498,6 +3853,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/archiver</property>
+      </properties>
     </component>
     <component type="library" bom-ref="are-we-there-yet@1.1.7">
       <author>Rebecca Turner (http://re-becca.org)</author>
@@ -3531,6 +3889,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/are-we-there-yet</property>
+      </properties>
     </component>
     <component type="library" bom-ref="arg@4.1.3">
       <author>Josh Junon &lt;junon@zeit.co&gt;</author>
@@ -3556,6 +3917,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/arg</property>
+      </properties>
     </component>
     <component type="library" bom-ref="argparse@1.0.10">
       <name>argparse</name>
@@ -3580,6 +3944,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/argparse</property>
+      </properties>
       <components>
         <component type="library" bom-ref="argparse@1.0.10|sprintf-js@1.0.3">
           <author>Alexandru Marasteanu &lt;hello@alexei.ro&gt; (http://alexei.ro/)</author>
@@ -3605,6 +3972,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/argparse/node_modules/sprintf-js</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -3640,6 +4010,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/arr-diff</property>
+      </properties>
     </component>
     <component type="library" bom-ref="arr-flatten@1.1.0">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -3673,6 +4046,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/arr-flatten</property>
+      </properties>
     </component>
     <component type="library" bom-ref="arr-union@3.1.0">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -3706,6 +4082,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/arr-union</property>
+      </properties>
     </component>
     <component type="library" bom-ref="array-each@1.0.1">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -3739,6 +4118,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/array-each</property>
+      </properties>
     </component>
     <component type="library" bom-ref="array-flatten@1.1.1">
       <author>Blake Embrey</author>
@@ -3772,6 +4154,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/array-flatten</property>
+      </properties>
     </component>
     <component type="library" bom-ref="array-slice@1.1.0">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -3805,6 +4190,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/array-slice</property>
+      </properties>
     </component>
     <component type="library" bom-ref="array-unique@0.3.2">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -3838,6 +4226,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/array-unique</property>
+      </properties>
     </component>
     <component type="library" bom-ref="asap@2.0.6">
       <name>asap</name>
@@ -3862,6 +4253,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/asap</property>
+      </properties>
     </component>
     <component type="library" bom-ref="asn1@0.2.6">
       <author>Joyent (joyent.com)</author>
@@ -3887,6 +4281,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/asn1</property>
+      </properties>
     </component>
     <component type="library" bom-ref="assert-never@1.2.1">
       <author>Daniel Lytkin &lt;dan.lytkin@gmail.com&gt;</author>
@@ -3912,6 +4309,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/assert-never</property>
+      </properties>
     </component>
     <component type="library" bom-ref="assert-plus@1.0.0">
       <author>Mark Cavage &lt;mcavage@gmail.com&gt;</author>
@@ -3937,6 +4337,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/assert-plus</property>
+      </properties>
     </component>
     <component type="library" bom-ref="assign-symbols@1.0.0">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -3970,6 +4373,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/assign-symbols</property>
+      </properties>
     </component>
     <component type="library" bom-ref="async@2.6.4">
       <author>Caolan McMahon</author>
@@ -4003,6 +4409,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/async</property>
+      </properties>
     </component>
     <component type="library" bom-ref="asynckit@0.4.0">
       <author>Alex Indigo &lt;iam@alexindigo.com&gt;</author>
@@ -4036,6 +4445,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/asynckit</property>
+      </properties>
     </component>
     <component type="library" bom-ref="at-least-node@1.0.0">
       <author>Ryan Zimmerman &lt;opensrc@ryanzim.com&gt;</author>
@@ -4069,6 +4481,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/at-least-node</property>
+      </properties>
     </component>
     <component type="library" bom-ref="atob@2.1.2">
       <author>AJ ONeal &lt;coolaj86@gmail.com&gt; (https://coolaj86.com)</author>
@@ -4096,6 +4511,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/atob</property>
+      </properties>
     </component>
     <component type="library" bom-ref="available-typed-arrays@1.0.5">
       <author>Jordan Harband &lt;ljharb@gmail.com&gt;</author>
@@ -4129,6 +4547,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/available-typed-arrays</property>
+      </properties>
     </component>
     <component type="library" bom-ref="aws-sign2@0.7.0">
       <author>Mikeal Rogers &lt;mikeal.rogers@gmail.com&gt; (http://www.futurealoof.com)</author>
@@ -4154,6 +4575,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/aws-sign2</property>
+      </properties>
     </component>
     <component type="library" bom-ref="aws4@1.11.0">
       <author>Michael Hart &lt;michael.hart.au@gmail.com&gt; (https://github.com/mhart)</author>
@@ -4179,6 +4603,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/aws4</property>
+      </properties>
     </component>
     <component type="library" bom-ref="babel-walk@3.0.0-canary-5">
       <author>Timothy Gu &lt;timothygu99@gmail.com&gt;</author>
@@ -4204,6 +4631,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/babel-walk</property>
+      </properties>
     </component>
     <component type="library" bom-ref="balanced-match@1.0.2">
       <author>Julian Gruber</author>
@@ -4233,6 +4663,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/balanced-match</property>
+      </properties>
     </component>
     <component type="library" bom-ref="base@0.11.2">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -4266,6 +4699,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/base</property>
+      </properties>
       <components>
         <component type="library" bom-ref="base@0.11.2|define-property@1.0.0">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -4299,6 +4735,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/base/node_modules/define-property</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -4310,6 +4749,12 @@
       <hashes>
         <hash alg="SHA-512">6b5788162e11f724ab6e232ec931b1e5ef76b911f9b5063a900acd70568a05495e2282e3763060ed9c66dccaa6dca9a47f6ec72d1ff57e7c57f6af0643b21abe</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <url>https://github.com/niklasvh/base64-arraybuffer/blob/master/LICENSE-MIT</url>
+        </license>
+      </licenses>
       <purl>pkg:npm/base64-arraybuffer@0.1.4</purl>
       <externalReferences>
         <reference type="distribution">
@@ -4329,6 +4774,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/base64-arraybuffer</property>
+      </properties>
     </component>
     <component type="library" bom-ref="base64-js@1.5.1">
       <author>T. Jameson Little &lt;t.jameson.little@gmail.com&gt;</author>
@@ -4362,6 +4810,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/base64-js</property>
+      </properties>
     </component>
     <component type="library" bom-ref="base64id@2.0.0">
       <author>Kristian Faeldt &lt;faeldt_kristian@cyberagent.co.jp&gt;</author>
@@ -4387,6 +4838,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/base64id</property>
+      </properties>
     </component>
     <component type="library" bom-ref="base64url@0.0.6">
       <author>Brian J Brennan</author>
@@ -4412,6 +4866,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/base64url</property>
+      </properties>
     </component>
     <component type="library" bom-ref="basic-auth@2.0.1">
       <name>basic-auth</name>
@@ -4436,6 +4893,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/basic-auth</property>
+      </properties>
     </component>
     <component type="library" bom-ref="batch@0.6.1">
       <author>TJ Holowaychuk &lt;tj@vision-media.ca&gt;</author>
@@ -4461,6 +4921,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/batch</property>
+      </properties>
     </component>
     <component type="library" bom-ref="bcrypt-pbkdf@1.0.2">
       <name>bcrypt-pbkdf</name>
@@ -4485,6 +4948,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/bcrypt-pbkdf</property>
+      </properties>
     </component>
     <component type="library" bom-ref="big-integer@1.6.51">
       <author>Peter Olson &lt;peter.e.c.olson+npm@gmail.com&gt;</author>
@@ -4506,6 +4972,9 @@
           <comment>as detected from npm-ls property "resolved"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/big-integer</property>
+      </properties>
     </component>
     <component type="library" bom-ref="binary-extensions@2.2.0">
       <author>Sindre Sorhus</author>
@@ -4531,6 +5000,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/binary-extensions</property>
+      </properties>
     </component>
     <component type="library" bom-ref="binary@0.3.0">
       <author>James Halliday</author>
@@ -4556,6 +5028,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/binary</property>
+      </properties>
     </component>
     <component type="library" bom-ref="bindings@1.5.0">
       <author>Nathan Rajlich &lt;nathan@tootallnate.net&gt; (http://tootallnate.net)</author>
@@ -4589,6 +5064,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/bindings</property>
+      </properties>
     </component>
     <component type="library" bom-ref="bintrees@1.0.2">
       <author>Vadim Graboys &lt;dimva13@gmail.com&gt;</author>
@@ -4614,6 +5092,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/bintrees</property>
+      </properties>
     </component>
     <component type="library" bom-ref="bl@1.2.3">
       <name>bl</name>
@@ -4642,6 +5123,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/bl</property>
+      </properties>
     </component>
     <component type="library" bom-ref="bluebird@3.7.2">
       <author>Petka Antonov</author>
@@ -4675,6 +5159,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/bluebird</property>
+      </properties>
     </component>
     <component type="library" bom-ref="body-parser@1.20.1">
       <name>body-parser</name>
@@ -4699,6 +5186,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/body-parser</property>
+      </properties>
     </component>
     <component type="library" bom-ref="bower-config@1.4.3">
       <author>Twitter</author>
@@ -4728,6 +5218,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/bower-config</property>
+      </properties>
       <components>
         <component type="library" bom-ref="bower-config@1.4.3|minimist@0.2.2">
           <author>James Halliday</author>
@@ -4757,6 +5250,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/bower-config/node_modules/minimist</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -4788,6 +5284,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/brace-expansion</property>
+      </properties>
     </component>
     <component type="library" bom-ref="braces@2.3.2">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -4821,6 +5320,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/braces</property>
+      </properties>
       <components>
         <component type="library" bom-ref="braces@2.3.2|extend-shallow@2.0.1">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -4854,6 +5356,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/braces/node_modules/extend-shallow</property>
+          </properties>
         </component>
         <component type="library" bom-ref="braces@2.3.2|is-extendable@0.1.1">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -4887,6 +5392,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/braces/node_modules/is-extendable</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -4922,6 +5430,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/brotli</property>
+      </properties>
     </component>
     <component type="library" bom-ref="buffer-alloc-unsafe@1.1.0">
       <name>buffer-alloc-unsafe</name>
@@ -4945,6 +5456,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/buffer-alloc-unsafe</property>
+      </properties>
     </component>
     <component type="library" bom-ref="buffer-alloc@1.2.0">
       <name>buffer-alloc</name>
@@ -4968,6 +5482,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/buffer-alloc</property>
+      </properties>
     </component>
     <component type="library" bom-ref="buffer-crc32@0.2.13">
       <author>Brian J. Brennan &lt;brianloveswords@gmail.com&gt;</author>
@@ -4980,6 +5497,10 @@
       <licenses>
         <license>
           <id>MIT</id>
+        </license>
+        <license>
+          <id>MIT</id>
+          <url>https://github.com/brianloveswords/buffer-crc32/raw/master/LICENSE</url>
         </license>
       </licenses>
       <purl>pkg:npm/buffer-crc32@0.2.13</purl>
@@ -4997,6 +5518,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/buffer-crc32</property>
+      </properties>
     </component>
     <component type="library" bom-ref="buffer-fill@1.0.0">
       <name>buffer-fill</name>
@@ -5020,6 +5544,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/buffer-fill</property>
+      </properties>
     </component>
     <component type="library" bom-ref="buffer-from@1.1.2">
       <name>buffer-from</name>
@@ -5043,6 +5570,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/buffer-from</property>
+      </properties>
     </component>
     <component type="library" bom-ref="buffer-indexof-polyfill@1.0.2">
       <author>https://github.com/sarosia</author>
@@ -5076,6 +5606,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/buffer-indexof-polyfill</property>
+      </properties>
     </component>
     <component type="library" bom-ref="buffer@5.7.1">
       <author>Feross Aboukhadijeh</author>
@@ -5109,6 +5642,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/buffer</property>
+      </properties>
     </component>
     <component type="library" bom-ref="buffers@0.1.1">
       <author>James Halliday &lt;mail@substack.net&gt; (http://substack.net)</author>
@@ -5129,6 +5665,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/buffers</property>
+      </properties>
     </component>
     <component type="library" bom-ref="busboy@0.2.14">
       <author>Brian White &lt;mscdex@mscdex.net&gt;</author>
@@ -5138,6 +5677,12 @@
       <hashes>
         <hash alg="SHA-512">2275850e89af964123fb158b05f53702f9db558a9e4d6990a29896d2d596132e727a1626d9890611ce7db149b0ff8b72e598ff6f45871acd4b81e72e052046ae</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <url>http://github.com/mscdex/busboy/raw/master/LICENSE</url>
+        </license>
+      </licenses>
       <purl>pkg:npm/busboy@0.2.14</purl>
       <externalReferences>
         <reference type="distribution">
@@ -5149,6 +5694,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/busboy</property>
+      </properties>
       <components>
         <component type="library" bom-ref="busboy@0.2.14|isarray@0.0.1">
           <author>Julian Gruber</author>
@@ -5178,6 +5726,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/busboy/node_modules/isarray</property>
+          </properties>
         </component>
         <component type="library" bom-ref="busboy@0.2.14|readable-stream@1.1.14">
           <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me/)</author>
@@ -5203,6 +5754,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/busboy/node_modules/readable-stream</property>
+          </properties>
         </component>
         <component type="library" bom-ref="busboy@0.2.14|string_decoder@0.10.31">
           <name>string_decoder</name>
@@ -5231,6 +5785,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/busboy/node_modules/string_decoder</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -5266,6 +5823,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/byline</property>
+      </properties>
     </component>
     <component type="library" bom-ref="bytes@3.1.2">
       <author>TJ Holowaychuk &lt;tj@vision-media.ca&gt; (http://tjholowaychuk.com)</author>
@@ -5291,6 +5851,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/bytes</property>
+      </properties>
     </component>
     <component type="library" bom-ref="cacache@15.3.0">
       <name>cacache</name>
@@ -5315,6 +5878,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/cacache</property>
+      </properties>
     </component>
     <component type="library" bom-ref="cache-base@1.0.1">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -5348,6 +5914,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/cache-base</property>
+      </properties>
     </component>
     <component type="library" bom-ref="cacheable-request@2.1.4">
       <author>Luke Childs &lt;lukechilds123@gmail.com&gt; (http://lukechilds.co.uk)</author>
@@ -5381,6 +5950,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/cacheable-request</property>
+      </properties>
       <components>
         <component type="library" bom-ref="cacheable-request@2.1.4|get-stream@3.0.0">
           <author>Sindre Sorhus</author>
@@ -5406,6 +5978,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/cacheable-request/node_modules/get-stream</property>
+          </properties>
         </component>
         <component type="library" bom-ref="cacheable-request@2.1.4|lowercase-keys@1.0.0">
           <author>Sindre Sorhus</author>
@@ -5431,6 +6006,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/cacheable-request/node_modules/lowercase-keys</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -5466,6 +6044,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/call-bind</property>
+      </properties>
     </component>
     <component type="library" bom-ref="camelcase@5.3.1">
       <author>Sindre Sorhus</author>
@@ -5491,6 +6072,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/camelcase</property>
+      </properties>
     </component>
     <component type="library" bom-ref="caseless@0.12.0">
       <author>Mikeal Rogers &lt;mikeal.rogers@gmail.com&gt;</author>
@@ -5520,6 +6104,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/caseless</property>
+      </properties>
     </component>
     <component type="library" bom-ref="chainsaw@0.1.0">
       <author>James Halliday &lt;mail@substack.net&gt; (http://substack.net)</author>
@@ -5545,6 +6132,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/chainsaw</property>
+      </properties>
     </component>
     <component type="library" bom-ref="chalk@2.4.2">
       <name>chalk</name>
@@ -5569,6 +6159,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/chalk</property>
+      </properties>
     </component>
     <component type="library" bom-ref="character-parser@2.2.0">
       <author>ForbesLindesay</author>
@@ -5594,6 +6187,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/character-parser</property>
+      </properties>
     </component>
     <component type="library" bom-ref="check-dependencies@1.1.0">
       <author>Michał Gołębiowski-Owczarek</author>
@@ -5627,6 +6223,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/check-dependencies</property>
+      </properties>
       <components>
         <component type="library" bom-ref="check-dependencies@1.1.0|semver@5.7.1">
           <name>semver</name>
@@ -5651,6 +6250,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/check-dependencies/node_modules/semver</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -5686,6 +6288,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/check-types</property>
+      </properties>
     </component>
     <component type="library" bom-ref="chokidar@3.5.3">
       <author>Paul Miller (https://paulmillr.com)</author>
@@ -5719,6 +6324,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/chokidar</property>
+      </properties>
       <components>
         <component type="library" bom-ref="chokidar@3.5.3|braces@3.0.2">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -5752,6 +6360,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/chokidar/node_modules/braces</property>
+          </properties>
         </component>
         <component type="library" bom-ref="chokidar@3.5.3|fill-range@7.0.1">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -5785,6 +6396,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/chokidar/node_modules/fill-range</property>
+          </properties>
         </component>
         <component type="library" bom-ref="chokidar@3.5.3|is-glob@4.0.3">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -5818,6 +6432,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/chokidar/node_modules/is-glob</property>
+          </properties>
         </component>
         <component type="library" bom-ref="chokidar@3.5.3|is-number@7.0.0">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -5851,6 +6468,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/chokidar/node_modules/is-number</property>
+          </properties>
         </component>
         <component type="library" bom-ref="chokidar@3.5.3|normalize-path@3.0.0">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -5884,6 +6504,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/chokidar/node_modules/normalize-path</property>
+          </properties>
         </component>
         <component type="library" bom-ref="chokidar@3.5.3|to-regex-range@5.0.1">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -5917,6 +6540,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/chokidar/node_modules/to-regex-range</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -5944,6 +6570,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/chownr</property>
+      </properties>
     </component>
     <component type="library" bom-ref="clarinet@0.12.5">
       <author>Nuno Job &lt;nunojobpinto@gmail.com&gt; (http://nunojob.com/)</author>
@@ -5977,6 +6606,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/clarinet</property>
+      </properties>
     </component>
     <component type="library" bom-ref="class-utils@0.3.6">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -6010,6 +6642,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/class-utils</property>
+      </properties>
       <components>
         <component type="library" bom-ref="class-utils@0.3.6|define-property@0.2.5">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -6043,6 +6678,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/class-utils/node_modules/define-property</property>
+          </properties>
         </component>
         <component type="library" bom-ref="class-utils@0.3.6|is-accessor-descriptor@0.1.6">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -6076,6 +6714,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/class-utils/node_modules/is-accessor-descriptor</property>
+          </properties>
           <components>
             <component type="library" bom-ref="class-utils@0.3.6|is-accessor-descriptor@0.1.6|kind-of@3.2.2">
               <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -6109,6 +6750,9 @@
                   <comment>as detected from PackageJson property "homepage"</comment>
                 </reference>
               </externalReferences>
+              <properties>
+                <property name="cdx:npm:package:installPath">node_modules/class-utils/node_modules/is-accessor-descriptor/node_modules/kind-of</property>
+              </properties>
             </component>
           </components>
         </component>
@@ -6144,6 +6788,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/class-utils/node_modules/is-data-descriptor</property>
+          </properties>
           <components>
             <component type="library" bom-ref="class-utils@0.3.6|is-data-descriptor@0.1.4|kind-of@3.2.2">
               <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -6177,6 +6824,9 @@
                   <comment>as detected from PackageJson property "homepage"</comment>
                 </reference>
               </externalReferences>
+              <properties>
+                <property name="cdx:npm:package:installPath">node_modules/class-utils/node_modules/is-data-descriptor/node_modules/kind-of</property>
+              </properties>
             </component>
           </components>
         </component>
@@ -6212,6 +6862,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/class-utils/node_modules/is-descriptor</property>
+          </properties>
         </component>
         <component type="library" bom-ref="class-utils@0.3.6|kind-of@5.1.0">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -6245,6 +6898,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/class-utils/node_modules/kind-of</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -6272,6 +6928,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/clean-stack</property>
+      </properties>
     </component>
     <component type="library" bom-ref="cliui@5.0.0">
       <author>Ben Coe &lt;ben@npmjs.com&gt;</author>
@@ -6297,6 +6956,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/cliui</property>
+      </properties>
       <components>
         <component type="library" bom-ref="cliui@5.0.0|ansi-regex@4.1.1">
           <author>Sindre Sorhus</author>
@@ -6322,6 +6984,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/cliui/node_modules/ansi-regex</property>
+          </properties>
         </component>
         <component type="library" bom-ref="cliui@5.0.0|emoji-regex@7.0.3">
           <author>Mathias Bynens</author>
@@ -6355,6 +7020,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/cliui/node_modules/emoji-regex</property>
+          </properties>
         </component>
         <component type="library" bom-ref="cliui@5.0.0|is-fullwidth-code-point@2.0.0">
           <author>Sindre Sorhus</author>
@@ -6380,6 +7048,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/cliui/node_modules/is-fullwidth-code-point</property>
+          </properties>
         </component>
         <component type="library" bom-ref="cliui@5.0.0|string-width@3.1.0">
           <author>Sindre Sorhus</author>
@@ -6405,6 +7076,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/cliui/node_modules/string-width</property>
+          </properties>
         </component>
         <component type="library" bom-ref="cliui@5.0.0|strip-ansi@5.2.0">
           <author>Sindre Sorhus</author>
@@ -6430,6 +7104,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/cliui/node_modules/strip-ansi</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -6465,6 +7142,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/clone-response</property>
+      </properties>
     </component>
     <component type="library" bom-ref="clone@2.1.2">
       <author>Paul Vorbach &lt;paul@vorba.ch&gt; (http://paul.vorba.ch/)</author>
@@ -6494,6 +7174,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/clone</property>
+      </properties>
     </component>
     <component type="library" bom-ref="code-point-at@1.1.0">
       <author>Sindre Sorhus</author>
@@ -6519,6 +7202,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/code-point-at</property>
+      </properties>
     </component>
     <component type="library" bom-ref="collection-visit@1.0.0">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -6552,6 +7238,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/collection-visit</property>
+      </properties>
     </component>
     <component type="library" bom-ref="color-convert@1.9.3">
       <author>Heather Arthur &lt;fayearthur@gmail.com&gt;</author>
@@ -6577,6 +7266,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/color-convert</property>
+      </properties>
     </component>
     <component type="library" bom-ref="color-name@1.1.3">
       <author>DY &lt;dfcreative@gmail.com&gt;</author>
@@ -6606,6 +7298,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/color-name</property>
+      </properties>
     </component>
     <component type="library" bom-ref="color-string@1.9.1">
       <author>Heather Arthur &lt;fayearthur@gmail.com&gt;</author>
@@ -6631,6 +7326,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/color-string</property>
+      </properties>
     </component>
     <component type="library" bom-ref="color-support@1.1.3">
       <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me/)</author>
@@ -6656,6 +7354,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/color-support</property>
+      </properties>
     </component>
     <component type="library" bom-ref="color@3.2.1">
       <name>color</name>
@@ -6680,6 +7381,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/color</property>
+      </properties>
     </component>
     <component type="library" bom-ref="colors@1.4.0">
       <author>Marak Squires</author>
@@ -6713,6 +7417,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/colors</property>
+      </properties>
     </component>
     <component type="library" bom-ref="colorspace@1.1.4">
       <author>Arnout Kazemier</author>
@@ -6746,6 +7453,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/colorspace</property>
+      </properties>
     </component>
     <component type="library" bom-ref="combined-stream@1.0.8">
       <author>Felix Geisendörfer &lt;felix@debuggable.com&gt; (http://debuggable.com/)</author>
@@ -6775,6 +7485,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/combined-stream</property>
+      </properties>
     </component>
     <component type="library" bom-ref="commander@2.20.3">
       <author>TJ Holowaychuk &lt;tj@vision-media.ca&gt;</author>
@@ -6800,6 +7513,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/commander</property>
+      </properties>
     </component>
     <component type="library" bom-ref="component-emitter@1.3.0">
       <name>component-emitter</name>
@@ -6824,6 +7540,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/component-emitter</property>
+      </properties>
     </component>
     <component type="library" bom-ref="component-type@1.2.1">
       <name>component-type</name>
@@ -6848,6 +7567,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/component-type</property>
+      </properties>
     </component>
     <component type="library" bom-ref="compress-commons@1.2.2">
       <author>Chris Talkington</author>
@@ -6881,6 +7603,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/compress-commons</property>
+      </properties>
     </component>
     <component type="library" bom-ref="compressible@2.0.18">
       <name>compressible</name>
@@ -6905,6 +7630,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/compressible</property>
+      </properties>
     </component>
     <component type="library" bom-ref="compression@1.7.4">
       <name>compression</name>
@@ -6929,6 +7657,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/compression</property>
+      </properties>
       <components>
         <component type="library" bom-ref="compression@1.7.4|bytes@3.0.0">
           <author>TJ Holowaychuk &lt;tj@vision-media.ca&gt; (http://tjholowaychuk.com)</author>
@@ -6954,6 +7685,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/compression/node_modules/bytes</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -6981,6 +7715,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/concat-map</property>
+      </properties>
     </component>
     <component type="library" bom-ref="concat-stream@1.6.2">
       <author>Max Ogden &lt;max@maxogden.com&gt;</author>
@@ -7010,6 +7747,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/concat-stream</property>
+      </properties>
     </component>
     <component type="library" bom-ref="concurrently@5.3.0">
       <author>Kimmo Brunfeldt</author>
@@ -7035,6 +7775,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/concurrently</property>
+      </properties>
       <components>
         <component type="library" bom-ref="concurrently@5.3.0|supports-color@6.1.0">
           <author>Sindre Sorhus</author>
@@ -7060,6 +7803,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/concurrently/node_modules/supports-color</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -7091,6 +7837,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/config</property>
+      </properties>
     </component>
     <component type="library" bom-ref="console-control-strings@1.1.0">
       <author>Rebecca Turner &lt;me@re-becca.org&gt; (http://re-becca.org/)</author>
@@ -7116,6 +7865,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/console-control-strings</property>
+      </properties>
     </component>
     <component type="library" bom-ref="constantinople@4.0.1">
       <author>ForbesLindesay</author>
@@ -7141,6 +7893,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/constantinople</property>
+      </properties>
     </component>
     <component type="library" bom-ref="content-disposition@0.5.4">
       <author>Douglas Christopher Wilson &lt;doug@somethingdoug.com&gt;</author>
@@ -7166,6 +7921,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/content-disposition</property>
+      </properties>
       <components>
         <component type="library" bom-ref="content-disposition@0.5.4|safe-buffer@5.2.1">
           <author>Feross Aboukhadijeh</author>
@@ -7199,6 +7957,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/content-disposition/node_modules/safe-buffer</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -7226,6 +7987,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/content-type</property>
+      </properties>
     </component>
     <component type="library" bom-ref="cookie-parser@1.4.6">
       <author>TJ Holowaychuk &lt;tj@vision-media.ca&gt; (http://tjholowaychuk.com)</author>
@@ -7251,6 +8015,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/cookie-parser</property>
+      </properties>
     </component>
     <component type="library" bom-ref="cookie-signature@1.0.6">
       <author>TJ Holowaychuk &lt;tj@learnboost.com&gt;</author>
@@ -7276,6 +8043,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/cookie-signature</property>
+      </properties>
     </component>
     <component type="library" bom-ref="cookie@0.4.1">
       <author>Roman Shtylman &lt;shtylman@gmail.com&gt;</author>
@@ -7301,6 +8071,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/cookie</property>
+      </properties>
     </component>
     <component type="library" bom-ref="copy-descriptor@0.1.1">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -7334,6 +8107,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/copy-descriptor</property>
+      </properties>
     </component>
     <component type="library" bom-ref="core-util-is@1.0.3">
       <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me/)</author>
@@ -7363,6 +8139,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/core-util-is</property>
+      </properties>
     </component>
     <component type="library" bom-ref="cors@2.8.5">
       <author>Troy Goode &lt;troygoode@gmail.com&gt; (https://github.com/troygoode/)</author>
@@ -7388,6 +8167,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/cors</property>
+      </properties>
     </component>
     <component type="library" bom-ref="crc@3.8.0">
       <author>Alex Gorbatchev</author>
@@ -7421,6 +8203,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/crc</property>
+      </properties>
     </component>
     <component type="library" bom-ref="crc32-stream@2.0.0">
       <author>Chris Talkington</author>
@@ -7454,6 +8239,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/crc32-stream</property>
+      </properties>
     </component>
     <component type="library" bom-ref="create-require@1.1.1">
       <name>create-require</name>
@@ -7478,6 +8266,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/create-require</property>
+      </properties>
     </component>
     <component type="library" bom-ref="crypto-js@3.3.0">
       <author>Evan Vosberg</author>
@@ -7507,6 +8298,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/crypto-js</property>
+      </properties>
     </component>
     <component type="library" bom-ref="dashdash@1.14.1">
       <author>Trent Mick &lt;trentm@gmail.com&gt; (http://trentm.com)</author>
@@ -7532,6 +8326,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/dashdash</property>
+      </properties>
     </component>
     <component type="library" bom-ref="date-fns@2.29.3">
       <name>date-fns</name>
@@ -7556,6 +8353,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/date-fns</property>
+      </properties>
     </component>
     <component type="library" bom-ref="dateformat@3.0.3">
       <author>Steven Levithan</author>
@@ -7585,6 +8385,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/dateformat</property>
+      </properties>
     </component>
     <component type="library" bom-ref="debug@2.6.9">
       <author>TJ Holowaychuk &lt;tj@vision-media.ca&gt;</author>
@@ -7610,6 +8413,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/debug</property>
+      </properties>
     </component>
     <component type="library" bom-ref="decamelize@1.2.0">
       <author>Sindre Sorhus</author>
@@ -7635,6 +8441,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/decamelize</property>
+      </properties>
     </component>
     <component type="library" bom-ref="decode-uri-component@0.2.0">
       <author>Sam Verschueren</author>
@@ -7660,6 +8469,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/decode-uri-component</property>
+      </properties>
     </component>
     <component type="library" bom-ref="decompress-response@3.3.0">
       <name>decompress-response</name>
@@ -7684,6 +8496,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/decompress-response</property>
+      </properties>
     </component>
     <component type="library" bom-ref="decompress-tar@4.1.1">
       <author>Kevin Mårtensson</author>
@@ -7709,6 +8524,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/decompress-tar</property>
+      </properties>
       <components>
         <component type="library" bom-ref="decompress-tar@4.1.1|file-type@5.2.0">
           <author>Sindre Sorhus</author>
@@ -7734,6 +8552,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/decompress-tar/node_modules/file-type</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -7761,6 +8582,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/decompress-tarbz2</property>
+      </properties>
       <components>
         <component type="library" bom-ref="decompress-tarbz2@4.1.1|file-type@6.2.0">
           <author>Sindre Sorhus</author>
@@ -7786,6 +8610,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/decompress-tarbz2/node_modules/file-type</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -7813,6 +8640,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/decompress-targz</property>
+      </properties>
       <components>
         <component type="library" bom-ref="decompress-targz@4.1.1|file-type@5.2.0">
           <author>Sindre Sorhus</author>
@@ -7838,6 +8668,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/decompress-targz/node_modules/file-type</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -7865,6 +8698,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/decompress-unzip</property>
+      </properties>
       <components>
         <component type="library" bom-ref="decompress-unzip@4.0.1|file-type@3.9.0">
           <author>Sindre Sorhus</author>
@@ -7890,6 +8726,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/decompress-unzip/node_modules/file-type</property>
+          </properties>
         </component>
         <component type="library" bom-ref="decompress-unzip@4.0.1|get-stream@2.3.1">
           <author>Sindre Sorhus</author>
@@ -7915,6 +8754,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/decompress-unzip/node_modules/get-stream</property>
+          </properties>
         </component>
         <component type="library" bom-ref="decompress-unzip@4.0.1|pify@2.3.0">
           <author>Sindre Sorhus</author>
@@ -7940,6 +8782,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/decompress-unzip/node_modules/pify</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -7967,6 +8812,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/decompress</property>
+      </properties>
       <components>
         <component type="library" bom-ref="decompress@4.2.1|make-dir@1.3.0">
           <author>Sindre Sorhus</author>
@@ -7992,6 +8840,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/decompress/node_modules/make-dir</property>
+          </properties>
           <components>
             <component type="library" bom-ref="decompress@4.2.1|make-dir@1.3.0|pify@3.0.0">
               <author>Sindre Sorhus</author>
@@ -8017,6 +8868,9 @@
                   <comment>as detected from PackageJson property "repository"</comment>
                 </reference>
               </externalReferences>
+              <properties>
+                <property name="cdx:npm:package:installPath">node_modules/decompress/node_modules/make-dir/node_modules/pify</property>
+              </properties>
             </component>
           </components>
         </component>
@@ -8044,6 +8898,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/decompress/node_modules/pify</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -8071,6 +8928,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/deep-equal</property>
+      </properties>
     </component>
     <component type="library" bom-ref="deep-extend@0.6.0">
       <author>Viacheslav Lotsmanov &lt;lotsmanov89@gmail.com&gt;</author>
@@ -8083,6 +8943,10 @@
       <licenses>
         <license>
           <id>MIT</id>
+        </license>
+        <license>
+          <id>MIT</id>
+          <url>https://raw.githubusercontent.com/unclechu/node-deep-extend/master/LICENSE</url>
         </license>
       </licenses>
       <purl>pkg:npm/deep-extend@0.6.0</purl>
@@ -8104,6 +8968,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/deep-extend</property>
+      </properties>
     </component>
     <component type="library" bom-ref="deep-is@0.1.4">
       <author>Thorsten Lorenz</author>
@@ -8129,6 +8996,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/deep-is</property>
+      </properties>
     </component>
     <component type="library" bom-ref="define-properties@1.1.4">
       <author>Jordan Harband &lt;ljharb@gmail.com&gt;</author>
@@ -8154,6 +9024,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/define-properties</property>
+      </properties>
     </component>
     <component type="library" bom-ref="define-property@2.0.2">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -8187,6 +9060,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/define-property</property>
+      </properties>
     </component>
     <component type="library" bom-ref="delayed-stream@1.0.0">
       <author>Felix Geisendörfer &lt;felix@debuggable.com&gt; (http://debuggable.com/)</author>
@@ -8216,6 +9092,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/delayed-stream</property>
+      </properties>
     </component>
     <component type="library" bom-ref="delegates@1.0.0">
       <name>delegates</name>
@@ -8240,6 +9119,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/delegates</property>
+      </properties>
     </component>
     <component type="library" bom-ref="depd@2.0.0">
       <author>Douglas Christopher Wilson &lt;doug@somethingdoug.com&gt;</author>
@@ -8265,6 +9147,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/depd</property>
+      </properties>
     </component>
     <component type="library" bom-ref="destroy@1.2.0">
       <author>Jonathan Ong</author>
@@ -8290,6 +9175,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/destroy</property>
+      </properties>
     </component>
     <component type="library" bom-ref="detect-file@1.0.0">
       <author>Brian Woodward (https://github.com/doowb)</author>
@@ -8323,6 +9211,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/detect-file</property>
+      </properties>
     </component>
     <component type="library" bom-ref="detect-libc@1.0.3">
       <author>Lovell Fuller &lt;npm@lovell.info&gt;</author>
@@ -8348,6 +9239,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/detect-libc</property>
+      </properties>
     </component>
     <component type="library" bom-ref="dfa@1.2.0">
       <author>Devon Govett &lt;devongovett@gmail.com&gt;</author>
@@ -8381,6 +9275,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/dfa</property>
+      </properties>
     </component>
     <component type="library" bom-ref="dicer@0.2.5">
       <author>Brian White &lt;mscdex@mscdex.net&gt;</author>
@@ -8390,6 +9287,12 @@
       <hashes>
         <hash alg="SHA-512">143bdbb67abb77394fcf4c32625384c627c311972ef21fab12b11781fc6a98b7d17c2fe4262744161e3e79f7c944edcfd3199fab23db48c1b42ef78d45f4ca56</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <url>http://github.com/mscdex/dicer/raw/master/LICENSE</url>
+        </license>
+      </licenses>
       <purl>pkg:npm/dicer@0.2.5</purl>
       <externalReferences>
         <reference type="distribution">
@@ -8401,6 +9304,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/dicer</property>
+      </properties>
       <components>
         <component type="library" bom-ref="dicer@0.2.5|isarray@0.0.1">
           <author>Julian Gruber</author>
@@ -8430,6 +9336,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/dicer/node_modules/isarray</property>
+          </properties>
         </component>
         <component type="library" bom-ref="dicer@0.2.5|readable-stream@1.1.14">
           <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me/)</author>
@@ -8455,6 +9364,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/dicer/node_modules/readable-stream</property>
+          </properties>
         </component>
         <component type="library" bom-ref="dicer@0.2.5|string_decoder@0.10.31">
           <name>string_decoder</name>
@@ -8483,6 +9395,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/dicer/node_modules/string_decoder</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -8513,6 +9428,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/diff</property>
+      </properties>
     </component>
     <component type="library" bom-ref="doctypes@1.1.0">
       <author>ForbesLindesay</author>
@@ -8538,6 +9456,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/doctypes</property>
+      </properties>
     </component>
     <component type="library" bom-ref="domelementtype@1.3.1">
       <author>Felix Boehm &lt;me@feedic.com&gt;</author>
@@ -8563,6 +9484,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/domelementtype</property>
+      </properties>
     </component>
     <component type="library" bom-ref="domhandler@2.1.0">
       <author>Felix Boehm &lt;me@feedic.com&gt;</author>
@@ -8583,6 +9507,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/domhandler</property>
+      </properties>
     </component>
     <component type="library" bom-ref="domutils@1.1.6">
       <author>Felix Boehm &lt;me@feedic.com&gt;</author>
@@ -8603,6 +9530,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/domutils</property>
+      </properties>
     </component>
     <component type="library" bom-ref="dottie@2.0.2">
       <author>Mick Hansen &lt;maker@mhansen.io&gt;</author>
@@ -8628,6 +9558,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/dottie</property>
+      </properties>
     </component>
     <component type="library" bom-ref="double-ended-queue@0.9.7">
       <author>Petka Antonov</author>
@@ -8661,6 +9594,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/double-ended-queue</property>
+      </properties>
     </component>
     <component type="library" bom-ref="doublearray@0.0.2">
       <author>takuyaa</author>
@@ -8694,6 +9630,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/doublearray</property>
+      </properties>
     </component>
     <component type="library" bom-ref="download@8.0.0">
       <author>Kevin Mårtensson</author>
@@ -8719,6 +9658,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/download</property>
+      </properties>
       <components>
         <component type="library" bom-ref="download@8.0.0|file-type@11.1.0">
           <author>Sindre Sorhus</author>
@@ -8744,6 +9686,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/download/node_modules/file-type</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -8771,6 +9716,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/duplexer2</property>
+      </properties>
     </component>
     <component type="library" bom-ref="duplexer3@0.1.5">
       <name>duplexer3</name>
@@ -8795,6 +9743,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/duplexer3</property>
+      </properties>
     </component>
     <component type="library" bom-ref="dynamic-dedupe@0.3.0">
       <author>Thorsten Lorenz</author>
@@ -8819,6 +9770,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/dynamic-dedupe</property>
+      </properties>
     </component>
     <component type="library" bom-ref="ecc-jsbn@0.1.2">
       <author>Jeremie Miller</author>
@@ -8852,6 +9806,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/ecc-jsbn</property>
+      </properties>
     </component>
     <component type="library" bom-ref="ee-first@1.1.1">
       <author>Jonathan Ong</author>
@@ -8877,6 +9834,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/ee-first</property>
+      </properties>
     </component>
     <component type="library" bom-ref="eivindfjeldstad-dot@0.0.1">
       <name>eivindfjeldstad-dot</name>
@@ -8909,6 +9869,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/eivindfjeldstad-dot</property>
+      </properties>
     </component>
     <component type="library" bom-ref="emoji-regex@8.0.0">
       <author>Mathias Bynens</author>
@@ -8942,6 +9905,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/emoji-regex</property>
+      </properties>
     </component>
     <component type="library" bom-ref="enabled@2.0.0">
       <author>Arnout Kazemier</author>
@@ -8967,6 +9933,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/enabled</property>
+      </properties>
     </component>
     <component type="library" bom-ref="encodeurl@1.0.2">
       <name>encodeurl</name>
@@ -8991,6 +9960,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/encodeurl</property>
+      </properties>
     </component>
     <component type="library" bom-ref="encoding@0.1.13">
       <author>Andris Reinman</author>
@@ -9016,6 +9988,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/encoding</property>
+      </properties>
       <components>
         <component type="library" bom-ref="encoding@0.1.13|iconv-lite@0.6.3">
           <author>Alexander Shtuchkin &lt;ashtuchkin@gmail.com&gt;</author>
@@ -9049,6 +10024,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/encoding/node_modules/iconv-lite</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -9084,6 +10062,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/end-of-stream</property>
+      </properties>
     </component>
     <component type="library" bom-ref="engine.io-parser@4.0.3">
       <name>engine.io-parser</name>
@@ -9108,6 +10089,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/engine.io-parser</property>
+      </properties>
     </component>
     <component type="library" bom-ref="engine.io@4.1.2">
       <author>Guillermo Rauch &lt;guillermo@learnboost.com&gt;</author>
@@ -9133,6 +10117,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/engine.io</property>
+      </properties>
       <components>
         <component type="library" bom-ref="engine.io@4.1.2|debug@4.3.4">
           <author>Josh Junon &lt;josh.junon@protonmail.com&gt;</author>
@@ -9158,6 +10145,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/engine.io/node_modules/debug</property>
+          </properties>
         </component>
         <component type="library" bom-ref="engine.io@4.1.2|ms@2.1.2">
           <name>ms</name>
@@ -9182,6 +10172,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/engine.io/node_modules/ms</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -9209,6 +10202,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/env-paths</property>
+      </properties>
     </component>
     <component type="library" bom-ref="err-code@1.1.2">
       <author>IndigoUnited &lt;hello@indigounited.com&gt; (http://indigounited.com)</author>
@@ -9238,6 +10234,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/err-code</property>
+      </properties>
     </component>
     <component type="library" bom-ref="error-ex@1.3.2">
       <name>error-ex</name>
@@ -9262,6 +10261,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/error-ex</property>
+      </properties>
     </component>
     <component type="library" bom-ref="errorhandler@1.5.1">
       <name>errorhandler</name>
@@ -9286,6 +10288,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/errorhandler</property>
+      </properties>
     </component>
     <component type="library" bom-ref="es-get-iterator@1.1.2">
       <author>Jordan Harband &lt;ljharb@gmail.com&gt;</author>
@@ -9319,6 +10324,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/es-get-iterator</property>
+      </properties>
     </component>
     <component type="library" bom-ref="escape-html@1.0.3">
       <name>escape-html</name>
@@ -9343,6 +10351,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/escape-html</property>
+      </properties>
     </component>
     <component type="library" bom-ref="escape-string-regexp@1.0.5">
       <author>Sindre Sorhus</author>
@@ -9368,6 +10379,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/escape-string-regexp</property>
+      </properties>
     </component>
     <component type="library" bom-ref="escodegen@2.0.0">
       <name>escodegen</name>
@@ -9396,6 +10410,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/escodegen</property>
+      </properties>
     </component>
     <component type="library" bom-ref="esprima@4.0.1">
       <author>Ariya Hidayat</author>
@@ -9429,6 +10446,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/esprima</property>
+      </properties>
     </component>
     <component type="library" bom-ref="estraverse@5.3.0">
       <name>estraverse</name>
@@ -9457,6 +10477,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/estraverse</property>
+      </properties>
     </component>
     <component type="library" bom-ref="esutils@2.0.3">
       <name>esutils</name>
@@ -9485,6 +10508,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/esutils</property>
+      </properties>
     </component>
     <component type="library" bom-ref="etag@1.8.1">
       <name>etag</name>
@@ -9509,6 +10535,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/etag</property>
+      </properties>
     </component>
     <component type="library" bom-ref="eventemitter2@0.4.14">
       <author>hij1nx &lt;paolo@async.ly&gt; http://twitter.com/hij1nx</author>
@@ -9534,6 +10563,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/eventemitter2</property>
+      </properties>
     </component>
     <component type="library" bom-ref="eventemitter3@1.1.1">
       <author>Arnout Kazemier</author>
@@ -9563,6 +10595,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/eventemitter3</property>
+      </properties>
     </component>
     <component type="library" bom-ref="exif@0.6.0">
       <name>exif</name>
@@ -9582,6 +10617,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/exif</property>
+      </properties>
     </component>
     <component type="library" bom-ref="exit@0.1.2">
       <author>"Cowboy" Ben Alman</author>
@@ -9591,6 +10629,12 @@
       <hashes>
         <hash alg="SHA-512">664fde34a576cdb8e92b3aec43e9f51baa6855b12b4312742c13895da299d445622f31fe86b2eef5c757238cf0f5d05026c970044a5b4363f5a12ee70f1b3a8d</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <url>https://github.com/cowboy/node-exit/blob/master/LICENSE-MIT</url>
+        </license>
+      </licenses>
       <purl>pkg:npm/exit@0.1.2</purl>
       <externalReferences>
         <reference type="distribution">
@@ -9610,6 +10654,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/exit</property>
+      </properties>
     </component>
     <component type="library" bom-ref="expand-brackets@2.1.4">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -9643,6 +10690,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/expand-brackets</property>
+      </properties>
       <components>
         <component type="library" bom-ref="expand-brackets@2.1.4|define-property@0.2.5">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -9676,6 +10726,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/expand-brackets/node_modules/define-property</property>
+          </properties>
         </component>
         <component type="library" bom-ref="expand-brackets@2.1.4|extend-shallow@2.0.1">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -9709,6 +10762,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/expand-brackets/node_modules/extend-shallow</property>
+          </properties>
         </component>
         <component type="library" bom-ref="expand-brackets@2.1.4|is-accessor-descriptor@0.1.6">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -9742,6 +10798,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/expand-brackets/node_modules/is-accessor-descriptor</property>
+          </properties>
           <components>
             <component type="library" bom-ref="expand-brackets@2.1.4|is-accessor-descriptor@0.1.6|kind-of@3.2.2">
               <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -9775,6 +10834,9 @@
                   <comment>as detected from PackageJson property "homepage"</comment>
                 </reference>
               </externalReferences>
+              <properties>
+                <property name="cdx:npm:package:installPath">node_modules/expand-brackets/node_modules/is-accessor-descriptor/node_modules/kind-of</property>
+              </properties>
             </component>
           </components>
         </component>
@@ -9810,6 +10872,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/expand-brackets/node_modules/is-data-descriptor</property>
+          </properties>
           <components>
             <component type="library" bom-ref="expand-brackets@2.1.4|is-data-descriptor@0.1.4|kind-of@3.2.2">
               <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -9843,6 +10908,9 @@
                   <comment>as detected from PackageJson property "homepage"</comment>
                 </reference>
               </externalReferences>
+              <properties>
+                <property name="cdx:npm:package:installPath">node_modules/expand-brackets/node_modules/is-data-descriptor/node_modules/kind-of</property>
+              </properties>
             </component>
           </components>
         </component>
@@ -9878,6 +10946,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/expand-brackets/node_modules/is-descriptor</property>
+          </properties>
         </component>
         <component type="library" bom-ref="expand-brackets@2.1.4|is-extendable@0.1.1">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -9911,6 +10982,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/expand-brackets/node_modules/is-extendable</property>
+          </properties>
         </component>
         <component type="library" bom-ref="expand-brackets@2.1.4|kind-of@5.1.0">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -9944,6 +11018,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/expand-brackets/node_modules/kind-of</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -9973,6 +11050,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/expand-template</property>
+      </properties>
     </component>
     <component type="library" bom-ref="expand-tilde@2.0.2">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -10006,6 +11086,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/expand-tilde</property>
+      </properties>
     </component>
     <component type="library" bom-ref="express-ipfilter@1.3.1">
       <author>jetersen</author>
@@ -10031,6 +11114,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/express-ipfilter</property>
+      </properties>
     </component>
     <component type="library" bom-ref="express-jwt@0.1.3">
       <author>Matias Woloski</author>
@@ -10040,6 +11126,12 @@
       <hashes>
         <hash alg="SHA-512">086481d1bddb3555c8e93d021797ffe7964a62b220fdbd3ad7b10f99728af44e32d6ad96d70f494e08cf7e1b16c2e3e20ad939b280609b966482ac6086c7da1e</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <url>http://www.opensource.org/licenses/MIT</url>
+        </license>
+      </licenses>
       <purl>pkg:npm/express-jwt@0.1.3</purl>
       <externalReferences>
         <reference type="distribution">
@@ -10055,6 +11147,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/express-jwt</property>
+      </properties>
       <components>
         <component type="library" bom-ref="express-jwt@0.1.3|jsonwebtoken@0.1.0">
           <author>auth0</author>
@@ -10084,6 +11179,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/express-jwt/node_modules/jsonwebtoken</property>
+          </properties>
         </component>
         <component type="library" bom-ref="express-jwt@0.1.3|moment@2.0.0">
           <author>Tim Wood &lt;washwithcare@gmail.com&gt; (http://timwoodcreates.com/)</author>
@@ -10093,6 +11191,11 @@
           <hashes>
             <hash alg="SHA-512">9778c28c225f0baa48b9c6b5dc6329094e2588462f624d7b5e9160a494b22e9f115fe770760ad906fb646a87e622282995ecdb1b55591548106c315149ddfb60</hash>
           </hashes>
+          <licenses>
+            <license>
+              <id>MIT</id>
+            </license>
+          </licenses>
           <purl>pkg:npm/moment@2.0.0</purl>
           <externalReferences>
             <reference type="distribution">
@@ -10112,6 +11215,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/express-jwt/node_modules/moment</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -10143,6 +11249,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/express-rate-limit</property>
+      </properties>
     </component>
     <component type="library" bom-ref="express-robots-txt@0.4.1">
       <author>modosc (http://github.com/modosc)</author>
@@ -10176,6 +11285,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/express-robots-txt</property>
+      </properties>
     </component>
     <component type="library" bom-ref="express-security.txt@2.0.0">
       <name>express-security.txt</name>
@@ -10207,6 +11319,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/express-security.txt</property>
+      </properties>
     </component>
     <component type="library" bom-ref="express@4.18.2">
       <author>TJ Holowaychuk &lt;tj@vision-media.ca&gt;</author>
@@ -10236,6 +11351,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/express</property>
+      </properties>
       <components>
         <component type="library" bom-ref="express@4.18.2|cookie@0.5.0">
           <author>Roman Shtylman &lt;shtylman@gmail.com&gt;</author>
@@ -10261,6 +11379,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/express/node_modules/cookie</property>
+          </properties>
         </component>
         <component type="library" bom-ref="express@4.18.2|safe-buffer@5.2.1">
           <author>Feross Aboukhadijeh</author>
@@ -10294,6 +11415,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/express/node_modules/safe-buffer</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -10321,6 +11445,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/ext-list</property>
+      </properties>
     </component>
     <component type="library" bom-ref="ext-name@5.0.0">
       <author>Kevin Mårtensson</author>
@@ -10346,6 +11473,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/ext-name</property>
+      </properties>
     </component>
     <component type="library" bom-ref="extend-shallow@3.0.2">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -10379,6 +11509,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/extend-shallow</property>
+      </properties>
     </component>
     <component type="library" bom-ref="extend@3.0.2">
       <author>Stefan Thomas &lt;justmoon@members.fsf.org&gt; (http://www.justmoon.net)</author>
@@ -10404,6 +11537,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/extend</property>
+      </properties>
     </component>
     <component type="library" bom-ref="extglob@2.0.4">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -10437,6 +11573,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/extglob</property>
+      </properties>
       <components>
         <component type="library" bom-ref="extglob@2.0.4|define-property@1.0.0">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -10470,6 +11609,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/extglob/node_modules/define-property</property>
+          </properties>
         </component>
         <component type="library" bom-ref="extglob@2.0.4|extend-shallow@2.0.1">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -10503,6 +11645,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/extglob/node_modules/extend-shallow</property>
+          </properties>
         </component>
         <component type="library" bom-ref="extglob@2.0.4|is-extendable@0.1.1">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -10536,6 +11681,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/extglob/node_modules/is-extendable</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -10562,6 +11710,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/extsprintf</property>
+      </properties>
     </component>
     <component type="library" bom-ref="fast-deep-equal@3.1.3">
       <author>Evgeny Poberezkin</author>
@@ -10595,6 +11746,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/fast-deep-equal</property>
+      </properties>
     </component>
     <component type="library" bom-ref="fast-json-stable-stringify@2.1.0">
       <author>James Halliday</author>
@@ -10624,6 +11778,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/fast-json-stable-stringify</property>
+      </properties>
     </component>
     <component type="library" bom-ref="fast-levenshtein@2.0.6">
       <author>Ramesh Nair &lt;ram@hiddentao.com&gt; (http://www.hiddentao.com/)</author>
@@ -10649,6 +11806,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/fast-levenshtein</property>
+      </properties>
     </component>
     <component type="library" bom-ref="fast.js@0.1.1">
       <author>Charles Pick &lt;charles@codemix.com&gt;</author>
@@ -10682,6 +11842,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/fast.js</property>
+      </properties>
     </component>
     <component type="library" bom-ref="fd-slicer@1.1.0">
       <author>Andrew Kelley &lt;superjoe30@gmail.com&gt;</author>
@@ -10711,6 +11874,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/fd-slicer</property>
+      </properties>
     </component>
     <component type="library" bom-ref="feature-policy@0.5.0">
       <author>Evan Hahn &lt;me@evanhahn.com&gt; (https://evanhahn.com)</author>
@@ -10744,6 +11910,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/feature-policy</property>
+      </properties>
     </component>
     <component type="library" bom-ref="fecha@4.2.3">
       <author>Taylor Hakes</author>
@@ -10777,6 +11946,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/fecha</property>
+      </properties>
     </component>
     <component type="library" bom-ref="file-js@0.3.0">
       <author>nspragg@gmail.com</author>
@@ -10810,6 +11982,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/file-js</property>
+      </properties>
       <components>
         <component type="library" bom-ref="file-js@0.3.0|brace-expansion@1.1.11">
           <author>Julian Gruber</author>
@@ -10839,6 +12014,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/file-js/node_modules/brace-expansion</property>
+          </properties>
         </component>
         <component type="library" bom-ref="file-js@0.3.0|minimatch@3.1.2">
           <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me)</author>
@@ -10864,6 +12042,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/file-js/node_modules/minimatch</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -10891,6 +12072,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/file-stream-rotator</property>
+      </properties>
     </component>
     <component type="library" bom-ref="file-type@16.5.4">
       <author>Sindre Sorhus</author>
@@ -10916,6 +12100,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/file-type</property>
+      </properties>
     </component>
     <component type="library" bom-ref="file-uri-to-path@1.0.0">
       <author>Nathan Rajlich &lt;nathan@tootallnate.net&gt; (http://n8.io/)</author>
@@ -10949,6 +12136,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/file-uri-to-path</property>
+      </properties>
     </component>
     <component type="library" bom-ref="filehound@1.17.6">
       <name>filehound</name>
@@ -10981,6 +12171,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/filehound</property>
+      </properties>
     </component>
     <component type="library" bom-ref="filename-reserved-regex@2.0.0">
       <author>Sindre Sorhus</author>
@@ -11006,6 +12199,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/filename-reserved-regex</property>
+      </properties>
     </component>
     <component type="library" bom-ref="filenamify@3.0.0">
       <author>Sindre Sorhus</author>
@@ -11031,6 +12227,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/filenamify</property>
+      </properties>
     </component>
     <component type="library" bom-ref="filesniffer@1.0.3">
       <name>filesniffer</name>
@@ -11063,6 +12262,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/filesniffer</property>
+      </properties>
     </component>
     <component type="library" bom-ref="fill-range@4.0.0">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -11096,6 +12298,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/fill-range</property>
+      </properties>
       <components>
         <component type="library" bom-ref="fill-range@4.0.0|extend-shallow@2.0.1">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -11129,6 +12334,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/fill-range/node_modules/extend-shallow</property>
+          </properties>
         </component>
         <component type="library" bom-ref="fill-range@4.0.0|is-extendable@0.1.1">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -11162,6 +12370,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/fill-range/node_modules/is-extendable</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -11193,6 +12404,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/finale-rest</property>
+      </properties>
     </component>
     <component type="library" bom-ref="finalhandler@1.2.0">
       <author>Douglas Christopher Wilson &lt;doug@somethingdoug.com&gt;</author>
@@ -11218,6 +12432,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/finalhandler</property>
+      </properties>
     </component>
     <component type="library" bom-ref="find-up@3.0.0">
       <author>Sindre Sorhus</author>
@@ -11243,6 +12460,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/find-up</property>
+      </properties>
     </component>
     <component type="library" bom-ref="findup-sync@2.0.0">
       <author>"Cowboy" Ben Alman (http://benalman.com)</author>
@@ -11268,6 +12488,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/findup-sync</property>
+      </properties>
     </component>
     <component type="library" bom-ref="fined@1.2.0">
       <author>Gulp Team &lt;team@gulpjs.com&gt; (http://gulpjs.com/)</author>
@@ -11293,6 +12516,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/fined</property>
+      </properties>
     </component>
     <component type="library" bom-ref="flagged-respawn@1.0.1">
       <author>Gulp Team &lt;team@gulpjs.com&gt; (http://gulpjs.com/)</author>
@@ -11318,6 +12544,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/flagged-respawn</property>
+      </properties>
     </component>
     <component type="library" bom-ref="fn.name@1.1.0">
       <author>Arnout Kazemier</author>
@@ -11351,6 +12580,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/fn.name</property>
+      </properties>
     </component>
     <component type="library" bom-ref="fontkit@1.9.0">
       <author>Devon Govett &lt;devongovett@gmail.com&gt;</author>
@@ -11376,6 +12608,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/fontkit</property>
+      </properties>
     </component>
     <component type="library" bom-ref="for-each@0.3.3">
       <author>Raynos &lt;raynos2@gmail.com&gt;</author>
@@ -11388,6 +12623,10 @@
       <licenses>
         <license>
           <id>MIT</id>
+        </license>
+        <license>
+          <id>MIT</id>
+          <url>http://github.com/Raynos/for-each/raw/master/LICENSE</url>
         </license>
       </licenses>
       <purl>pkg:npm/for-each@0.3.3</purl>
@@ -11409,6 +12648,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/for-each</property>
+      </properties>
     </component>
     <component type="library" bom-ref="for-in@1.0.2">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -11442,6 +12684,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/for-in</property>
+      </properties>
     </component>
     <component type="library" bom-ref="for-own@1.0.0">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -11475,6 +12720,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/for-own</property>
+      </properties>
     </component>
     <component type="library" bom-ref="foreachasync@3.0.0">
       <author>AJ ONeal &lt;coolaj86@gmail.com&gt; (http://coolaj86.com/)</author>
@@ -11508,6 +12756,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/foreachasync</property>
+      </properties>
     </component>
     <component type="library" bom-ref="forever-agent@0.6.1">
       <author>Mikeal Rogers &lt;mikeal.rogers@gmail.com&gt; (http://www.futurealoof.com)</author>
@@ -11533,6 +12784,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/forever-agent</property>
+      </properties>
     </component>
     <component type="library" bom-ref="form-data@2.3.3">
       <author>Felix Geisendörfer &lt;felix@debuggable.com&gt; (http://debuggable.com/)</author>
@@ -11558,6 +12812,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/form-data</property>
+      </properties>
     </component>
     <component type="library" bom-ref="formatio@1.1.1">
       <author>Christian Johansen</author>
@@ -11582,6 +12839,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/formatio</property>
+      </properties>
     </component>
     <component type="library" bom-ref="forwarded@0.2.0">
       <name>forwarded</name>
@@ -11606,6 +12866,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/forwarded</property>
+      </properties>
     </component>
     <component type="library" bom-ref="fragment-cache@0.2.1">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -11639,6 +12902,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/fragment-cache</property>
+      </properties>
     </component>
     <component type="library" bom-ref="fresh@0.5.2">
       <author>TJ Holowaychuk &lt;tj@vision-media.ca&gt; (http://tjholowaychuk.com)</author>
@@ -11664,6 +12930,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/fresh</property>
+      </properties>
     </component>
     <component type="library" bom-ref="from2@2.3.0">
       <author>Hugh Kennedy &lt;hughskennedy@gmail.com&gt; (http://hughsk.io/)</author>
@@ -11697,6 +12966,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/from2</property>
+      </properties>
     </component>
     <component type="library" bom-ref="fs-constants@1.0.0">
       <author>Mathias Buus (@mafintosh)</author>
@@ -11730,6 +13002,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/fs-constants</property>
+      </properties>
     </component>
     <component type="library" bom-ref="fs-extra@9.1.0">
       <author>JP Richardson &lt;jprichardson@gmail.com&gt;</author>
@@ -11759,6 +13034,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/fs-extra</property>
+      </properties>
     </component>
     <component type="library" bom-ref="fs-minipass@2.1.0">
       <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me/)</author>
@@ -11792,6 +13070,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/fs-minipass</property>
+      </properties>
     </component>
     <component type="library" bom-ref="fs.realpath@1.0.0">
       <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me/)</author>
@@ -11817,6 +13098,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/fs.realpath</property>
+      </properties>
     </component>
     <component type="library" bom-ref="fstream@1.0.12">
       <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me/)</author>
@@ -11842,6 +13126,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/fstream</property>
+      </properties>
       <components>
         <component type="library" bom-ref="fstream@1.0.12|mkdirp@0.5.6">
           <author>James Halliday &lt;mail@substack.net&gt; (http://substack.net)</author>
@@ -11867,6 +13154,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/fstream/node_modules/mkdirp</property>
+          </properties>
         </component>
         <component type="library" bom-ref="fstream@1.0.12|rimraf@2.7.1">
           <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me/)</author>
@@ -11892,6 +13182,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/fstream/node_modules/rimraf</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -11927,6 +13220,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/function-bind</property>
+      </properties>
     </component>
     <component type="library" bom-ref="functions-have-names@1.2.3">
       <author>Jordan Harband &lt;ljharb@gmail.com&gt;</author>
@@ -11960,6 +13256,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/functions-have-names</property>
+      </properties>
     </component>
     <component type="library" bom-ref="fuzzball@1.4.0">
       <author>Nolan Kaplan &lt;nolan@nolankaplan.com&gt;</author>
@@ -11985,6 +13284,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/fuzzball</property>
+      </properties>
     </component>
     <component type="library" bom-ref="gauge@2.7.4">
       <author>Rebecca Turner &lt;me@re-becca.org&gt;</author>
@@ -12018,6 +13320,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/gauge</property>
+      </properties>
     </component>
     <component type="library" bom-ref="geojson-utils@1.1.0">
       <author>Max Ogden</author>
@@ -12043,6 +13348,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/geojson-utils</property>
+      </properties>
     </component>
     <component type="library" bom-ref="get-caller-file@2.0.5">
       <author>Stefan Penner</author>
@@ -12075,6 +13383,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/get-caller-file</property>
+      </properties>
     </component>
     <component type="library" bom-ref="get-intrinsic@1.1.3">
       <author>Jordan Harband &lt;ljharb@gmail.com&gt;</author>
@@ -12108,6 +13419,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/get-intrinsic</property>
+      </properties>
     </component>
     <component type="library" bom-ref="get-stream@4.1.0">
       <author>Sindre Sorhus</author>
@@ -12133,6 +13447,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/get-stream</property>
+      </properties>
     </component>
     <component type="library" bom-ref="get-value@2.0.6">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -12166,6 +13483,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/get-value</property>
+      </properties>
     </component>
     <component type="library" bom-ref="getobject@1.0.2">
       <author>"Cowboy" Ben Alman</author>
@@ -12175,6 +13495,12 @@
       <hashes>
         <hash alg="SHA-512">db36e50c168571bdeb078ac5efb5d59ee20d384da1da4fce9ea5c08b2d08ad3c547d5d62169de56b7de8010558f690a9594dbaf1615856ddadef586532e2ec3a</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <url>https://github.com/cowboy/node-getobject/blob/master/LICENSE-MIT</url>
+        </license>
+      </licenses>
       <purl>pkg:npm/getobject@1.0.2</purl>
       <externalReferences>
         <reference type="distribution">
@@ -12194,6 +13520,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/getobject</property>
+      </properties>
     </component>
     <component type="library" bom-ref="getpass@0.1.7">
       <author>Alex Wilson &lt;alex.wilson@joyent.com&gt;</author>
@@ -12219,6 +13548,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/getpass</property>
+      </properties>
     </component>
     <component type="library" bom-ref="github-from-package@0.0.0">
       <author>James Halliday</author>
@@ -12248,6 +13580,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/github-from-package</property>
+      </properties>
     </component>
     <component type="library" bom-ref="glob-parent@5.1.2">
       <author>Gulp Team &lt;team@gulpjs.com&gt; (https://gulpjs.com/)</author>
@@ -12273,6 +13608,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/glob-parent</property>
+      </properties>
       <components>
         <component type="library" bom-ref="glob-parent@5.1.2|is-glob@4.0.3">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -12306,6 +13644,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/glob-parent/node_modules/is-glob</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -12333,6 +13674,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/glob</property>
+      </properties>
       <components>
         <component type="library" bom-ref="glob@7.2.3|brace-expansion@1.1.11">
           <author>Julian Gruber</author>
@@ -12362,6 +13706,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/glob/node_modules/brace-expansion</property>
+          </properties>
         </component>
         <component type="library" bom-ref="glob@7.2.3|minimatch@3.1.2">
           <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me)</author>
@@ -12387,6 +13734,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/glob/node_modules/minimatch</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -12422,6 +13772,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/global-modules</property>
+      </properties>
     </component>
     <component type="library" bom-ref="global-prefix@1.0.2">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -12455,6 +13808,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/global-prefix</property>
+      </properties>
       <components>
         <component type="library" bom-ref="global-prefix@1.0.2|which@1.3.1">
           <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me)</author>
@@ -12480,6 +13836,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/global-prefix/node_modules/which</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -12515,6 +13874,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/gopd</property>
+      </properties>
     </component>
     <component type="library" bom-ref="got@8.3.2">
       <name>got</name>
@@ -12539,6 +13901,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/got</property>
+      </properties>
       <components>
         <component type="library" bom-ref="got@8.3.2|get-stream@3.0.0">
           <author>Sindre Sorhus</author>
@@ -12564,6 +13929,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/got/node_modules/get-stream</property>
+          </properties>
         </component>
         <component type="library" bom-ref="got@8.3.2|pify@3.0.0">
           <author>Sindre Sorhus</author>
@@ -12589,6 +13957,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/got/node_modules/pify</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -12615,6 +13986,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/graceful-fs</property>
+      </properties>
     </component>
     <component type="library" bom-ref="grunt-cli@1.4.3">
       <author>Grunt Development Team (http://gruntjs.com/development-team)</author>
@@ -12640,6 +14014,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/grunt-cli</property>
+      </properties>
       <components>
         <component type="library" bom-ref="grunt-cli@1.4.3|nopt@4.0.3">
           <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me/)</author>
@@ -12665,6 +14042,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/grunt-cli/node_modules/nopt</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -12692,6 +14072,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/grunt-contrib-compress</property>
+      </properties>
       <components>
         <component type="library" bom-ref="grunt-contrib-compress@1.6.0|ansi-styles@2.2.1">
           <author>Sindre Sorhus</author>
@@ -12717,6 +14100,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/grunt-contrib-compress/node_modules/ansi-styles</property>
+          </properties>
         </component>
         <component type="library" bom-ref="grunt-contrib-compress@1.6.0|chalk@1.1.3">
           <name>chalk</name>
@@ -12741,6 +14127,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/grunt-contrib-compress/node_modules/chalk</property>
+          </properties>
         </component>
         <component type="library" bom-ref="grunt-contrib-compress@1.6.0|supports-color@2.0.0">
           <author>Sindre Sorhus</author>
@@ -12766,6 +14155,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/grunt-contrib-compress/node_modules/supports-color</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -12797,6 +14189,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/grunt-known-options</property>
+      </properties>
     </component>
     <component type="library" bom-ref="grunt-legacy-log-utils@2.1.0">
       <author>"Cowboy" Ben Alman (http://benalman.com/)</author>
@@ -12830,6 +14225,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/grunt-legacy-log-utils</property>
+      </properties>
       <components>
         <component type="library" bom-ref="grunt-legacy-log-utils@2.1.0|ansi-styles@4.3.0">
           <author>Sindre Sorhus</author>
@@ -12855,6 +14253,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/grunt-legacy-log-utils/node_modules/ansi-styles</property>
+          </properties>
         </component>
         <component type="library" bom-ref="grunt-legacy-log-utils@2.1.0|chalk@4.1.2">
           <name>chalk</name>
@@ -12879,6 +14280,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/grunt-legacy-log-utils/node_modules/chalk</property>
+          </properties>
         </component>
         <component type="library" bom-ref="grunt-legacy-log-utils@2.1.0|color-convert@2.0.1">
           <author>Heather Arthur &lt;fayearthur@gmail.com&gt;</author>
@@ -12904,6 +14308,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/grunt-legacy-log-utils/node_modules/color-convert</property>
+          </properties>
         </component>
         <component type="library" bom-ref="grunt-legacy-log-utils@2.1.0|color-name@1.1.4">
           <author>DY &lt;dfcreative@gmail.com&gt;</author>
@@ -12933,6 +14340,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/grunt-legacy-log-utils/node_modules/color-name</property>
+          </properties>
         </component>
         <component type="library" bom-ref="grunt-legacy-log-utils@2.1.0|has-flag@4.0.0">
           <author>Sindre Sorhus</author>
@@ -12958,6 +14368,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/grunt-legacy-log-utils/node_modules/has-flag</property>
+          </properties>
         </component>
         <component type="library" bom-ref="grunt-legacy-log-utils@2.1.0|supports-color@7.2.0">
           <author>Sindre Sorhus</author>
@@ -12983,6 +14396,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/grunt-legacy-log-utils/node_modules/supports-color</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -13018,6 +14434,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/grunt-legacy-log</property>
+      </properties>
       <components>
         <component type="library" bom-ref="grunt-legacy-log@3.0.0|colors@1.1.2">
           <author>Marak Squires</author>
@@ -13051,6 +14470,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/grunt-legacy-log/node_modules/colors</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -13086,6 +14508,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/grunt-legacy-util</property>
+      </properties>
       <components>
         <component type="library" bom-ref="grunt-legacy-util@2.0.1|async@3.2.4">
           <author>Caolan McMahon</author>
@@ -13119,6 +14544,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/grunt-legacy-util/node_modules/async</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -13130,6 +14558,12 @@
       <hashes>
         <hash alg="SHA-512">60b88341ab38e198a5fdb3648561423fade923291348ce1368dcd73e257b9e23241d179f9a9c857b96968919f80ace6e24c2e15da77ca63ac08b604e9a44e465</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <url>https://github.com/exo-dev/grunt-replace-json/blob/master/LICENCE.md</url>
+        </license>
+      </licenses>
       <purl>pkg:npm/grunt-replace-json@0.1.0</purl>
       <externalReferences>
         <reference type="distribution">
@@ -13149,6 +14583,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/grunt-replace-json</property>
+      </properties>
     </component>
     <component type="library" bom-ref="grunt@1.5.3">
       <author>Grunt Development Team (https://gruntjs.com/development-team)</author>
@@ -13178,6 +14615,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/grunt</property>
+      </properties>
       <components>
         <component type="library" bom-ref="grunt@1.5.3|brace-expansion@1.1.11">
           <author>Julian Gruber</author>
@@ -13207,6 +14647,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/grunt/node_modules/brace-expansion</property>
+          </properties>
         </component>
         <component type="library" bom-ref="grunt@1.5.3|findup-sync@0.3.0">
           <author>"Cowboy" Ben Alman</author>
@@ -13216,6 +14659,12 @@
           <hashes>
             <hash alg="SHA-512">cfc36bc218bac33c4d3086f196b4f3b945ba296b8a928819ffb39d0d5abed3e9319fbeca507d678a9c7c894eacbaa907a9ce32ea7edaf40f08a66c58fe94e35a</hash>
           </hashes>
+          <licenses>
+            <license>
+              <id>MIT</id>
+              <url>https://github.com/cowboy/node-findup-sync/blob/master/LICENSE-MIT</url>
+            </license>
+          </licenses>
           <purl>pkg:npm/findup-sync@0.3.0</purl>
           <externalReferences>
             <reference type="distribution">
@@ -13235,6 +14684,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/grunt/node_modules/findup-sync</property>
+          </properties>
           <components>
             <component type="library" bom-ref="grunt@1.5.3|findup-sync@0.3.0|glob@5.0.15">
               <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me/)</author>
@@ -13260,6 +14712,9 @@
                   <comment>as detected from PackageJson property "repository.url"</comment>
                 </reference>
               </externalReferences>
+              <properties>
+                <property name="cdx:npm:package:installPath">node_modules/grunt/node_modules/findup-sync/node_modules/glob</property>
+              </properties>
             </component>
           </components>
         </component>
@@ -13287,6 +14742,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/grunt/node_modules/glob</property>
+          </properties>
         </component>
         <component type="library" bom-ref="grunt@1.5.3|minimatch@3.0.8">
           <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me)</author>
@@ -13312,6 +14770,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/grunt/node_modules/minimatch</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -13343,6 +14804,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/handlebars</property>
+      </properties>
       <components>
         <component type="library" bom-ref="handlebars@4.7.7|wordwrap@1.0.0">
           <author>James Halliday</author>
@@ -13368,6 +14832,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/handlebars/node_modules/wordwrap</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -13403,6 +14870,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/har-schema</property>
+      </properties>
     </component>
     <component type="library" bom-ref="har-validator@5.1.5">
       <author>Ahmad Nassri &lt;ahmad@ahmadnassri.com&gt; (https://www.ahmadnassri.com/)</author>
@@ -13436,6 +14906,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/har-validator</property>
+      </properties>
     </component>
     <component type="library" bom-ref="has-ansi@2.0.0">
       <author>Sindre Sorhus</author>
@@ -13461,6 +14934,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/has-ansi</property>
+      </properties>
     </component>
     <component type="library" bom-ref="has-bigints@1.0.2">
       <author>Jordan Harband &lt;ljharb@gmail.com&gt;</author>
@@ -13494,6 +14970,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/has-bigints</property>
+      </properties>
     </component>
     <component type="library" bom-ref="has-flag@3.0.0">
       <author>Sindre Sorhus</author>
@@ -13519,6 +14998,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/has-flag</property>
+      </properties>
     </component>
     <component type="library" bom-ref="has-property-descriptors@1.0.0">
       <author>Jordan Harband &lt;ljharb@gmail.com&gt;</author>
@@ -13552,6 +15034,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/has-property-descriptors</property>
+      </properties>
     </component>
     <component type="library" bom-ref="has-symbol-support-x@1.4.2">
       <author>Graham Fairweather</author>
@@ -13585,6 +15070,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/has-symbol-support-x</property>
+      </properties>
     </component>
     <component type="library" bom-ref="has-symbols@1.0.3">
       <author>Jordan Harband</author>
@@ -13618,6 +15106,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/has-symbols</property>
+      </properties>
     </component>
     <component type="library" bom-ref="has-to-string-tag-x@1.4.1">
       <author>Graham Fairweather</author>
@@ -13651,6 +15142,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/has-to-string-tag-x</property>
+      </properties>
     </component>
     <component type="library" bom-ref="has-tostringtag@1.0.0">
       <author>Jordan Harband</author>
@@ -13684,6 +15178,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/has-tostringtag</property>
+      </properties>
     </component>
     <component type="library" bom-ref="has-unicode@2.0.1">
       <author>Rebecca Turner &lt;me@re-becca.org&gt;</author>
@@ -13717,6 +15214,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/has-unicode</property>
+      </properties>
     </component>
     <component type="library" bom-ref="has-value@1.0.0">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -13750,6 +15250,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/has-value</property>
+      </properties>
     </component>
     <component type="library" bom-ref="has-values@1.0.0">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -13783,6 +15286,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/has-values</property>
+      </properties>
       <components>
         <component type="library" bom-ref="has-values@1.0.0|kind-of@4.0.0">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -13816,6 +15322,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/has-values/node_modules/kind-of</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -13830,6 +15339,10 @@
       <licenses>
         <license>
           <id>MIT</id>
+        </license>
+        <license>
+          <id>MIT</id>
+          <url>https://github.com/tarruda/has/blob/master/LICENSE-MIT</url>
         </license>
       </licenses>
       <purl>pkg:npm/has@1.0.3</purl>
@@ -13851,6 +15364,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/has</property>
+      </properties>
     </component>
     <component type="library" bom-ref="hashids@2.2.10">
       <author>hashids.org &lt;npm@invent.life&gt; (https://github.com/hashids)</author>
@@ -13884,6 +15400,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/hashids</property>
+      </properties>
     </component>
     <component type="library" bom-ref="hbs@4.2.0">
       <author>Don Park &lt;donpark@docuverse.com&gt; (http://blog.docuverse.com)</author>
@@ -13909,6 +15428,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/hbs</property>
+      </properties>
     </component>
     <component type="library" bom-ref="he@0.4.1">
       <author>Mathias Bynens</author>
@@ -13918,6 +15440,12 @@
       <hashes>
         <hash alg="SHA-512">c059f526572c81b71611ac10e80d46ced80d45197a53212d6804480e901e1f7737e53ffd89dfd040abdaa75340cfa624da82ab2b05d0659144452d2d97d13426</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <url>http://mths.be/mit</url>
+        </license>
+      </licenses>
       <purl>pkg:npm/he@0.4.1</purl>
       <externalReferences>
         <reference type="distribution">
@@ -13937,6 +15465,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/he</property>
+      </properties>
     </component>
     <component type="library" bom-ref="heap@0.2.7">
       <author>Xueqiao Xu &lt;xueqiaoxu@gmail.com&gt;</author>
@@ -13966,6 +15497,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/heap</property>
+      </properties>
     </component>
     <component type="library" bom-ref="helmet@4.6.0">
       <author>Adam Baldwin &lt;adam@npmjs.com&gt; (https://evilpacket.net)</author>
@@ -13999,6 +15533,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/helmet</property>
+      </properties>
     </component>
     <component type="library" bom-ref="hoister@0.0.2">
       <author>Matt McKegg</author>
@@ -14028,6 +15565,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/hoister</property>
+      </properties>
     </component>
     <component type="library" bom-ref="homedir-polyfill@1.0.3">
       <author>Brian Woodward (https://github.com/doowb)</author>
@@ -14061,6 +15601,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/homedir-polyfill</property>
+      </properties>
     </component>
     <component type="library" bom-ref="hooker@0.2.3">
       <author>"Cowboy" Ben Alman</author>
@@ -14070,6 +15613,12 @@
       <hashes>
         <hash alg="SHA-512">b7e51eac2b10be24b29802270f4d4fc3e0e7feeb26cf5b113bedd9935fa5c7c7a0f962a90f6ba57305aa1c72f4f9ab1e441afedfebc88621b52b5253c1a21c4c</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <url>https://github.com/cowboy/javascript-hooker/blob/master/LICENSE-MIT</url>
+        </license>
+      </licenses>
       <purl>pkg:npm/hooker@0.2.3</purl>
       <externalReferences>
         <reference type="distribution">
@@ -14089,6 +15638,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/hooker</property>
+      </properties>
     </component>
     <component type="library" bom-ref="hosted-git-info@2.8.9">
       <author>Rebecca Turner &lt;me@re-becca.org&gt; (http://re-becca.org)</author>
@@ -14122,6 +15674,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/hosted-git-info</property>
+      </properties>
     </component>
     <component type="library" bom-ref="html-entities@1.4.0">
       <author>Marat Dulin</author>
@@ -14147,6 +15702,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/html-entities</property>
+      </properties>
     </component>
     <component type="library" bom-ref="htmlparser2@3.3.0">
       <author>Felix Boehm &lt;me@feedic.com&gt;</author>
@@ -14156,6 +15714,12 @@
       <hashes>
         <hash alg="SHA-512">67c8bade7eec7ae3ef45ed4f432ae39a8552b6fedb8cc6b4b24ace97f93ab674ffe56a4f36bcd62c1d4783f749c415c7fcce8a66f9b6e494065428901b15112d</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <url>http://github.com/fb55/htmlparser2/raw/master/LICENSE</url>
+        </license>
+      </licenses>
       <purl>pkg:npm/htmlparser2@3.3.0</purl>
       <externalReferences>
         <reference type="distribution">
@@ -14171,6 +15735,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/htmlparser2</property>
+      </properties>
       <components>
         <component type="library" bom-ref="htmlparser2@3.3.0|isarray@0.0.1">
           <author>Julian Gruber</author>
@@ -14200,6 +15767,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/htmlparser2/node_modules/isarray</property>
+          </properties>
         </component>
         <component type="library" bom-ref="htmlparser2@3.3.0|readable-stream@1.0.34">
           <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me/)</author>
@@ -14225,6 +15795,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/htmlparser2/node_modules/readable-stream</property>
+          </properties>
         </component>
         <component type="library" bom-ref="htmlparser2@3.3.0|string_decoder@0.10.31">
           <name>string_decoder</name>
@@ -14253,6 +15826,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/htmlparser2/node_modules/string_decoder</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -14280,6 +15856,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/http-cache-semantics</property>
+      </properties>
     </component>
     <component type="library" bom-ref="http-errors@2.0.0">
       <author>Jonathan Ong &lt;me@jongleberry.com&gt; (http://jongleberry.com)</author>
@@ -14305,6 +15884,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/http-errors</property>
+      </properties>
     </component>
     <component type="library" bom-ref="http-proxy-agent@5.0.0">
       <author>Nathan Rajlich &lt;nathan@tootallnate.net&gt; (http://n8.io/)</author>
@@ -14334,6 +15916,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/http-proxy-agent</property>
+      </properties>
       <components>
         <component type="library" bom-ref="http-proxy-agent@5.0.0|debug@4.3.4">
           <author>Josh Junon &lt;josh.junon@protonmail.com&gt;</author>
@@ -14359,6 +15944,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/http-proxy-agent/node_modules/debug</property>
+          </properties>
         </component>
         <component type="library" bom-ref="http-proxy-agent@5.0.0|ms@2.1.2">
           <name>ms</name>
@@ -14383,6 +15971,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/http-proxy-agent/node_modules/ms</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -14418,6 +16009,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/http-signature</property>
+      </properties>
     </component>
     <component type="library" bom-ref="https-proxy-agent@5.0.1">
       <author>Nathan Rajlich &lt;nathan@tootallnate.net&gt; (http://n8.io/)</author>
@@ -14447,6 +16041,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/https-proxy-agent</property>
+      </properties>
       <components>
         <component type="library" bom-ref="https-proxy-agent@5.0.1|debug@4.3.4">
           <author>Josh Junon &lt;josh.junon@protonmail.com&gt;</author>
@@ -14472,6 +16069,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/https-proxy-agent/node_modules/debug</property>
+          </properties>
         </component>
         <component type="library" bom-ref="https-proxy-agent@5.0.1|ms@2.1.2">
           <name>ms</name>
@@ -14496,6 +16096,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/https-proxy-agent/node_modules/ms</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -14523,6 +16126,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/humanize-ms</property>
+      </properties>
     </component>
     <component type="library" bom-ref="i18n@0.11.1">
       <author>Marcus Spiegel &lt;marcus.spiegel@gmail.com&gt;</author>
@@ -14552,6 +16158,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/i18n</property>
+      </properties>
     </component>
     <component type="library" bom-ref="iconv-lite@0.4.24">
       <author>Alexander Shtuchkin &lt;ashtuchkin@gmail.com&gt;</author>
@@ -14585,6 +16194,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/iconv-lite</property>
+      </properties>
     </component>
     <component type="library" bom-ref="ieee754@1.2.1">
       <author>Feross Aboukhadijeh</author>
@@ -14610,6 +16222,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/ieee754</property>
+      </properties>
     </component>
     <component type="library" bom-ref="ignore-walk@3.0.4">
       <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me/)</author>
@@ -14635,6 +16250,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/ignore-walk</property>
+      </properties>
       <components>
         <component type="library" bom-ref="ignore-walk@3.0.4|brace-expansion@1.1.11">
           <author>Julian Gruber</author>
@@ -14664,6 +16282,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/ignore-walk/node_modules/brace-expansion</property>
+          </properties>
         </component>
         <component type="library" bom-ref="ignore-walk@3.0.4|minimatch@3.1.2">
           <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me)</author>
@@ -14689,6 +16310,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/ignore-walk/node_modules/minimatch</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -14723,6 +16347,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/iltorb</property>
+      </properties>
     </component>
     <component type="library" bom-ref="imurmurhash@0.1.4">
       <author>Jens Taylor</author>
@@ -14756,6 +16383,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/imurmurhash</property>
+      </properties>
     </component>
     <component type="library" bom-ref="indent-string@4.0.0">
       <author>Sindre Sorhus</author>
@@ -14781,6 +16411,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/indent-string</property>
+      </properties>
     </component>
     <component type="library" bom-ref="infer-owner@1.0.4">
       <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (https://izs.me)</author>
@@ -14806,6 +16439,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/infer-owner</property>
+      </properties>
     </component>
     <component type="library" bom-ref="inflection@1.13.4">
       <author>dreamerslab &lt;ben@dreamerslab.com&gt;</author>
@@ -14831,6 +16467,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/inflection</property>
+      </properties>
     </component>
     <component type="library" bom-ref="inflight@1.0.6">
       <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me/)</author>
@@ -14864,6 +16503,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/inflight</property>
+      </properties>
     </component>
     <component type="library" bom-ref="inherits@2.0.4">
       <name>inherits</name>
@@ -14888,6 +16530,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/inherits</property>
+      </properties>
     </component>
     <component type="library" bom-ref="ini@1.3.8">
       <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me/)</author>
@@ -14913,6 +16558,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/ini</property>
+      </properties>
     </component>
     <component type="library" bom-ref="interpret@1.1.0">
       <author>Tyler Kellen</author>
@@ -14946,6 +16594,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/interpret</property>
+      </properties>
     </component>
     <component type="library" bom-ref="into-stream@3.1.0">
       <author>Sindre Sorhus</author>
@@ -14971,6 +16622,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/into-stream</property>
+      </properties>
     </component>
     <component type="library" bom-ref="invariant@2.2.4">
       <author>Andres Suarez &lt;zertosh@gmail.com&gt;</author>
@@ -14996,6 +16650,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/invariant</property>
+      </properties>
     </component>
     <component type="library" bom-ref="ip@1.1.8">
       <author>Fedor Indutny &lt;fedor@indutny.com&gt;</author>
@@ -15024,6 +16681,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/ip</property>
+      </properties>
     </component>
     <component type="library" bom-ref="ip6@0.2.10">
       <author>Qian Chen</author>
@@ -15057,6 +16717,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/ip6</property>
+      </properties>
     </component>
     <component type="library" bom-ref="ipaddr.js@1.9.1">
       <author>whitequark &lt;whitequark@whitequark.org&gt;</author>
@@ -15082,6 +16745,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/ipaddr.js</property>
+      </properties>
     </component>
     <component type="library" bom-ref="is-absolute@1.0.0">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -15115,6 +16781,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/is-absolute</property>
+      </properties>
     </component>
     <component type="library" bom-ref="is-accessor-descriptor@1.0.0">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -15148,6 +16817,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/is-accessor-descriptor</property>
+      </properties>
     </component>
     <component type="library" bom-ref="is-arguments@1.1.1">
       <author>Jordan Harband</author>
@@ -15181,6 +16853,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/is-arguments</property>
+      </properties>
     </component>
     <component type="library" bom-ref="is-arrayish@0.2.1">
       <author>Qix (http://github.com/qix-)</author>
@@ -15206,6 +16881,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/is-arrayish</property>
+      </properties>
     </component>
     <component type="library" bom-ref="is-bigint@1.0.4">
       <author>Jordan Harband &lt;ljharb@gmail.com&gt;</author>
@@ -15239,6 +16917,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/is-bigint</property>
+      </properties>
     </component>
     <component type="library" bom-ref="is-binary-path@2.1.0">
       <author>Sindre Sorhus</author>
@@ -15264,6 +16945,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/is-binary-path</property>
+      </properties>
     </component>
     <component type="library" bom-ref="is-boolean-object@1.1.2">
       <author>Jordan Harband &lt;ljharb@gmail.com&gt;</author>
@@ -15289,6 +16973,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/is-boolean-object</property>
+      </properties>
     </component>
     <component type="library" bom-ref="is-buffer@1.1.6">
       <author>Feross Aboukhadijeh</author>
@@ -15318,6 +17005,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/is-buffer</property>
+      </properties>
     </component>
     <component type="library" bom-ref="is-callable@1.2.7">
       <author>Jordan Harband</author>
@@ -15343,6 +17033,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/is-callable</property>
+      </properties>
     </component>
     <component type="library" bom-ref="is-core-module@2.11.0">
       <author>Jordan Harband &lt;ljharb@gmail.com&gt;</author>
@@ -15376,6 +17069,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/is-core-module</property>
+      </properties>
     </component>
     <component type="library" bom-ref="is-data-descriptor@1.0.0">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -15409,6 +17105,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/is-data-descriptor</property>
+      </properties>
     </component>
     <component type="library" bom-ref="is-date-object@1.0.5">
       <author>Jordan Harband</author>
@@ -15434,6 +17133,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/is-date-object</property>
+      </properties>
     </component>
     <component type="library" bom-ref="is-descriptor@1.0.2">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -15467,6 +17169,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/is-descriptor</property>
+      </properties>
     </component>
     <component type="library" bom-ref="is-docker@2.2.1">
       <author>Sindre Sorhus</author>
@@ -15492,6 +17197,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/is-docker</property>
+      </properties>
     </component>
     <component type="library" bom-ref="is-expression@4.0.0">
       <author>Timothy Gu &lt;timothygu99@gmail.com&gt;</author>
@@ -15517,6 +17225,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/is-expression</property>
+      </properties>
     </component>
     <component type="library" bom-ref="is-extendable@1.0.1">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -15550,6 +17261,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/is-extendable</property>
+      </properties>
     </component>
     <component type="library" bom-ref="is-extglob@2.1.1">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -15583,6 +17297,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/is-extglob</property>
+      </properties>
     </component>
     <component type="library" bom-ref="is-fullwidth-code-point@1.0.0">
       <author>Sindre Sorhus</author>
@@ -15608,6 +17325,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/is-fullwidth-code-point</property>
+      </properties>
     </component>
     <component type="library" bom-ref="is-generator-function@1.0.10">
       <author>Jordan Harband &lt;ljharb@gmail.com&gt;</author>
@@ -15637,6 +17357,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/is-generator-function</property>
+      </properties>
     </component>
     <component type="library" bom-ref="is-glob@3.1.0">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -15670,6 +17393,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/is-glob</property>
+      </properties>
     </component>
     <component type="library" bom-ref="is-heroku@2.0.0">
       <author>Sindre Sorhus</author>
@@ -15695,6 +17421,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/is-heroku</property>
+      </properties>
     </component>
     <component type="library" bom-ref="is-lambda@1.0.1">
       <author>Thomas Watson Steen &lt;w@tson.dk&gt; (https://twitter.com/wa7son)</author>
@@ -15728,6 +17457,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/is-lambda</property>
+      </properties>
     </component>
     <component type="library" bom-ref="is-map@2.0.2">
       <author>Jordan Harband &lt;ljharb@gmail.com&gt;</author>
@@ -15761,6 +17493,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/is-map</property>
+      </properties>
     </component>
     <component type="library" bom-ref="is-natural-number@4.0.1">
       <author>Shinnosuke Watanabe (https://github.com/shinnn)</author>
@@ -15786,6 +17521,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/is-natural-number</property>
+      </properties>
     </component>
     <component type="library" bom-ref="is-number-like@1.0.8">
       <author>Vigour.io &lt;dev@vigour.io&gt;</author>
@@ -15819,6 +17557,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/is-number-like</property>
+      </properties>
     </component>
     <component type="library" bom-ref="is-number-object@1.0.7">
       <author>Jordan Harband &lt;ljharb@gmail.com&gt;</author>
@@ -15852,6 +17593,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/is-number-object</property>
+      </properties>
     </component>
     <component type="library" bom-ref="is-number@3.0.0">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -15885,6 +17629,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/is-number</property>
+      </properties>
       <components>
         <component type="library" bom-ref="is-number@3.0.0|kind-of@3.2.2">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -15918,6 +17665,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/is-number/node_modules/kind-of</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -15932,6 +17682,10 @@
       <licenses>
         <license>
           <id>MIT</id>
+        </license>
+        <license>
+          <id>MIT</id>
+          <url>http://github.com/inspect-js/is-object/raw/master/LICENSE</url>
         </license>
       </licenses>
       <purl>pkg:npm/is-object@1.0.2</purl>
@@ -15953,6 +17707,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/is-object</property>
+      </properties>
     </component>
     <component type="library" bom-ref="is-plain-obj@1.1.0">
       <author>Sindre Sorhus</author>
@@ -15978,6 +17735,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/is-plain-obj</property>
+      </properties>
     </component>
     <component type="library" bom-ref="is-plain-object@2.0.4">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -16011,6 +17771,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/is-plain-object</property>
+      </properties>
     </component>
     <component type="library" bom-ref="is-promise@2.2.2">
       <author>ForbesLindesay</author>
@@ -16036,6 +17799,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/is-promise</property>
+      </properties>
     </component>
     <component type="library" bom-ref="is-regex@1.1.4">
       <author>Jordan Harband &lt;ljharb@gmail.com&gt;</author>
@@ -16069,6 +17835,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/is-regex</property>
+      </properties>
     </component>
     <component type="library" bom-ref="is-relative@1.0.0">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -16102,6 +17871,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/is-relative</property>
+      </properties>
     </component>
     <component type="library" bom-ref="is-retry-allowed@1.2.0">
       <author>Vsevolod Strukchinsky</author>
@@ -16127,6 +17899,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/is-retry-allowed</property>
+      </properties>
     </component>
     <component type="library" bom-ref="is-set@2.0.2">
       <author>Jordan Harband &lt;ljharb@gmail.com&gt;</author>
@@ -16160,6 +17935,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/is-set</property>
+      </properties>
     </component>
     <component type="library" bom-ref="is-stream@1.1.0">
       <author>Sindre Sorhus</author>
@@ -16185,6 +17963,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/is-stream</property>
+      </properties>
     </component>
     <component type="library" bom-ref="is-string@1.0.7">
       <author>Jordan Harband &lt;ljharb@gmail.com&gt;</author>
@@ -16210,6 +17991,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/is-string</property>
+      </properties>
     </component>
     <component type="library" bom-ref="is-symbol@1.0.4">
       <author>Jordan Harband &lt;ljharb@gmail.com&gt;</author>
@@ -16239,6 +18023,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/is-symbol</property>
+      </properties>
     </component>
     <component type="library" bom-ref="is-typed-array@1.1.10">
       <author>Jordan Harband</author>
@@ -16264,6 +18051,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/is-typed-array</property>
+      </properties>
     </component>
     <component type="library" bom-ref="is-typedarray@1.0.0">
       <author>Hugh Kennedy &lt;hughskennedy@gmail.com&gt; (http://hughsk.io/)</author>
@@ -16297,6 +18087,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/is-typedarray</property>
+      </properties>
     </component>
     <component type="library" bom-ref="is-unc-path@1.0.0">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -16330,6 +18123,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/is-unc-path</property>
+      </properties>
     </component>
     <component type="library" bom-ref="is-weakmap@2.0.1">
       <author>Jordan Harband &lt;ljharb@gmail.com&gt;</author>
@@ -16363,6 +18159,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/is-weakmap</property>
+      </properties>
     </component>
     <component type="library" bom-ref="is-weakset@2.0.2">
       <author>Jordan Harband &lt;ljharb@gmail.com&gt;</author>
@@ -16396,6 +18195,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/is-weakset</property>
+      </properties>
     </component>
     <component type="library" bom-ref="is-windows@1.0.2">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -16429,6 +18231,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/is-windows</property>
+      </properties>
     </component>
     <component type="library" bom-ref="isarray@2.0.5">
       <author>Julian Gruber</author>
@@ -16458,6 +18263,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/isarray</property>
+      </properties>
     </component>
     <component type="library" bom-ref="isexe@2.0.0">
       <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me/)</author>
@@ -16491,6 +18299,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/isexe</property>
+      </properties>
     </component>
     <component type="library" bom-ref="isobject@3.0.1">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -16524,6 +18335,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/isobject</property>
+      </properties>
     </component>
     <component type="library" bom-ref="isstream@0.1.2">
       <author>Rod Vagg &lt;rod@vagg.org&gt;</author>
@@ -16557,6 +18371,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/isstream</property>
+      </properties>
     </component>
     <component type="library" bom-ref="isurl@1.0.0">
       <author>Steven Vachon &lt;contact@svachon.com&gt; (https://www.svachon.com/)</author>
@@ -16582,6 +18399,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/isurl</property>
+      </properties>
     </component>
     <component type="library" bom-ref="js-stringify@1.0.2">
       <author>ForbesLindesay</author>
@@ -16607,6 +18427,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/js-stringify</property>
+      </properties>
     </component>
     <component type="library" bom-ref="js-tokens@4.0.0">
       <author>Simon Lydell</author>
@@ -16632,6 +18455,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/js-tokens</property>
+      </properties>
     </component>
     <component type="library" bom-ref="js-yaml@3.14.1">
       <author>Vladimir Zapparov &lt;dervus.grim@gmail.com&gt;</author>
@@ -16661,6 +18487,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/js-yaml</property>
+      </properties>
     </component>
     <component type="library" bom-ref="jsbn@0.1.1">
       <author>Tom Wu</author>
@@ -16686,6 +18515,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/jsbn</property>
+      </properties>
     </component>
     <component type="library" bom-ref="json-buffer@3.0.0">
       <author>Dominic Tarr &lt;dominic.tarr@gmail.com&gt; (http://dominictarr.com)</author>
@@ -16715,6 +18547,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/json-buffer</property>
+      </properties>
     </component>
     <component type="library" bom-ref="json-parse-better-errors@1.0.2">
       <author>Kat Marchán</author>
@@ -16740,6 +18575,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/json-parse-better-errors</property>
+      </properties>
     </component>
     <component type="library" bom-ref="json-schema-traverse@0.4.1">
       <author>Evgeny Poberezkin</author>
@@ -16773,6 +18611,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/json-schema-traverse</property>
+      </properties>
     </component>
     <component type="library" bom-ref="json-schema@0.4.0">
       <author>Kris Zyp</author>
@@ -16796,6 +18637,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/json-schema</property>
+      </properties>
     </component>
     <component type="library" bom-ref="json-stringify-safe@5.0.1">
       <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me)</author>
@@ -16829,6 +18673,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/json-stringify-safe</property>
+      </properties>
     </component>
     <component type="library" bom-ref="json5@2.2.1">
       <author>Aseem Kishore &lt;aseem.kishore@gmail.com&gt;</author>
@@ -16862,6 +18709,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/json5</property>
+      </properties>
     </component>
     <component type="library" bom-ref="jsonfile@6.1.0">
       <author>JP Richardson &lt;jprichardson@gmail.com&gt;</author>
@@ -16883,6 +18733,9 @@
           <comment>as detected from npm-ls property "resolved"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/jsonfile</property>
+      </properties>
     </component>
     <component type="library" bom-ref="jsonwebtoken@0.4.0">
       <author>auth0</author>
@@ -16912,6 +18765,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/jsonwebtoken</property>
+      </properties>
     </component>
     <component type="library" bom-ref="jsprim@1.4.2">
       <name>jsprim</name>
@@ -16936,6 +18792,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/jsprim</property>
+      </properties>
     </component>
     <component type="library" bom-ref="jssha@3.3.0">
       <author>Brian Turek &lt;brian.turek@gmail.com&gt;</author>
@@ -16969,6 +18828,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/jssha</property>
+      </properties>
     </component>
     <component type="library" bom-ref="jstransformer@1.0.0">
       <author>ForbesLindesay</author>
@@ -16994,6 +18856,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/jstransformer</property>
+      </properties>
     </component>
     <component type="library" bom-ref="juicy-chat-bot@0.6.6">
       <author>Björn Kimminich &lt;bjoern.kimminich@owasp.org&gt; (https://kimminich.de)</author>
@@ -17027,6 +18892,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/juicy-chat-bot</property>
+      </properties>
     </component>
     <component type="library" bom-ref="jwa@0.0.1">
       <author>Brian J. Brennan</author>
@@ -17052,6 +18920,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/jwa</property>
+      </properties>
     </component>
     <component type="library" bom-ref="jws@0.2.6">
       <author>Brian J Brennan</author>
@@ -17077,6 +18948,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/jws</property>
+      </properties>
     </component>
     <component type="library" bom-ref="keyv@3.0.0">
       <author>Luke Childs &lt;lukechilds123@gmail.com&gt; (http://lukechilds.co.uk)</author>
@@ -17110,6 +18984,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/keyv</property>
+      </properties>
     </component>
     <component type="library" bom-ref="kind-of@6.0.3">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -17143,6 +19020,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/kind-of</property>
+      </properties>
     </component>
     <component type="library" bom-ref="kuler@2.0.0">
       <author>Arnout Kazemier</author>
@@ -17176,6 +19056,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/kuler</property>
+      </properties>
     </component>
     <component type="library" bom-ref="kuromoji@0.1.2">
       <author>Takuya Asano &lt;takuya.a@gmail.com&gt;</author>
@@ -17209,6 +19092,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/kuromoji</property>
+      </properties>
     </component>
     <component type="library" bom-ref="lazystream@1.0.1">
       <author>Jonas Pommerening</author>
@@ -17242,6 +19128,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/lazystream</property>
+      </properties>
     </component>
     <component type="library" bom-ref="levn@0.3.0">
       <author>George Zahariev &lt;z@georgezahariev.com&gt;</author>
@@ -17275,6 +19164,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/levn</property>
+      </properties>
     </component>
     <component type="library" bom-ref="libxmljs2@0.30.1">
       <author>marudor</author>
@@ -17304,6 +19196,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/libxmljs2</property>
+      </properties>
       <components>
         <component type="library" bom-ref="libxmljs2@0.30.1|nan@2.15.0">
           <name>nan</name>
@@ -17328,6 +19223,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/libxmljs2/node_modules/nan</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -17355,6 +19253,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/liftup</property>
+      </properties>
       <components>
         <component type="library" bom-ref="liftup@3.0.1|braces@3.0.2">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -17388,6 +19289,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/liftup/node_modules/braces</property>
+          </properties>
         </component>
         <component type="library" bom-ref="liftup@3.0.1|fill-range@7.0.1">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -17421,6 +19325,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/liftup/node_modules/fill-range</property>
+          </properties>
         </component>
         <component type="library" bom-ref="liftup@3.0.1|findup-sync@4.0.0">
           <author>Gulp Team &lt;team@gulpjs.com&gt; (https://gulpjs.com/)</author>
@@ -17446,6 +19353,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/liftup/node_modules/findup-sync</property>
+          </properties>
         </component>
         <component type="library" bom-ref="liftup@3.0.1|is-glob@4.0.3">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -17479,6 +19389,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/liftup/node_modules/is-glob</property>
+          </properties>
         </component>
         <component type="library" bom-ref="liftup@3.0.1|is-number@7.0.0">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -17512,6 +19425,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/liftup/node_modules/is-number</property>
+          </properties>
         </component>
         <component type="library" bom-ref="liftup@3.0.1|micromatch@4.0.5">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -17545,6 +19461,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/liftup/node_modules/micromatch</property>
+          </properties>
         </component>
         <component type="library" bom-ref="liftup@3.0.1|to-regex-range@5.0.1">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -17578,6 +19497,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/liftup/node_modules/to-regex-range</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -17613,6 +19535,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/linebreak</property>
+      </properties>
       <components>
         <component type="library" bom-ref="linebreak@1.1.0|base64-js@0.0.8">
           <author>T. Jameson Little &lt;t.jameson.little@gmail.com&gt;</author>
@@ -17638,6 +19563,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/linebreak/node_modules/base64-js</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -17661,6 +19589,9 @@
           <comment>as detected from npm-ls property "resolved"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/listenercount</property>
+      </properties>
     </component>
     <component type="library" bom-ref="locate-path@3.0.0">
       <author>Sindre Sorhus</author>
@@ -17686,6 +19617,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/locate-path</property>
+      </properties>
     </component>
     <component type="library" bom-ref="lodash.camelcase@4.3.0">
       <author>John-David Dalton &lt;john.david.dalton@gmail.com&gt; (http://allyoucanleet.com/)</author>
@@ -17715,6 +19649,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/lodash.camelcase</property>
+      </properties>
     </component>
     <component type="library" bom-ref="lodash.isfinite@3.3.2">
       <author>John-David Dalton &lt;john.david.dalton@gmail.com&gt; (http://allyoucanleet.com/)</author>
@@ -17744,6 +19681,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/lodash.isfinite</property>
+      </properties>
     </component>
     <component type="library" bom-ref="lodash.set@4.3.2">
       <author>John-David Dalton &lt;john.david.dalton@gmail.com&gt; (http://allyoucanleet.com/)</author>
@@ -17773,6 +19713,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/lodash.set</property>
+      </properties>
     </component>
     <component type="library" bom-ref="lodash@4.17.21">
       <author>John-David Dalton &lt;john.david.dalton@gmail.com&gt;</author>
@@ -17802,6 +19745,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/lodash</property>
+      </properties>
     </component>
     <component type="library" bom-ref="logform@2.4.2">
       <author>Charlie Robbins &lt;charlie.robbins@gmail.com&gt;</author>
@@ -17835,6 +19781,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/logform</property>
+      </properties>
       <components>
         <component type="library" bom-ref="logform@2.4.2|ms@2.1.3">
           <name>ms</name>
@@ -17859,6 +19808,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/logform/node_modules/ms</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -17894,6 +19846,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/lolex</property>
+      </properties>
     </component>
     <component type="library" bom-ref="loose-envify@1.4.0">
       <author>Andres Suarez &lt;zertosh@gmail.com&gt;</author>
@@ -17923,6 +19878,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/loose-envify</property>
+      </properties>
     </component>
     <component type="library" bom-ref="lowercase-keys@1.0.1">
       <author>Sindre Sorhus</author>
@@ -17948,6 +19906,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/lowercase-keys</property>
+      </properties>
     </component>
     <component type="library" bom-ref="lru-cache@6.0.0">
       <author>Isaac Z. Schlueter &lt;i@izs.me&gt;</author>
@@ -17973,6 +19934,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/lru-cache</property>
+      </properties>
     </component>
     <component type="library" bom-ref="make-dir@2.1.0">
       <author>Sindre Sorhus</author>
@@ -17998,6 +19962,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/make-dir</property>
+      </properties>
       <components>
         <component type="library" bom-ref="make-dir@2.1.0|semver@5.7.1">
           <name>semver</name>
@@ -18022,6 +19989,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/make-dir/node_modules/semver</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -18057,6 +20027,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/make-error</property>
+      </properties>
     </component>
     <component type="library" bom-ref="make-fetch-happen@9.1.0">
       <author>Kat Marchán</author>
@@ -18082,6 +20055,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/make-fetch-happen</property>
+      </properties>
       <components>
         <component type="library" bom-ref="make-fetch-happen@9.1.0|@tootallnate/once@1.1.2">
           <author>Nathan Rajlich &lt;nathan@tootallnate.net&gt; (http://n8.io/)</author>
@@ -18112,6 +20088,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/make-fetch-happen/node_modules/@tootallnate/once</property>
+          </properties>
         </component>
         <component type="library" bom-ref="make-fetch-happen@9.1.0|debug@4.3.4">
           <author>Josh Junon &lt;josh.junon@protonmail.com&gt;</author>
@@ -18137,6 +20116,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/make-fetch-happen/node_modules/debug</property>
+          </properties>
         </component>
         <component type="library" bom-ref="make-fetch-happen@9.1.0|http-cache-semantics@4.1.0">
           <author>Kornel Lesiński &lt;kornel@geekhood.net&gt; (https://kornel.ski/)</author>
@@ -18162,6 +20144,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/make-fetch-happen/node_modules/http-cache-semantics</property>
+          </properties>
         </component>
         <component type="library" bom-ref="make-fetch-happen@9.1.0|http-proxy-agent@4.0.1">
           <author>Nathan Rajlich &lt;nathan@tootallnate.net&gt; (http://n8.io/)</author>
@@ -18191,6 +20176,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/make-fetch-happen/node_modules/http-proxy-agent</property>
+          </properties>
         </component>
         <component type="library" bom-ref="make-fetch-happen@9.1.0|ms@2.1.2">
           <name>ms</name>
@@ -18215,6 +20203,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/make-fetch-happen/node_modules/ms</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -18250,6 +20241,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/make-iterator</property>
+      </properties>
     </component>
     <component type="library" bom-ref="make-plural@6.2.2">
       <author>Eemeli Aro &lt;eemeli@gmail.com&gt;</author>
@@ -18283,6 +20277,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/make-plural</property>
+      </properties>
     </component>
     <component type="library" bom-ref="map-cache@0.2.2">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -18316,6 +20313,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/map-cache</property>
+      </properties>
     </component>
     <component type="library" bom-ref="map-visit@1.0.0">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -18349,6 +20349,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/map-visit</property>
+      </properties>
     </component>
     <component type="library" bom-ref="marsdb@0.6.11">
       <author>Artem Artemev</author>
@@ -18374,6 +20377,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/marsdb</property>
+      </properties>
     </component>
     <component type="library" bom-ref="math-interval-parser@2.0.1">
       <author>Dmitry Semigradsky</author>
@@ -18399,6 +20405,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/math-interval-parser</property>
+      </properties>
     </component>
     <component type="library" bom-ref="media-typer@0.3.0">
       <author>Douglas Christopher Wilson &lt;doug@somethingdoug.com&gt;</author>
@@ -18424,6 +20433,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/media-typer</property>
+      </properties>
     </component>
     <component type="library" bom-ref="merge-descriptors@1.0.1">
       <author>Jonathan Ong</author>
@@ -18449,6 +20461,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/merge-descriptors</property>
+      </properties>
     </component>
     <component type="library" bom-ref="messageformat-formatters@2.0.1">
       <author>Eemeli Aro &lt;eemeli@gmail.com&gt;</author>
@@ -18478,6 +20493,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/messageformat-formatters</property>
+      </properties>
     </component>
     <component type="library" bom-ref="messageformat-parser@4.1.3">
       <name>messageformat-parser</name>
@@ -18506,6 +20524,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/messageformat-parser</property>
+      </properties>
     </component>
     <component type="library" bom-ref="messageformat@2.3.0">
       <author>Alex Sexton &lt;alexsexton@gmail.com&gt;</author>
@@ -18535,6 +20556,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/messageformat</property>
+      </properties>
       <components>
         <component type="library" bom-ref="messageformat@2.3.0|make-plural@4.3.0">
           <author>Eemeli Aro &lt;eemeli@gmail.com&gt;</author>
@@ -18568,6 +20592,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/messageformat/node_modules/make-plural</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -18594,6 +20621,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/methods</property>
+      </properties>
     </component>
     <component type="library" bom-ref="micromatch@3.1.10">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -18627,6 +20657,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/micromatch</property>
+      </properties>
     </component>
     <component type="library" bom-ref="mime-db@1.52.0">
       <name>mime-db</name>
@@ -18651,6 +20684,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/mime-db</property>
+      </properties>
     </component>
     <component type="library" bom-ref="mime-types@2.1.35">
       <name>mime-types</name>
@@ -18675,6 +20711,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/mime-types</property>
+      </properties>
     </component>
     <component type="library" bom-ref="mime@1.6.0">
       <author>Robert Kieffer</author>
@@ -18700,6 +20739,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/mime</property>
+      </properties>
     </component>
     <component type="library" bom-ref="mimic-response@1.0.1">
       <author>Sindre Sorhus</author>
@@ -18725,6 +20767,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/mimic-response</property>
+      </properties>
     </component>
     <component type="library" bom-ref="minimatch@5.1.0">
       <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me)</author>
@@ -18750,6 +20795,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/minimatch</property>
+      </properties>
     </component>
     <component type="library" bom-ref="minimist@1.2.7">
       <author>James Halliday</author>
@@ -18779,6 +20827,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/minimist</property>
+      </properties>
     </component>
     <component type="library" bom-ref="minipass-collect@1.0.2">
       <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (https://izs.me)</author>
@@ -18800,6 +20851,9 @@
           <comment>as detected from npm-ls property "resolved"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/minipass-collect</property>
+      </properties>
     </component>
     <component type="library" bom-ref="minipass-fetch@1.4.1">
       <name>minipass-fetch</name>
@@ -18824,6 +20878,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/minipass-fetch</property>
+      </properties>
     </component>
     <component type="library" bom-ref="minipass-flush@1.0.5">
       <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (https://izs.me)</author>
@@ -18849,6 +20906,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/minipass-flush</property>
+      </properties>
     </component>
     <component type="library" bom-ref="minipass-pipeline@1.2.4">
       <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (https://izs.me)</author>
@@ -18870,6 +20930,9 @@
           <comment>as detected from npm-ls property "resolved"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/minipass-pipeline</property>
+      </properties>
     </component>
     <component type="library" bom-ref="minipass-sized@1.0.3">
       <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (https://izs.me)</author>
@@ -18895,6 +20958,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/minipass-sized</property>
+      </properties>
     </component>
     <component type="library" bom-ref="minipass@3.3.4">
       <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me/)</author>
@@ -18920,6 +20986,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/minipass</property>
+      </properties>
     </component>
     <component type="library" bom-ref="minizlib@2.1.2">
       <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me/)</author>
@@ -18945,6 +21014,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/minizlib</property>
+      </properties>
     </component>
     <component type="library" bom-ref="mixin-deep@1.3.2">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -18978,6 +21050,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/mixin-deep</property>
+      </properties>
     </component>
     <component type="library" bom-ref="mkdirp-classic@0.5.3">
       <author>Mathias Buus (@mafintosh)</author>
@@ -19011,6 +21086,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/mkdirp-classic</property>
+      </properties>
     </component>
     <component type="library" bom-ref="mkdirp@1.0.4">
       <name>mkdirp</name>
@@ -19035,6 +21113,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/mkdirp</property>
+      </properties>
     </component>
     <component type="library" bom-ref="moment-timezone@0.5.38">
       <author>Tim Wood &lt;washwithcare@gmail.com&gt; (http://timwoodcreates.com/)</author>
@@ -19068,6 +21149,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/moment-timezone</property>
+      </properties>
     </component>
     <component type="library" bom-ref="moment@2.29.4">
       <author>Iskren Ivov Chernev &lt;iskren.chernev@gmail.com&gt; (https://github.com/ichernev)</author>
@@ -19101,6 +21185,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/moment</property>
+      </properties>
     </component>
     <component type="library" bom-ref="morgan@1.10.0">
       <name>morgan</name>
@@ -19125,6 +21212,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/morgan</property>
+      </properties>
       <components>
         <component type="library" bom-ref="morgan@1.10.0|on-finished@2.3.0">
           <name>on-finished</name>
@@ -19149,6 +21239,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/morgan/node_modules/on-finished</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -19184,6 +21277,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/mout</property>
+      </properties>
     </component>
     <component type="library" bom-ref="ms@2.0.0">
       <name>ms</name>
@@ -19208,6 +21304,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/ms</property>
+      </properties>
     </component>
     <component type="library" bom-ref="multer@1.4.4">
       <name>multer</name>
@@ -19232,6 +21331,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/multer</property>
+      </properties>
       <components>
         <component type="library" bom-ref="multer@1.4.4|mkdirp@0.5.6">
           <author>James Halliday &lt;mail@substack.net&gt; (http://substack.net)</author>
@@ -19257,6 +21359,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/multer/node_modules/mkdirp</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -19288,6 +21393,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/mustache</property>
+      </properties>
     </component>
     <component type="library" bom-ref="nan@2.17.0">
       <name>nan</name>
@@ -19312,6 +21420,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/nan</property>
+      </properties>
     </component>
     <component type="library" bom-ref="nanomatch@1.2.13">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -19345,6 +21456,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/nanomatch</property>
+      </properties>
     </component>
     <component type="library" bom-ref="napi-build-utils@1.0.2">
       <author>Jim Schlight</author>
@@ -19378,6 +21492,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/napi-build-utils</property>
+      </properties>
     </component>
     <component type="library" bom-ref="needle@2.9.1">
       <author>Tomás Pollak &lt;tomas@forkhq.com&gt;</author>
@@ -19403,6 +21520,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/needle</property>
+      </properties>
       <components>
         <component type="library" bom-ref="needle@2.9.1|debug@3.2.7">
           <author>TJ Holowaychuk &lt;tj@vision-media.ca&gt;</author>
@@ -19428,6 +21548,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/needle/node_modules/debug</property>
+          </properties>
         </component>
         <component type="library" bom-ref="needle@2.9.1|ms@2.1.3">
           <name>ms</name>
@@ -19452,6 +21575,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/needle/node_modules/ms</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -19478,6 +21604,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/negotiator</property>
+      </properties>
     </component>
     <component type="library" bom-ref="neo-async@2.6.2">
       <name>neo-async</name>
@@ -19502,6 +21631,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/neo-async</property>
+      </properties>
     </component>
     <component type="library" bom-ref="node-abi@2.30.1">
       <author>Lukas Geiger</author>
@@ -19535,6 +21667,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/node-abi</property>
+      </properties>
       <components>
         <component type="library" bom-ref="node-abi@2.30.1|semver@5.7.1">
           <name>semver</name>
@@ -19559,6 +21694,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/node-abi/node_modules/semver</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -19593,6 +21731,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/node-addon-api</property>
+      </properties>
     </component>
     <component type="library" bom-ref="node-fetch@2.6.7">
       <author>David Frank</author>
@@ -19626,6 +21767,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/node-fetch</property>
+      </properties>
     </component>
     <component type="library" bom-ref="node-gyp@8.4.1">
       <author>Nathan Rajlich &lt;nathan@tootallnate.net&gt; (http://tootallnate.net)</author>
@@ -19651,6 +21795,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/node-gyp</property>
+      </properties>
       <components>
         <component type="library" bom-ref="node-gyp@8.4.1|ansi-regex@5.0.1">
           <author>Sindre Sorhus</author>
@@ -19676,6 +21823,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/node-gyp/node_modules/ansi-regex</property>
+          </properties>
         </component>
         <component type="library" bom-ref="node-gyp@8.4.1|are-we-there-yet@3.0.1">
           <author>GitHub Inc.</author>
@@ -19709,6 +21859,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/node-gyp/node_modules/are-we-there-yet</property>
+          </properties>
         </component>
         <component type="library" bom-ref="node-gyp@8.4.1|gauge@4.0.4">
           <author>GitHub Inc.</author>
@@ -19742,6 +21895,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/node-gyp/node_modules/gauge</property>
+          </properties>
         </component>
         <component type="library" bom-ref="node-gyp@8.4.1|is-fullwidth-code-point@3.0.0">
           <author>Sindre Sorhus</author>
@@ -19767,6 +21923,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/node-gyp/node_modules/is-fullwidth-code-point</property>
+          </properties>
         </component>
         <component type="library" bom-ref="node-gyp@8.4.1|nopt@5.0.0">
           <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me/)</author>
@@ -19792,6 +21951,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/node-gyp/node_modules/nopt</property>
+          </properties>
         </component>
         <component type="library" bom-ref="node-gyp@8.4.1|npmlog@6.0.2">
           <author>GitHub Inc.</author>
@@ -19817,6 +21979,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/node-gyp/node_modules/npmlog</property>
+          </properties>
         </component>
         <component type="library" bom-ref="node-gyp@8.4.1|readable-stream@3.6.0">
           <name>readable-stream</name>
@@ -19841,6 +22006,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/node-gyp/node_modules/readable-stream</property>
+          </properties>
         </component>
         <component type="library" bom-ref="node-gyp@8.4.1|string-width@4.2.3">
           <author>Sindre Sorhus</author>
@@ -19866,6 +22034,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/node-gyp/node_modules/string-width</property>
+          </properties>
         </component>
         <component type="library" bom-ref="node-gyp@8.4.1|strip-ansi@6.0.1">
           <author>Sindre Sorhus</author>
@@ -19891,6 +22062,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/node-gyp/node_modules/strip-ansi</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -19918,6 +22092,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/node-pre-gyp</property>
+      </properties>
       <components>
         <component type="library" bom-ref="node-pre-gyp@0.15.0|chownr@1.1.4">
           <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me/)</author>
@@ -19943,6 +22120,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/node-pre-gyp/node_modules/chownr</property>
+          </properties>
         </component>
         <component type="library" bom-ref="node-pre-gyp@0.15.0|fs-minipass@1.2.7">
           <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me/)</author>
@@ -19976,6 +22156,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/node-pre-gyp/node_modules/fs-minipass</property>
+          </properties>
         </component>
         <component type="library" bom-ref="node-pre-gyp@0.15.0|minipass@2.9.0">
           <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me/)</author>
@@ -20001,6 +22184,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/node-pre-gyp/node_modules/minipass</property>
+          </properties>
         </component>
         <component type="library" bom-ref="node-pre-gyp@0.15.0|minizlib@1.3.3">
           <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me/)</author>
@@ -20026,6 +22212,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/node-pre-gyp/node_modules/minizlib</property>
+          </properties>
         </component>
         <component type="library" bom-ref="node-pre-gyp@0.15.0|mkdirp@0.5.6">
           <author>James Halliday &lt;mail@substack.net&gt; (http://substack.net)</author>
@@ -20051,6 +22240,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/node-pre-gyp/node_modules/mkdirp</property>
+          </properties>
         </component>
         <component type="library" bom-ref="node-pre-gyp@0.15.0|nopt@4.0.3">
           <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me/)</author>
@@ -20076,6 +22268,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/node-pre-gyp/node_modules/nopt</property>
+          </properties>
         </component>
         <component type="library" bom-ref="node-pre-gyp@0.15.0|rimraf@2.7.1">
           <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me/)</author>
@@ -20101,6 +22296,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/node-pre-gyp/node_modules/rimraf</property>
+          </properties>
         </component>
         <component type="library" bom-ref="node-pre-gyp@0.15.0|safe-buffer@5.2.1">
           <author>Feross Aboukhadijeh</author>
@@ -20134,6 +22332,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/node-pre-gyp/node_modules/safe-buffer</property>
+          </properties>
         </component>
         <component type="library" bom-ref="node-pre-gyp@0.15.0|semver@5.7.1">
           <name>semver</name>
@@ -20158,6 +22359,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/node-pre-gyp/node_modules/semver</property>
+          </properties>
         </component>
         <component type="library" bom-ref="node-pre-gyp@0.15.0|tar@4.4.19">
           <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me/)</author>
@@ -20183,6 +22387,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/node-pre-gyp/node_modules/tar</property>
+          </properties>
         </component>
         <component type="library" bom-ref="node-pre-gyp@0.15.0|yallist@3.1.1">
           <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me/)</author>
@@ -20208,6 +22415,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/node-pre-gyp/node_modules/yallist</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -20234,6 +22444,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/noop-logger</property>
+      </properties>
     </component>
     <component type="library" bom-ref="nopt@3.0.6">
       <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me/)</author>
@@ -20259,6 +22472,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/nopt</property>
+      </properties>
     </component>
     <component type="library" bom-ref="normalize-package-data@2.5.0">
       <author>Meryn Stol &lt;merynstol@gmail.com&gt;</author>
@@ -20284,6 +22500,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/normalize-package-data</property>
+      </properties>
       <components>
         <component type="library" bom-ref="normalize-package-data@2.5.0|semver@5.7.1">
           <name>semver</name>
@@ -20308,6 +22527,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/normalize-package-data/node_modules/semver</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -20343,6 +22565,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/normalize-path</property>
+      </properties>
     </component>
     <component type="library" bom-ref="normalize-url@2.0.1">
       <author>Sindre Sorhus</author>
@@ -20368,6 +22593,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/normalize-url</property>
+      </properties>
     </component>
     <component type="library" bom-ref="notevil@1.3.3">
       <author>Matt McKegg</author>
@@ -20397,6 +22625,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/notevil</property>
+      </properties>
       <components>
         <component type="library" bom-ref="notevil@1.3.3|esprima@1.0.4">
           <name>esprima</name>
@@ -20405,6 +22636,12 @@
           <hashes>
             <hash alg="SHA-512">ae9e5d30a37ccc4b3d75f8bd8345f50a52e657ffd647293f475e66a6914d202205446e4ff7654fed9d38a7ca64fbe800068f56dad63e907caee8fd661078264c</hash>
           </hashes>
+          <licenses>
+            <license>
+              <name>BSD</name>
+              <url>http://github.com/ariya/esprima/raw/master/LICENSE.BSD</url>
+            </license>
+          </licenses>
           <purl>pkg:npm/esprima@1.0.4</purl>
           <externalReferences>
             <reference type="distribution">
@@ -20420,6 +22657,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/notevil/node_modules/esprima</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -20447,6 +22687,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/npm-bundled</property>
+      </properties>
     </component>
     <component type="library" bom-ref="npm-normalize-package-bin@1.0.1">
       <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (https://izs.me)</author>
@@ -20472,6 +22715,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/npm-normalize-package-bin</property>
+      </properties>
     </component>
     <component type="library" bom-ref="npm-packlist@1.4.8">
       <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me/)</author>
@@ -20505,6 +22751,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/npm-packlist</property>
+      </properties>
     </component>
     <component type="library" bom-ref="npmlog@4.1.2">
       <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me/)</author>
@@ -20530,6 +22779,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/npmlog</property>
+      </properties>
     </component>
     <component type="library" bom-ref="number-is-nan@1.0.1">
       <author>Sindre Sorhus</author>
@@ -20555,6 +22807,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/number-is-nan</property>
+      </properties>
     </component>
     <component type="library" bom-ref="oauth-sign@0.9.0">
       <author>Mikeal Rogers &lt;mikeal.rogers@gmail.com&gt; (http://www.futurealoof.com)</author>
@@ -20580,6 +22835,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/oauth-sign</property>
+      </properties>
     </component>
     <component type="library" bom-ref="object-assign@4.1.1">
       <author>Sindre Sorhus</author>
@@ -20605,6 +22863,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/object-assign</property>
+      </properties>
     </component>
     <component type="library" bom-ref="object-copy@0.1.0">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -20638,6 +22899,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/object-copy</property>
+      </properties>
       <components>
         <component type="library" bom-ref="object-copy@0.1.0|define-property@0.2.5">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -20671,6 +22935,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/object-copy/node_modules/define-property</property>
+          </properties>
         </component>
         <component type="library" bom-ref="object-copy@0.1.0|is-accessor-descriptor@0.1.6">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -20704,6 +22971,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/object-copy/node_modules/is-accessor-descriptor</property>
+          </properties>
         </component>
         <component type="library" bom-ref="object-copy@0.1.0|is-data-descriptor@0.1.4">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -20737,6 +23007,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/object-copy/node_modules/is-data-descriptor</property>
+          </properties>
         </component>
         <component type="library" bom-ref="object-copy@0.1.0|is-descriptor@0.1.6">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -20770,6 +23043,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/object-copy/node_modules/is-descriptor</property>
+          </properties>
           <components>
             <component type="library" bom-ref="object-copy@0.1.0|is-descriptor@0.1.6|kind-of@5.1.0">
               <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -20803,6 +23079,9 @@
                   <comment>as detected from PackageJson property "homepage"</comment>
                 </reference>
               </externalReferences>
+              <properties>
+                <property name="cdx:npm:package:installPath">node_modules/object-copy/node_modules/is-descriptor/node_modules/kind-of</property>
+              </properties>
             </component>
           </components>
         </component>
@@ -20838,6 +23117,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/object-copy/node_modules/kind-of</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -20869,6 +23151,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/object-inspect</property>
+      </properties>
     </component>
     <component type="library" bom-ref="object-is@1.1.5">
       <author>Jordan Harband</author>
@@ -20902,6 +23187,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/object-is</property>
+      </properties>
     </component>
     <component type="library" bom-ref="object-keys@1.1.1">
       <author>Jordan Harband</author>
@@ -20927,6 +23215,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/object-keys</property>
+      </properties>
     </component>
     <component type="library" bom-ref="object-visit@1.0.1">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -20960,6 +23251,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/object-visit</property>
+      </properties>
     </component>
     <component type="library" bom-ref="object.assign@4.1.4">
       <author>Jordan Harband</author>
@@ -20985,6 +23279,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/object.assign</property>
+      </properties>
     </component>
     <component type="library" bom-ref="object.defaults@1.1.0">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -21018,6 +23315,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/object.defaults</property>
+      </properties>
     </component>
     <component type="library" bom-ref="object.map@1.0.1">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -21051,6 +23351,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/object.map</property>
+      </properties>
     </component>
     <component type="library" bom-ref="object.pick@1.3.0">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -21084,6 +23387,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/object.pick</property>
+      </properties>
     </component>
     <component type="library" bom-ref="on-finished@2.4.1">
       <name>on-finished</name>
@@ -21108,6 +23414,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/on-finished</property>
+      </properties>
     </component>
     <component type="library" bom-ref="on-headers@1.0.2">
       <author>Douglas Christopher Wilson &lt;doug@somethingdoug.com&gt;</author>
@@ -21133,6 +23442,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/on-headers</property>
+      </properties>
     </component>
     <component type="library" bom-ref="once@1.4.0">
       <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me/)</author>
@@ -21158,6 +23470,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/once</property>
+      </properties>
     </component>
     <component type="library" bom-ref="one-time@1.0.0">
       <author>Arnout Kazemier</author>
@@ -21183,6 +23498,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/one-time</property>
+      </properties>
     </component>
     <component type="library" bom-ref="opentype.js@0.7.3">
       <author>Frederik De Bleser</author>
@@ -21208,6 +23526,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/opentype.js</property>
+      </properties>
     </component>
     <component type="library" bom-ref="optionator@0.8.3">
       <author>George Zahariev &lt;z@georgezahariev.com&gt;</author>
@@ -21241,6 +23562,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/optionator</property>
+      </properties>
     </component>
     <component type="library" bom-ref="os-homedir@1.0.2">
       <author>Sindre Sorhus</author>
@@ -21266,6 +23590,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/os-homedir</property>
+      </properties>
     </component>
     <component type="library" bom-ref="os-tmpdir@1.0.2">
       <author>Sindre Sorhus</author>
@@ -21291,6 +23618,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/os-tmpdir</property>
+      </properties>
     </component>
     <component type="library" bom-ref="osenv@0.1.5">
       <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me/)</author>
@@ -21316,6 +23646,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/osenv</property>
+      </properties>
     </component>
     <component type="library" bom-ref="otplib@12.0.1">
       <author>Gerald Yeo &lt;contact@fusedthought.com&gt;</author>
@@ -21345,6 +23678,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/otplib</property>
+      </properties>
     </component>
     <component type="library" bom-ref="p-cancelable@0.4.1">
       <author>Sindre Sorhus</author>
@@ -21370,6 +23706,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/p-cancelable</property>
+      </properties>
     </component>
     <component type="library" bom-ref="p-event@2.3.1">
       <author>Sindre Sorhus</author>
@@ -21395,6 +23734,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/p-event</property>
+      </properties>
     </component>
     <component type="library" bom-ref="p-finally@1.0.0">
       <author>Sindre Sorhus</author>
@@ -21420,6 +23762,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/p-finally</property>
+      </properties>
     </component>
     <component type="library" bom-ref="p-is-promise@1.1.0">
       <author>Sindre Sorhus</author>
@@ -21445,6 +23790,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/p-is-promise</property>
+      </properties>
     </component>
     <component type="library" bom-ref="p-limit@2.3.0">
       <author>Sindre Sorhus</author>
@@ -21470,6 +23818,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/p-limit</property>
+      </properties>
     </component>
     <component type="library" bom-ref="p-locate@3.0.0">
       <author>Sindre Sorhus</author>
@@ -21495,6 +23846,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/p-locate</property>
+      </properties>
     </component>
     <component type="library" bom-ref="p-map@4.0.0">
       <author>Sindre Sorhus</author>
@@ -21520,6 +23874,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/p-map</property>
+      </properties>
     </component>
     <component type="library" bom-ref="p-timeout@2.0.1">
       <author>Sindre Sorhus</author>
@@ -21545,6 +23902,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/p-timeout</property>
+      </properties>
     </component>
     <component type="library" bom-ref="p-try@2.2.0">
       <author>Sindre Sorhus</author>
@@ -21570,6 +23930,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/p-try</property>
+      </properties>
     </component>
     <component type="library" bom-ref="pako@0.2.9">
       <name>pako</name>
@@ -21598,6 +23961,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/pako</property>
+      </properties>
     </component>
     <component type="library" bom-ref="parse-filepath@1.0.2">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -21631,6 +23997,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/parse-filepath</property>
+      </properties>
     </component>
     <component type="library" bom-ref="parse-json@4.0.0">
       <author>Sindre Sorhus</author>
@@ -21656,6 +24025,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/parse-json</property>
+      </properties>
     </component>
     <component type="library" bom-ref="parse-passwd@1.0.0">
       <author>Brian Woodward (https://github.com/doowb)</author>
@@ -21689,6 +24061,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/parse-passwd</property>
+      </properties>
     </component>
     <component type="library" bom-ref="parseurl@1.3.3">
       <name>parseurl</name>
@@ -21713,6 +24088,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/parseurl</property>
+      </properties>
     </component>
     <component type="library" bom-ref="pascalcase@0.1.1">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -21746,6 +24124,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/pascalcase</property>
+      </properties>
     </component>
     <component type="library" bom-ref="path-exists@3.0.0">
       <author>Sindre Sorhus</author>
@@ -21771,6 +24152,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/path-exists</property>
+      </properties>
     </component>
     <component type="library" bom-ref="path-is-absolute@1.0.1">
       <author>Sindre Sorhus</author>
@@ -21796,6 +24180,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/path-is-absolute</property>
+      </properties>
     </component>
     <component type="library" bom-ref="path-parse@1.0.7">
       <author>Javier Blanco &lt;http://jbgutierrez.info&gt;</author>
@@ -21829,6 +24216,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/path-parse</property>
+      </properties>
     </component>
     <component type="library" bom-ref="path-root-regex@0.1.2">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -21862,6 +24252,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/path-root-regex</property>
+      </properties>
     </component>
     <component type="library" bom-ref="path-root@0.1.1">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -21895,6 +24288,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/path-root</property>
+      </properties>
     </component>
     <component type="library" bom-ref="path-to-regexp@0.1.7">
       <name>path-to-regexp</name>
@@ -21919,6 +24315,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/path-to-regexp</property>
+      </properties>
     </component>
     <component type="library" bom-ref="pdfkit@0.11.0">
       <author>Devon Govett</author>
@@ -21952,6 +24351,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/pdfkit</property>
+      </properties>
     </component>
     <component type="library" bom-ref="peek-readable@4.1.0">
       <author>Borewit</author>
@@ -21981,6 +24383,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/peek-readable</property>
+      </properties>
     </component>
     <component type="library" bom-ref="pend@1.2.0">
       <author>Andrew Kelley &lt;superjoe30@gmail.com&gt;</author>
@@ -22010,6 +24415,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/pend</property>
+      </properties>
     </component>
     <component type="library" bom-ref="performance-now@2.1.0">
       <author>Braveg1rl &lt;braveg1rl@outlook.com&gt;</author>
@@ -22043,6 +24451,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/performance-now</property>
+      </properties>
     </component>
     <component type="library" bom-ref="pg-connection-string@2.5.0">
       <author>Blaine Bublitz &lt;blaine@iceddev.com&gt; (http://iceddev.com/)</author>
@@ -22076,6 +24487,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/pg-connection-string</property>
+      </properties>
     </component>
     <component type="library" bom-ref="picomatch@2.3.1">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -22109,6 +24523,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/picomatch</property>
+      </properties>
     </component>
     <component type="library" bom-ref="pify@4.0.1">
       <author>Sindre Sorhus</author>
@@ -22134,6 +24551,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/pify</property>
+      </properties>
     </component>
     <component type="library" bom-ref="pinkie-promise@2.0.1">
       <author>Vsevolod Strukchinsky</author>
@@ -22159,6 +24579,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/pinkie-promise</property>
+      </properties>
     </component>
     <component type="library" bom-ref="pinkie@2.0.4">
       <author>Vsevolod Strukchinsky</author>
@@ -22184,6 +24607,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/pinkie</property>
+      </properties>
     </component>
     <component type="library" bom-ref="png-js@1.0.0">
       <author>Devon Govett</author>
@@ -22208,6 +24634,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/png-js</property>
+      </properties>
     </component>
     <component type="library" bom-ref="portscanner@2.2.0">
       <name>portscanner</name>
@@ -22240,6 +24669,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/portscanner</property>
+      </properties>
     </component>
     <component type="library" bom-ref="posix-character-classes@0.1.1">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -22273,6 +24705,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/posix-character-classes</property>
+      </properties>
     </component>
     <component type="library" bom-ref="prebuild-install@5.3.6">
       <author>Mathias Buus (@mafintosh)</author>
@@ -22306,6 +24741,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/prebuild-install</property>
+      </properties>
     </component>
     <component type="library" bom-ref="prelude-ls@1.1.2">
       <author>George Zahariev &lt;z@georgezahariev.com&gt;</author>
@@ -22315,6 +24753,12 @@
       <hashes>
         <hash alg="SHA-512">112176dd5e12286ea55521998183696ec89a02475a6fa6603b17b9da9efe2a27775b7bb76f147855f77fa36d5d98dee34add08c20678bf9314776e8512d5c4f7</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <url>https://raw.github.com/gkz/prelude-ls/master/LICENSE</url>
+        </license>
+      </licenses>
       <purl>pkg:npm/prelude-ls@1.1.2</purl>
       <externalReferences>
         <reference type="distribution">
@@ -22334,6 +24778,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/prelude-ls</property>
+      </properties>
     </component>
     <component type="library" bom-ref="prepend-http@2.0.0">
       <author>Sindre Sorhus</author>
@@ -22359,6 +24806,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/prepend-http</property>
+      </properties>
     </component>
     <component type="library" bom-ref="pretty-bytes@4.0.2">
       <author>Sindre Sorhus</author>
@@ -22384,6 +24834,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/pretty-bytes</property>
+      </properties>
     </component>
     <component type="library" bom-ref="process-nextick-args@2.0.1">
       <name>process-nextick-args</name>
@@ -22416,6 +24869,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/process-nextick-args</property>
+      </properties>
     </component>
     <component type="library" bom-ref="prom-client@12.0.0">
       <author>Simon Nyberg</author>
@@ -22441,6 +24897,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/prom-client</property>
+      </properties>
     </component>
     <component type="library" bom-ref="promise-inflight@1.0.1">
       <author>Rebecca Turner &lt;me@re-becca.org&gt; (http://re-becca.org/)</author>
@@ -22474,6 +24933,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/promise-inflight</property>
+      </properties>
     </component>
     <component type="library" bom-ref="promise-retry@2.0.1">
       <author>IndigoUnited &lt;hello@indigounited.com&gt; (http://indigounited.com)</author>
@@ -22503,6 +24965,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/promise-retry</property>
+      </properties>
       <components>
         <component type="library" bom-ref="promise-retry@2.0.1|err-code@2.0.3">
           <author>IndigoUnited &lt;hello@indigounited.com&gt; (http://indigounited.com)</author>
@@ -22532,6 +24997,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/promise-retry/node_modules/err-code</property>
+          </properties>
         </component>
         <component type="library" bom-ref="promise-retry@2.0.1|retry@0.12.0">
           <author>Tim Koschützki &lt;tim@debuggable.com&gt; (http://debuggable.com/)</author>
@@ -22561,6 +25029,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/promise-retry/node_modules/retry</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -22588,6 +25059,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/promise</property>
+      </properties>
     </component>
     <component type="library" bom-ref="proper-lockfile@1.2.0">
       <author>IndigoUnited &lt;hello@indigounited.com&gt; (http://indigounited.com)</author>
@@ -22617,6 +25091,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/proper-lockfile</property>
+      </properties>
     </component>
     <component type="library" bom-ref="proxy-addr@2.0.7">
       <author>Douglas Christopher Wilson &lt;doug@somethingdoug.com&gt;</author>
@@ -22642,6 +25119,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/proxy-addr</property>
+      </properties>
     </component>
     <component type="library" bom-ref="psl@1.9.0">
       <author>Lupo Montero &lt;lupomontero@gmail.com&gt; (https://lupomontero.com/)</author>
@@ -22663,6 +25143,9 @@
           <comment>as detected from npm-ls property "resolved"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/psl</property>
+      </properties>
     </component>
     <component type="library" bom-ref="pug-attrs@3.0.0">
       <author>Forbes Lindesay</author>
@@ -22688,6 +25171,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/pug-attrs</property>
+      </properties>
     </component>
     <component type="library" bom-ref="pug-code-gen@3.0.2">
       <author>Forbes Lindesay</author>
@@ -22713,6 +25199,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/pug-code-gen</property>
+      </properties>
     </component>
     <component type="library" bom-ref="pug-error@2.0.0">
       <author>Forbes Lindesay</author>
@@ -22738,6 +25227,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/pug-error</property>
+      </properties>
     </component>
     <component type="library" bom-ref="pug-filters@4.0.0">
       <author>Forbes Lindesay</author>
@@ -22763,6 +25255,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/pug-filters</property>
+      </properties>
     </component>
     <component type="library" bom-ref="pug-lexer@5.0.1">
       <author>ForbesLindesay</author>
@@ -22788,6 +25283,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/pug-lexer</property>
+      </properties>
     </component>
     <component type="library" bom-ref="pug-linker@4.0.0">
       <author>Forbes Lindesay</author>
@@ -22813,6 +25311,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/pug-linker</property>
+      </properties>
     </component>
     <component type="library" bom-ref="pug-load@3.0.0">
       <author>ForbesLindesay</author>
@@ -22838,6 +25339,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/pug-load</property>
+      </properties>
     </component>
     <component type="library" bom-ref="pug-parser@6.0.0">
       <author>ForbesLindesay</author>
@@ -22863,6 +25367,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/pug-parser</property>
+      </properties>
     </component>
     <component type="library" bom-ref="pug-runtime@3.0.1">
       <author>ForbesLindesay</author>
@@ -22888,6 +25395,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/pug-runtime</property>
+      </properties>
     </component>
     <component type="library" bom-ref="pug-strip-comments@2.0.0">
       <author>Timothy Gu &lt;timothygu99@gmail.com&gt;</author>
@@ -22913,6 +25423,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/pug-strip-comments</property>
+      </properties>
     </component>
     <component type="library" bom-ref="pug-walk@2.0.0">
       <author>ForbesLindesay</author>
@@ -22938,6 +25451,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/pug-walk</property>
+      </properties>
     </component>
     <component type="library" bom-ref="pug@3.0.2">
       <author>TJ Holowaychuk &lt;tj@vision-media.ca&gt;</author>
@@ -22967,6 +25483,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/pug</property>
+      </properties>
     </component>
     <component type="library" bom-ref="pump@3.0.0">
       <author>Mathias Buus Madsen &lt;mathiasbuus@gmail.com&gt;</author>
@@ -22992,6 +25511,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/pump</property>
+      </properties>
     </component>
     <component type="library" bom-ref="punycode@2.1.1">
       <author>Mathias Bynens</author>
@@ -23025,6 +25547,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/punycode</property>
+      </properties>
     </component>
     <component type="library" bom-ref="qs@6.11.0">
       <name>qs</name>
@@ -23053,6 +25578,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/qs</property>
+      </properties>
     </component>
     <component type="library" bom-ref="query-string@5.1.1">
       <author>Sindre Sorhus</author>
@@ -23078,6 +25606,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/query-string</property>
+      </properties>
     </component>
     <component type="library" bom-ref="range_check@2.0.4">
       <author>Kevin Whitman (https://github.com/keverw)</author>
@@ -23103,6 +25634,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/range_check</property>
+      </properties>
     </component>
     <component type="library" bom-ref="range-parser@1.2.1">
       <author>TJ Holowaychuk &lt;tj@vision-media.ca&gt; (http://tjholowaychuk.com)</author>
@@ -23128,6 +25662,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/range-parser</property>
+      </properties>
     </component>
     <component type="library" bom-ref="raw-body@2.5.1">
       <author>Jonathan Ong &lt;me@jongleberry.com&gt; (http://jongleberry.com)</author>
@@ -23153,6 +25690,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/raw-body</property>
+      </properties>
     </component>
     <component type="library" bom-ref="rc@1.2.8">
       <author>Dominic Tarr &lt;dominic.tarr@gmail.com&gt; (dominictarr.com)</author>
@@ -23176,6 +25716,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/rc</property>
+      </properties>
     </component>
     <component type="library" bom-ref="read-pkg@4.0.1">
       <author>Sindre Sorhus</author>
@@ -23201,6 +25744,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/read-pkg</property>
+      </properties>
       <components>
         <component type="library" bom-ref="read-pkg@4.0.1|pify@3.0.0">
           <author>Sindre Sorhus</author>
@@ -23226,6 +25772,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/read-pkg/node_modules/pify</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -23252,6 +25801,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/readable-stream</property>
+      </properties>
       <components>
         <component type="library" bom-ref="readable-stream@2.3.7|isarray@1.0.0">
           <author>Julian Gruber</author>
@@ -23281,6 +25833,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/readable-stream/node_modules/isarray</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -23312,6 +25867,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/readable-web-to-node-stream</property>
+      </properties>
       <components>
         <component type="library" bom-ref="readable-web-to-node-stream@3.0.2|readable-stream@3.6.0">
           <name>readable-stream</name>
@@ -23336,6 +25894,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/readable-web-to-node-stream/node_modules/readable-stream</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -23371,6 +25932,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/readdirp</property>
+      </properties>
     </component>
     <component type="library" bom-ref="rechoir@0.7.1">
       <author>Gulp Team &lt;team@gulpjs.com&gt; (http://gulpjs.com/)</author>
@@ -23396,6 +25960,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/rechoir</property>
+      </properties>
     </component>
     <component type="library" bom-ref="regex-not@1.0.2">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -23429,6 +25996,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/regex-not</property>
+      </properties>
     </component>
     <component type="library" bom-ref="regexp.prototype.flags@1.4.3">
       <author>Jordan Harband &lt;ljharb@gmail.com&gt;</author>
@@ -23454,6 +26024,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/regexp.prototype.flags</property>
+      </properties>
     </component>
     <component type="library" bom-ref="remove-trailing-separator@1.1.0">
       <author>darsain</author>
@@ -23487,6 +26060,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/remove-trailing-separator</property>
+      </properties>
     </component>
     <component type="library" bom-ref="repeat-element@1.1.4">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -23520,6 +26096,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/repeat-element</property>
+      </properties>
     </component>
     <component type="library" bom-ref="repeat-string@1.6.1">
       <author>Jon Schlinkert (http://github.com/jonschlinkert)</author>
@@ -23553,6 +26132,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/repeat-string</property>
+      </properties>
     </component>
     <component type="library" bom-ref="replace@1.2.2">
       <author>Alessandro Maclaine &lt;almaclaine@gmail.com&gt;</author>
@@ -23578,6 +26160,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/replace</property>
+      </properties>
       <components>
         <component type="library" bom-ref="replace@1.2.2|ansi-regex@5.0.1">
           <author>Sindre Sorhus</author>
@@ -23603,6 +26188,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/replace/node_modules/ansi-regex</property>
+          </properties>
         </component>
         <component type="library" bom-ref="replace@1.2.2|ansi-styles@4.3.0">
           <author>Sindre Sorhus</author>
@@ -23628,6 +26216,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/replace/node_modules/ansi-styles</property>
+          </properties>
         </component>
         <component type="library" bom-ref="replace@1.2.2|brace-expansion@1.1.11">
           <author>Julian Gruber</author>
@@ -23657,6 +26248,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/replace/node_modules/brace-expansion</property>
+          </properties>
         </component>
         <component type="library" bom-ref="replace@1.2.2|cliui@6.0.0">
           <author>Ben Coe &lt;ben@npmjs.com&gt;</author>
@@ -23682,6 +26276,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/replace/node_modules/cliui</property>
+          </properties>
         </component>
         <component type="library" bom-ref="replace@1.2.2|color-convert@2.0.1">
           <author>Heather Arthur &lt;fayearthur@gmail.com&gt;</author>
@@ -23707,6 +26304,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/replace/node_modules/color-convert</property>
+          </properties>
         </component>
         <component type="library" bom-ref="replace@1.2.2|color-name@1.1.4">
           <author>DY &lt;dfcreative@gmail.com&gt;</author>
@@ -23736,6 +26336,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/replace/node_modules/color-name</property>
+          </properties>
         </component>
         <component type="library" bom-ref="replace@1.2.2|find-up@4.1.0">
           <author>Sindre Sorhus</author>
@@ -23761,6 +26364,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/replace/node_modules/find-up</property>
+          </properties>
         </component>
         <component type="library" bom-ref="replace@1.2.2|is-fullwidth-code-point@3.0.0">
           <author>Sindre Sorhus</author>
@@ -23786,6 +26392,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/replace/node_modules/is-fullwidth-code-point</property>
+          </properties>
         </component>
         <component type="library" bom-ref="replace@1.2.2|locate-path@5.0.0">
           <author>Sindre Sorhus</author>
@@ -23811,6 +26420,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/replace/node_modules/locate-path</property>
+          </properties>
         </component>
         <component type="library" bom-ref="replace@1.2.2|minimatch@3.0.5">
           <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me)</author>
@@ -23836,6 +26448,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/replace/node_modules/minimatch</property>
+          </properties>
         </component>
         <component type="library" bom-ref="replace@1.2.2|p-locate@4.1.0">
           <author>Sindre Sorhus</author>
@@ -23861,6 +26476,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/replace/node_modules/p-locate</property>
+          </properties>
         </component>
         <component type="library" bom-ref="replace@1.2.2|path-exists@4.0.0">
           <author>Sindre Sorhus</author>
@@ -23886,6 +26504,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/replace/node_modules/path-exists</property>
+          </properties>
         </component>
         <component type="library" bom-ref="replace@1.2.2|string-width@4.2.3">
           <author>Sindre Sorhus</author>
@@ -23911,6 +26532,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/replace/node_modules/string-width</property>
+          </properties>
         </component>
         <component type="library" bom-ref="replace@1.2.2|strip-ansi@6.0.1">
           <author>Sindre Sorhus</author>
@@ -23936,6 +26560,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/replace/node_modules/strip-ansi</property>
+          </properties>
         </component>
         <component type="library" bom-ref="replace@1.2.2|wrap-ansi@6.2.0">
           <author>Sindre Sorhus</author>
@@ -23961,6 +26588,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/replace/node_modules/wrap-ansi</property>
+          </properties>
         </component>
         <component type="library" bom-ref="replace@1.2.2|yargs-parser@18.1.3">
           <author>Ben Coe &lt;ben@npmjs.com&gt;</author>
@@ -23986,6 +26616,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/replace/node_modules/yargs-parser</property>
+          </properties>
         </component>
         <component type="library" bom-ref="replace@1.2.2|yargs@15.4.1">
           <name>yargs</name>
@@ -24014,6 +26647,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/replace/node_modules/yargs</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -24045,6 +26681,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/request</property>
+      </properties>
       <components>
         <component type="library" bom-ref="request@2.88.2|qs@6.5.3">
           <name>qs</name>
@@ -24073,6 +26712,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/request/node_modules/qs</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -24108,6 +26750,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/require-directory</property>
+      </properties>
     </component>
     <component type="library" bom-ref="require-main-filename@2.0.0">
       <author>Ben Coe &lt;ben@npmjs.com&gt;</author>
@@ -24141,6 +26786,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/require-main-filename</property>
+      </properties>
     </component>
     <component type="library" bom-ref="resolve-dir@1.0.1">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -24174,6 +26822,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/resolve-dir</property>
+      </properties>
     </component>
     <component type="library" bom-ref="resolve-url@0.2.1">
       <author>Simon Lydell</author>
@@ -24199,6 +26850,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/resolve-url</property>
+      </properties>
     </component>
     <component type="library" bom-ref="resolve@1.22.1">
       <author>James Halliday</author>
@@ -24224,6 +26878,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/resolve</property>
+      </properties>
     </component>
     <component type="library" bom-ref="responselike@1.0.2">
       <author>lukechilds</author>
@@ -24249,6 +26906,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/responselike</property>
+      </properties>
     </component>
     <component type="library" bom-ref="restructure@2.0.1">
       <author>Devon Govett &lt;devongovett@gmail.com&gt;</author>
@@ -24282,6 +26942,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/restructure</property>
+      </properties>
     </component>
     <component type="library" bom-ref="ret@0.1.15">
       <author>Roly Fentanes (https://github.com/fent)</author>
@@ -24307,6 +26970,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/ret</property>
+      </properties>
     </component>
     <component type="library" bom-ref="retry-as-promised@6.1.0">
       <author>Mick Hansen &lt;maker@mhansen.io&gt;</author>
@@ -24340,6 +27006,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/retry-as-promised</property>
+      </properties>
     </component>
     <component type="library" bom-ref="retry@0.10.1">
       <author>Tim Koschützki &lt;tim@debuggable.com&gt; (http://debuggable.com/)</author>
@@ -24369,6 +27038,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/retry</property>
+      </properties>
     </component>
     <component type="library" bom-ref="rimraf@3.0.2">
       <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me/)</author>
@@ -24394,6 +27066,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/rimraf</property>
+      </properties>
     </component>
     <component type="library" bom-ref="rxjs@6.6.7">
       <author>Ben Lesh &lt;ben@benlesh.com&gt;</author>
@@ -24427,6 +27102,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/rxjs</property>
+      </properties>
       <components>
         <component type="library" bom-ref="rxjs@6.6.7|tslib@1.14.1">
           <author>Microsoft Corp.</author>
@@ -24460,6 +27138,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/rxjs/node_modules/tslib</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -24495,6 +27176,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/safe-buffer</property>
+      </properties>
     </component>
     <component type="library" bom-ref="safe-regex@1.1.0">
       <author>James Halliday</author>
@@ -24524,6 +27208,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/safe-regex</property>
+      </properties>
     </component>
     <component type="library" bom-ref="safe-stable-stringify@2.4.1">
       <author>Ruben Bridgewater</author>
@@ -24557,6 +27244,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/safe-stable-stringify</property>
+      </properties>
     </component>
     <component type="library" bom-ref="safer-buffer@2.1.2">
       <author>Nikita Skovoroda</author>
@@ -24586,6 +27276,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/safer-buffer</property>
+      </properties>
     </component>
     <component type="library" bom-ref="samsam@1.1.2">
       <author>Christian Johansen</author>
@@ -24610,6 +27303,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/samsam</property>
+      </properties>
     </component>
     <component type="library" bom-ref="sanitize-filename@1.6.3">
       <author>Parsha Pourkhomami</author>
@@ -24631,6 +27327,9 @@
           <comment>as detected from npm-ls property "resolved"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/sanitize-filename</property>
+      </properties>
     </component>
     <component type="library" bom-ref="sanitize-html@1.4.2">
       <author>P'unk Avenue LLC</author>
@@ -24656,6 +27355,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/sanitize-html</property>
+      </properties>
       <components>
         <component type="library" bom-ref="sanitize-html@1.4.2|lodash@2.4.2">
           <author>John-David Dalton &lt;john.david.dalton@gmail.com&gt; (http://allyoucanleet.com/)</author>
@@ -24689,6 +27391,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/sanitize-html/node_modules/lodash</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -24716,6 +27421,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/sax</property>
+      </properties>
     </component>
     <component type="library" bom-ref="seek-bzip@1.0.6">
       <name>seek-bzip</name>
@@ -24740,6 +27448,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/seek-bzip</property>
+      </properties>
     </component>
     <component type="library" bom-ref="semver@7.3.8">
       <author>GitHub Inc.</author>
@@ -24765,6 +27476,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/semver</property>
+      </properties>
     </component>
     <component type="library" bom-ref="send@0.18.0">
       <author>TJ Holowaychuk &lt;tj@vision-media.ca&gt;</author>
@@ -24790,6 +27504,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/send</property>
+      </properties>
       <components>
         <component type="library" bom-ref="send@0.18.0|ms@2.1.3">
           <name>ms</name>
@@ -24814,6 +27531,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/send/node_modules/ms</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -24841,6 +27561,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/sequelize-pool</property>
+      </properties>
     </component>
     <component type="library" bom-ref="sequelize@6.25.3">
       <name>sequelize</name>
@@ -24873,6 +27596,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/sequelize</property>
+      </properties>
       <components>
         <component type="library" bom-ref="sequelize@6.25.3|debug@4.3.4">
           <author>Josh Junon &lt;josh.junon@protonmail.com&gt;</author>
@@ -24898,6 +27624,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/sequelize/node_modules/debug</property>
+          </properties>
         </component>
         <component type="library" bom-ref="sequelize@6.25.3|ms@2.1.2">
           <name>ms</name>
@@ -24922,6 +27651,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/sequelize/node_modules/ms</property>
+          </properties>
         </component>
         <component type="library" bom-ref="sequelize@6.25.3|uuid@8.3.2">
           <name>uuid</name>
@@ -24946,6 +27678,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/sequelize/node_modules/uuid</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -24973,6 +27708,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/serve-index</property>
+      </properties>
       <components>
         <component type="library" bom-ref="serve-index@1.9.1|depd@1.1.2">
           <author>Douglas Christopher Wilson &lt;doug@somethingdoug.com&gt;</author>
@@ -24998,6 +27736,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/serve-index/node_modules/depd</property>
+          </properties>
         </component>
         <component type="library" bom-ref="serve-index@1.9.1|http-errors@1.6.3">
           <author>Jonathan Ong &lt;me@jongleberry.com&gt; (http://jongleberry.com)</author>
@@ -25023,6 +27764,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/serve-index/node_modules/http-errors</property>
+          </properties>
         </component>
         <component type="library" bom-ref="serve-index@1.9.1|inherits@2.0.3">
           <name>inherits</name>
@@ -25047,6 +27791,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/serve-index/node_modules/inherits</property>
+          </properties>
         </component>
         <component type="library" bom-ref="serve-index@1.9.1|setprototypeof@1.1.0">
           <author>Wes Todd</author>
@@ -25080,6 +27827,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/serve-index/node_modules/setprototypeof</property>
+          </properties>
         </component>
         <component type="library" bom-ref="serve-index@1.9.1|statuses@1.5.0">
           <name>statuses</name>
@@ -25104,6 +27854,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/serve-index/node_modules/statuses</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -25131,6 +27884,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/serve-static</property>
+      </properties>
     </component>
     <component type="library" bom-ref="set-blocking@2.0.0">
       <author>Ben Coe &lt;ben@npmjs.com&gt;</author>
@@ -25164,6 +27920,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/set-blocking</property>
+      </properties>
     </component>
     <component type="library" bom-ref="set-value@2.0.1">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -25197,6 +27956,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/set-value</property>
+      </properties>
       <components>
         <component type="library" bom-ref="set-value@2.0.1|extend-shallow@2.0.1">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -25230,6 +27992,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/set-value/node_modules/extend-shallow</property>
+          </properties>
         </component>
         <component type="library" bom-ref="set-value@2.0.1|is-extendable@0.1.1">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -25263,6 +28028,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/set-value/node_modules/is-extendable</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -25290,6 +28058,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/setimmediate</property>
+      </properties>
     </component>
     <component type="library" bom-ref="setprototypeof@1.2.0">
       <author>Wes Todd</author>
@@ -25323,6 +28094,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/setprototypeof</property>
+      </properties>
     </component>
     <component type="library" bom-ref="side-channel@1.0.4">
       <author>Jordan Harband &lt;ljharb@gmail.com&gt;</author>
@@ -25356,6 +28130,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/side-channel</property>
+      </properties>
     </component>
     <component type="library" bom-ref="signal-exit@3.0.7">
       <author>Ben Coe &lt;ben@npmjs.com&gt;</author>
@@ -25389,6 +28166,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/signal-exit</property>
+      </properties>
     </component>
     <component type="library" bom-ref="simple-concat@1.0.1">
       <author>Feross Aboukhadijeh</author>
@@ -25422,6 +28202,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/simple-concat</property>
+      </properties>
     </component>
     <component type="library" bom-ref="simple-get@3.1.1">
       <author>Feross Aboukhadijeh</author>
@@ -25455,6 +28238,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/simple-get</property>
+      </properties>
       <components>
         <component type="library" bom-ref="simple-get@3.1.1|decompress-response@4.2.1">
           <author>Sindre Sorhus</author>
@@ -25480,6 +28266,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/simple-get/node_modules/decompress-response</property>
+          </properties>
         </component>
         <component type="library" bom-ref="simple-get@3.1.1|mimic-response@2.1.0">
           <author>Sindre Sorhus</author>
@@ -25505,6 +28294,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/simple-get/node_modules/mimic-response</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -25532,6 +28324,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/simple-swizzle</property>
+      </properties>
       <components>
         <component type="library" bom-ref="simple-swizzle@0.2.2|is-arrayish@0.3.2">
           <author>Qix (http://github.com/qix-)</author>
@@ -25557,6 +28352,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/simple-swizzle/node_modules/is-arrayish</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -25592,6 +28390,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/sinon</property>
+      </properties>
     </component>
     <component type="library" bom-ref="smart-buffer@4.2.0">
       <author>Josh Glazebrook</author>
@@ -25625,6 +28426,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/smart-buffer</property>
+      </properties>
     </component>
     <component type="library" bom-ref="snapdragon-node@2.1.1">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -25658,6 +28462,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/snapdragon-node</property>
+      </properties>
       <components>
         <component type="library" bom-ref="snapdragon-node@2.1.1|define-property@1.0.0">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -25691,6 +28498,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/snapdragon-node/node_modules/define-property</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -25726,6 +28536,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/snapdragon-util</property>
+      </properties>
       <components>
         <component type="library" bom-ref="snapdragon-util@3.0.1|kind-of@3.2.2">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -25759,6 +28572,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/snapdragon-util/node_modules/kind-of</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -25794,6 +28610,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/snapdragon</property>
+      </properties>
       <components>
         <component type="library" bom-ref="snapdragon@0.8.2|define-property@0.2.5">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -25827,6 +28646,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/snapdragon/node_modules/define-property</property>
+          </properties>
         </component>
         <component type="library" bom-ref="snapdragon@0.8.2|extend-shallow@2.0.1">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -25860,6 +28682,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/snapdragon/node_modules/extend-shallow</property>
+          </properties>
         </component>
         <component type="library" bom-ref="snapdragon@0.8.2|is-accessor-descriptor@0.1.6">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -25893,6 +28718,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/snapdragon/node_modules/is-accessor-descriptor</property>
+          </properties>
           <components>
             <component type="library" bom-ref="snapdragon@0.8.2|is-accessor-descriptor@0.1.6|kind-of@3.2.2">
               <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -25926,6 +28754,9 @@
                   <comment>as detected from PackageJson property "homepage"</comment>
                 </reference>
               </externalReferences>
+              <properties>
+                <property name="cdx:npm:package:installPath">node_modules/snapdragon/node_modules/is-accessor-descriptor/node_modules/kind-of</property>
+              </properties>
             </component>
           </components>
         </component>
@@ -25961,6 +28792,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/snapdragon/node_modules/is-data-descriptor</property>
+          </properties>
           <components>
             <component type="library" bom-ref="snapdragon@0.8.2|is-data-descriptor@0.1.4|kind-of@3.2.2">
               <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -25994,6 +28828,9 @@
                   <comment>as detected from PackageJson property "homepage"</comment>
                 </reference>
               </externalReferences>
+              <properties>
+                <property name="cdx:npm:package:installPath">node_modules/snapdragon/node_modules/is-data-descriptor/node_modules/kind-of</property>
+              </properties>
             </component>
           </components>
         </component>
@@ -26029,6 +28866,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/snapdragon/node_modules/is-descriptor</property>
+          </properties>
         </component>
         <component type="library" bom-ref="snapdragon@0.8.2|is-extendable@0.1.1">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -26062,6 +28902,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/snapdragon/node_modules/is-extendable</property>
+          </properties>
         </component>
         <component type="library" bom-ref="snapdragon@0.8.2|kind-of@5.1.0">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -26095,6 +28938,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/snapdragon/node_modules/kind-of</property>
+          </properties>
         </component>
         <component type="library" bom-ref="snapdragon@0.8.2|source-map@0.5.7">
           <author>Nick Fitzgerald &lt;nfitzgerald@mozilla.com&gt;</author>
@@ -26124,6 +28970,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/snapdragon/node_modules/source-map</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -26150,6 +28999,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/socket.io-adapter</property>
+      </properties>
     </component>
     <component type="library" bom-ref="socket.io-parser@4.0.5">
       <name>socket.io-parser</name>
@@ -26174,6 +29026,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/socket.io-parser</property>
+      </properties>
       <components>
         <component type="library" bom-ref="socket.io-parser@4.0.5|debug@4.3.4">
           <author>Josh Junon &lt;josh.junon@protonmail.com&gt;</author>
@@ -26199,6 +29054,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/socket.io-parser/node_modules/debug</property>
+          </properties>
         </component>
         <component type="library" bom-ref="socket.io-parser@4.0.5|ms@2.1.2">
           <name>ms</name>
@@ -26223,6 +29081,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/socket.io-parser/node_modules/ms</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -26249,6 +29110,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/socket.io</property>
+      </properties>
       <components>
         <component type="library" bom-ref="socket.io@3.1.2|debug@4.3.4">
           <author>Josh Junon &lt;josh.junon@protonmail.com&gt;</author>
@@ -26274,6 +29138,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/socket.io/node_modules/debug</property>
+          </properties>
         </component>
         <component type="library" bom-ref="socket.io@3.1.2|ms@2.1.2">
           <name>ms</name>
@@ -26298,6 +29165,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/socket.io/node_modules/ms</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -26333,6 +29203,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/socks-proxy-agent</property>
+      </properties>
       <components>
         <component type="library" bom-ref="socks-proxy-agent@6.2.1|debug@4.3.4">
           <author>Josh Junon &lt;josh.junon@protonmail.com&gt;</author>
@@ -26358,6 +29231,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/socks-proxy-agent/node_modules/debug</property>
+          </properties>
         </component>
         <component type="library" bom-ref="socks-proxy-agent@6.2.1|ms@2.1.2">
           <name>ms</name>
@@ -26382,6 +29258,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/socks-proxy-agent/node_modules/ms</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -26417,6 +29296,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/socks</property>
+      </properties>
       <components>
         <component type="library" bom-ref="socks@2.7.1|ip@2.0.0">
           <author>Fedor Indutny &lt;fedor@indutny.com&gt;</author>
@@ -26445,6 +29327,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/socks/node_modules/ip</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -26472,6 +29357,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/sort-keys-length</property>
+      </properties>
       <components>
         <component type="library" bom-ref="sort-keys-length@1.0.1|sort-keys@1.1.2">
           <author>Sindre Sorhus</author>
@@ -26497,6 +29385,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/sort-keys-length/node_modules/sort-keys</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -26524,6 +29415,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/sort-keys</property>
+      </properties>
     </component>
     <component type="library" bom-ref="source-map-resolve@0.5.3">
       <author>Simon Lydell</author>
@@ -26549,6 +29443,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/source-map-resolve</property>
+      </properties>
     </component>
     <component type="library" bom-ref="source-map-support@0.5.21">
       <name>source-map-support</name>
@@ -26577,6 +29474,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/source-map-support</property>
+      </properties>
     </component>
     <component type="library" bom-ref="source-map-url@0.4.1">
       <author>Simon Lydell</author>
@@ -26602,6 +29502,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/source-map-url</property>
+      </properties>
     </component>
     <component type="library" bom-ref="source-map@0.6.1">
       <author>Nick Fitzgerald &lt;nfitzgerald@mozilla.com&gt;</author>
@@ -26631,6 +29534,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/source-map</property>
+      </properties>
     </component>
     <component type="library" bom-ref="spawn-command@0.0.2-1">
       <author>Maciej Małecki &lt;me@mmalecki.com&gt;</author>
@@ -26656,6 +29562,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/spawn-command</property>
+      </properties>
     </component>
     <component type="library" bom-ref="spdx-correct@3.1.1">
       <author>Kyle E. Mitchell &lt;kyle@kemitchell.com&gt; (https://kemitchell.com)</author>
@@ -26681,6 +29590,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/spdx-correct</property>
+      </properties>
     </component>
     <component type="library" bom-ref="spdx-exceptions@2.3.0">
       <author>The Linux Foundation</author>
@@ -26706,6 +29618,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/spdx-exceptions</property>
+      </properties>
     </component>
     <component type="library" bom-ref="spdx-expression-parse@3.0.1">
       <author>Kyle E. Mitchell &lt;kyle@kemitchell.com&gt; (https://kemitchell.com)</author>
@@ -26731,6 +29646,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/spdx-expression-parse</property>
+      </properties>
     </component>
     <component type="library" bom-ref="spdx-license-ids@3.0.12">
       <author>Shinnosuke Watanabe (https://github.com/shinnn)</author>
@@ -26756,6 +29674,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/spdx-license-ids</property>
+      </properties>
     </component>
     <component type="library" bom-ref="split-string@3.1.0">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -26789,6 +29710,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/split-string</property>
+      </properties>
     </component>
     <component type="library" bom-ref="sprintf-js@1.1.2">
       <author>Alexandru Mărășteanu &lt;hello@alexei.ro&gt;</author>
@@ -26814,6 +29738,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/sprintf-js</property>
+      </properties>
     </component>
     <component type="library" bom-ref="sqlite3@5.1.2">
       <author>Mapbox</author>
@@ -26843,6 +29770,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/sqlite3</property>
+      </properties>
     </component>
     <component type="library" bom-ref="sshpk@1.17.0">
       <author>Joyent, Inc</author>
@@ -26876,6 +29806,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/sshpk</property>
+      </properties>
     </component>
     <component type="library" bom-ref="ssri@8.0.1">
       <author>Kat Marchán</author>
@@ -26901,6 +29834,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/ssri</property>
+      </properties>
     </component>
     <component type="library" bom-ref="stack-trace@0.0.10">
       <author>Felix Geisendörfer &lt;felix@debuggable.com&gt; (http://debuggable.com/)</author>
@@ -26930,6 +29866,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/stack-trace</property>
+      </properties>
     </component>
     <component type="library" bom-ref="static-extend@0.1.2">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -26963,6 +29902,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/static-extend</property>
+      </properties>
       <components>
         <component type="library" bom-ref="static-extend@0.1.2|define-property@0.2.5">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -26996,6 +29938,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/static-extend/node_modules/define-property</property>
+          </properties>
         </component>
         <component type="library" bom-ref="static-extend@0.1.2|is-accessor-descriptor@0.1.6">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -27029,6 +29974,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/static-extend/node_modules/is-accessor-descriptor</property>
+          </properties>
           <components>
             <component type="library" bom-ref="static-extend@0.1.2|is-accessor-descriptor@0.1.6|kind-of@3.2.2">
               <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -27062,6 +30010,9 @@
                   <comment>as detected from PackageJson property "homepage"</comment>
                 </reference>
               </externalReferences>
+              <properties>
+                <property name="cdx:npm:package:installPath">node_modules/static-extend/node_modules/is-accessor-descriptor/node_modules/kind-of</property>
+              </properties>
             </component>
           </components>
         </component>
@@ -27097,6 +30048,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/static-extend/node_modules/is-data-descriptor</property>
+          </properties>
           <components>
             <component type="library" bom-ref="static-extend@0.1.2|is-data-descriptor@0.1.4|kind-of@3.2.2">
               <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -27130,6 +30084,9 @@
                   <comment>as detected from PackageJson property "homepage"</comment>
                 </reference>
               </externalReferences>
+              <properties>
+                <property name="cdx:npm:package:installPath">node_modules/static-extend/node_modules/is-data-descriptor/node_modules/kind-of</property>
+              </properties>
             </component>
           </components>
         </component>
@@ -27165,6 +30122,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/static-extend/node_modules/is-descriptor</property>
+          </properties>
         </component>
         <component type="library" bom-ref="static-extend@0.1.2|kind-of@5.1.0">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -27198,6 +30158,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/static-extend/node_modules/kind-of</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -27224,6 +30187,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/statuses</property>
+      </properties>
     </component>
     <component type="library" bom-ref="stream-buffers@2.2.0">
       <author>Sam Day &lt;me@samcday.com.au&gt;</author>
@@ -27249,6 +30215,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/stream-buffers</property>
+      </properties>
     </component>
     <component type="library" bom-ref="streamsearch@0.1.2">
       <author>Brian White &lt;mscdex@mscdex.net&gt;</author>
@@ -27258,6 +30227,12 @@
       <hashes>
         <hash alg="SHA-512">8e8b3cbbef892a6d0045c4944c06573950b4992a31ec1867eac060b72ef73f57f72467fbc86d9c9536c134751d75efe476f3f614449a9bebccea5f2306b3711c</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <url>http://github.com/mscdex/streamsearch/raw/master/LICENSE</url>
+        </license>
+      </licenses>
       <purl>pkg:npm/streamsearch@0.1.2</purl>
       <externalReferences>
         <reference type="distribution">
@@ -27269,6 +30244,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/streamsearch</property>
+      </properties>
     </component>
     <component type="library" bom-ref="strict-uri-encode@1.1.0">
       <author>Kevin Mårtensson</author>
@@ -27294,6 +30272,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/strict-uri-encode</property>
+      </properties>
     </component>
     <component type="library" bom-ref="string_decoder@1.1.1">
       <name>string_decoder</name>
@@ -27322,6 +30303,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/string_decoder</property>
+      </properties>
     </component>
     <component type="library" bom-ref="string-width@1.0.2">
       <author>Sindre Sorhus</author>
@@ -27347,6 +30331,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/string-width</property>
+      </properties>
     </component>
     <component type="library" bom-ref="string.fromcodepoint@0.2.1">
       <author>Mathias Bynens</author>
@@ -27356,6 +30343,12 @@
       <hashes>
         <hash alg="SHA-512">9faf47df53a7c5219267265b80196f6085e5acc849434750017d63b354038696941face6537418963d3b6c2c023653cebb7a115c8b9b18f9768031a71ec882aa</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <url>http://mths.be/mit</url>
+        </license>
+      </licenses>
       <purl>pkg:npm/string.fromcodepoint@0.2.1</purl>
       <externalReferences>
         <reference type="distribution">
@@ -27375,6 +30368,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/string.fromcodepoint</property>
+      </properties>
     </component>
     <component type="library" bom-ref="string.prototype.codepointat@0.2.1">
       <author>Mathias Bynens</author>
@@ -27408,6 +30404,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/string.prototype.codepointat</property>
+      </properties>
     </component>
     <component type="library" bom-ref="strip-ansi@3.0.1">
       <author>Sindre Sorhus</author>
@@ -27433,6 +30432,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/strip-ansi</property>
+      </properties>
     </component>
     <component type="library" bom-ref="strip-bom@3.0.0">
       <author>Sindre Sorhus</author>
@@ -27458,6 +30460,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/strip-bom</property>
+      </properties>
     </component>
     <component type="library" bom-ref="strip-dirs@2.1.0">
       <author>Shinnosuke Watanabe (https://github.com/shinnn)</author>
@@ -27483,6 +30488,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/strip-dirs</property>
+      </properties>
     </component>
     <component type="library" bom-ref="strip-json-comments@2.0.1">
       <author>Sindre Sorhus</author>
@@ -27508,6 +30516,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/strip-json-comments</property>
+      </properties>
     </component>
     <component type="library" bom-ref="strip-outer@1.0.1">
       <author>Sindre Sorhus</author>
@@ -27533,6 +30544,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/strip-outer</property>
+      </properties>
     </component>
     <component type="library" bom-ref="strtok3@6.3.0">
       <author>Borewit</author>
@@ -27562,6 +30576,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/strtok3</property>
+      </properties>
     </component>
     <component type="library" bom-ref="supports-color@5.5.0">
       <author>Sindre Sorhus</author>
@@ -27587,6 +30604,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/supports-color</property>
+      </properties>
     </component>
     <component type="library" bom-ref="supports-preserve-symlinks-flag@1.0.0">
       <author>Jordan Harband &lt;ljharb@gmail.com&gt;</author>
@@ -27620,6 +30640,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/supports-preserve-symlinks-flag</property>
+      </properties>
     </component>
     <component type="library" bom-ref="svg-captcha@1.4.0">
       <author>Weilin Shi</author>
@@ -27653,6 +30676,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/svg-captcha</property>
+      </properties>
     </component>
     <component type="library" bom-ref="swagger-ui-dist@4.15.2">
       <name>swagger-ui-dist</name>
@@ -27672,6 +30698,9 @@
           <comment>as detected from npm-ls property "resolved"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/swagger-ui-dist</property>
+      </properties>
     </component>
     <component type="library" bom-ref="swagger-ui-express@4.5.0">
       <author>Stephen Scott</author>
@@ -27701,6 +30730,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/swagger-ui-express</property>
+      </properties>
     </component>
     <component type="library" bom-ref="tar-fs@2.1.1">
       <author>Mathias Buus</author>
@@ -27734,6 +30766,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/tar-fs</property>
+      </properties>
       <components>
         <component type="library" bom-ref="tar-fs@2.1.1|bl@4.1.0">
           <name>bl</name>
@@ -27762,6 +30797,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/tar-fs/node_modules/bl</property>
+          </properties>
         </component>
         <component type="library" bom-ref="tar-fs@2.1.1|chownr@1.1.4">
           <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me/)</author>
@@ -27787,6 +30825,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/tar-fs/node_modules/chownr</property>
+          </properties>
         </component>
         <component type="library" bom-ref="tar-fs@2.1.1|readable-stream@3.6.0">
           <name>readable-stream</name>
@@ -27811,6 +30852,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/tar-fs/node_modules/readable-stream</property>
+          </properties>
         </component>
         <component type="library" bom-ref="tar-fs@2.1.1|tar-stream@2.2.0">
           <author>Mathias Buus &lt;mathiasbuus@gmail.com&gt;</author>
@@ -27844,6 +30888,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/tar-fs/node_modules/tar-stream</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -27879,6 +30926,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/tar-stream</property>
+      </properties>
     </component>
     <component type="library" bom-ref="tar@6.1.12">
       <author>GitHub Inc.</author>
@@ -27904,6 +30954,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/tar</property>
+      </properties>
     </component>
     <component type="library" bom-ref="tdigest@0.1.2">
       <author>Will Welch &lt;welch@quietplease.com&gt; (http://quietplease.com/)</author>
@@ -27937,6 +30990,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/tdigest</property>
+      </properties>
     </component>
     <component type="library" bom-ref="text-hex@1.0.0">
       <author>Arnout Kazemier</author>
@@ -27970,6 +31026,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/text-hex</property>
+      </properties>
     </component>
     <component type="library" bom-ref="thirty-two@1.0.2">
       <author>Chris Umbel &lt;chris@chrisumbel.com&gt;</author>
@@ -27990,6 +31049,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/thirty-two</property>
+      </properties>
     </component>
     <component type="library" bom-ref="through@2.3.8">
       <author>Dominic Tarr &lt;dominic.tarr@gmail.com&gt; (dominictarr.com)</author>
@@ -28019,6 +31081,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/through</property>
+      </properties>
     </component>
     <component type="library" bom-ref="timed-out@4.0.1">
       <author>Vsevolod Strukchinsky</author>
@@ -28044,6 +31109,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/timed-out</property>
+      </properties>
     </component>
     <component type="library" bom-ref="tiny-inflate@1.0.3">
       <author>Devon Govett &lt;devongovett@gmail.com&gt;</author>
@@ -28077,6 +31145,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/tiny-inflate</property>
+      </properties>
     </component>
     <component type="library" bom-ref="to-buffer@1.1.1">
       <author>Mathias Buus (@mafintosh)</author>
@@ -28110,6 +31181,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/to-buffer</property>
+      </properties>
     </component>
     <component type="library" bom-ref="to-fast-properties@2.0.0">
       <author>Sindre Sorhus</author>
@@ -28135,6 +31209,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/to-fast-properties</property>
+      </properties>
     </component>
     <component type="library" bom-ref="to-object-path@0.3.0">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -28168,6 +31245,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/to-object-path</property>
+      </properties>
       <components>
         <component type="library" bom-ref="to-object-path@0.3.0|kind-of@3.2.2">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -28201,6 +31281,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/to-object-path/node_modules/kind-of</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -28236,6 +31319,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/to-regex-range</property>
+      </properties>
     </component>
     <component type="library" bom-ref="to-regex@3.0.2">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -28269,6 +31355,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/to-regex</property>
+      </properties>
     </component>
     <component type="library" bom-ref="toidentifier@1.0.1">
       <author>Douglas Christopher Wilson &lt;doug@somethingdoug.com&gt;</author>
@@ -28294,6 +31383,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/toidentifier</property>
+      </properties>
     </component>
     <component type="library" bom-ref="token-stream@1.0.0">
       <author>ForbesLindesay</author>
@@ -28319,6 +31411,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/token-stream</property>
+      </properties>
     </component>
     <component type="library" bom-ref="token-types@4.2.1">
       <author>Borewit</author>
@@ -28348,6 +31443,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/token-types</property>
+      </properties>
     </component>
     <component type="library" bom-ref="toposort-class@1.0.1">
       <name>toposort-class</name>
@@ -28372,6 +31470,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/toposort-class</property>
+      </properties>
     </component>
     <component type="library" bom-ref="tough-cookie@2.5.0">
       <author>Jeremy Stashewsky</author>
@@ -28405,6 +31506,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/tough-cookie</property>
+      </properties>
     </component>
     <component type="library" bom-ref="tr46@0.0.3">
       <author>Sebastian Mayr &lt;npm@smayr.name&gt;</author>
@@ -28438,6 +31542,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/tr46</property>
+      </properties>
     </component>
     <component type="library" bom-ref="traverse@0.3.9">
       <author>James Halliday</author>
@@ -28463,6 +31570,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/traverse</property>
+      </properties>
     </component>
     <component type="library" bom-ref="tree-kill@1.2.2">
       <author>Peteris Krumins</author>
@@ -28492,6 +31602,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/tree-kill</property>
+      </properties>
     </component>
     <component type="library" bom-ref="trim-repeated@1.0.0">
       <author>Sindre Sorhus</author>
@@ -28517,6 +31630,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/trim-repeated</property>
+      </properties>
     </component>
     <component type="library" bom-ref="triple-beam@1.3.0">
       <author>Charlie Robbins &lt;charlie.robbins@gmail.com&gt;</author>
@@ -28550,6 +31666,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/triple-beam</property>
+      </properties>
     </component>
     <component type="library" bom-ref="truncate-utf8-bytes@1.0.2">
       <author>Carl Xiong &lt;xiongc05@gmail.com&gt;</author>
@@ -28583,6 +31702,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/truncate-utf8-bytes</property>
+      </properties>
     </component>
     <component type="library" bom-ref="ts-node-dev@1.1.8">
       <name>ts-node-dev</name>
@@ -28607,6 +31729,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/ts-node-dev</property>
+      </properties>
       <components>
         <component type="library" bom-ref="ts-node-dev@1.1.8|rimraf@2.7.1">
           <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me/)</author>
@@ -28632,6 +31757,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/ts-node-dev/node_modules/rimraf</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -28667,6 +31795,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/ts-node</property>
+      </properties>
     </component>
     <component type="library" bom-ref="tsconfig@7.0.0">
       <author>Blake Embrey</author>
@@ -28700,6 +31831,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/tsconfig</property>
+      </properties>
     </component>
     <component type="library" bom-ref="tslib@2.4.1">
       <author>Microsoft Corp.</author>
@@ -28733,6 +31867,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/tslib</property>
+      </properties>
     </component>
     <component type="library" bom-ref="tunnel-agent@0.6.0">
       <author>Mikeal Rogers &lt;mikeal.rogers@gmail.com&gt; (http://www.futurealoof.com)</author>
@@ -28758,6 +31895,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/tunnel-agent</property>
+      </properties>
     </component>
     <component type="library" bom-ref="tweetnacl@0.14.5">
       <author>TweetNaCl-js contributors</author>
@@ -28791,6 +31931,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/tweetnacl</property>
+      </properties>
     </component>
     <component type="library" bom-ref="type-check@0.3.2">
       <author>George Zahariev &lt;z@georgezahariev.com&gt;</author>
@@ -28824,6 +31967,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/type-check</property>
+      </properties>
     </component>
     <component type="library" bom-ref="type-is@1.6.18">
       <name>type-is</name>
@@ -28848,6 +31994,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/type-is</property>
+      </properties>
     </component>
     <component type="library" bom-ref="typecast@0.0.1">
       <name>typecast</name>
@@ -28872,6 +32021,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/typecast</property>
+      </properties>
     </component>
     <component type="library" bom-ref="typedarray@0.0.6">
       <author>James Halliday</author>
@@ -28901,6 +32053,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/typedarray</property>
+      </properties>
     </component>
     <component type="library" bom-ref="typescript@4.8.4">
       <author>Microsoft Corp.</author>
@@ -28934,6 +32089,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/typescript</property>
+      </properties>
     </component>
     <component type="library" bom-ref="uglify-js@3.17.4">
       <author>Mihai Bazon &lt;mihai.bazon@gmail.com&gt; (http://lisperator.net/)</author>
@@ -28959,6 +32117,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/uglify-js</property>
+      </properties>
     </component>
     <component type="library" bom-ref="unbzip2-stream@1.4.3">
       <author>Jan Bölsche &lt;jan@lagomorph.de&gt;</author>
@@ -28988,6 +32149,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/unbzip2-stream</property>
+      </properties>
     </component>
     <component type="library" bom-ref="unc-path-regex@0.1.2">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -29021,6 +32185,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/unc-path-regex</property>
+      </properties>
     </component>
     <component type="library" bom-ref="underscore.string@3.3.6">
       <name>underscore.string</name>
@@ -29053,6 +32220,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/underscore.string</property>
+      </properties>
     </component>
     <component type="library" bom-ref="unicode-properties@1.4.1">
       <author>Devon Govett &lt;devongovett@gmail.com&gt;</author>
@@ -29086,6 +32256,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/unicode-properties</property>
+      </properties>
     </component>
     <component type="library" bom-ref="unicode-trie@2.0.0">
       <author>Devon Govett &lt;devongovett@gmail.com&gt;</author>
@@ -29119,6 +32292,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/unicode-trie</property>
+      </properties>
     </component>
     <component type="library" bom-ref="union-value@1.0.1">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -29152,6 +32328,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/union-value</property>
+      </properties>
       <components>
         <component type="library" bom-ref="union-value@1.0.1|is-extendable@0.1.1">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -29185,6 +32364,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/union-value/node_modules/is-extendable</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -29220,6 +32402,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/unique-filename</property>
+      </properties>
     </component>
     <component type="library" bom-ref="unique-slug@2.0.2">
       <author>Rebecca Turner &lt;me@re-becca.org&gt; (http://re-becca.org)</author>
@@ -29245,6 +32430,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/unique-slug</property>
+      </properties>
     </component>
     <component type="library" bom-ref="unit-compare@1.0.1">
       <author>nspragg@gmail.com</author>
@@ -29278,6 +32466,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/unit-compare</property>
+      </properties>
     </component>
     <component type="library" bom-ref="universalify@2.0.0">
       <author>Ryan Zimmerman &lt;opensrc@ryanzim.com&gt;</author>
@@ -29311,6 +32502,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/universalify</property>
+      </properties>
     </component>
     <component type="library" bom-ref="unpipe@1.0.0">
       <author>Douglas Christopher Wilson &lt;doug@somethingdoug.com&gt;</author>
@@ -29336,6 +32530,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/unpipe</property>
+      </properties>
     </component>
     <component type="library" bom-ref="unset-value@1.0.0">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -29369,6 +32566,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/unset-value</property>
+      </properties>
       <components>
         <component type="library" bom-ref="unset-value@1.0.0|has-value@0.3.1">
           <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -29402,6 +32602,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/unset-value/node_modules/has-value</property>
+          </properties>
           <components>
             <component type="library" bom-ref="unset-value@1.0.0|has-value@0.3.1|isobject@2.1.0">
               <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -29435,6 +32638,9 @@
                   <comment>as detected from PackageJson property "homepage"</comment>
                 </reference>
               </externalReferences>
+              <properties>
+                <property name="cdx:npm:package:installPath">node_modules/unset-value/node_modules/has-value/node_modules/isobject</property>
+              </properties>
             </component>
           </components>
         </component>
@@ -29470,6 +32676,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/unset-value/node_modules/has-values</property>
+          </properties>
         </component>
         <component type="library" bom-ref="unset-value@1.0.0|isarray@1.0.0">
           <author>Julian Gruber</author>
@@ -29499,6 +32708,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/unset-value/node_modules/isarray</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -29526,6 +32738,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/untildify</property>
+      </properties>
     </component>
     <component type="library" bom-ref="unzipper@0.9.15">
       <author>Evan Oxfeld &lt;eoxfeld@gmail.com&gt;</author>
@@ -29551,6 +32766,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/unzipper</property>
+      </properties>
       <components>
         <component type="library" bom-ref="unzipper@0.9.15|bluebird@3.4.7">
           <author>Petka Antonov</author>
@@ -29584,6 +32802,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/unzipper/node_modules/bluebird</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -29619,6 +32840,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/uri-js</property>
+      </properties>
     </component>
     <component type="library" bom-ref="urix@0.1.0">
       <author>Simon Lydell</author>
@@ -29644,6 +32868,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/urix</property>
+      </properties>
     </component>
     <component type="library" bom-ref="url-parse-lax@3.0.0">
       <author>Sindre Sorhus</author>
@@ -29669,6 +32896,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/url-parse-lax</property>
+      </properties>
     </component>
     <component type="library" bom-ref="url-to-options@1.0.1">
       <author>Steven Vachon &lt;contact@svachon.com&gt; (https://www.svachon.com/)</author>
@@ -29694,6 +32924,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/url-to-options</property>
+      </properties>
     </component>
     <component type="library" bom-ref="use@3.1.1">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -29727,6 +32960,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/use</property>
+      </properties>
     </component>
     <component type="library" bom-ref="utf8-byte-length@1.0.4">
       <author>Carl Xiong &lt;xiongc05@gmail.com&gt;</author>
@@ -29760,6 +32996,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/utf8-byte-length</property>
+      </properties>
     </component>
     <component type="library" bom-ref="util-deprecate@1.0.2">
       <author>Nathan Rajlich &lt;nathan@tootallnate.net&gt; (http://n8.io/)</author>
@@ -29793,6 +33032,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/util-deprecate</property>
+      </properties>
     </component>
     <component type="library" bom-ref="util@0.12.5">
       <author>Joyent</author>
@@ -29822,6 +33064,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/util</property>
+      </properties>
     </component>
     <component type="library" bom-ref="utils-merge@1.0.1">
       <author>Jared Hanson</author>
@@ -29834,6 +33079,10 @@
       <licenses>
         <license>
           <id>MIT</id>
+        </license>
+        <license>
+          <id>MIT</id>
+          <url>http://opensource.org/licenses/MIT</url>
         </license>
       </licenses>
       <purl>pkg:npm/utils-merge@1.0.1</purl>
@@ -29851,6 +33100,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/utils-merge</property>
+      </properties>
     </component>
     <component type="library" bom-ref="uuid@3.4.0">
       <name>uuid</name>
@@ -29875,6 +33127,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/uuid</property>
+      </properties>
     </component>
     <component type="library" bom-ref="v8flags@3.2.0">
       <author>Gulp Team &lt;team@gulpjs.com&gt; (http://gulpjs.com/)</author>
@@ -29900,6 +33155,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/v8flags</property>
+      </properties>
     </component>
     <component type="library" bom-ref="validate-npm-package-license@3.0.4">
       <author>Kyle E. Mitchell &lt;kyle@kemitchell.com&gt; (https://kemitchell.com)</author>
@@ -29925,6 +33183,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/validate-npm-package-license</property>
+      </properties>
     </component>
     <component type="library" bom-ref="validate@4.5.1">
       <author>Eivind Fjeldstad</author>
@@ -29950,6 +33211,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/validate</property>
+      </properties>
     </component>
     <component type="library" bom-ref="validator@13.7.0">
       <author>Chris O'Hara &lt;cohara87@gmail.com&gt;</author>
@@ -29983,6 +33247,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/validator</property>
+      </properties>
     </component>
     <component type="library" bom-ref="vary@1.1.2">
       <author>Douglas Christopher Wilson &lt;doug@somethingdoug.com&gt;</author>
@@ -30008,6 +33275,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/vary</property>
+      </properties>
     </component>
     <component type="library" bom-ref="verror@1.10.0">
       <name>verror</name>
@@ -30032,6 +33302,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/verror</property>
+      </properties>
       <components>
         <component type="library" bom-ref="verror@1.10.0|core-util-is@1.0.2">
           <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me/)</author>
@@ -30061,6 +33334,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/verror/node_modules/core-util-is</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -30088,6 +33364,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/vm2</property>
+      </properties>
       <components>
         <component type="library" bom-ref="vm2@3.9.11|acorn@8.8.1">
           <name>acorn</name>
@@ -30116,6 +33395,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/vm2/node_modules/acorn</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -30151,6 +33433,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/void-elements</property>
+      </properties>
     </component>
     <component type="library" bom-ref="walk@2.3.15">
       <author>AJ ONeal &lt;coolaj86@gmail.com&gt;</author>
@@ -30182,6 +33467,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/walk</property>
+      </properties>
     </component>
     <component type="library" bom-ref="walkdir@0.0.11">
       <author>Ryan Day &lt;soldair@gmail.com&gt;</author>
@@ -30211,6 +33499,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/walkdir</property>
+      </properties>
     </component>
     <component type="library" bom-ref="webidl-conversions@3.0.1">
       <author>Domenic Denicola &lt;d@domenic.me&gt; (https://domenic.me/)</author>
@@ -30236,6 +33527,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/webidl-conversions</property>
+      </properties>
     </component>
     <component type="library" bom-ref="whatwg-url@5.0.0">
       <author>Sebastian Mayr &lt;github@smayr.name&gt;</author>
@@ -30261,6 +33555,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/whatwg-url</property>
+      </properties>
     </component>
     <component type="library" bom-ref="which-boxed-primitive@1.0.2">
       <author>Jordan Harband &lt;ljharb@gmail.com&gt;</author>
@@ -30294,6 +33591,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/which-boxed-primitive</property>
+      </properties>
     </component>
     <component type="library" bom-ref="which-collection@1.0.1">
       <author>Jordan Harband &lt;ljharb@gmail.com&gt;</author>
@@ -30327,6 +33627,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/which-collection</property>
+      </properties>
     </component>
     <component type="library" bom-ref="which-module@2.0.0">
       <author>nexdrew</author>
@@ -30360,6 +33663,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/which-module</property>
+      </properties>
     </component>
     <component type="library" bom-ref="which-pm-runs@1.1.0">
       <author>Zoltan Kochan</author>
@@ -30393,6 +33699,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/which-pm-runs</property>
+      </properties>
     </component>
     <component type="library" bom-ref="which-typed-array@1.1.9">
       <author>Jordan Harband</author>
@@ -30418,6 +33727,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/which-typed-array</property>
+      </properties>
     </component>
     <component type="library" bom-ref="which@2.0.2">
       <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me)</author>
@@ -30443,6 +33755,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/which</property>
+      </properties>
     </component>
     <component type="library" bom-ref="wide-align@1.1.5">
       <author>Rebecca Turner &lt;me@re-becca.org&gt; (http://re-becca.org/)</author>
@@ -30468,6 +33783,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/wide-align</property>
+      </properties>
     </component>
     <component type="library" bom-ref="winston-transport@4.5.0">
       <author>Charlie Robbins &lt;charlie.robbins@gmail.com&gt;</author>
@@ -30497,6 +33815,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/winston-transport</property>
+      </properties>
       <components>
         <component type="library" bom-ref="winston-transport@4.5.0|readable-stream@3.6.0">
           <name>readable-stream</name>
@@ -30521,6 +33842,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/winston-transport/node_modules/readable-stream</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -30548,6 +33872,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/winston</property>
+      </properties>
       <components>
         <component type="library" bom-ref="winston@3.8.2|async@3.2.4">
           <author>Caolan McMahon</author>
@@ -30581,6 +33908,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/winston/node_modules/async</property>
+          </properties>
         </component>
         <component type="library" bom-ref="winston@3.8.2|is-stream@2.0.1">
           <author>Sindre Sorhus</author>
@@ -30606,6 +33936,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/winston/node_modules/is-stream</property>
+          </properties>
         </component>
         <component type="library" bom-ref="winston@3.8.2|readable-stream@3.6.0">
           <name>readable-stream</name>
@@ -30630,6 +33963,9 @@
               <comment>as detected from PackageJson property "repository.url"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/winston/node_modules/readable-stream</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -30657,6 +33993,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/with</property>
+      </properties>
     </component>
     <component type="library" bom-ref="wkx@0.5.0">
       <author>Christian Schwarz</author>
@@ -30682,6 +34021,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/wkx</property>
+      </properties>
     </component>
     <component type="library" bom-ref="word-wrap@1.2.3">
       <author>Jon Schlinkert (https://github.com/jonschlinkert)</author>
@@ -30715,6 +34057,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/word-wrap</property>
+      </properties>
     </component>
     <component type="library" bom-ref="wordwrap@0.0.3">
       <author>James Halliday</author>
@@ -30740,6 +34085,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/wordwrap</property>
+      </properties>
     </component>
     <component type="library" bom-ref="wrap-ansi@5.1.0">
       <author>Sindre Sorhus</author>
@@ -30765,6 +34113,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/wrap-ansi</property>
+      </properties>
       <components>
         <component type="library" bom-ref="wrap-ansi@5.1.0|ansi-regex@4.1.1">
           <author>Sindre Sorhus</author>
@@ -30790,6 +34141,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/wrap-ansi/node_modules/ansi-regex</property>
+          </properties>
         </component>
         <component type="library" bom-ref="wrap-ansi@5.1.0|emoji-regex@7.0.3">
           <author>Mathias Bynens</author>
@@ -30823,6 +34177,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/wrap-ansi/node_modules/emoji-regex</property>
+          </properties>
         </component>
         <component type="library" bom-ref="wrap-ansi@5.1.0|is-fullwidth-code-point@2.0.0">
           <author>Sindre Sorhus</author>
@@ -30848,6 +34205,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/wrap-ansi/node_modules/is-fullwidth-code-point</property>
+          </properties>
         </component>
         <component type="library" bom-ref="wrap-ansi@5.1.0|string-width@3.1.0">
           <author>Sindre Sorhus</author>
@@ -30873,6 +34233,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/wrap-ansi/node_modules/string-width</property>
+          </properties>
         </component>
         <component type="library" bom-ref="wrap-ansi@5.1.0|strip-ansi@5.2.0">
           <author>Sindre Sorhus</author>
@@ -30898,6 +34261,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/wrap-ansi/node_modules/strip-ansi</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -30933,6 +34299,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/wrappy</property>
+      </properties>
     </component>
     <component type="library" bom-ref="ws@7.4.6">
       <author>Einar Otto Stangvik &lt;einaros@gmail.com&gt; (http://2x.io)</author>
@@ -30966,6 +34335,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/ws</property>
+      </properties>
     </component>
     <component type="library" bom-ref="xtend@4.0.2">
       <author>Raynos &lt;raynos2@gmail.com&gt;</author>
@@ -30999,6 +34371,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/xtend</property>
+      </properties>
     </component>
     <component type="library" bom-ref="y18n@4.0.3">
       <author>Ben Coe &lt;ben@npmjs.com&gt;</author>
@@ -31028,6 +34403,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/y18n</property>
+      </properties>
     </component>
     <component type="library" bom-ref="yallist@4.0.0">
       <author>Isaac Z. Schlueter &lt;i@izs.me&gt; (http://blog.izs.me/)</author>
@@ -31053,6 +34431,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/yallist</property>
+      </properties>
     </component>
     <component type="library" bom-ref="yaml-schema-validator@1.2.3">
       <author>Ketan Saxena</author>
@@ -31078,6 +34459,9 @@
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/yaml-schema-validator</property>
+      </properties>
     </component>
     <component type="library" bom-ref="yargs-parser@13.1.2">
       <author>Ben Coe &lt;ben@npmjs.com&gt;</author>
@@ -31099,6 +34483,9 @@
           <comment>as detected from npm-ls property "resolved"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/yargs-parser</property>
+      </properties>
     </component>
     <component type="library" bom-ref="yargs@13.3.2">
       <name>yargs</name>
@@ -31127,6 +34514,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/yargs</property>
+      </properties>
       <components>
         <component type="library" bom-ref="yargs@13.3.2|ansi-regex@4.1.1">
           <author>Sindre Sorhus</author>
@@ -31152,6 +34542,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/yargs/node_modules/ansi-regex</property>
+          </properties>
         </component>
         <component type="library" bom-ref="yargs@13.3.2|emoji-regex@7.0.3">
           <author>Mathias Bynens</author>
@@ -31185,6 +34578,9 @@
               <comment>as detected from PackageJson property "homepage"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/yargs/node_modules/emoji-regex</property>
+          </properties>
         </component>
         <component type="library" bom-ref="yargs@13.3.2|is-fullwidth-code-point@2.0.0">
           <author>Sindre Sorhus</author>
@@ -31210,6 +34606,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/yargs/node_modules/is-fullwidth-code-point</property>
+          </properties>
         </component>
         <component type="library" bom-ref="yargs@13.3.2|string-width@3.1.0">
           <author>Sindre Sorhus</author>
@@ -31235,6 +34634,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/yargs/node_modules/string-width</property>
+          </properties>
         </component>
         <component type="library" bom-ref="yargs@13.3.2|strip-ansi@5.2.0">
           <author>Sindre Sorhus</author>
@@ -31260,6 +34662,9 @@
               <comment>as detected from PackageJson property "repository"</comment>
             </reference>
           </externalReferences>
+          <properties>
+            <property name="cdx:npm:package:installPath">node_modules/yargs/node_modules/strip-ansi</property>
+          </properties>
         </component>
       </components>
     </component>
@@ -31295,6 +34700,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/yauzl</property>
+      </properties>
     </component>
     <component type="library" bom-ref="yn@3.1.1">
       <author>Sindre Sorhus</author>
@@ -31320,6 +34728,9 @@
           <comment>as detected from PackageJson property "repository"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/yn</property>
+      </properties>
     </component>
     <component type="library" bom-ref="z85@0.0.2">
       <author>Michael Sealand &lt;msealand@gmail.com&gt;</author>
@@ -31353,6 +34764,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/z85</property>
+      </properties>
     </component>
     <component type="library" bom-ref="zip-stream@1.2.0">
       <author>Chris Talkington</author>
@@ -31386,6 +34800,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/zip-stream</property>
+      </properties>
     </component>
     <component type="library" bom-ref="zlibjs@0.3.1">
       <author>Yuta Imaya</author>
@@ -31415,6 +34832,9 @@
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+      <properties>
+        <property name="cdx:npm:package:installPath">node_modules/zlibjs</property>
+      </properties>
     </component>
   </components>
   <dependencies>

--- a/demo/juice-shop/example-results/bom.1.4.xml
+++ b/demo/juice-shop/example-results/bom.1.4.xml
@@ -48,7 +48,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath"/>
+        <property name="cdx:npm:package:path"/>
         <property name="cdx:npm:package:private">true</property>
       </properties>
     </component>
@@ -84,7 +84,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@babel/helper-string-parser</property>
+        <property name="cdx:npm:package:path">node_modules/@babel/helper-string-parser</property>
       </properties>
     </component>
     <component type="library" bom-ref="@babel/helper-validator-identifier@7.19.1">
@@ -113,7 +113,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@babel/helper-validator-identifier</property>
+        <property name="cdx:npm:package:path">node_modules/@babel/helper-validator-identifier</property>
       </properties>
     </component>
     <component type="library" bom-ref="@babel/parser@7.20.2">
@@ -150,7 +150,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@babel/parser</property>
+        <property name="cdx:npm:package:path">node_modules/@babel/parser</property>
       </properties>
     </component>
     <component type="library" bom-ref="@babel/types@7.20.2">
@@ -187,7 +187,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@babel/types</property>
+        <property name="cdx:npm:package:path">node_modules/@babel/types</property>
       </properties>
     </component>
     <component type="library" bom-ref="@colors/colors@1.5.0">
@@ -224,7 +224,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@colors/colors</property>
+        <property name="cdx:npm:package:path">node_modules/@colors/colors</property>
       </properties>
     </component>
     <component type="library" bom-ref="@dabh/diagnostics@2.0.3">
@@ -261,7 +261,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@dabh/diagnostics</property>
+        <property name="cdx:npm:package:path">node_modules/@dabh/diagnostics</property>
       </properties>
     </component>
     <component type="library" bom-ref="@gar/promisify@1.1.3">
@@ -290,7 +290,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@gar/promisify</property>
+        <property name="cdx:npm:package:path">node_modules/@gar/promisify</property>
       </properties>
     </component>
     <component type="library" bom-ref="@mapbox/node-pre-gyp@1.0.10">
@@ -319,7 +319,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@mapbox/node-pre-gyp</property>
+        <property name="cdx:npm:package:path">node_modules/@mapbox/node-pre-gyp</property>
       </properties>
       <components>
         <component type="library" bom-ref="@mapbox/node-pre-gyp@1.0.10|ansi-regex@5.0.1">
@@ -347,7 +347,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/@mapbox/node-pre-gyp/node_modules/ansi-regex</property>
+            <property name="cdx:npm:package:path">node_modules/@mapbox/node-pre-gyp/node_modules/ansi-regex</property>
           </properties>
         </component>
         <component type="library" bom-ref="@mapbox/node-pre-gyp@1.0.10|are-we-there-yet@2.0.0">
@@ -383,7 +383,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/@mapbox/node-pre-gyp/node_modules/are-we-there-yet</property>
+            <property name="cdx:npm:package:path">node_modules/@mapbox/node-pre-gyp/node_modules/are-we-there-yet</property>
           </properties>
         </component>
         <component type="library" bom-ref="@mapbox/node-pre-gyp@1.0.10|detect-libc@2.0.1">
@@ -411,7 +411,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/@mapbox/node-pre-gyp/node_modules/detect-libc</property>
+            <property name="cdx:npm:package:path">node_modules/@mapbox/node-pre-gyp/node_modules/detect-libc</property>
           </properties>
         </component>
         <component type="library" bom-ref="@mapbox/node-pre-gyp@1.0.10|gauge@3.0.2">
@@ -447,7 +447,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/@mapbox/node-pre-gyp/node_modules/gauge</property>
+            <property name="cdx:npm:package:path">node_modules/@mapbox/node-pre-gyp/node_modules/gauge</property>
           </properties>
         </component>
         <component type="library" bom-ref="@mapbox/node-pre-gyp@1.0.10|is-fullwidth-code-point@3.0.0">
@@ -475,7 +475,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/@mapbox/node-pre-gyp/node_modules/is-fullwidth-code-point</property>
+            <property name="cdx:npm:package:path">node_modules/@mapbox/node-pre-gyp/node_modules/is-fullwidth-code-point</property>
           </properties>
         </component>
         <component type="library" bom-ref="@mapbox/node-pre-gyp@1.0.10|make-dir@3.1.0">
@@ -503,7 +503,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/@mapbox/node-pre-gyp/node_modules/make-dir</property>
+            <property name="cdx:npm:package:path">node_modules/@mapbox/node-pre-gyp/node_modules/make-dir</property>
           </properties>
           <components>
             <component type="library" bom-ref="@mapbox/node-pre-gyp@1.0.10|make-dir@3.1.0|semver@6.3.0">
@@ -530,7 +530,7 @@
                 </reference>
               </externalReferences>
               <properties>
-                <property name="cdx:npm:package:installPath">node_modules/@mapbox/node-pre-gyp/node_modules/make-dir/node_modules/semver</property>
+                <property name="cdx:npm:package:path">node_modules/@mapbox/node-pre-gyp/node_modules/make-dir/node_modules/semver</property>
               </properties>
             </component>
           </components>
@@ -560,7 +560,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/@mapbox/node-pre-gyp/node_modules/nopt</property>
+            <property name="cdx:npm:package:path">node_modules/@mapbox/node-pre-gyp/node_modules/nopt</property>
           </properties>
         </component>
         <component type="library" bom-ref="@mapbox/node-pre-gyp@1.0.10|npmlog@5.0.1">
@@ -588,7 +588,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/@mapbox/node-pre-gyp/node_modules/npmlog</property>
+            <property name="cdx:npm:package:path">node_modules/@mapbox/node-pre-gyp/node_modules/npmlog</property>
           </properties>
         </component>
         <component type="library" bom-ref="@mapbox/node-pre-gyp@1.0.10|readable-stream@3.6.0">
@@ -615,7 +615,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/@mapbox/node-pre-gyp/node_modules/readable-stream</property>
+            <property name="cdx:npm:package:path">node_modules/@mapbox/node-pre-gyp/node_modules/readable-stream</property>
           </properties>
         </component>
         <component type="library" bom-ref="@mapbox/node-pre-gyp@1.0.10|string-width@4.2.3">
@@ -643,7 +643,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/@mapbox/node-pre-gyp/node_modules/string-width</property>
+            <property name="cdx:npm:package:path">node_modules/@mapbox/node-pre-gyp/node_modules/string-width</property>
           </properties>
         </component>
         <component type="library" bom-ref="@mapbox/node-pre-gyp@1.0.10|strip-ansi@6.0.1">
@@ -671,7 +671,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/@mapbox/node-pre-gyp/node_modules/strip-ansi</property>
+            <property name="cdx:npm:package:path">node_modules/@mapbox/node-pre-gyp/node_modules/strip-ansi</property>
           </properties>
         </component>
       </components>
@@ -706,7 +706,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/core-loader</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/core-loader</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/core@4.23.4">
@@ -739,7 +739,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/core</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/core</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/evaluator@4.22.7">
@@ -772,7 +772,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/evaluator</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/evaluator</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-all@4.24.0">
@@ -805,7 +805,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-all</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/lang-all</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-ar@4.23.4">
@@ -838,7 +838,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-ar</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/lang-ar</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-bn@4.23.4">
@@ -871,7 +871,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-bn</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/lang-bn</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-ca@4.23.4">
@@ -904,7 +904,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-ca</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/lang-ca</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-cs@4.23.4">
@@ -937,7 +937,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-cs</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/lang-cs</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-da@4.23.4">
@@ -970,7 +970,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-da</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/lang-da</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-de@4.23.4">
@@ -1003,7 +1003,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-de</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/lang-de</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-el@4.23.4">
@@ -1036,7 +1036,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-el</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/lang-el</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-en-min@4.23.4">
@@ -1069,7 +1069,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-en-min</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/lang-en-min</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-en@4.23.4">
@@ -1102,7 +1102,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-en</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/lang-en</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-es@4.23.4">
@@ -1135,7 +1135,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-es</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/lang-es</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-eu@4.23.4">
@@ -1168,7 +1168,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-eu</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/lang-eu</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-fa@4.23.4">
@@ -1201,7 +1201,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-fa</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/lang-fa</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-fi@4.23.4">
@@ -1234,7 +1234,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-fi</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/lang-fi</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-fr@4.23.4">
@@ -1267,7 +1267,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-fr</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/lang-fr</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-ga@4.23.4">
@@ -1300,7 +1300,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-ga</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/lang-ga</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-gl@4.23.4">
@@ -1333,7 +1333,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-gl</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/lang-gl</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-hi@4.23.4">
@@ -1366,7 +1366,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-hi</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/lang-hi</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-hu@4.23.4">
@@ -1399,7 +1399,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-hu</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/lang-hu</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-hy@4.23.4">
@@ -1432,7 +1432,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-hy</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/lang-hy</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-id@4.23.4">
@@ -1465,7 +1465,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-id</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/lang-id</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-it@4.23.4">
@@ -1498,7 +1498,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-it</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/lang-it</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-ja@4.24.0">
@@ -1531,7 +1531,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-ja</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/lang-ja</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-ko@4.23.4">
@@ -1564,7 +1564,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-ko</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/lang-ko</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-lt@4.23.4">
@@ -1597,7 +1597,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-lt</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/lang-lt</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-ms@4.23.4">
@@ -1630,7 +1630,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-ms</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/lang-ms</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-ne@4.23.4">
@@ -1663,7 +1663,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-ne</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/lang-ne</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-nl@4.23.4">
@@ -1696,7 +1696,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-nl</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/lang-nl</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-no@4.23.4">
@@ -1729,7 +1729,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-no</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/lang-no</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-pl@4.23.4">
@@ -1762,7 +1762,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-pl</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/lang-pl</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-pt@4.23.4">
@@ -1795,7 +1795,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-pt</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/lang-pt</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-ro@4.23.4">
@@ -1828,7 +1828,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-ro</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/lang-ro</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-ru@4.23.4">
@@ -1861,7 +1861,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-ru</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/lang-ru</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-sl@4.23.4">
@@ -1894,7 +1894,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-sl</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/lang-sl</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-sr@4.23.4">
@@ -1927,7 +1927,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-sr</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/lang-sr</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-sv@4.23.4">
@@ -1960,7 +1960,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-sv</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/lang-sv</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-ta@4.23.4">
@@ -1993,7 +1993,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-ta</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/lang-ta</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-th@4.23.4">
@@ -2026,7 +2026,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-th</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/lang-th</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-tl@4.23.4">
@@ -2059,7 +2059,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-tl</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/lang-tl</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-tr@4.23.4">
@@ -2092,7 +2092,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-tr</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/lang-tr</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-uk@4.23.4">
@@ -2125,7 +2125,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-uk</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/lang-uk</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/lang-zh@4.23.4">
@@ -2158,7 +2158,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/lang-zh</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/lang-zh</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/language-min@4.22.7">
@@ -2191,7 +2191,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/language-min</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/language-min</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/language@4.22.7">
@@ -2224,7 +2224,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/language</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/language</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/ner@4.23.4">
@@ -2257,7 +2257,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/ner</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/ner</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/neural@4.22.7">
@@ -2290,7 +2290,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/neural</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/neural</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/nlg@4.23.4">
@@ -2323,7 +2323,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/nlg</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/nlg</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/nlp@4.23.5">
@@ -2356,7 +2356,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/nlp</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/nlp</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/nlu@4.23.5">
@@ -2389,7 +2389,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/nlu</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/nlu</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/request@4.22.7">
@@ -2422,7 +2422,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/request</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/request</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/sentiment@4.23.4">
@@ -2455,7 +2455,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/sentiment</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/sentiment</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/similarity@4.22.7">
@@ -2488,7 +2488,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/similarity</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/similarity</property>
       </properties>
     </component>
     <component type="library" bom-ref="@nlpjs/slot@4.22.17">
@@ -2521,7 +2521,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@nlpjs/slot</property>
+        <property name="cdx:npm:package:path">node_modules/@nlpjs/slot</property>
       </properties>
     </component>
     <component type="library" bom-ref="@npmcli/fs@1.1.1">
@@ -2546,7 +2546,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@npmcli/fs</property>
+        <property name="cdx:npm:package:path">node_modules/@npmcli/fs</property>
       </properties>
     </component>
     <component type="library" bom-ref="@npmcli/move-file@1.1.2">
@@ -2574,7 +2574,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@npmcli/move-file</property>
+        <property name="cdx:npm:package:path">node_modules/@npmcli/move-file</property>
       </properties>
     </component>
     <component type="library" bom-ref="@otplib/core@12.0.1">
@@ -2607,7 +2607,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@otplib/core</property>
+        <property name="cdx:npm:package:path">node_modules/@otplib/core</property>
       </properties>
     </component>
     <component type="library" bom-ref="@otplib/plugin-crypto@12.0.1">
@@ -2640,7 +2640,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@otplib/plugin-crypto</property>
+        <property name="cdx:npm:package:path">node_modules/@otplib/plugin-crypto</property>
       </properties>
     </component>
     <component type="library" bom-ref="@otplib/plugin-thirty-two@12.0.1">
@@ -2673,7 +2673,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@otplib/plugin-thirty-two</property>
+        <property name="cdx:npm:package:path">node_modules/@otplib/plugin-thirty-two</property>
       </properties>
     </component>
     <component type="library" bom-ref="@otplib/preset-default@12.0.1">
@@ -2706,7 +2706,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@otplib/preset-default</property>
+        <property name="cdx:npm:package:path">node_modules/@otplib/preset-default</property>
       </properties>
     </component>
     <component type="library" bom-ref="@otplib/preset-v11@12.0.1">
@@ -2739,7 +2739,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@otplib/preset-v11</property>
+        <property name="cdx:npm:package:path">node_modules/@otplib/preset-v11</property>
       </properties>
     </component>
     <component type="library" bom-ref="@sindresorhus/is@0.7.0">
@@ -2768,7 +2768,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@sindresorhus/is</property>
+        <property name="cdx:npm:package:path">node_modules/@sindresorhus/is</property>
       </properties>
     </component>
     <component type="library" bom-ref="@swc/helpers@0.3.17">
@@ -2805,7 +2805,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@swc/helpers</property>
+        <property name="cdx:npm:package:path">node_modules/@swc/helpers</property>
       </properties>
     </component>
     <component type="library" bom-ref="@tokenizer/token@0.3.0">
@@ -2838,7 +2838,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@tokenizer/token</property>
+        <property name="cdx:npm:package:path">node_modules/@tokenizer/token</property>
       </properties>
     </component>
     <component type="library" bom-ref="@tootallnate/once@2.0.0">
@@ -2871,7 +2871,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@tootallnate/once</property>
+        <property name="cdx:npm:package:path">node_modules/@tootallnate/once</property>
       </properties>
     </component>
     <component type="library" bom-ref="@types/component-emitter@1.2.11">
@@ -2903,7 +2903,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@types/component-emitter</property>
+        <property name="cdx:npm:package:path">node_modules/@types/component-emitter</property>
       </properties>
     </component>
     <component type="library" bom-ref="@types/cookie@0.4.1">
@@ -2935,7 +2935,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@types/cookie</property>
+        <property name="cdx:npm:package:path">node_modules/@types/cookie</property>
       </properties>
     </component>
     <component type="library" bom-ref="@types/cors@2.8.12">
@@ -2967,7 +2967,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@types/cors</property>
+        <property name="cdx:npm:package:path">node_modules/@types/cors</property>
       </properties>
     </component>
     <component type="library" bom-ref="@types/debug@4.1.7">
@@ -2999,7 +2999,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@types/debug</property>
+        <property name="cdx:npm:package:path">node_modules/@types/debug</property>
       </properties>
     </component>
     <component type="library" bom-ref="@types/ms@0.7.31">
@@ -3027,7 +3027,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@types/ms</property>
+        <property name="cdx:npm:package:path">node_modules/@types/ms</property>
       </properties>
     </component>
     <component type="library" bom-ref="@types/node@18.11.9">
@@ -3059,7 +3059,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@types/node</property>
+        <property name="cdx:npm:package:path">node_modules/@types/node</property>
       </properties>
     </component>
     <component type="library" bom-ref="@types/strip-bom@3.0.0">
@@ -3088,7 +3088,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@types/strip-bom</property>
+        <property name="cdx:npm:package:path">node_modules/@types/strip-bom</property>
       </properties>
     </component>
     <component type="library" bom-ref="@types/strip-json-comments@0.0.30">
@@ -3116,7 +3116,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@types/strip-json-comments</property>
+        <property name="cdx:npm:package:path">node_modules/@types/strip-json-comments</property>
       </properties>
     </component>
     <component type="library" bom-ref="@types/validator@13.7.10">
@@ -3148,7 +3148,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/@types/validator</property>
+        <property name="cdx:npm:package:path">node_modules/@types/validator</property>
       </properties>
     </component>
     <component type="library" bom-ref="abbrev@1.1.1">
@@ -3176,7 +3176,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/abbrev</property>
+        <property name="cdx:npm:package:path">node_modules/abbrev</property>
       </properties>
     </component>
     <component type="library" bom-ref="accepts@1.3.8">
@@ -3203,7 +3203,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/accepts</property>
+        <property name="cdx:npm:package:path">node_modules/accepts</property>
       </properties>
     </component>
     <component type="library" bom-ref="acorn-walk@8.2.0">
@@ -3234,7 +3234,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/acorn-walk</property>
+        <property name="cdx:npm:package:path">node_modules/acorn-walk</property>
       </properties>
     </component>
     <component type="library" bom-ref="acorn@7.4.1">
@@ -3265,7 +3265,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/acorn</property>
+        <property name="cdx:npm:package:path">node_modules/acorn</property>
       </properties>
     </component>
     <component type="library" bom-ref="agent-base@6.0.2">
@@ -3297,7 +3297,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/agent-base</property>
+        <property name="cdx:npm:package:path">node_modules/agent-base</property>
       </properties>
       <components>
         <component type="library" bom-ref="agent-base@6.0.2|debug@4.3.4">
@@ -3325,7 +3325,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/agent-base/node_modules/debug</property>
+            <property name="cdx:npm:package:path">node_modules/agent-base/node_modules/debug</property>
           </properties>
         </component>
         <component type="library" bom-ref="agent-base@6.0.2|ms@2.1.2">
@@ -3352,7 +3352,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/agent-base/node_modules/ms</property>
+            <property name="cdx:npm:package:path">node_modules/agent-base/node_modules/ms</property>
           </properties>
         </component>
       </components>
@@ -3386,7 +3386,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/agentkeepalive</property>
+        <property name="cdx:npm:package:path">node_modules/agentkeepalive</property>
       </properties>
       <components>
         <component type="library" bom-ref="agentkeepalive@4.2.1|debug@4.3.4">
@@ -3414,7 +3414,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/agentkeepalive/node_modules/debug</property>
+            <property name="cdx:npm:package:path">node_modules/agentkeepalive/node_modules/debug</property>
           </properties>
         </component>
         <component type="library" bom-ref="agentkeepalive@4.2.1|depd@1.1.2">
@@ -3442,7 +3442,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/agentkeepalive/node_modules/depd</property>
+            <property name="cdx:npm:package:path">node_modules/agentkeepalive/node_modules/depd</property>
           </properties>
         </component>
         <component type="library" bom-ref="agentkeepalive@4.2.1|ms@2.1.2">
@@ -3469,7 +3469,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/agentkeepalive/node_modules/ms</property>
+            <property name="cdx:npm:package:path">node_modules/agentkeepalive/node_modules/ms</property>
           </properties>
         </component>
       </components>
@@ -3499,7 +3499,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/aggregate-error</property>
+        <property name="cdx:npm:package:path">node_modules/aggregate-error</property>
       </properties>
     </component>
     <component type="library" bom-ref="ajv@6.12.6">
@@ -3535,7 +3535,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/ajv</property>
+        <property name="cdx:npm:package:path">node_modules/ajv</property>
       </properties>
     </component>
     <component type="library" bom-ref="ansi-regex@2.1.1">
@@ -3563,7 +3563,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/ansi-regex</property>
+        <property name="cdx:npm:package:path">node_modules/ansi-regex</property>
       </properties>
     </component>
     <component type="library" bom-ref="ansi-styles@3.2.1">
@@ -3591,7 +3591,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/ansi-styles</property>
+        <property name="cdx:npm:package:path">node_modules/ansi-styles</property>
       </properties>
     </component>
     <component type="library" bom-ref="anymatch@3.1.2">
@@ -3623,7 +3623,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/anymatch</property>
+        <property name="cdx:npm:package:path">node_modules/anymatch</property>
       </properties>
       <components>
         <component type="library" bom-ref="anymatch@3.1.2|normalize-path@3.0.0">
@@ -3659,7 +3659,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/anymatch/node_modules/normalize-path</property>
+            <property name="cdx:npm:package:path">node_modules/anymatch/node_modules/normalize-path</property>
           </properties>
         </component>
       </components>
@@ -3688,7 +3688,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/append-field</property>
+        <property name="cdx:npm:package:path">node_modules/append-field</property>
       </properties>
     </component>
     <component type="library" bom-ref="aproba@1.2.0">
@@ -3724,7 +3724,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/aproba</property>
+        <property name="cdx:npm:package:path">node_modules/aproba</property>
       </properties>
     </component>
     <component type="library" bom-ref="archive-type@4.0.0">
@@ -3752,7 +3752,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/archive-type</property>
+        <property name="cdx:npm:package:path">node_modules/archive-type</property>
       </properties>
       <components>
         <component type="library" bom-ref="archive-type@4.0.0|file-type@4.4.0">
@@ -3780,7 +3780,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/archive-type/node_modules/file-type</property>
+            <property name="cdx:npm:package:path">node_modules/archive-type/node_modules/file-type</property>
           </properties>
         </component>
       </components>
@@ -3818,7 +3818,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/archiver-utils</property>
+        <property name="cdx:npm:package:path">node_modules/archiver-utils</property>
       </properties>
     </component>
     <component type="library" bom-ref="archiver@1.3.0">
@@ -3854,7 +3854,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/archiver</property>
+        <property name="cdx:npm:package:path">node_modules/archiver</property>
       </properties>
     </component>
     <component type="library" bom-ref="are-we-there-yet@1.1.7">
@@ -3890,7 +3890,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/are-we-there-yet</property>
+        <property name="cdx:npm:package:path">node_modules/are-we-there-yet</property>
       </properties>
     </component>
     <component type="library" bom-ref="arg@4.1.3">
@@ -3918,7 +3918,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/arg</property>
+        <property name="cdx:npm:package:path">node_modules/arg</property>
       </properties>
     </component>
     <component type="library" bom-ref="argparse@1.0.10">
@@ -3945,7 +3945,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/argparse</property>
+        <property name="cdx:npm:package:path">node_modules/argparse</property>
       </properties>
       <components>
         <component type="library" bom-ref="argparse@1.0.10|sprintf-js@1.0.3">
@@ -3973,7 +3973,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/argparse/node_modules/sprintf-js</property>
+            <property name="cdx:npm:package:path">node_modules/argparse/node_modules/sprintf-js</property>
           </properties>
         </component>
       </components>
@@ -4011,7 +4011,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/arr-diff</property>
+        <property name="cdx:npm:package:path">node_modules/arr-diff</property>
       </properties>
     </component>
     <component type="library" bom-ref="arr-flatten@1.1.0">
@@ -4047,7 +4047,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/arr-flatten</property>
+        <property name="cdx:npm:package:path">node_modules/arr-flatten</property>
       </properties>
     </component>
     <component type="library" bom-ref="arr-union@3.1.0">
@@ -4083,7 +4083,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/arr-union</property>
+        <property name="cdx:npm:package:path">node_modules/arr-union</property>
       </properties>
     </component>
     <component type="library" bom-ref="array-each@1.0.1">
@@ -4119,7 +4119,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/array-each</property>
+        <property name="cdx:npm:package:path">node_modules/array-each</property>
       </properties>
     </component>
     <component type="library" bom-ref="array-flatten@1.1.1">
@@ -4155,7 +4155,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/array-flatten</property>
+        <property name="cdx:npm:package:path">node_modules/array-flatten</property>
       </properties>
     </component>
     <component type="library" bom-ref="array-slice@1.1.0">
@@ -4191,7 +4191,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/array-slice</property>
+        <property name="cdx:npm:package:path">node_modules/array-slice</property>
       </properties>
     </component>
     <component type="library" bom-ref="array-unique@0.3.2">
@@ -4227,7 +4227,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/array-unique</property>
+        <property name="cdx:npm:package:path">node_modules/array-unique</property>
       </properties>
     </component>
     <component type="library" bom-ref="asap@2.0.6">
@@ -4254,7 +4254,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/asap</property>
+        <property name="cdx:npm:package:path">node_modules/asap</property>
       </properties>
     </component>
     <component type="library" bom-ref="asn1@0.2.6">
@@ -4282,7 +4282,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/asn1</property>
+        <property name="cdx:npm:package:path">node_modules/asn1</property>
       </properties>
     </component>
     <component type="library" bom-ref="assert-never@1.2.1">
@@ -4310,7 +4310,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/assert-never</property>
+        <property name="cdx:npm:package:path">node_modules/assert-never</property>
       </properties>
     </component>
     <component type="library" bom-ref="assert-plus@1.0.0">
@@ -4338,7 +4338,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/assert-plus</property>
+        <property name="cdx:npm:package:path">node_modules/assert-plus</property>
       </properties>
     </component>
     <component type="library" bom-ref="assign-symbols@1.0.0">
@@ -4374,7 +4374,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/assign-symbols</property>
+        <property name="cdx:npm:package:path">node_modules/assign-symbols</property>
       </properties>
     </component>
     <component type="library" bom-ref="async@2.6.4">
@@ -4410,7 +4410,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/async</property>
+        <property name="cdx:npm:package:path">node_modules/async</property>
       </properties>
     </component>
     <component type="library" bom-ref="asynckit@0.4.0">
@@ -4446,7 +4446,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/asynckit</property>
+        <property name="cdx:npm:package:path">node_modules/asynckit</property>
       </properties>
     </component>
     <component type="library" bom-ref="at-least-node@1.0.0">
@@ -4482,7 +4482,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/at-least-node</property>
+        <property name="cdx:npm:package:path">node_modules/at-least-node</property>
       </properties>
     </component>
     <component type="library" bom-ref="atob@2.1.2">
@@ -4512,7 +4512,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/atob</property>
+        <property name="cdx:npm:package:path">node_modules/atob</property>
       </properties>
     </component>
     <component type="library" bom-ref="available-typed-arrays@1.0.5">
@@ -4548,7 +4548,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/available-typed-arrays</property>
+        <property name="cdx:npm:package:path">node_modules/available-typed-arrays</property>
       </properties>
     </component>
     <component type="library" bom-ref="aws-sign2@0.7.0">
@@ -4576,7 +4576,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/aws-sign2</property>
+        <property name="cdx:npm:package:path">node_modules/aws-sign2</property>
       </properties>
     </component>
     <component type="library" bom-ref="aws4@1.11.0">
@@ -4604,7 +4604,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/aws4</property>
+        <property name="cdx:npm:package:path">node_modules/aws4</property>
       </properties>
     </component>
     <component type="library" bom-ref="babel-walk@3.0.0-canary-5">
@@ -4632,7 +4632,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/babel-walk</property>
+        <property name="cdx:npm:package:path">node_modules/babel-walk</property>
       </properties>
     </component>
     <component type="library" bom-ref="balanced-match@1.0.2">
@@ -4664,7 +4664,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/balanced-match</property>
+        <property name="cdx:npm:package:path">node_modules/balanced-match</property>
       </properties>
     </component>
     <component type="library" bom-ref="base@0.11.2">
@@ -4700,7 +4700,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/base</property>
+        <property name="cdx:npm:package:path">node_modules/base</property>
       </properties>
       <components>
         <component type="library" bom-ref="base@0.11.2|define-property@1.0.0">
@@ -4736,7 +4736,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/base/node_modules/define-property</property>
+            <property name="cdx:npm:package:path">node_modules/base/node_modules/define-property</property>
           </properties>
         </component>
       </components>
@@ -4775,7 +4775,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/base64-arraybuffer</property>
+        <property name="cdx:npm:package:path">node_modules/base64-arraybuffer</property>
       </properties>
     </component>
     <component type="library" bom-ref="base64-js@1.5.1">
@@ -4811,7 +4811,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/base64-js</property>
+        <property name="cdx:npm:package:path">node_modules/base64-js</property>
       </properties>
     </component>
     <component type="library" bom-ref="base64id@2.0.0">
@@ -4839,7 +4839,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/base64id</property>
+        <property name="cdx:npm:package:path">node_modules/base64id</property>
       </properties>
     </component>
     <component type="library" bom-ref="base64url@0.0.6">
@@ -4867,7 +4867,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/base64url</property>
+        <property name="cdx:npm:package:path">node_modules/base64url</property>
       </properties>
     </component>
     <component type="library" bom-ref="basic-auth@2.0.1">
@@ -4894,7 +4894,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/basic-auth</property>
+        <property name="cdx:npm:package:path">node_modules/basic-auth</property>
       </properties>
     </component>
     <component type="library" bom-ref="batch@0.6.1">
@@ -4922,7 +4922,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/batch</property>
+        <property name="cdx:npm:package:path">node_modules/batch</property>
       </properties>
     </component>
     <component type="library" bom-ref="bcrypt-pbkdf@1.0.2">
@@ -4949,7 +4949,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/bcrypt-pbkdf</property>
+        <property name="cdx:npm:package:path">node_modules/bcrypt-pbkdf</property>
       </properties>
     </component>
     <component type="library" bom-ref="big-integer@1.6.51">
@@ -4973,7 +4973,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/big-integer</property>
+        <property name="cdx:npm:package:path">node_modules/big-integer</property>
       </properties>
     </component>
     <component type="library" bom-ref="binary-extensions@2.2.0">
@@ -5001,7 +5001,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/binary-extensions</property>
+        <property name="cdx:npm:package:path">node_modules/binary-extensions</property>
       </properties>
     </component>
     <component type="library" bom-ref="binary@0.3.0">
@@ -5029,7 +5029,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/binary</property>
+        <property name="cdx:npm:package:path">node_modules/binary</property>
       </properties>
     </component>
     <component type="library" bom-ref="bindings@1.5.0">
@@ -5065,7 +5065,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/bindings</property>
+        <property name="cdx:npm:package:path">node_modules/bindings</property>
       </properties>
     </component>
     <component type="library" bom-ref="bintrees@1.0.2">
@@ -5093,7 +5093,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/bintrees</property>
+        <property name="cdx:npm:package:path">node_modules/bintrees</property>
       </properties>
     </component>
     <component type="library" bom-ref="bl@1.2.3">
@@ -5124,7 +5124,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/bl</property>
+        <property name="cdx:npm:package:path">node_modules/bl</property>
       </properties>
     </component>
     <component type="library" bom-ref="bluebird@3.7.2">
@@ -5160,7 +5160,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/bluebird</property>
+        <property name="cdx:npm:package:path">node_modules/bluebird</property>
       </properties>
     </component>
     <component type="library" bom-ref="body-parser@1.20.1">
@@ -5187,7 +5187,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/body-parser</property>
+        <property name="cdx:npm:package:path">node_modules/body-parser</property>
       </properties>
     </component>
     <component type="library" bom-ref="bower-config@1.4.3">
@@ -5219,7 +5219,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/bower-config</property>
+        <property name="cdx:npm:package:path">node_modules/bower-config</property>
       </properties>
       <components>
         <component type="library" bom-ref="bower-config@1.4.3|minimist@0.2.2">
@@ -5251,7 +5251,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/bower-config/node_modules/minimist</property>
+            <property name="cdx:npm:package:path">node_modules/bower-config/node_modules/minimist</property>
           </properties>
         </component>
       </components>
@@ -5285,7 +5285,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/brace-expansion</property>
+        <property name="cdx:npm:package:path">node_modules/brace-expansion</property>
       </properties>
     </component>
     <component type="library" bom-ref="braces@2.3.2">
@@ -5321,7 +5321,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/braces</property>
+        <property name="cdx:npm:package:path">node_modules/braces</property>
       </properties>
       <components>
         <component type="library" bom-ref="braces@2.3.2|extend-shallow@2.0.1">
@@ -5357,7 +5357,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/braces/node_modules/extend-shallow</property>
+            <property name="cdx:npm:package:path">node_modules/braces/node_modules/extend-shallow</property>
           </properties>
         </component>
         <component type="library" bom-ref="braces@2.3.2|is-extendable@0.1.1">
@@ -5393,7 +5393,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/braces/node_modules/is-extendable</property>
+            <property name="cdx:npm:package:path">node_modules/braces/node_modules/is-extendable</property>
           </properties>
         </component>
       </components>
@@ -5431,7 +5431,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/brotli</property>
+        <property name="cdx:npm:package:path">node_modules/brotli</property>
       </properties>
     </component>
     <component type="library" bom-ref="buffer-alloc-unsafe@1.1.0">
@@ -5457,7 +5457,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/buffer-alloc-unsafe</property>
+        <property name="cdx:npm:package:path">node_modules/buffer-alloc-unsafe</property>
       </properties>
     </component>
     <component type="library" bom-ref="buffer-alloc@1.2.0">
@@ -5483,7 +5483,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/buffer-alloc</property>
+        <property name="cdx:npm:package:path">node_modules/buffer-alloc</property>
       </properties>
     </component>
     <component type="library" bom-ref="buffer-crc32@0.2.13">
@@ -5519,7 +5519,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/buffer-crc32</property>
+        <property name="cdx:npm:package:path">node_modules/buffer-crc32</property>
       </properties>
     </component>
     <component type="library" bom-ref="buffer-fill@1.0.0">
@@ -5545,7 +5545,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/buffer-fill</property>
+        <property name="cdx:npm:package:path">node_modules/buffer-fill</property>
       </properties>
     </component>
     <component type="library" bom-ref="buffer-from@1.1.2">
@@ -5571,7 +5571,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/buffer-from</property>
+        <property name="cdx:npm:package:path">node_modules/buffer-from</property>
       </properties>
     </component>
     <component type="library" bom-ref="buffer-indexof-polyfill@1.0.2">
@@ -5607,7 +5607,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/buffer-indexof-polyfill</property>
+        <property name="cdx:npm:package:path">node_modules/buffer-indexof-polyfill</property>
       </properties>
     </component>
     <component type="library" bom-ref="buffer@5.7.1">
@@ -5643,7 +5643,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/buffer</property>
+        <property name="cdx:npm:package:path">node_modules/buffer</property>
       </properties>
     </component>
     <component type="library" bom-ref="buffers@0.1.1">
@@ -5666,7 +5666,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/buffers</property>
+        <property name="cdx:npm:package:path">node_modules/buffers</property>
       </properties>
     </component>
     <component type="library" bom-ref="busboy@0.2.14">
@@ -5695,7 +5695,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/busboy</property>
+        <property name="cdx:npm:package:path">node_modules/busboy</property>
       </properties>
       <components>
         <component type="library" bom-ref="busboy@0.2.14|isarray@0.0.1">
@@ -5727,7 +5727,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/busboy/node_modules/isarray</property>
+            <property name="cdx:npm:package:path">node_modules/busboy/node_modules/isarray</property>
           </properties>
         </component>
         <component type="library" bom-ref="busboy@0.2.14|readable-stream@1.1.14">
@@ -5755,7 +5755,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/busboy/node_modules/readable-stream</property>
+            <property name="cdx:npm:package:path">node_modules/busboy/node_modules/readable-stream</property>
           </properties>
         </component>
         <component type="library" bom-ref="busboy@0.2.14|string_decoder@0.10.31">
@@ -5786,7 +5786,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/busboy/node_modules/string_decoder</property>
+            <property name="cdx:npm:package:path">node_modules/busboy/node_modules/string_decoder</property>
           </properties>
         </component>
       </components>
@@ -5824,7 +5824,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/byline</property>
+        <property name="cdx:npm:package:path">node_modules/byline</property>
       </properties>
     </component>
     <component type="library" bom-ref="bytes@3.1.2">
@@ -5852,7 +5852,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/bytes</property>
+        <property name="cdx:npm:package:path">node_modules/bytes</property>
       </properties>
     </component>
     <component type="library" bom-ref="cacache@15.3.0">
@@ -5879,7 +5879,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/cacache</property>
+        <property name="cdx:npm:package:path">node_modules/cacache</property>
       </properties>
     </component>
     <component type="library" bom-ref="cache-base@1.0.1">
@@ -5915,7 +5915,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/cache-base</property>
+        <property name="cdx:npm:package:path">node_modules/cache-base</property>
       </properties>
     </component>
     <component type="library" bom-ref="cacheable-request@2.1.4">
@@ -5951,7 +5951,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/cacheable-request</property>
+        <property name="cdx:npm:package:path">node_modules/cacheable-request</property>
       </properties>
       <components>
         <component type="library" bom-ref="cacheable-request@2.1.4|get-stream@3.0.0">
@@ -5979,7 +5979,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/cacheable-request/node_modules/get-stream</property>
+            <property name="cdx:npm:package:path">node_modules/cacheable-request/node_modules/get-stream</property>
           </properties>
         </component>
         <component type="library" bom-ref="cacheable-request@2.1.4|lowercase-keys@1.0.0">
@@ -6007,7 +6007,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/cacheable-request/node_modules/lowercase-keys</property>
+            <property name="cdx:npm:package:path">node_modules/cacheable-request/node_modules/lowercase-keys</property>
           </properties>
         </component>
       </components>
@@ -6045,7 +6045,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/call-bind</property>
+        <property name="cdx:npm:package:path">node_modules/call-bind</property>
       </properties>
     </component>
     <component type="library" bom-ref="camelcase@5.3.1">
@@ -6073,7 +6073,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/camelcase</property>
+        <property name="cdx:npm:package:path">node_modules/camelcase</property>
       </properties>
     </component>
     <component type="library" bom-ref="caseless@0.12.0">
@@ -6105,7 +6105,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/caseless</property>
+        <property name="cdx:npm:package:path">node_modules/caseless</property>
       </properties>
     </component>
     <component type="library" bom-ref="chainsaw@0.1.0">
@@ -6133,7 +6133,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/chainsaw</property>
+        <property name="cdx:npm:package:path">node_modules/chainsaw</property>
       </properties>
     </component>
     <component type="library" bom-ref="chalk@2.4.2">
@@ -6160,7 +6160,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/chalk</property>
+        <property name="cdx:npm:package:path">node_modules/chalk</property>
       </properties>
     </component>
     <component type="library" bom-ref="character-parser@2.2.0">
@@ -6188,7 +6188,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/character-parser</property>
+        <property name="cdx:npm:package:path">node_modules/character-parser</property>
       </properties>
     </component>
     <component type="library" bom-ref="check-dependencies@1.1.0">
@@ -6224,7 +6224,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/check-dependencies</property>
+        <property name="cdx:npm:package:path">node_modules/check-dependencies</property>
       </properties>
       <components>
         <component type="library" bom-ref="check-dependencies@1.1.0|semver@5.7.1">
@@ -6251,7 +6251,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/check-dependencies/node_modules/semver</property>
+            <property name="cdx:npm:package:path">node_modules/check-dependencies/node_modules/semver</property>
           </properties>
         </component>
       </components>
@@ -6289,7 +6289,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/check-types</property>
+        <property name="cdx:npm:package:path">node_modules/check-types</property>
       </properties>
     </component>
     <component type="library" bom-ref="chokidar@3.5.3">
@@ -6325,7 +6325,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/chokidar</property>
+        <property name="cdx:npm:package:path">node_modules/chokidar</property>
       </properties>
       <components>
         <component type="library" bom-ref="chokidar@3.5.3|braces@3.0.2">
@@ -6361,7 +6361,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/chokidar/node_modules/braces</property>
+            <property name="cdx:npm:package:path">node_modules/chokidar/node_modules/braces</property>
           </properties>
         </component>
         <component type="library" bom-ref="chokidar@3.5.3|fill-range@7.0.1">
@@ -6397,7 +6397,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/chokidar/node_modules/fill-range</property>
+            <property name="cdx:npm:package:path">node_modules/chokidar/node_modules/fill-range</property>
           </properties>
         </component>
         <component type="library" bom-ref="chokidar@3.5.3|is-glob@4.0.3">
@@ -6433,7 +6433,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/chokidar/node_modules/is-glob</property>
+            <property name="cdx:npm:package:path">node_modules/chokidar/node_modules/is-glob</property>
           </properties>
         </component>
         <component type="library" bom-ref="chokidar@3.5.3|is-number@7.0.0">
@@ -6469,7 +6469,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/chokidar/node_modules/is-number</property>
+            <property name="cdx:npm:package:path">node_modules/chokidar/node_modules/is-number</property>
           </properties>
         </component>
         <component type="library" bom-ref="chokidar@3.5.3|normalize-path@3.0.0">
@@ -6505,7 +6505,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/chokidar/node_modules/normalize-path</property>
+            <property name="cdx:npm:package:path">node_modules/chokidar/node_modules/normalize-path</property>
           </properties>
         </component>
         <component type="library" bom-ref="chokidar@3.5.3|to-regex-range@5.0.1">
@@ -6541,7 +6541,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/chokidar/node_modules/to-regex-range</property>
+            <property name="cdx:npm:package:path">node_modules/chokidar/node_modules/to-regex-range</property>
           </properties>
         </component>
       </components>
@@ -6571,7 +6571,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/chownr</property>
+        <property name="cdx:npm:package:path">node_modules/chownr</property>
       </properties>
     </component>
     <component type="library" bom-ref="clarinet@0.12.5">
@@ -6607,7 +6607,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/clarinet</property>
+        <property name="cdx:npm:package:path">node_modules/clarinet</property>
       </properties>
     </component>
     <component type="library" bom-ref="class-utils@0.3.6">
@@ -6643,7 +6643,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/class-utils</property>
+        <property name="cdx:npm:package:path">node_modules/class-utils</property>
       </properties>
       <components>
         <component type="library" bom-ref="class-utils@0.3.6|define-property@0.2.5">
@@ -6679,7 +6679,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/class-utils/node_modules/define-property</property>
+            <property name="cdx:npm:package:path">node_modules/class-utils/node_modules/define-property</property>
           </properties>
         </component>
         <component type="library" bom-ref="class-utils@0.3.6|is-accessor-descriptor@0.1.6">
@@ -6715,7 +6715,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/class-utils/node_modules/is-accessor-descriptor</property>
+            <property name="cdx:npm:package:path">node_modules/class-utils/node_modules/is-accessor-descriptor</property>
           </properties>
           <components>
             <component type="library" bom-ref="class-utils@0.3.6|is-accessor-descriptor@0.1.6|kind-of@3.2.2">
@@ -6751,7 +6751,7 @@
                 </reference>
               </externalReferences>
               <properties>
-                <property name="cdx:npm:package:installPath">node_modules/class-utils/node_modules/is-accessor-descriptor/node_modules/kind-of</property>
+                <property name="cdx:npm:package:path">node_modules/class-utils/node_modules/is-accessor-descriptor/node_modules/kind-of</property>
               </properties>
             </component>
           </components>
@@ -6789,7 +6789,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/class-utils/node_modules/is-data-descriptor</property>
+            <property name="cdx:npm:package:path">node_modules/class-utils/node_modules/is-data-descriptor</property>
           </properties>
           <components>
             <component type="library" bom-ref="class-utils@0.3.6|is-data-descriptor@0.1.4|kind-of@3.2.2">
@@ -6825,7 +6825,7 @@
                 </reference>
               </externalReferences>
               <properties>
-                <property name="cdx:npm:package:installPath">node_modules/class-utils/node_modules/is-data-descriptor/node_modules/kind-of</property>
+                <property name="cdx:npm:package:path">node_modules/class-utils/node_modules/is-data-descriptor/node_modules/kind-of</property>
               </properties>
             </component>
           </components>
@@ -6863,7 +6863,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/class-utils/node_modules/is-descriptor</property>
+            <property name="cdx:npm:package:path">node_modules/class-utils/node_modules/is-descriptor</property>
           </properties>
         </component>
         <component type="library" bom-ref="class-utils@0.3.6|kind-of@5.1.0">
@@ -6899,7 +6899,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/class-utils/node_modules/kind-of</property>
+            <property name="cdx:npm:package:path">node_modules/class-utils/node_modules/kind-of</property>
           </properties>
         </component>
       </components>
@@ -6929,7 +6929,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/clean-stack</property>
+        <property name="cdx:npm:package:path">node_modules/clean-stack</property>
       </properties>
     </component>
     <component type="library" bom-ref="cliui@5.0.0">
@@ -6957,7 +6957,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/cliui</property>
+        <property name="cdx:npm:package:path">node_modules/cliui</property>
       </properties>
       <components>
         <component type="library" bom-ref="cliui@5.0.0|ansi-regex@4.1.1">
@@ -6985,7 +6985,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/cliui/node_modules/ansi-regex</property>
+            <property name="cdx:npm:package:path">node_modules/cliui/node_modules/ansi-regex</property>
           </properties>
         </component>
         <component type="library" bom-ref="cliui@5.0.0|emoji-regex@7.0.3">
@@ -7021,7 +7021,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/cliui/node_modules/emoji-regex</property>
+            <property name="cdx:npm:package:path">node_modules/cliui/node_modules/emoji-regex</property>
           </properties>
         </component>
         <component type="library" bom-ref="cliui@5.0.0|is-fullwidth-code-point@2.0.0">
@@ -7049,7 +7049,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/cliui/node_modules/is-fullwidth-code-point</property>
+            <property name="cdx:npm:package:path">node_modules/cliui/node_modules/is-fullwidth-code-point</property>
           </properties>
         </component>
         <component type="library" bom-ref="cliui@5.0.0|string-width@3.1.0">
@@ -7077,7 +7077,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/cliui/node_modules/string-width</property>
+            <property name="cdx:npm:package:path">node_modules/cliui/node_modules/string-width</property>
           </properties>
         </component>
         <component type="library" bom-ref="cliui@5.0.0|strip-ansi@5.2.0">
@@ -7105,7 +7105,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/cliui/node_modules/strip-ansi</property>
+            <property name="cdx:npm:package:path">node_modules/cliui/node_modules/strip-ansi</property>
           </properties>
         </component>
       </components>
@@ -7143,7 +7143,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/clone-response</property>
+        <property name="cdx:npm:package:path">node_modules/clone-response</property>
       </properties>
     </component>
     <component type="library" bom-ref="clone@2.1.2">
@@ -7175,7 +7175,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/clone</property>
+        <property name="cdx:npm:package:path">node_modules/clone</property>
       </properties>
     </component>
     <component type="library" bom-ref="code-point-at@1.1.0">
@@ -7203,7 +7203,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/code-point-at</property>
+        <property name="cdx:npm:package:path">node_modules/code-point-at</property>
       </properties>
     </component>
     <component type="library" bom-ref="collection-visit@1.0.0">
@@ -7239,7 +7239,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/collection-visit</property>
+        <property name="cdx:npm:package:path">node_modules/collection-visit</property>
       </properties>
     </component>
     <component type="library" bom-ref="color-convert@1.9.3">
@@ -7267,7 +7267,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/color-convert</property>
+        <property name="cdx:npm:package:path">node_modules/color-convert</property>
       </properties>
     </component>
     <component type="library" bom-ref="color-name@1.1.3">
@@ -7299,7 +7299,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/color-name</property>
+        <property name="cdx:npm:package:path">node_modules/color-name</property>
       </properties>
     </component>
     <component type="library" bom-ref="color-string@1.9.1">
@@ -7327,7 +7327,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/color-string</property>
+        <property name="cdx:npm:package:path">node_modules/color-string</property>
       </properties>
     </component>
     <component type="library" bom-ref="color-support@1.1.3">
@@ -7355,7 +7355,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/color-support</property>
+        <property name="cdx:npm:package:path">node_modules/color-support</property>
       </properties>
     </component>
     <component type="library" bom-ref="color@3.2.1">
@@ -7382,7 +7382,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/color</property>
+        <property name="cdx:npm:package:path">node_modules/color</property>
       </properties>
     </component>
     <component type="library" bom-ref="colors@1.4.0">
@@ -7418,7 +7418,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/colors</property>
+        <property name="cdx:npm:package:path">node_modules/colors</property>
       </properties>
     </component>
     <component type="library" bom-ref="colorspace@1.1.4">
@@ -7454,7 +7454,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/colorspace</property>
+        <property name="cdx:npm:package:path">node_modules/colorspace</property>
       </properties>
     </component>
     <component type="library" bom-ref="combined-stream@1.0.8">
@@ -7486,7 +7486,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/combined-stream</property>
+        <property name="cdx:npm:package:path">node_modules/combined-stream</property>
       </properties>
     </component>
     <component type="library" bom-ref="commander@2.20.3">
@@ -7514,7 +7514,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/commander</property>
+        <property name="cdx:npm:package:path">node_modules/commander</property>
       </properties>
     </component>
     <component type="library" bom-ref="component-emitter@1.3.0">
@@ -7541,7 +7541,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/component-emitter</property>
+        <property name="cdx:npm:package:path">node_modules/component-emitter</property>
       </properties>
     </component>
     <component type="library" bom-ref="component-type@1.2.1">
@@ -7568,7 +7568,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/component-type</property>
+        <property name="cdx:npm:package:path">node_modules/component-type</property>
       </properties>
     </component>
     <component type="library" bom-ref="compress-commons@1.2.2">
@@ -7604,7 +7604,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/compress-commons</property>
+        <property name="cdx:npm:package:path">node_modules/compress-commons</property>
       </properties>
     </component>
     <component type="library" bom-ref="compressible@2.0.18">
@@ -7631,7 +7631,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/compressible</property>
+        <property name="cdx:npm:package:path">node_modules/compressible</property>
       </properties>
     </component>
     <component type="library" bom-ref="compression@1.7.4">
@@ -7658,7 +7658,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/compression</property>
+        <property name="cdx:npm:package:path">node_modules/compression</property>
       </properties>
       <components>
         <component type="library" bom-ref="compression@1.7.4|bytes@3.0.0">
@@ -7686,7 +7686,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/compression/node_modules/bytes</property>
+            <property name="cdx:npm:package:path">node_modules/compression/node_modules/bytes</property>
           </properties>
         </component>
       </components>
@@ -7716,7 +7716,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/concat-map</property>
+        <property name="cdx:npm:package:path">node_modules/concat-map</property>
       </properties>
     </component>
     <component type="library" bom-ref="concat-stream@1.6.2">
@@ -7748,7 +7748,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/concat-stream</property>
+        <property name="cdx:npm:package:path">node_modules/concat-stream</property>
       </properties>
     </component>
     <component type="library" bom-ref="concurrently@5.3.0">
@@ -7776,7 +7776,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/concurrently</property>
+        <property name="cdx:npm:package:path">node_modules/concurrently</property>
       </properties>
       <components>
         <component type="library" bom-ref="concurrently@5.3.0|supports-color@6.1.0">
@@ -7804,7 +7804,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/concurrently/node_modules/supports-color</property>
+            <property name="cdx:npm:package:path">node_modules/concurrently/node_modules/supports-color</property>
           </properties>
         </component>
       </components>
@@ -7838,7 +7838,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/config</property>
+        <property name="cdx:npm:package:path">node_modules/config</property>
       </properties>
     </component>
     <component type="library" bom-ref="console-control-strings@1.1.0">
@@ -7866,7 +7866,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/console-control-strings</property>
+        <property name="cdx:npm:package:path">node_modules/console-control-strings</property>
       </properties>
     </component>
     <component type="library" bom-ref="constantinople@4.0.1">
@@ -7894,7 +7894,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/constantinople</property>
+        <property name="cdx:npm:package:path">node_modules/constantinople</property>
       </properties>
     </component>
     <component type="library" bom-ref="content-disposition@0.5.4">
@@ -7922,7 +7922,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/content-disposition</property>
+        <property name="cdx:npm:package:path">node_modules/content-disposition</property>
       </properties>
       <components>
         <component type="library" bom-ref="content-disposition@0.5.4|safe-buffer@5.2.1">
@@ -7958,7 +7958,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/content-disposition/node_modules/safe-buffer</property>
+            <property name="cdx:npm:package:path">node_modules/content-disposition/node_modules/safe-buffer</property>
           </properties>
         </component>
       </components>
@@ -7988,7 +7988,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/content-type</property>
+        <property name="cdx:npm:package:path">node_modules/content-type</property>
       </properties>
     </component>
     <component type="library" bom-ref="cookie-parser@1.4.6">
@@ -8016,7 +8016,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/cookie-parser</property>
+        <property name="cdx:npm:package:path">node_modules/cookie-parser</property>
       </properties>
     </component>
     <component type="library" bom-ref="cookie-signature@1.0.6">
@@ -8044,7 +8044,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/cookie-signature</property>
+        <property name="cdx:npm:package:path">node_modules/cookie-signature</property>
       </properties>
     </component>
     <component type="library" bom-ref="cookie@0.4.1">
@@ -8072,7 +8072,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/cookie</property>
+        <property name="cdx:npm:package:path">node_modules/cookie</property>
       </properties>
     </component>
     <component type="library" bom-ref="copy-descriptor@0.1.1">
@@ -8108,7 +8108,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/copy-descriptor</property>
+        <property name="cdx:npm:package:path">node_modules/copy-descriptor</property>
       </properties>
     </component>
     <component type="library" bom-ref="core-util-is@1.0.3">
@@ -8140,7 +8140,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/core-util-is</property>
+        <property name="cdx:npm:package:path">node_modules/core-util-is</property>
       </properties>
     </component>
     <component type="library" bom-ref="cors@2.8.5">
@@ -8168,7 +8168,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/cors</property>
+        <property name="cdx:npm:package:path">node_modules/cors</property>
       </properties>
     </component>
     <component type="library" bom-ref="crc@3.8.0">
@@ -8204,7 +8204,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/crc</property>
+        <property name="cdx:npm:package:path">node_modules/crc</property>
       </properties>
     </component>
     <component type="library" bom-ref="crc32-stream@2.0.0">
@@ -8240,7 +8240,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/crc32-stream</property>
+        <property name="cdx:npm:package:path">node_modules/crc32-stream</property>
       </properties>
     </component>
     <component type="library" bom-ref="create-require@1.1.1">
@@ -8267,7 +8267,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/create-require</property>
+        <property name="cdx:npm:package:path">node_modules/create-require</property>
       </properties>
     </component>
     <component type="library" bom-ref="crypto-js@3.3.0">
@@ -8299,7 +8299,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/crypto-js</property>
+        <property name="cdx:npm:package:path">node_modules/crypto-js</property>
       </properties>
     </component>
     <component type="library" bom-ref="dashdash@1.14.1">
@@ -8327,7 +8327,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/dashdash</property>
+        <property name="cdx:npm:package:path">node_modules/dashdash</property>
       </properties>
     </component>
     <component type="library" bom-ref="date-fns@2.29.3">
@@ -8354,7 +8354,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/date-fns</property>
+        <property name="cdx:npm:package:path">node_modules/date-fns</property>
       </properties>
     </component>
     <component type="library" bom-ref="dateformat@3.0.3">
@@ -8386,7 +8386,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/dateformat</property>
+        <property name="cdx:npm:package:path">node_modules/dateformat</property>
       </properties>
     </component>
     <component type="library" bom-ref="debug@2.6.9">
@@ -8414,7 +8414,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/debug</property>
+        <property name="cdx:npm:package:path">node_modules/debug</property>
       </properties>
     </component>
     <component type="library" bom-ref="decamelize@1.2.0">
@@ -8442,7 +8442,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/decamelize</property>
+        <property name="cdx:npm:package:path">node_modules/decamelize</property>
       </properties>
     </component>
     <component type="library" bom-ref="decode-uri-component@0.2.0">
@@ -8470,7 +8470,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/decode-uri-component</property>
+        <property name="cdx:npm:package:path">node_modules/decode-uri-component</property>
       </properties>
     </component>
     <component type="library" bom-ref="decompress-response@3.3.0">
@@ -8497,7 +8497,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/decompress-response</property>
+        <property name="cdx:npm:package:path">node_modules/decompress-response</property>
       </properties>
     </component>
     <component type="library" bom-ref="decompress-tar@4.1.1">
@@ -8525,7 +8525,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/decompress-tar</property>
+        <property name="cdx:npm:package:path">node_modules/decompress-tar</property>
       </properties>
       <components>
         <component type="library" bom-ref="decompress-tar@4.1.1|file-type@5.2.0">
@@ -8553,7 +8553,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/decompress-tar/node_modules/file-type</property>
+            <property name="cdx:npm:package:path">node_modules/decompress-tar/node_modules/file-type</property>
           </properties>
         </component>
       </components>
@@ -8583,7 +8583,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/decompress-tarbz2</property>
+        <property name="cdx:npm:package:path">node_modules/decompress-tarbz2</property>
       </properties>
       <components>
         <component type="library" bom-ref="decompress-tarbz2@4.1.1|file-type@6.2.0">
@@ -8611,7 +8611,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/decompress-tarbz2/node_modules/file-type</property>
+            <property name="cdx:npm:package:path">node_modules/decompress-tarbz2/node_modules/file-type</property>
           </properties>
         </component>
       </components>
@@ -8641,7 +8641,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/decompress-targz</property>
+        <property name="cdx:npm:package:path">node_modules/decompress-targz</property>
       </properties>
       <components>
         <component type="library" bom-ref="decompress-targz@4.1.1|file-type@5.2.0">
@@ -8669,7 +8669,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/decompress-targz/node_modules/file-type</property>
+            <property name="cdx:npm:package:path">node_modules/decompress-targz/node_modules/file-type</property>
           </properties>
         </component>
       </components>
@@ -8699,7 +8699,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/decompress-unzip</property>
+        <property name="cdx:npm:package:path">node_modules/decompress-unzip</property>
       </properties>
       <components>
         <component type="library" bom-ref="decompress-unzip@4.0.1|file-type@3.9.0">
@@ -8727,7 +8727,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/decompress-unzip/node_modules/file-type</property>
+            <property name="cdx:npm:package:path">node_modules/decompress-unzip/node_modules/file-type</property>
           </properties>
         </component>
         <component type="library" bom-ref="decompress-unzip@4.0.1|get-stream@2.3.1">
@@ -8755,7 +8755,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/decompress-unzip/node_modules/get-stream</property>
+            <property name="cdx:npm:package:path">node_modules/decompress-unzip/node_modules/get-stream</property>
           </properties>
         </component>
         <component type="library" bom-ref="decompress-unzip@4.0.1|pify@2.3.0">
@@ -8783,7 +8783,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/decompress-unzip/node_modules/pify</property>
+            <property name="cdx:npm:package:path">node_modules/decompress-unzip/node_modules/pify</property>
           </properties>
         </component>
       </components>
@@ -8813,7 +8813,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/decompress</property>
+        <property name="cdx:npm:package:path">node_modules/decompress</property>
       </properties>
       <components>
         <component type="library" bom-ref="decompress@4.2.1|make-dir@1.3.0">
@@ -8841,7 +8841,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/decompress/node_modules/make-dir</property>
+            <property name="cdx:npm:package:path">node_modules/decompress/node_modules/make-dir</property>
           </properties>
           <components>
             <component type="library" bom-ref="decompress@4.2.1|make-dir@1.3.0|pify@3.0.0">
@@ -8869,7 +8869,7 @@
                 </reference>
               </externalReferences>
               <properties>
-                <property name="cdx:npm:package:installPath">node_modules/decompress/node_modules/make-dir/node_modules/pify</property>
+                <property name="cdx:npm:package:path">node_modules/decompress/node_modules/make-dir/node_modules/pify</property>
               </properties>
             </component>
           </components>
@@ -8899,7 +8899,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/decompress/node_modules/pify</property>
+            <property name="cdx:npm:package:path">node_modules/decompress/node_modules/pify</property>
           </properties>
         </component>
       </components>
@@ -8929,7 +8929,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/deep-equal</property>
+        <property name="cdx:npm:package:path">node_modules/deep-equal</property>
       </properties>
     </component>
     <component type="library" bom-ref="deep-extend@0.6.0">
@@ -8969,7 +8969,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/deep-extend</property>
+        <property name="cdx:npm:package:path">node_modules/deep-extend</property>
       </properties>
     </component>
     <component type="library" bom-ref="deep-is@0.1.4">
@@ -8997,7 +8997,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/deep-is</property>
+        <property name="cdx:npm:package:path">node_modules/deep-is</property>
       </properties>
     </component>
     <component type="library" bom-ref="define-properties@1.1.4">
@@ -9025,7 +9025,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/define-properties</property>
+        <property name="cdx:npm:package:path">node_modules/define-properties</property>
       </properties>
     </component>
     <component type="library" bom-ref="define-property@2.0.2">
@@ -9061,7 +9061,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/define-property</property>
+        <property name="cdx:npm:package:path">node_modules/define-property</property>
       </properties>
     </component>
     <component type="library" bom-ref="delayed-stream@1.0.0">
@@ -9093,7 +9093,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/delayed-stream</property>
+        <property name="cdx:npm:package:path">node_modules/delayed-stream</property>
       </properties>
     </component>
     <component type="library" bom-ref="delegates@1.0.0">
@@ -9120,7 +9120,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/delegates</property>
+        <property name="cdx:npm:package:path">node_modules/delegates</property>
       </properties>
     </component>
     <component type="library" bom-ref="depd@2.0.0">
@@ -9148,7 +9148,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/depd</property>
+        <property name="cdx:npm:package:path">node_modules/depd</property>
       </properties>
     </component>
     <component type="library" bom-ref="destroy@1.2.0">
@@ -9176,7 +9176,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/destroy</property>
+        <property name="cdx:npm:package:path">node_modules/destroy</property>
       </properties>
     </component>
     <component type="library" bom-ref="detect-file@1.0.0">
@@ -9212,7 +9212,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/detect-file</property>
+        <property name="cdx:npm:package:path">node_modules/detect-file</property>
       </properties>
     </component>
     <component type="library" bom-ref="detect-libc@1.0.3">
@@ -9240,7 +9240,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/detect-libc</property>
+        <property name="cdx:npm:package:path">node_modules/detect-libc</property>
       </properties>
     </component>
     <component type="library" bom-ref="dfa@1.2.0">
@@ -9276,7 +9276,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/dfa</property>
+        <property name="cdx:npm:package:path">node_modules/dfa</property>
       </properties>
     </component>
     <component type="library" bom-ref="dicer@0.2.5">
@@ -9305,7 +9305,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/dicer</property>
+        <property name="cdx:npm:package:path">node_modules/dicer</property>
       </properties>
       <components>
         <component type="library" bom-ref="dicer@0.2.5|isarray@0.0.1">
@@ -9337,7 +9337,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/dicer/node_modules/isarray</property>
+            <property name="cdx:npm:package:path">node_modules/dicer/node_modules/isarray</property>
           </properties>
         </component>
         <component type="library" bom-ref="dicer@0.2.5|readable-stream@1.1.14">
@@ -9365,7 +9365,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/dicer/node_modules/readable-stream</property>
+            <property name="cdx:npm:package:path">node_modules/dicer/node_modules/readable-stream</property>
           </properties>
         </component>
         <component type="library" bom-ref="dicer@0.2.5|string_decoder@0.10.31">
@@ -9396,7 +9396,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/dicer/node_modules/string_decoder</property>
+            <property name="cdx:npm:package:path">node_modules/dicer/node_modules/string_decoder</property>
           </properties>
         </component>
       </components>
@@ -9429,7 +9429,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/diff</property>
+        <property name="cdx:npm:package:path">node_modules/diff</property>
       </properties>
     </component>
     <component type="library" bom-ref="doctypes@1.1.0">
@@ -9457,7 +9457,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/doctypes</property>
+        <property name="cdx:npm:package:path">node_modules/doctypes</property>
       </properties>
     </component>
     <component type="library" bom-ref="domelementtype@1.3.1">
@@ -9485,7 +9485,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/domelementtype</property>
+        <property name="cdx:npm:package:path">node_modules/domelementtype</property>
       </properties>
     </component>
     <component type="library" bom-ref="domhandler@2.1.0">
@@ -9508,7 +9508,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/domhandler</property>
+        <property name="cdx:npm:package:path">node_modules/domhandler</property>
       </properties>
     </component>
     <component type="library" bom-ref="domutils@1.1.6">
@@ -9531,7 +9531,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/domutils</property>
+        <property name="cdx:npm:package:path">node_modules/domutils</property>
       </properties>
     </component>
     <component type="library" bom-ref="dottie@2.0.2">
@@ -9559,7 +9559,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/dottie</property>
+        <property name="cdx:npm:package:path">node_modules/dottie</property>
       </properties>
     </component>
     <component type="library" bom-ref="double-ended-queue@0.9.7">
@@ -9595,7 +9595,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/double-ended-queue</property>
+        <property name="cdx:npm:package:path">node_modules/double-ended-queue</property>
       </properties>
     </component>
     <component type="library" bom-ref="doublearray@0.0.2">
@@ -9631,7 +9631,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/doublearray</property>
+        <property name="cdx:npm:package:path">node_modules/doublearray</property>
       </properties>
     </component>
     <component type="library" bom-ref="download@8.0.0">
@@ -9659,7 +9659,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/download</property>
+        <property name="cdx:npm:package:path">node_modules/download</property>
       </properties>
       <components>
         <component type="library" bom-ref="download@8.0.0|file-type@11.1.0">
@@ -9687,7 +9687,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/download/node_modules/file-type</property>
+            <property name="cdx:npm:package:path">node_modules/download/node_modules/file-type</property>
           </properties>
         </component>
       </components>
@@ -9717,7 +9717,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/duplexer2</property>
+        <property name="cdx:npm:package:path">node_modules/duplexer2</property>
       </properties>
     </component>
     <component type="library" bom-ref="duplexer3@0.1.5">
@@ -9744,7 +9744,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/duplexer3</property>
+        <property name="cdx:npm:package:path">node_modules/duplexer3</property>
       </properties>
     </component>
     <component type="library" bom-ref="dynamic-dedupe@0.3.0">
@@ -9771,7 +9771,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/dynamic-dedupe</property>
+        <property name="cdx:npm:package:path">node_modules/dynamic-dedupe</property>
       </properties>
     </component>
     <component type="library" bom-ref="ecc-jsbn@0.1.2">
@@ -9807,7 +9807,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/ecc-jsbn</property>
+        <property name="cdx:npm:package:path">node_modules/ecc-jsbn</property>
       </properties>
     </component>
     <component type="library" bom-ref="ee-first@1.1.1">
@@ -9835,7 +9835,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/ee-first</property>
+        <property name="cdx:npm:package:path">node_modules/ee-first</property>
       </properties>
     </component>
     <component type="library" bom-ref="eivindfjeldstad-dot@0.0.1">
@@ -9870,7 +9870,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/eivindfjeldstad-dot</property>
+        <property name="cdx:npm:package:path">node_modules/eivindfjeldstad-dot</property>
       </properties>
     </component>
     <component type="library" bom-ref="emoji-regex@8.0.0">
@@ -9906,7 +9906,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/emoji-regex</property>
+        <property name="cdx:npm:package:path">node_modules/emoji-regex</property>
       </properties>
     </component>
     <component type="library" bom-ref="enabled@2.0.0">
@@ -9934,7 +9934,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/enabled</property>
+        <property name="cdx:npm:package:path">node_modules/enabled</property>
       </properties>
     </component>
     <component type="library" bom-ref="encodeurl@1.0.2">
@@ -9961,7 +9961,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/encodeurl</property>
+        <property name="cdx:npm:package:path">node_modules/encodeurl</property>
       </properties>
     </component>
     <component type="library" bom-ref="encoding@0.1.13">
@@ -9989,7 +9989,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/encoding</property>
+        <property name="cdx:npm:package:path">node_modules/encoding</property>
       </properties>
       <components>
         <component type="library" bom-ref="encoding@0.1.13|iconv-lite@0.6.3">
@@ -10025,7 +10025,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/encoding/node_modules/iconv-lite</property>
+            <property name="cdx:npm:package:path">node_modules/encoding/node_modules/iconv-lite</property>
           </properties>
         </component>
       </components>
@@ -10063,7 +10063,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/end-of-stream</property>
+        <property name="cdx:npm:package:path">node_modules/end-of-stream</property>
       </properties>
     </component>
     <component type="library" bom-ref="engine.io-parser@4.0.3">
@@ -10090,7 +10090,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/engine.io-parser</property>
+        <property name="cdx:npm:package:path">node_modules/engine.io-parser</property>
       </properties>
     </component>
     <component type="library" bom-ref="engine.io@4.1.2">
@@ -10118,7 +10118,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/engine.io</property>
+        <property name="cdx:npm:package:path">node_modules/engine.io</property>
       </properties>
       <components>
         <component type="library" bom-ref="engine.io@4.1.2|debug@4.3.4">
@@ -10146,7 +10146,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/engine.io/node_modules/debug</property>
+            <property name="cdx:npm:package:path">node_modules/engine.io/node_modules/debug</property>
           </properties>
         </component>
         <component type="library" bom-ref="engine.io@4.1.2|ms@2.1.2">
@@ -10173,7 +10173,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/engine.io/node_modules/ms</property>
+            <property name="cdx:npm:package:path">node_modules/engine.io/node_modules/ms</property>
           </properties>
         </component>
       </components>
@@ -10203,7 +10203,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/env-paths</property>
+        <property name="cdx:npm:package:path">node_modules/env-paths</property>
       </properties>
     </component>
     <component type="library" bom-ref="err-code@1.1.2">
@@ -10235,7 +10235,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/err-code</property>
+        <property name="cdx:npm:package:path">node_modules/err-code</property>
       </properties>
     </component>
     <component type="library" bom-ref="error-ex@1.3.2">
@@ -10262,7 +10262,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/error-ex</property>
+        <property name="cdx:npm:package:path">node_modules/error-ex</property>
       </properties>
     </component>
     <component type="library" bom-ref="errorhandler@1.5.1">
@@ -10289,7 +10289,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/errorhandler</property>
+        <property name="cdx:npm:package:path">node_modules/errorhandler</property>
       </properties>
     </component>
     <component type="library" bom-ref="es-get-iterator@1.1.2">
@@ -10325,7 +10325,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/es-get-iterator</property>
+        <property name="cdx:npm:package:path">node_modules/es-get-iterator</property>
       </properties>
     </component>
     <component type="library" bom-ref="escape-html@1.0.3">
@@ -10352,7 +10352,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/escape-html</property>
+        <property name="cdx:npm:package:path">node_modules/escape-html</property>
       </properties>
     </component>
     <component type="library" bom-ref="escape-string-regexp@1.0.5">
@@ -10380,7 +10380,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/escape-string-regexp</property>
+        <property name="cdx:npm:package:path">node_modules/escape-string-regexp</property>
       </properties>
     </component>
     <component type="library" bom-ref="escodegen@2.0.0">
@@ -10411,7 +10411,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/escodegen</property>
+        <property name="cdx:npm:package:path">node_modules/escodegen</property>
       </properties>
     </component>
     <component type="library" bom-ref="esprima@4.0.1">
@@ -10447,7 +10447,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/esprima</property>
+        <property name="cdx:npm:package:path">node_modules/esprima</property>
       </properties>
     </component>
     <component type="library" bom-ref="estraverse@5.3.0">
@@ -10478,7 +10478,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/estraverse</property>
+        <property name="cdx:npm:package:path">node_modules/estraverse</property>
       </properties>
     </component>
     <component type="library" bom-ref="esutils@2.0.3">
@@ -10509,7 +10509,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/esutils</property>
+        <property name="cdx:npm:package:path">node_modules/esutils</property>
       </properties>
     </component>
     <component type="library" bom-ref="etag@1.8.1">
@@ -10536,7 +10536,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/etag</property>
+        <property name="cdx:npm:package:path">node_modules/etag</property>
       </properties>
     </component>
     <component type="library" bom-ref="eventemitter2@0.4.14">
@@ -10564,7 +10564,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/eventemitter2</property>
+        <property name="cdx:npm:package:path">node_modules/eventemitter2</property>
       </properties>
     </component>
     <component type="library" bom-ref="eventemitter3@1.1.1">
@@ -10596,7 +10596,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/eventemitter3</property>
+        <property name="cdx:npm:package:path">node_modules/eventemitter3</property>
       </properties>
     </component>
     <component type="library" bom-ref="exif@0.6.0">
@@ -10618,7 +10618,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/exif</property>
+        <property name="cdx:npm:package:path">node_modules/exif</property>
       </properties>
     </component>
     <component type="library" bom-ref="exit@0.1.2">
@@ -10655,7 +10655,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/exit</property>
+        <property name="cdx:npm:package:path">node_modules/exit</property>
       </properties>
     </component>
     <component type="library" bom-ref="expand-brackets@2.1.4">
@@ -10691,7 +10691,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/expand-brackets</property>
+        <property name="cdx:npm:package:path">node_modules/expand-brackets</property>
       </properties>
       <components>
         <component type="library" bom-ref="expand-brackets@2.1.4|define-property@0.2.5">
@@ -10727,7 +10727,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/expand-brackets/node_modules/define-property</property>
+            <property name="cdx:npm:package:path">node_modules/expand-brackets/node_modules/define-property</property>
           </properties>
         </component>
         <component type="library" bom-ref="expand-brackets@2.1.4|extend-shallow@2.0.1">
@@ -10763,7 +10763,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/expand-brackets/node_modules/extend-shallow</property>
+            <property name="cdx:npm:package:path">node_modules/expand-brackets/node_modules/extend-shallow</property>
           </properties>
         </component>
         <component type="library" bom-ref="expand-brackets@2.1.4|is-accessor-descriptor@0.1.6">
@@ -10799,7 +10799,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/expand-brackets/node_modules/is-accessor-descriptor</property>
+            <property name="cdx:npm:package:path">node_modules/expand-brackets/node_modules/is-accessor-descriptor</property>
           </properties>
           <components>
             <component type="library" bom-ref="expand-brackets@2.1.4|is-accessor-descriptor@0.1.6|kind-of@3.2.2">
@@ -10835,7 +10835,7 @@
                 </reference>
               </externalReferences>
               <properties>
-                <property name="cdx:npm:package:installPath">node_modules/expand-brackets/node_modules/is-accessor-descriptor/node_modules/kind-of</property>
+                <property name="cdx:npm:package:path">node_modules/expand-brackets/node_modules/is-accessor-descriptor/node_modules/kind-of</property>
               </properties>
             </component>
           </components>
@@ -10873,7 +10873,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/expand-brackets/node_modules/is-data-descriptor</property>
+            <property name="cdx:npm:package:path">node_modules/expand-brackets/node_modules/is-data-descriptor</property>
           </properties>
           <components>
             <component type="library" bom-ref="expand-brackets@2.1.4|is-data-descriptor@0.1.4|kind-of@3.2.2">
@@ -10909,7 +10909,7 @@
                 </reference>
               </externalReferences>
               <properties>
-                <property name="cdx:npm:package:installPath">node_modules/expand-brackets/node_modules/is-data-descriptor/node_modules/kind-of</property>
+                <property name="cdx:npm:package:path">node_modules/expand-brackets/node_modules/is-data-descriptor/node_modules/kind-of</property>
               </properties>
             </component>
           </components>
@@ -10947,7 +10947,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/expand-brackets/node_modules/is-descriptor</property>
+            <property name="cdx:npm:package:path">node_modules/expand-brackets/node_modules/is-descriptor</property>
           </properties>
         </component>
         <component type="library" bom-ref="expand-brackets@2.1.4|is-extendable@0.1.1">
@@ -10983,7 +10983,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/expand-brackets/node_modules/is-extendable</property>
+            <property name="cdx:npm:package:path">node_modules/expand-brackets/node_modules/is-extendable</property>
           </properties>
         </component>
         <component type="library" bom-ref="expand-brackets@2.1.4|kind-of@5.1.0">
@@ -11019,7 +11019,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/expand-brackets/node_modules/kind-of</property>
+            <property name="cdx:npm:package:path">node_modules/expand-brackets/node_modules/kind-of</property>
           </properties>
         </component>
       </components>
@@ -11051,7 +11051,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/expand-template</property>
+        <property name="cdx:npm:package:path">node_modules/expand-template</property>
       </properties>
     </component>
     <component type="library" bom-ref="expand-tilde@2.0.2">
@@ -11087,7 +11087,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/expand-tilde</property>
+        <property name="cdx:npm:package:path">node_modules/expand-tilde</property>
       </properties>
     </component>
     <component type="library" bom-ref="express-ipfilter@1.3.1">
@@ -11115,7 +11115,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/express-ipfilter</property>
+        <property name="cdx:npm:package:path">node_modules/express-ipfilter</property>
       </properties>
     </component>
     <component type="library" bom-ref="express-jwt@0.1.3">
@@ -11148,7 +11148,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/express-jwt</property>
+        <property name="cdx:npm:package:path">node_modules/express-jwt</property>
       </properties>
       <components>
         <component type="library" bom-ref="express-jwt@0.1.3|jsonwebtoken@0.1.0">
@@ -11180,7 +11180,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/express-jwt/node_modules/jsonwebtoken</property>
+            <property name="cdx:npm:package:path">node_modules/express-jwt/node_modules/jsonwebtoken</property>
           </properties>
         </component>
         <component type="library" bom-ref="express-jwt@0.1.3|moment@2.0.0">
@@ -11216,7 +11216,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/express-jwt/node_modules/moment</property>
+            <property name="cdx:npm:package:path">node_modules/express-jwt/node_modules/moment</property>
           </properties>
         </component>
       </components>
@@ -11250,7 +11250,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/express-rate-limit</property>
+        <property name="cdx:npm:package:path">node_modules/express-rate-limit</property>
       </properties>
     </component>
     <component type="library" bom-ref="express-robots-txt@0.4.1">
@@ -11286,7 +11286,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/express-robots-txt</property>
+        <property name="cdx:npm:package:path">node_modules/express-robots-txt</property>
       </properties>
     </component>
     <component type="library" bom-ref="express-security.txt@2.0.0">
@@ -11320,7 +11320,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/express-security.txt</property>
+        <property name="cdx:npm:package:path">node_modules/express-security.txt</property>
       </properties>
     </component>
     <component type="library" bom-ref="express@4.18.2">
@@ -11352,7 +11352,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/express</property>
+        <property name="cdx:npm:package:path">node_modules/express</property>
       </properties>
       <components>
         <component type="library" bom-ref="express@4.18.2|cookie@0.5.0">
@@ -11380,7 +11380,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/express/node_modules/cookie</property>
+            <property name="cdx:npm:package:path">node_modules/express/node_modules/cookie</property>
           </properties>
         </component>
         <component type="library" bom-ref="express@4.18.2|safe-buffer@5.2.1">
@@ -11416,7 +11416,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/express/node_modules/safe-buffer</property>
+            <property name="cdx:npm:package:path">node_modules/express/node_modules/safe-buffer</property>
           </properties>
         </component>
       </components>
@@ -11446,7 +11446,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/ext-list</property>
+        <property name="cdx:npm:package:path">node_modules/ext-list</property>
       </properties>
     </component>
     <component type="library" bom-ref="ext-name@5.0.0">
@@ -11474,7 +11474,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/ext-name</property>
+        <property name="cdx:npm:package:path">node_modules/ext-name</property>
       </properties>
     </component>
     <component type="library" bom-ref="extend-shallow@3.0.2">
@@ -11510,7 +11510,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/extend-shallow</property>
+        <property name="cdx:npm:package:path">node_modules/extend-shallow</property>
       </properties>
     </component>
     <component type="library" bom-ref="extend@3.0.2">
@@ -11538,7 +11538,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/extend</property>
+        <property name="cdx:npm:package:path">node_modules/extend</property>
       </properties>
     </component>
     <component type="library" bom-ref="extglob@2.0.4">
@@ -11574,7 +11574,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/extglob</property>
+        <property name="cdx:npm:package:path">node_modules/extglob</property>
       </properties>
       <components>
         <component type="library" bom-ref="extglob@2.0.4|define-property@1.0.0">
@@ -11610,7 +11610,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/extglob/node_modules/define-property</property>
+            <property name="cdx:npm:package:path">node_modules/extglob/node_modules/define-property</property>
           </properties>
         </component>
         <component type="library" bom-ref="extglob@2.0.4|extend-shallow@2.0.1">
@@ -11646,7 +11646,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/extglob/node_modules/extend-shallow</property>
+            <property name="cdx:npm:package:path">node_modules/extglob/node_modules/extend-shallow</property>
           </properties>
         </component>
         <component type="library" bom-ref="extglob@2.0.4|is-extendable@0.1.1">
@@ -11682,7 +11682,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/extglob/node_modules/is-extendable</property>
+            <property name="cdx:npm:package:path">node_modules/extglob/node_modules/is-extendable</property>
           </properties>
         </component>
       </components>
@@ -11711,7 +11711,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/extsprintf</property>
+        <property name="cdx:npm:package:path">node_modules/extsprintf</property>
       </properties>
     </component>
     <component type="library" bom-ref="fast-deep-equal@3.1.3">
@@ -11747,7 +11747,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/fast-deep-equal</property>
+        <property name="cdx:npm:package:path">node_modules/fast-deep-equal</property>
       </properties>
     </component>
     <component type="library" bom-ref="fast-json-stable-stringify@2.1.0">
@@ -11779,7 +11779,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/fast-json-stable-stringify</property>
+        <property name="cdx:npm:package:path">node_modules/fast-json-stable-stringify</property>
       </properties>
     </component>
     <component type="library" bom-ref="fast-levenshtein@2.0.6">
@@ -11807,7 +11807,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/fast-levenshtein</property>
+        <property name="cdx:npm:package:path">node_modules/fast-levenshtein</property>
       </properties>
     </component>
     <component type="library" bom-ref="fast.js@0.1.1">
@@ -11843,7 +11843,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/fast.js</property>
+        <property name="cdx:npm:package:path">node_modules/fast.js</property>
       </properties>
     </component>
     <component type="library" bom-ref="fd-slicer@1.1.0">
@@ -11875,7 +11875,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/fd-slicer</property>
+        <property name="cdx:npm:package:path">node_modules/fd-slicer</property>
       </properties>
     </component>
     <component type="library" bom-ref="feature-policy@0.5.0">
@@ -11911,7 +11911,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/feature-policy</property>
+        <property name="cdx:npm:package:path">node_modules/feature-policy</property>
       </properties>
     </component>
     <component type="library" bom-ref="fecha@4.2.3">
@@ -11947,7 +11947,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/fecha</property>
+        <property name="cdx:npm:package:path">node_modules/fecha</property>
       </properties>
     </component>
     <component type="library" bom-ref="file-js@0.3.0">
@@ -11983,7 +11983,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/file-js</property>
+        <property name="cdx:npm:package:path">node_modules/file-js</property>
       </properties>
       <components>
         <component type="library" bom-ref="file-js@0.3.0|brace-expansion@1.1.11">
@@ -12015,7 +12015,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/file-js/node_modules/brace-expansion</property>
+            <property name="cdx:npm:package:path">node_modules/file-js/node_modules/brace-expansion</property>
           </properties>
         </component>
         <component type="library" bom-ref="file-js@0.3.0|minimatch@3.1.2">
@@ -12043,7 +12043,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/file-js/node_modules/minimatch</property>
+            <property name="cdx:npm:package:path">node_modules/file-js/node_modules/minimatch</property>
           </properties>
         </component>
       </components>
@@ -12073,7 +12073,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/file-stream-rotator</property>
+        <property name="cdx:npm:package:path">node_modules/file-stream-rotator</property>
       </properties>
     </component>
     <component type="library" bom-ref="file-type@16.5.4">
@@ -12101,7 +12101,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/file-type</property>
+        <property name="cdx:npm:package:path">node_modules/file-type</property>
       </properties>
     </component>
     <component type="library" bom-ref="file-uri-to-path@1.0.0">
@@ -12137,7 +12137,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/file-uri-to-path</property>
+        <property name="cdx:npm:package:path">node_modules/file-uri-to-path</property>
       </properties>
     </component>
     <component type="library" bom-ref="filehound@1.17.6">
@@ -12172,7 +12172,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/filehound</property>
+        <property name="cdx:npm:package:path">node_modules/filehound</property>
       </properties>
     </component>
     <component type="library" bom-ref="filename-reserved-regex@2.0.0">
@@ -12200,7 +12200,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/filename-reserved-regex</property>
+        <property name="cdx:npm:package:path">node_modules/filename-reserved-regex</property>
       </properties>
     </component>
     <component type="library" bom-ref="filenamify@3.0.0">
@@ -12228,7 +12228,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/filenamify</property>
+        <property name="cdx:npm:package:path">node_modules/filenamify</property>
       </properties>
     </component>
     <component type="library" bom-ref="filesniffer@1.0.3">
@@ -12263,7 +12263,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/filesniffer</property>
+        <property name="cdx:npm:package:path">node_modules/filesniffer</property>
       </properties>
     </component>
     <component type="library" bom-ref="fill-range@4.0.0">
@@ -12299,7 +12299,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/fill-range</property>
+        <property name="cdx:npm:package:path">node_modules/fill-range</property>
       </properties>
       <components>
         <component type="library" bom-ref="fill-range@4.0.0|extend-shallow@2.0.1">
@@ -12335,7 +12335,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/fill-range/node_modules/extend-shallow</property>
+            <property name="cdx:npm:package:path">node_modules/fill-range/node_modules/extend-shallow</property>
           </properties>
         </component>
         <component type="library" bom-ref="fill-range@4.0.0|is-extendable@0.1.1">
@@ -12371,7 +12371,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/fill-range/node_modules/is-extendable</property>
+            <property name="cdx:npm:package:path">node_modules/fill-range/node_modules/is-extendable</property>
           </properties>
         </component>
       </components>
@@ -12405,7 +12405,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/finale-rest</property>
+        <property name="cdx:npm:package:path">node_modules/finale-rest</property>
       </properties>
     </component>
     <component type="library" bom-ref="finalhandler@1.2.0">
@@ -12433,7 +12433,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/finalhandler</property>
+        <property name="cdx:npm:package:path">node_modules/finalhandler</property>
       </properties>
     </component>
     <component type="library" bom-ref="find-up@3.0.0">
@@ -12461,7 +12461,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/find-up</property>
+        <property name="cdx:npm:package:path">node_modules/find-up</property>
       </properties>
     </component>
     <component type="library" bom-ref="findup-sync@2.0.0">
@@ -12489,7 +12489,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/findup-sync</property>
+        <property name="cdx:npm:package:path">node_modules/findup-sync</property>
       </properties>
     </component>
     <component type="library" bom-ref="fined@1.2.0">
@@ -12517,7 +12517,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/fined</property>
+        <property name="cdx:npm:package:path">node_modules/fined</property>
       </properties>
     </component>
     <component type="library" bom-ref="flagged-respawn@1.0.1">
@@ -12545,7 +12545,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/flagged-respawn</property>
+        <property name="cdx:npm:package:path">node_modules/flagged-respawn</property>
       </properties>
     </component>
     <component type="library" bom-ref="fn.name@1.1.0">
@@ -12581,7 +12581,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/fn.name</property>
+        <property name="cdx:npm:package:path">node_modules/fn.name</property>
       </properties>
     </component>
     <component type="library" bom-ref="fontkit@1.9.0">
@@ -12609,7 +12609,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/fontkit</property>
+        <property name="cdx:npm:package:path">node_modules/fontkit</property>
       </properties>
     </component>
     <component type="library" bom-ref="for-each@0.3.3">
@@ -12649,7 +12649,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/for-each</property>
+        <property name="cdx:npm:package:path">node_modules/for-each</property>
       </properties>
     </component>
     <component type="library" bom-ref="for-in@1.0.2">
@@ -12685,7 +12685,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/for-in</property>
+        <property name="cdx:npm:package:path">node_modules/for-in</property>
       </properties>
     </component>
     <component type="library" bom-ref="for-own@1.0.0">
@@ -12721,7 +12721,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/for-own</property>
+        <property name="cdx:npm:package:path">node_modules/for-own</property>
       </properties>
     </component>
     <component type="library" bom-ref="foreachasync@3.0.0">
@@ -12757,7 +12757,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/foreachasync</property>
+        <property name="cdx:npm:package:path">node_modules/foreachasync</property>
       </properties>
     </component>
     <component type="library" bom-ref="forever-agent@0.6.1">
@@ -12785,7 +12785,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/forever-agent</property>
+        <property name="cdx:npm:package:path">node_modules/forever-agent</property>
       </properties>
     </component>
     <component type="library" bom-ref="form-data@2.3.3">
@@ -12813,7 +12813,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/form-data</property>
+        <property name="cdx:npm:package:path">node_modules/form-data</property>
       </properties>
     </component>
     <component type="library" bom-ref="formatio@1.1.1">
@@ -12840,7 +12840,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/formatio</property>
+        <property name="cdx:npm:package:path">node_modules/formatio</property>
       </properties>
     </component>
     <component type="library" bom-ref="forwarded@0.2.0">
@@ -12867,7 +12867,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/forwarded</property>
+        <property name="cdx:npm:package:path">node_modules/forwarded</property>
       </properties>
     </component>
     <component type="library" bom-ref="fragment-cache@0.2.1">
@@ -12903,7 +12903,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/fragment-cache</property>
+        <property name="cdx:npm:package:path">node_modules/fragment-cache</property>
       </properties>
     </component>
     <component type="library" bom-ref="fresh@0.5.2">
@@ -12931,7 +12931,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/fresh</property>
+        <property name="cdx:npm:package:path">node_modules/fresh</property>
       </properties>
     </component>
     <component type="library" bom-ref="from2@2.3.0">
@@ -12967,7 +12967,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/from2</property>
+        <property name="cdx:npm:package:path">node_modules/from2</property>
       </properties>
     </component>
     <component type="library" bom-ref="fs-constants@1.0.0">
@@ -13003,7 +13003,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/fs-constants</property>
+        <property name="cdx:npm:package:path">node_modules/fs-constants</property>
       </properties>
     </component>
     <component type="library" bom-ref="fs-extra@9.1.0">
@@ -13035,7 +13035,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/fs-extra</property>
+        <property name="cdx:npm:package:path">node_modules/fs-extra</property>
       </properties>
     </component>
     <component type="library" bom-ref="fs-minipass@2.1.0">
@@ -13071,7 +13071,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/fs-minipass</property>
+        <property name="cdx:npm:package:path">node_modules/fs-minipass</property>
       </properties>
     </component>
     <component type="library" bom-ref="fs.realpath@1.0.0">
@@ -13099,7 +13099,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/fs.realpath</property>
+        <property name="cdx:npm:package:path">node_modules/fs.realpath</property>
       </properties>
     </component>
     <component type="library" bom-ref="fstream@1.0.12">
@@ -13127,7 +13127,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/fstream</property>
+        <property name="cdx:npm:package:path">node_modules/fstream</property>
       </properties>
       <components>
         <component type="library" bom-ref="fstream@1.0.12|mkdirp@0.5.6">
@@ -13155,7 +13155,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/fstream/node_modules/mkdirp</property>
+            <property name="cdx:npm:package:path">node_modules/fstream/node_modules/mkdirp</property>
           </properties>
         </component>
         <component type="library" bom-ref="fstream@1.0.12|rimraf@2.7.1">
@@ -13183,7 +13183,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/fstream/node_modules/rimraf</property>
+            <property name="cdx:npm:package:path">node_modules/fstream/node_modules/rimraf</property>
           </properties>
         </component>
       </components>
@@ -13221,7 +13221,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/function-bind</property>
+        <property name="cdx:npm:package:path">node_modules/function-bind</property>
       </properties>
     </component>
     <component type="library" bom-ref="functions-have-names@1.2.3">
@@ -13257,7 +13257,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/functions-have-names</property>
+        <property name="cdx:npm:package:path">node_modules/functions-have-names</property>
       </properties>
     </component>
     <component type="library" bom-ref="fuzzball@1.4.0">
@@ -13285,7 +13285,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/fuzzball</property>
+        <property name="cdx:npm:package:path">node_modules/fuzzball</property>
       </properties>
     </component>
     <component type="library" bom-ref="gauge@2.7.4">
@@ -13321,7 +13321,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/gauge</property>
+        <property name="cdx:npm:package:path">node_modules/gauge</property>
       </properties>
     </component>
     <component type="library" bom-ref="geojson-utils@1.1.0">
@@ -13349,7 +13349,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/geojson-utils</property>
+        <property name="cdx:npm:package:path">node_modules/geojson-utils</property>
       </properties>
     </component>
     <component type="library" bom-ref="get-caller-file@2.0.5">
@@ -13384,7 +13384,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/get-caller-file</property>
+        <property name="cdx:npm:package:path">node_modules/get-caller-file</property>
       </properties>
     </component>
     <component type="library" bom-ref="get-intrinsic@1.1.3">
@@ -13420,7 +13420,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/get-intrinsic</property>
+        <property name="cdx:npm:package:path">node_modules/get-intrinsic</property>
       </properties>
     </component>
     <component type="library" bom-ref="get-stream@4.1.0">
@@ -13448,7 +13448,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/get-stream</property>
+        <property name="cdx:npm:package:path">node_modules/get-stream</property>
       </properties>
     </component>
     <component type="library" bom-ref="get-value@2.0.6">
@@ -13484,7 +13484,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/get-value</property>
+        <property name="cdx:npm:package:path">node_modules/get-value</property>
       </properties>
     </component>
     <component type="library" bom-ref="getobject@1.0.2">
@@ -13521,7 +13521,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/getobject</property>
+        <property name="cdx:npm:package:path">node_modules/getobject</property>
       </properties>
     </component>
     <component type="library" bom-ref="getpass@0.1.7">
@@ -13549,7 +13549,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/getpass</property>
+        <property name="cdx:npm:package:path">node_modules/getpass</property>
       </properties>
     </component>
     <component type="library" bom-ref="github-from-package@0.0.0">
@@ -13581,7 +13581,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/github-from-package</property>
+        <property name="cdx:npm:package:path">node_modules/github-from-package</property>
       </properties>
     </component>
     <component type="library" bom-ref="glob-parent@5.1.2">
@@ -13609,7 +13609,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/glob-parent</property>
+        <property name="cdx:npm:package:path">node_modules/glob-parent</property>
       </properties>
       <components>
         <component type="library" bom-ref="glob-parent@5.1.2|is-glob@4.0.3">
@@ -13645,7 +13645,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/glob-parent/node_modules/is-glob</property>
+            <property name="cdx:npm:package:path">node_modules/glob-parent/node_modules/is-glob</property>
           </properties>
         </component>
       </components>
@@ -13675,7 +13675,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/glob</property>
+        <property name="cdx:npm:package:path">node_modules/glob</property>
       </properties>
       <components>
         <component type="library" bom-ref="glob@7.2.3|brace-expansion@1.1.11">
@@ -13707,7 +13707,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/glob/node_modules/brace-expansion</property>
+            <property name="cdx:npm:package:path">node_modules/glob/node_modules/brace-expansion</property>
           </properties>
         </component>
         <component type="library" bom-ref="glob@7.2.3|minimatch@3.1.2">
@@ -13735,7 +13735,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/glob/node_modules/minimatch</property>
+            <property name="cdx:npm:package:path">node_modules/glob/node_modules/minimatch</property>
           </properties>
         </component>
       </components>
@@ -13773,7 +13773,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/global-modules</property>
+        <property name="cdx:npm:package:path">node_modules/global-modules</property>
       </properties>
     </component>
     <component type="library" bom-ref="global-prefix@1.0.2">
@@ -13809,7 +13809,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/global-prefix</property>
+        <property name="cdx:npm:package:path">node_modules/global-prefix</property>
       </properties>
       <components>
         <component type="library" bom-ref="global-prefix@1.0.2|which@1.3.1">
@@ -13837,7 +13837,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/global-prefix/node_modules/which</property>
+            <property name="cdx:npm:package:path">node_modules/global-prefix/node_modules/which</property>
           </properties>
         </component>
       </components>
@@ -13875,7 +13875,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/gopd</property>
+        <property name="cdx:npm:package:path">node_modules/gopd</property>
       </properties>
     </component>
     <component type="library" bom-ref="got@8.3.2">
@@ -13902,7 +13902,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/got</property>
+        <property name="cdx:npm:package:path">node_modules/got</property>
       </properties>
       <components>
         <component type="library" bom-ref="got@8.3.2|get-stream@3.0.0">
@@ -13930,7 +13930,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/got/node_modules/get-stream</property>
+            <property name="cdx:npm:package:path">node_modules/got/node_modules/get-stream</property>
           </properties>
         </component>
         <component type="library" bom-ref="got@8.3.2|pify@3.0.0">
@@ -13958,7 +13958,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/got/node_modules/pify</property>
+            <property name="cdx:npm:package:path">node_modules/got/node_modules/pify</property>
           </properties>
         </component>
       </components>
@@ -13987,7 +13987,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/graceful-fs</property>
+        <property name="cdx:npm:package:path">node_modules/graceful-fs</property>
       </properties>
     </component>
     <component type="library" bom-ref="grunt-cli@1.4.3">
@@ -14015,7 +14015,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/grunt-cli</property>
+        <property name="cdx:npm:package:path">node_modules/grunt-cli</property>
       </properties>
       <components>
         <component type="library" bom-ref="grunt-cli@1.4.3|nopt@4.0.3">
@@ -14043,7 +14043,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/grunt-cli/node_modules/nopt</property>
+            <property name="cdx:npm:package:path">node_modules/grunt-cli/node_modules/nopt</property>
           </properties>
         </component>
       </components>
@@ -14073,7 +14073,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/grunt-contrib-compress</property>
+        <property name="cdx:npm:package:path">node_modules/grunt-contrib-compress</property>
       </properties>
       <components>
         <component type="library" bom-ref="grunt-contrib-compress@1.6.0|ansi-styles@2.2.1">
@@ -14101,7 +14101,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/grunt-contrib-compress/node_modules/ansi-styles</property>
+            <property name="cdx:npm:package:path">node_modules/grunt-contrib-compress/node_modules/ansi-styles</property>
           </properties>
         </component>
         <component type="library" bom-ref="grunt-contrib-compress@1.6.0|chalk@1.1.3">
@@ -14128,7 +14128,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/grunt-contrib-compress/node_modules/chalk</property>
+            <property name="cdx:npm:package:path">node_modules/grunt-contrib-compress/node_modules/chalk</property>
           </properties>
         </component>
         <component type="library" bom-ref="grunt-contrib-compress@1.6.0|supports-color@2.0.0">
@@ -14156,7 +14156,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/grunt-contrib-compress/node_modules/supports-color</property>
+            <property name="cdx:npm:package:path">node_modules/grunt-contrib-compress/node_modules/supports-color</property>
           </properties>
         </component>
       </components>
@@ -14190,7 +14190,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/grunt-known-options</property>
+        <property name="cdx:npm:package:path">node_modules/grunt-known-options</property>
       </properties>
     </component>
     <component type="library" bom-ref="grunt-legacy-log-utils@2.1.0">
@@ -14226,7 +14226,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/grunt-legacy-log-utils</property>
+        <property name="cdx:npm:package:path">node_modules/grunt-legacy-log-utils</property>
       </properties>
       <components>
         <component type="library" bom-ref="grunt-legacy-log-utils@2.1.0|ansi-styles@4.3.0">
@@ -14254,7 +14254,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/grunt-legacy-log-utils/node_modules/ansi-styles</property>
+            <property name="cdx:npm:package:path">node_modules/grunt-legacy-log-utils/node_modules/ansi-styles</property>
           </properties>
         </component>
         <component type="library" bom-ref="grunt-legacy-log-utils@2.1.0|chalk@4.1.2">
@@ -14281,7 +14281,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/grunt-legacy-log-utils/node_modules/chalk</property>
+            <property name="cdx:npm:package:path">node_modules/grunt-legacy-log-utils/node_modules/chalk</property>
           </properties>
         </component>
         <component type="library" bom-ref="grunt-legacy-log-utils@2.1.0|color-convert@2.0.1">
@@ -14309,7 +14309,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/grunt-legacy-log-utils/node_modules/color-convert</property>
+            <property name="cdx:npm:package:path">node_modules/grunt-legacy-log-utils/node_modules/color-convert</property>
           </properties>
         </component>
         <component type="library" bom-ref="grunt-legacy-log-utils@2.1.0|color-name@1.1.4">
@@ -14341,7 +14341,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/grunt-legacy-log-utils/node_modules/color-name</property>
+            <property name="cdx:npm:package:path">node_modules/grunt-legacy-log-utils/node_modules/color-name</property>
           </properties>
         </component>
         <component type="library" bom-ref="grunt-legacy-log-utils@2.1.0|has-flag@4.0.0">
@@ -14369,7 +14369,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/grunt-legacy-log-utils/node_modules/has-flag</property>
+            <property name="cdx:npm:package:path">node_modules/grunt-legacy-log-utils/node_modules/has-flag</property>
           </properties>
         </component>
         <component type="library" bom-ref="grunt-legacy-log-utils@2.1.0|supports-color@7.2.0">
@@ -14397,7 +14397,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/grunt-legacy-log-utils/node_modules/supports-color</property>
+            <property name="cdx:npm:package:path">node_modules/grunt-legacy-log-utils/node_modules/supports-color</property>
           </properties>
         </component>
       </components>
@@ -14435,7 +14435,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/grunt-legacy-log</property>
+        <property name="cdx:npm:package:path">node_modules/grunt-legacy-log</property>
       </properties>
       <components>
         <component type="library" bom-ref="grunt-legacy-log@3.0.0|colors@1.1.2">
@@ -14471,7 +14471,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/grunt-legacy-log/node_modules/colors</property>
+            <property name="cdx:npm:package:path">node_modules/grunt-legacy-log/node_modules/colors</property>
           </properties>
         </component>
       </components>
@@ -14509,7 +14509,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/grunt-legacy-util</property>
+        <property name="cdx:npm:package:path">node_modules/grunt-legacy-util</property>
       </properties>
       <components>
         <component type="library" bom-ref="grunt-legacy-util@2.0.1|async@3.2.4">
@@ -14545,7 +14545,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/grunt-legacy-util/node_modules/async</property>
+            <property name="cdx:npm:package:path">node_modules/grunt-legacy-util/node_modules/async</property>
           </properties>
         </component>
       </components>
@@ -14584,7 +14584,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/grunt-replace-json</property>
+        <property name="cdx:npm:package:path">node_modules/grunt-replace-json</property>
       </properties>
     </component>
     <component type="library" bom-ref="grunt@1.5.3">
@@ -14616,7 +14616,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/grunt</property>
+        <property name="cdx:npm:package:path">node_modules/grunt</property>
       </properties>
       <components>
         <component type="library" bom-ref="grunt@1.5.3|brace-expansion@1.1.11">
@@ -14648,7 +14648,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/grunt/node_modules/brace-expansion</property>
+            <property name="cdx:npm:package:path">node_modules/grunt/node_modules/brace-expansion</property>
           </properties>
         </component>
         <component type="library" bom-ref="grunt@1.5.3|findup-sync@0.3.0">
@@ -14685,7 +14685,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/grunt/node_modules/findup-sync</property>
+            <property name="cdx:npm:package:path">node_modules/grunt/node_modules/findup-sync</property>
           </properties>
           <components>
             <component type="library" bom-ref="grunt@1.5.3|findup-sync@0.3.0|glob@5.0.15">
@@ -14713,7 +14713,7 @@
                 </reference>
               </externalReferences>
               <properties>
-                <property name="cdx:npm:package:installPath">node_modules/grunt/node_modules/findup-sync/node_modules/glob</property>
+                <property name="cdx:npm:package:path">node_modules/grunt/node_modules/findup-sync/node_modules/glob</property>
               </properties>
             </component>
           </components>
@@ -14743,7 +14743,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/grunt/node_modules/glob</property>
+            <property name="cdx:npm:package:path">node_modules/grunt/node_modules/glob</property>
           </properties>
         </component>
         <component type="library" bom-ref="grunt@1.5.3|minimatch@3.0.8">
@@ -14771,7 +14771,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/grunt/node_modules/minimatch</property>
+            <property name="cdx:npm:package:path">node_modules/grunt/node_modules/minimatch</property>
           </properties>
         </component>
       </components>
@@ -14805,7 +14805,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/handlebars</property>
+        <property name="cdx:npm:package:path">node_modules/handlebars</property>
       </properties>
       <components>
         <component type="library" bom-ref="handlebars@4.7.7|wordwrap@1.0.0">
@@ -14833,7 +14833,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/handlebars/node_modules/wordwrap</property>
+            <property name="cdx:npm:package:path">node_modules/handlebars/node_modules/wordwrap</property>
           </properties>
         </component>
       </components>
@@ -14871,7 +14871,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/har-schema</property>
+        <property name="cdx:npm:package:path">node_modules/har-schema</property>
       </properties>
     </component>
     <component type="library" bom-ref="har-validator@5.1.5">
@@ -14907,7 +14907,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/har-validator</property>
+        <property name="cdx:npm:package:path">node_modules/har-validator</property>
       </properties>
     </component>
     <component type="library" bom-ref="has-ansi@2.0.0">
@@ -14935,7 +14935,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/has-ansi</property>
+        <property name="cdx:npm:package:path">node_modules/has-ansi</property>
       </properties>
     </component>
     <component type="library" bom-ref="has-bigints@1.0.2">
@@ -14971,7 +14971,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/has-bigints</property>
+        <property name="cdx:npm:package:path">node_modules/has-bigints</property>
       </properties>
     </component>
     <component type="library" bom-ref="has-flag@3.0.0">
@@ -14999,7 +14999,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/has-flag</property>
+        <property name="cdx:npm:package:path">node_modules/has-flag</property>
       </properties>
     </component>
     <component type="library" bom-ref="has-property-descriptors@1.0.0">
@@ -15035,7 +15035,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/has-property-descriptors</property>
+        <property name="cdx:npm:package:path">node_modules/has-property-descriptors</property>
       </properties>
     </component>
     <component type="library" bom-ref="has-symbol-support-x@1.4.2">
@@ -15071,7 +15071,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/has-symbol-support-x</property>
+        <property name="cdx:npm:package:path">node_modules/has-symbol-support-x</property>
       </properties>
     </component>
     <component type="library" bom-ref="has-symbols@1.0.3">
@@ -15107,7 +15107,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/has-symbols</property>
+        <property name="cdx:npm:package:path">node_modules/has-symbols</property>
       </properties>
     </component>
     <component type="library" bom-ref="has-to-string-tag-x@1.4.1">
@@ -15143,7 +15143,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/has-to-string-tag-x</property>
+        <property name="cdx:npm:package:path">node_modules/has-to-string-tag-x</property>
       </properties>
     </component>
     <component type="library" bom-ref="has-tostringtag@1.0.0">
@@ -15179,7 +15179,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/has-tostringtag</property>
+        <property name="cdx:npm:package:path">node_modules/has-tostringtag</property>
       </properties>
     </component>
     <component type="library" bom-ref="has-unicode@2.0.1">
@@ -15215,7 +15215,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/has-unicode</property>
+        <property name="cdx:npm:package:path">node_modules/has-unicode</property>
       </properties>
     </component>
     <component type="library" bom-ref="has-value@1.0.0">
@@ -15251,7 +15251,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/has-value</property>
+        <property name="cdx:npm:package:path">node_modules/has-value</property>
       </properties>
     </component>
     <component type="library" bom-ref="has-values@1.0.0">
@@ -15287,7 +15287,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/has-values</property>
+        <property name="cdx:npm:package:path">node_modules/has-values</property>
       </properties>
       <components>
         <component type="library" bom-ref="has-values@1.0.0|kind-of@4.0.0">
@@ -15323,7 +15323,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/has-values/node_modules/kind-of</property>
+            <property name="cdx:npm:package:path">node_modules/has-values/node_modules/kind-of</property>
           </properties>
         </component>
       </components>
@@ -15365,7 +15365,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/has</property>
+        <property name="cdx:npm:package:path">node_modules/has</property>
       </properties>
     </component>
     <component type="library" bom-ref="hashids@2.2.10">
@@ -15401,7 +15401,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/hashids</property>
+        <property name="cdx:npm:package:path">node_modules/hashids</property>
       </properties>
     </component>
     <component type="library" bom-ref="hbs@4.2.0">
@@ -15429,7 +15429,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/hbs</property>
+        <property name="cdx:npm:package:path">node_modules/hbs</property>
       </properties>
     </component>
     <component type="library" bom-ref="he@0.4.1">
@@ -15466,7 +15466,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/he</property>
+        <property name="cdx:npm:package:path">node_modules/he</property>
       </properties>
     </component>
     <component type="library" bom-ref="heap@0.2.7">
@@ -15498,7 +15498,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/heap</property>
+        <property name="cdx:npm:package:path">node_modules/heap</property>
       </properties>
     </component>
     <component type="library" bom-ref="helmet@4.6.0">
@@ -15534,7 +15534,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/helmet</property>
+        <property name="cdx:npm:package:path">node_modules/helmet</property>
       </properties>
     </component>
     <component type="library" bom-ref="hoister@0.0.2">
@@ -15566,7 +15566,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/hoister</property>
+        <property name="cdx:npm:package:path">node_modules/hoister</property>
       </properties>
     </component>
     <component type="library" bom-ref="homedir-polyfill@1.0.3">
@@ -15602,7 +15602,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/homedir-polyfill</property>
+        <property name="cdx:npm:package:path">node_modules/homedir-polyfill</property>
       </properties>
     </component>
     <component type="library" bom-ref="hooker@0.2.3">
@@ -15639,7 +15639,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/hooker</property>
+        <property name="cdx:npm:package:path">node_modules/hooker</property>
       </properties>
     </component>
     <component type="library" bom-ref="hosted-git-info@2.8.9">
@@ -15675,7 +15675,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/hosted-git-info</property>
+        <property name="cdx:npm:package:path">node_modules/hosted-git-info</property>
       </properties>
     </component>
     <component type="library" bom-ref="html-entities@1.4.0">
@@ -15703,7 +15703,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/html-entities</property>
+        <property name="cdx:npm:package:path">node_modules/html-entities</property>
       </properties>
     </component>
     <component type="library" bom-ref="htmlparser2@3.3.0">
@@ -15736,7 +15736,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/htmlparser2</property>
+        <property name="cdx:npm:package:path">node_modules/htmlparser2</property>
       </properties>
       <components>
         <component type="library" bom-ref="htmlparser2@3.3.0|isarray@0.0.1">
@@ -15768,7 +15768,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/htmlparser2/node_modules/isarray</property>
+            <property name="cdx:npm:package:path">node_modules/htmlparser2/node_modules/isarray</property>
           </properties>
         </component>
         <component type="library" bom-ref="htmlparser2@3.3.0|readable-stream@1.0.34">
@@ -15796,7 +15796,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/htmlparser2/node_modules/readable-stream</property>
+            <property name="cdx:npm:package:path">node_modules/htmlparser2/node_modules/readable-stream</property>
           </properties>
         </component>
         <component type="library" bom-ref="htmlparser2@3.3.0|string_decoder@0.10.31">
@@ -15827,7 +15827,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/htmlparser2/node_modules/string_decoder</property>
+            <property name="cdx:npm:package:path">node_modules/htmlparser2/node_modules/string_decoder</property>
           </properties>
         </component>
       </components>
@@ -15857,7 +15857,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/http-cache-semantics</property>
+        <property name="cdx:npm:package:path">node_modules/http-cache-semantics</property>
       </properties>
     </component>
     <component type="library" bom-ref="http-errors@2.0.0">
@@ -15885,7 +15885,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/http-errors</property>
+        <property name="cdx:npm:package:path">node_modules/http-errors</property>
       </properties>
     </component>
     <component type="library" bom-ref="http-proxy-agent@5.0.0">
@@ -15917,7 +15917,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/http-proxy-agent</property>
+        <property name="cdx:npm:package:path">node_modules/http-proxy-agent</property>
       </properties>
       <components>
         <component type="library" bom-ref="http-proxy-agent@5.0.0|debug@4.3.4">
@@ -15945,7 +15945,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/http-proxy-agent/node_modules/debug</property>
+            <property name="cdx:npm:package:path">node_modules/http-proxy-agent/node_modules/debug</property>
           </properties>
         </component>
         <component type="library" bom-ref="http-proxy-agent@5.0.0|ms@2.1.2">
@@ -15972,7 +15972,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/http-proxy-agent/node_modules/ms</property>
+            <property name="cdx:npm:package:path">node_modules/http-proxy-agent/node_modules/ms</property>
           </properties>
         </component>
       </components>
@@ -16010,7 +16010,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/http-signature</property>
+        <property name="cdx:npm:package:path">node_modules/http-signature</property>
       </properties>
     </component>
     <component type="library" bom-ref="https-proxy-agent@5.0.1">
@@ -16042,7 +16042,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/https-proxy-agent</property>
+        <property name="cdx:npm:package:path">node_modules/https-proxy-agent</property>
       </properties>
       <components>
         <component type="library" bom-ref="https-proxy-agent@5.0.1|debug@4.3.4">
@@ -16070,7 +16070,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/https-proxy-agent/node_modules/debug</property>
+            <property name="cdx:npm:package:path">node_modules/https-proxy-agent/node_modules/debug</property>
           </properties>
         </component>
         <component type="library" bom-ref="https-proxy-agent@5.0.1|ms@2.1.2">
@@ -16097,7 +16097,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/https-proxy-agent/node_modules/ms</property>
+            <property name="cdx:npm:package:path">node_modules/https-proxy-agent/node_modules/ms</property>
           </properties>
         </component>
       </components>
@@ -16127,7 +16127,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/humanize-ms</property>
+        <property name="cdx:npm:package:path">node_modules/humanize-ms</property>
       </properties>
     </component>
     <component type="library" bom-ref="i18n@0.11.1">
@@ -16159,7 +16159,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/i18n</property>
+        <property name="cdx:npm:package:path">node_modules/i18n</property>
       </properties>
     </component>
     <component type="library" bom-ref="iconv-lite@0.4.24">
@@ -16195,7 +16195,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/iconv-lite</property>
+        <property name="cdx:npm:package:path">node_modules/iconv-lite</property>
       </properties>
     </component>
     <component type="library" bom-ref="ieee754@1.2.1">
@@ -16223,7 +16223,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/ieee754</property>
+        <property name="cdx:npm:package:path">node_modules/ieee754</property>
       </properties>
     </component>
     <component type="library" bom-ref="ignore-walk@3.0.4">
@@ -16251,7 +16251,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/ignore-walk</property>
+        <property name="cdx:npm:package:path">node_modules/ignore-walk</property>
       </properties>
       <components>
         <component type="library" bom-ref="ignore-walk@3.0.4|brace-expansion@1.1.11">
@@ -16283,7 +16283,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/ignore-walk/node_modules/brace-expansion</property>
+            <property name="cdx:npm:package:path">node_modules/ignore-walk/node_modules/brace-expansion</property>
           </properties>
         </component>
         <component type="library" bom-ref="ignore-walk@3.0.4|minimatch@3.1.2">
@@ -16311,7 +16311,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/ignore-walk/node_modules/minimatch</property>
+            <property name="cdx:npm:package:path">node_modules/ignore-walk/node_modules/minimatch</property>
           </properties>
         </component>
       </components>
@@ -16348,7 +16348,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/iltorb</property>
+        <property name="cdx:npm:package:path">node_modules/iltorb</property>
       </properties>
     </component>
     <component type="library" bom-ref="imurmurhash@0.1.4">
@@ -16384,7 +16384,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/imurmurhash</property>
+        <property name="cdx:npm:package:path">node_modules/imurmurhash</property>
       </properties>
     </component>
     <component type="library" bom-ref="indent-string@4.0.0">
@@ -16412,7 +16412,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/indent-string</property>
+        <property name="cdx:npm:package:path">node_modules/indent-string</property>
       </properties>
     </component>
     <component type="library" bom-ref="infer-owner@1.0.4">
@@ -16440,7 +16440,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/infer-owner</property>
+        <property name="cdx:npm:package:path">node_modules/infer-owner</property>
       </properties>
     </component>
     <component type="library" bom-ref="inflection@1.13.4">
@@ -16468,7 +16468,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/inflection</property>
+        <property name="cdx:npm:package:path">node_modules/inflection</property>
       </properties>
     </component>
     <component type="library" bom-ref="inflight@1.0.6">
@@ -16504,7 +16504,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/inflight</property>
+        <property name="cdx:npm:package:path">node_modules/inflight</property>
       </properties>
     </component>
     <component type="library" bom-ref="inherits@2.0.4">
@@ -16531,7 +16531,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/inherits</property>
+        <property name="cdx:npm:package:path">node_modules/inherits</property>
       </properties>
     </component>
     <component type="library" bom-ref="ini@1.3.8">
@@ -16559,7 +16559,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/ini</property>
+        <property name="cdx:npm:package:path">node_modules/ini</property>
       </properties>
     </component>
     <component type="library" bom-ref="interpret@1.1.0">
@@ -16595,7 +16595,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/interpret</property>
+        <property name="cdx:npm:package:path">node_modules/interpret</property>
       </properties>
     </component>
     <component type="library" bom-ref="into-stream@3.1.0">
@@ -16623,7 +16623,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/into-stream</property>
+        <property name="cdx:npm:package:path">node_modules/into-stream</property>
       </properties>
     </component>
     <component type="library" bom-ref="invariant@2.2.4">
@@ -16651,7 +16651,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/invariant</property>
+        <property name="cdx:npm:package:path">node_modules/invariant</property>
       </properties>
     </component>
     <component type="library" bom-ref="ip@1.1.8">
@@ -16682,7 +16682,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/ip</property>
+        <property name="cdx:npm:package:path">node_modules/ip</property>
       </properties>
     </component>
     <component type="library" bom-ref="ip6@0.2.10">
@@ -16718,7 +16718,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/ip6</property>
+        <property name="cdx:npm:package:path">node_modules/ip6</property>
       </properties>
     </component>
     <component type="library" bom-ref="ipaddr.js@1.9.1">
@@ -16746,7 +16746,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/ipaddr.js</property>
+        <property name="cdx:npm:package:path">node_modules/ipaddr.js</property>
       </properties>
     </component>
     <component type="library" bom-ref="is-absolute@1.0.0">
@@ -16782,7 +16782,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/is-absolute</property>
+        <property name="cdx:npm:package:path">node_modules/is-absolute</property>
       </properties>
     </component>
     <component type="library" bom-ref="is-accessor-descriptor@1.0.0">
@@ -16818,7 +16818,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/is-accessor-descriptor</property>
+        <property name="cdx:npm:package:path">node_modules/is-accessor-descriptor</property>
       </properties>
     </component>
     <component type="library" bom-ref="is-arguments@1.1.1">
@@ -16854,7 +16854,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/is-arguments</property>
+        <property name="cdx:npm:package:path">node_modules/is-arguments</property>
       </properties>
     </component>
     <component type="library" bom-ref="is-arrayish@0.2.1">
@@ -16882,7 +16882,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/is-arrayish</property>
+        <property name="cdx:npm:package:path">node_modules/is-arrayish</property>
       </properties>
     </component>
     <component type="library" bom-ref="is-bigint@1.0.4">
@@ -16918,7 +16918,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/is-bigint</property>
+        <property name="cdx:npm:package:path">node_modules/is-bigint</property>
       </properties>
     </component>
     <component type="library" bom-ref="is-binary-path@2.1.0">
@@ -16946,7 +16946,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/is-binary-path</property>
+        <property name="cdx:npm:package:path">node_modules/is-binary-path</property>
       </properties>
     </component>
     <component type="library" bom-ref="is-boolean-object@1.1.2">
@@ -16974,7 +16974,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/is-boolean-object</property>
+        <property name="cdx:npm:package:path">node_modules/is-boolean-object</property>
       </properties>
     </component>
     <component type="library" bom-ref="is-buffer@1.1.6">
@@ -17006,7 +17006,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/is-buffer</property>
+        <property name="cdx:npm:package:path">node_modules/is-buffer</property>
       </properties>
     </component>
     <component type="library" bom-ref="is-callable@1.2.7">
@@ -17034,7 +17034,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/is-callable</property>
+        <property name="cdx:npm:package:path">node_modules/is-callable</property>
       </properties>
     </component>
     <component type="library" bom-ref="is-core-module@2.11.0">
@@ -17070,7 +17070,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/is-core-module</property>
+        <property name="cdx:npm:package:path">node_modules/is-core-module</property>
       </properties>
     </component>
     <component type="library" bom-ref="is-data-descriptor@1.0.0">
@@ -17106,7 +17106,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/is-data-descriptor</property>
+        <property name="cdx:npm:package:path">node_modules/is-data-descriptor</property>
       </properties>
     </component>
     <component type="library" bom-ref="is-date-object@1.0.5">
@@ -17134,7 +17134,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/is-date-object</property>
+        <property name="cdx:npm:package:path">node_modules/is-date-object</property>
       </properties>
     </component>
     <component type="library" bom-ref="is-descriptor@1.0.2">
@@ -17170,7 +17170,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/is-descriptor</property>
+        <property name="cdx:npm:package:path">node_modules/is-descriptor</property>
       </properties>
     </component>
     <component type="library" bom-ref="is-docker@2.2.1">
@@ -17198,7 +17198,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/is-docker</property>
+        <property name="cdx:npm:package:path">node_modules/is-docker</property>
       </properties>
     </component>
     <component type="library" bom-ref="is-expression@4.0.0">
@@ -17226,7 +17226,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/is-expression</property>
+        <property name="cdx:npm:package:path">node_modules/is-expression</property>
       </properties>
     </component>
     <component type="library" bom-ref="is-extendable@1.0.1">
@@ -17262,7 +17262,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/is-extendable</property>
+        <property name="cdx:npm:package:path">node_modules/is-extendable</property>
       </properties>
     </component>
     <component type="library" bom-ref="is-extglob@2.1.1">
@@ -17298,7 +17298,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/is-extglob</property>
+        <property name="cdx:npm:package:path">node_modules/is-extglob</property>
       </properties>
     </component>
     <component type="library" bom-ref="is-fullwidth-code-point@1.0.0">
@@ -17326,7 +17326,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/is-fullwidth-code-point</property>
+        <property name="cdx:npm:package:path">node_modules/is-fullwidth-code-point</property>
       </properties>
     </component>
     <component type="library" bom-ref="is-generator-function@1.0.10">
@@ -17358,7 +17358,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/is-generator-function</property>
+        <property name="cdx:npm:package:path">node_modules/is-generator-function</property>
       </properties>
     </component>
     <component type="library" bom-ref="is-glob@3.1.0">
@@ -17394,7 +17394,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/is-glob</property>
+        <property name="cdx:npm:package:path">node_modules/is-glob</property>
       </properties>
     </component>
     <component type="library" bom-ref="is-heroku@2.0.0">
@@ -17422,7 +17422,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/is-heroku</property>
+        <property name="cdx:npm:package:path">node_modules/is-heroku</property>
       </properties>
     </component>
     <component type="library" bom-ref="is-lambda@1.0.1">
@@ -17458,7 +17458,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/is-lambda</property>
+        <property name="cdx:npm:package:path">node_modules/is-lambda</property>
       </properties>
     </component>
     <component type="library" bom-ref="is-map@2.0.2">
@@ -17494,7 +17494,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/is-map</property>
+        <property name="cdx:npm:package:path">node_modules/is-map</property>
       </properties>
     </component>
     <component type="library" bom-ref="is-natural-number@4.0.1">
@@ -17522,7 +17522,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/is-natural-number</property>
+        <property name="cdx:npm:package:path">node_modules/is-natural-number</property>
       </properties>
     </component>
     <component type="library" bom-ref="is-number-like@1.0.8">
@@ -17558,7 +17558,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/is-number-like</property>
+        <property name="cdx:npm:package:path">node_modules/is-number-like</property>
       </properties>
     </component>
     <component type="library" bom-ref="is-number-object@1.0.7">
@@ -17594,7 +17594,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/is-number-object</property>
+        <property name="cdx:npm:package:path">node_modules/is-number-object</property>
       </properties>
     </component>
     <component type="library" bom-ref="is-number@3.0.0">
@@ -17630,7 +17630,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/is-number</property>
+        <property name="cdx:npm:package:path">node_modules/is-number</property>
       </properties>
       <components>
         <component type="library" bom-ref="is-number@3.0.0|kind-of@3.2.2">
@@ -17666,7 +17666,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/is-number/node_modules/kind-of</property>
+            <property name="cdx:npm:package:path">node_modules/is-number/node_modules/kind-of</property>
           </properties>
         </component>
       </components>
@@ -17708,7 +17708,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/is-object</property>
+        <property name="cdx:npm:package:path">node_modules/is-object</property>
       </properties>
     </component>
     <component type="library" bom-ref="is-plain-obj@1.1.0">
@@ -17736,7 +17736,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/is-plain-obj</property>
+        <property name="cdx:npm:package:path">node_modules/is-plain-obj</property>
       </properties>
     </component>
     <component type="library" bom-ref="is-plain-object@2.0.4">
@@ -17772,7 +17772,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/is-plain-object</property>
+        <property name="cdx:npm:package:path">node_modules/is-plain-object</property>
       </properties>
     </component>
     <component type="library" bom-ref="is-promise@2.2.2">
@@ -17800,7 +17800,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/is-promise</property>
+        <property name="cdx:npm:package:path">node_modules/is-promise</property>
       </properties>
     </component>
     <component type="library" bom-ref="is-regex@1.1.4">
@@ -17836,7 +17836,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/is-regex</property>
+        <property name="cdx:npm:package:path">node_modules/is-regex</property>
       </properties>
     </component>
     <component type="library" bom-ref="is-relative@1.0.0">
@@ -17872,7 +17872,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/is-relative</property>
+        <property name="cdx:npm:package:path">node_modules/is-relative</property>
       </properties>
     </component>
     <component type="library" bom-ref="is-retry-allowed@1.2.0">
@@ -17900,7 +17900,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/is-retry-allowed</property>
+        <property name="cdx:npm:package:path">node_modules/is-retry-allowed</property>
       </properties>
     </component>
     <component type="library" bom-ref="is-set@2.0.2">
@@ -17936,7 +17936,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/is-set</property>
+        <property name="cdx:npm:package:path">node_modules/is-set</property>
       </properties>
     </component>
     <component type="library" bom-ref="is-stream@1.1.0">
@@ -17964,7 +17964,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/is-stream</property>
+        <property name="cdx:npm:package:path">node_modules/is-stream</property>
       </properties>
     </component>
     <component type="library" bom-ref="is-string@1.0.7">
@@ -17992,7 +17992,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/is-string</property>
+        <property name="cdx:npm:package:path">node_modules/is-string</property>
       </properties>
     </component>
     <component type="library" bom-ref="is-symbol@1.0.4">
@@ -18024,7 +18024,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/is-symbol</property>
+        <property name="cdx:npm:package:path">node_modules/is-symbol</property>
       </properties>
     </component>
     <component type="library" bom-ref="is-typed-array@1.1.10">
@@ -18052,7 +18052,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/is-typed-array</property>
+        <property name="cdx:npm:package:path">node_modules/is-typed-array</property>
       </properties>
     </component>
     <component type="library" bom-ref="is-typedarray@1.0.0">
@@ -18088,7 +18088,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/is-typedarray</property>
+        <property name="cdx:npm:package:path">node_modules/is-typedarray</property>
       </properties>
     </component>
     <component type="library" bom-ref="is-unc-path@1.0.0">
@@ -18124,7 +18124,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/is-unc-path</property>
+        <property name="cdx:npm:package:path">node_modules/is-unc-path</property>
       </properties>
     </component>
     <component type="library" bom-ref="is-weakmap@2.0.1">
@@ -18160,7 +18160,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/is-weakmap</property>
+        <property name="cdx:npm:package:path">node_modules/is-weakmap</property>
       </properties>
     </component>
     <component type="library" bom-ref="is-weakset@2.0.2">
@@ -18196,7 +18196,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/is-weakset</property>
+        <property name="cdx:npm:package:path">node_modules/is-weakset</property>
       </properties>
     </component>
     <component type="library" bom-ref="is-windows@1.0.2">
@@ -18232,7 +18232,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/is-windows</property>
+        <property name="cdx:npm:package:path">node_modules/is-windows</property>
       </properties>
     </component>
     <component type="library" bom-ref="isarray@2.0.5">
@@ -18264,7 +18264,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/isarray</property>
+        <property name="cdx:npm:package:path">node_modules/isarray</property>
       </properties>
     </component>
     <component type="library" bom-ref="isexe@2.0.0">
@@ -18300,7 +18300,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/isexe</property>
+        <property name="cdx:npm:package:path">node_modules/isexe</property>
       </properties>
     </component>
     <component type="library" bom-ref="isobject@3.0.1">
@@ -18336,7 +18336,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/isobject</property>
+        <property name="cdx:npm:package:path">node_modules/isobject</property>
       </properties>
     </component>
     <component type="library" bom-ref="isstream@0.1.2">
@@ -18372,7 +18372,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/isstream</property>
+        <property name="cdx:npm:package:path">node_modules/isstream</property>
       </properties>
     </component>
     <component type="library" bom-ref="isurl@1.0.0">
@@ -18400,7 +18400,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/isurl</property>
+        <property name="cdx:npm:package:path">node_modules/isurl</property>
       </properties>
     </component>
     <component type="library" bom-ref="js-stringify@1.0.2">
@@ -18428,7 +18428,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/js-stringify</property>
+        <property name="cdx:npm:package:path">node_modules/js-stringify</property>
       </properties>
     </component>
     <component type="library" bom-ref="js-tokens@4.0.0">
@@ -18456,7 +18456,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/js-tokens</property>
+        <property name="cdx:npm:package:path">node_modules/js-tokens</property>
       </properties>
     </component>
     <component type="library" bom-ref="js-yaml@3.14.1">
@@ -18488,7 +18488,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/js-yaml</property>
+        <property name="cdx:npm:package:path">node_modules/js-yaml</property>
       </properties>
     </component>
     <component type="library" bom-ref="jsbn@0.1.1">
@@ -18516,7 +18516,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/jsbn</property>
+        <property name="cdx:npm:package:path">node_modules/jsbn</property>
       </properties>
     </component>
     <component type="library" bom-ref="json-buffer@3.0.0">
@@ -18548,7 +18548,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/json-buffer</property>
+        <property name="cdx:npm:package:path">node_modules/json-buffer</property>
       </properties>
     </component>
     <component type="library" bom-ref="json-parse-better-errors@1.0.2">
@@ -18576,7 +18576,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/json-parse-better-errors</property>
+        <property name="cdx:npm:package:path">node_modules/json-parse-better-errors</property>
       </properties>
     </component>
     <component type="library" bom-ref="json-schema-traverse@0.4.1">
@@ -18612,7 +18612,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/json-schema-traverse</property>
+        <property name="cdx:npm:package:path">node_modules/json-schema-traverse</property>
       </properties>
     </component>
     <component type="library" bom-ref="json-schema@0.4.0">
@@ -18638,7 +18638,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/json-schema</property>
+        <property name="cdx:npm:package:path">node_modules/json-schema</property>
       </properties>
     </component>
     <component type="library" bom-ref="json-stringify-safe@5.0.1">
@@ -18674,7 +18674,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/json-stringify-safe</property>
+        <property name="cdx:npm:package:path">node_modules/json-stringify-safe</property>
       </properties>
     </component>
     <component type="library" bom-ref="json5@2.2.1">
@@ -18710,7 +18710,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/json5</property>
+        <property name="cdx:npm:package:path">node_modules/json5</property>
       </properties>
     </component>
     <component type="library" bom-ref="jsonfile@6.1.0">
@@ -18734,7 +18734,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/jsonfile</property>
+        <property name="cdx:npm:package:path">node_modules/jsonfile</property>
       </properties>
     </component>
     <component type="library" bom-ref="jsonwebtoken@0.4.0">
@@ -18766,7 +18766,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/jsonwebtoken</property>
+        <property name="cdx:npm:package:path">node_modules/jsonwebtoken</property>
       </properties>
     </component>
     <component type="library" bom-ref="jsprim@1.4.2">
@@ -18793,7 +18793,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/jsprim</property>
+        <property name="cdx:npm:package:path">node_modules/jsprim</property>
       </properties>
     </component>
     <component type="library" bom-ref="jssha@3.3.0">
@@ -18829,7 +18829,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/jssha</property>
+        <property name="cdx:npm:package:path">node_modules/jssha</property>
       </properties>
     </component>
     <component type="library" bom-ref="jstransformer@1.0.0">
@@ -18857,7 +18857,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/jstransformer</property>
+        <property name="cdx:npm:package:path">node_modules/jstransformer</property>
       </properties>
     </component>
     <component type="library" bom-ref="juicy-chat-bot@0.6.6">
@@ -18893,7 +18893,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/juicy-chat-bot</property>
+        <property name="cdx:npm:package:path">node_modules/juicy-chat-bot</property>
       </properties>
     </component>
     <component type="library" bom-ref="jwa@0.0.1">
@@ -18921,7 +18921,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/jwa</property>
+        <property name="cdx:npm:package:path">node_modules/jwa</property>
       </properties>
     </component>
     <component type="library" bom-ref="jws@0.2.6">
@@ -18949,7 +18949,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/jws</property>
+        <property name="cdx:npm:package:path">node_modules/jws</property>
       </properties>
     </component>
     <component type="library" bom-ref="keyv@3.0.0">
@@ -18985,7 +18985,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/keyv</property>
+        <property name="cdx:npm:package:path">node_modules/keyv</property>
       </properties>
     </component>
     <component type="library" bom-ref="kind-of@6.0.3">
@@ -19021,7 +19021,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/kind-of</property>
+        <property name="cdx:npm:package:path">node_modules/kind-of</property>
       </properties>
     </component>
     <component type="library" bom-ref="kuler@2.0.0">
@@ -19057,7 +19057,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/kuler</property>
+        <property name="cdx:npm:package:path">node_modules/kuler</property>
       </properties>
     </component>
     <component type="library" bom-ref="kuromoji@0.1.2">
@@ -19093,7 +19093,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/kuromoji</property>
+        <property name="cdx:npm:package:path">node_modules/kuromoji</property>
       </properties>
     </component>
     <component type="library" bom-ref="lazystream@1.0.1">
@@ -19129,7 +19129,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/lazystream</property>
+        <property name="cdx:npm:package:path">node_modules/lazystream</property>
       </properties>
     </component>
     <component type="library" bom-ref="levn@0.3.0">
@@ -19165,7 +19165,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/levn</property>
+        <property name="cdx:npm:package:path">node_modules/levn</property>
       </properties>
     </component>
     <component type="library" bom-ref="libxmljs2@0.30.1">
@@ -19197,7 +19197,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/libxmljs2</property>
+        <property name="cdx:npm:package:path">node_modules/libxmljs2</property>
       </properties>
       <components>
         <component type="library" bom-ref="libxmljs2@0.30.1|nan@2.15.0">
@@ -19224,7 +19224,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/libxmljs2/node_modules/nan</property>
+            <property name="cdx:npm:package:path">node_modules/libxmljs2/node_modules/nan</property>
           </properties>
         </component>
       </components>
@@ -19254,7 +19254,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/liftup</property>
+        <property name="cdx:npm:package:path">node_modules/liftup</property>
       </properties>
       <components>
         <component type="library" bom-ref="liftup@3.0.1|braces@3.0.2">
@@ -19290,7 +19290,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/liftup/node_modules/braces</property>
+            <property name="cdx:npm:package:path">node_modules/liftup/node_modules/braces</property>
           </properties>
         </component>
         <component type="library" bom-ref="liftup@3.0.1|fill-range@7.0.1">
@@ -19326,7 +19326,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/liftup/node_modules/fill-range</property>
+            <property name="cdx:npm:package:path">node_modules/liftup/node_modules/fill-range</property>
           </properties>
         </component>
         <component type="library" bom-ref="liftup@3.0.1|findup-sync@4.0.0">
@@ -19354,7 +19354,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/liftup/node_modules/findup-sync</property>
+            <property name="cdx:npm:package:path">node_modules/liftup/node_modules/findup-sync</property>
           </properties>
         </component>
         <component type="library" bom-ref="liftup@3.0.1|is-glob@4.0.3">
@@ -19390,7 +19390,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/liftup/node_modules/is-glob</property>
+            <property name="cdx:npm:package:path">node_modules/liftup/node_modules/is-glob</property>
           </properties>
         </component>
         <component type="library" bom-ref="liftup@3.0.1|is-number@7.0.0">
@@ -19426,7 +19426,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/liftup/node_modules/is-number</property>
+            <property name="cdx:npm:package:path">node_modules/liftup/node_modules/is-number</property>
           </properties>
         </component>
         <component type="library" bom-ref="liftup@3.0.1|micromatch@4.0.5">
@@ -19462,7 +19462,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/liftup/node_modules/micromatch</property>
+            <property name="cdx:npm:package:path">node_modules/liftup/node_modules/micromatch</property>
           </properties>
         </component>
         <component type="library" bom-ref="liftup@3.0.1|to-regex-range@5.0.1">
@@ -19498,7 +19498,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/liftup/node_modules/to-regex-range</property>
+            <property name="cdx:npm:package:path">node_modules/liftup/node_modules/to-regex-range</property>
           </properties>
         </component>
       </components>
@@ -19536,7 +19536,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/linebreak</property>
+        <property name="cdx:npm:package:path">node_modules/linebreak</property>
       </properties>
       <components>
         <component type="library" bom-ref="linebreak@1.1.0|base64-js@0.0.8">
@@ -19564,7 +19564,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/linebreak/node_modules/base64-js</property>
+            <property name="cdx:npm:package:path">node_modules/linebreak/node_modules/base64-js</property>
           </properties>
         </component>
       </components>
@@ -19590,7 +19590,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/listenercount</property>
+        <property name="cdx:npm:package:path">node_modules/listenercount</property>
       </properties>
     </component>
     <component type="library" bom-ref="locate-path@3.0.0">
@@ -19618,7 +19618,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/locate-path</property>
+        <property name="cdx:npm:package:path">node_modules/locate-path</property>
       </properties>
     </component>
     <component type="library" bom-ref="lodash.camelcase@4.3.0">
@@ -19650,7 +19650,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/lodash.camelcase</property>
+        <property name="cdx:npm:package:path">node_modules/lodash.camelcase</property>
       </properties>
     </component>
     <component type="library" bom-ref="lodash.isfinite@3.3.2">
@@ -19682,7 +19682,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/lodash.isfinite</property>
+        <property name="cdx:npm:package:path">node_modules/lodash.isfinite</property>
       </properties>
     </component>
     <component type="library" bom-ref="lodash.set@4.3.2">
@@ -19714,7 +19714,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/lodash.set</property>
+        <property name="cdx:npm:package:path">node_modules/lodash.set</property>
       </properties>
     </component>
     <component type="library" bom-ref="lodash@4.17.21">
@@ -19746,7 +19746,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/lodash</property>
+        <property name="cdx:npm:package:path">node_modules/lodash</property>
       </properties>
     </component>
     <component type="library" bom-ref="logform@2.4.2">
@@ -19782,7 +19782,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/logform</property>
+        <property name="cdx:npm:package:path">node_modules/logform</property>
       </properties>
       <components>
         <component type="library" bom-ref="logform@2.4.2|ms@2.1.3">
@@ -19809,7 +19809,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/logform/node_modules/ms</property>
+            <property name="cdx:npm:package:path">node_modules/logform/node_modules/ms</property>
           </properties>
         </component>
       </components>
@@ -19847,7 +19847,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/lolex</property>
+        <property name="cdx:npm:package:path">node_modules/lolex</property>
       </properties>
     </component>
     <component type="library" bom-ref="loose-envify@1.4.0">
@@ -19879,7 +19879,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/loose-envify</property>
+        <property name="cdx:npm:package:path">node_modules/loose-envify</property>
       </properties>
     </component>
     <component type="library" bom-ref="lowercase-keys@1.0.1">
@@ -19907,7 +19907,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/lowercase-keys</property>
+        <property name="cdx:npm:package:path">node_modules/lowercase-keys</property>
       </properties>
     </component>
     <component type="library" bom-ref="lru-cache@6.0.0">
@@ -19935,7 +19935,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/lru-cache</property>
+        <property name="cdx:npm:package:path">node_modules/lru-cache</property>
       </properties>
     </component>
     <component type="library" bom-ref="make-dir@2.1.0">
@@ -19963,7 +19963,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/make-dir</property>
+        <property name="cdx:npm:package:path">node_modules/make-dir</property>
       </properties>
       <components>
         <component type="library" bom-ref="make-dir@2.1.0|semver@5.7.1">
@@ -19990,7 +19990,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/make-dir/node_modules/semver</property>
+            <property name="cdx:npm:package:path">node_modules/make-dir/node_modules/semver</property>
           </properties>
         </component>
       </components>
@@ -20028,7 +20028,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/make-error</property>
+        <property name="cdx:npm:package:path">node_modules/make-error</property>
       </properties>
     </component>
     <component type="library" bom-ref="make-fetch-happen@9.1.0">
@@ -20056,7 +20056,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/make-fetch-happen</property>
+        <property name="cdx:npm:package:path">node_modules/make-fetch-happen</property>
       </properties>
       <components>
         <component type="library" bom-ref="make-fetch-happen@9.1.0|@tootallnate/once@1.1.2">
@@ -20089,7 +20089,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/make-fetch-happen/node_modules/@tootallnate/once</property>
+            <property name="cdx:npm:package:path">node_modules/make-fetch-happen/node_modules/@tootallnate/once</property>
           </properties>
         </component>
         <component type="library" bom-ref="make-fetch-happen@9.1.0|debug@4.3.4">
@@ -20117,7 +20117,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/make-fetch-happen/node_modules/debug</property>
+            <property name="cdx:npm:package:path">node_modules/make-fetch-happen/node_modules/debug</property>
           </properties>
         </component>
         <component type="library" bom-ref="make-fetch-happen@9.1.0|http-cache-semantics@4.1.0">
@@ -20145,7 +20145,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/make-fetch-happen/node_modules/http-cache-semantics</property>
+            <property name="cdx:npm:package:path">node_modules/make-fetch-happen/node_modules/http-cache-semantics</property>
           </properties>
         </component>
         <component type="library" bom-ref="make-fetch-happen@9.1.0|http-proxy-agent@4.0.1">
@@ -20177,7 +20177,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/make-fetch-happen/node_modules/http-proxy-agent</property>
+            <property name="cdx:npm:package:path">node_modules/make-fetch-happen/node_modules/http-proxy-agent</property>
           </properties>
         </component>
         <component type="library" bom-ref="make-fetch-happen@9.1.0|ms@2.1.2">
@@ -20204,7 +20204,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/make-fetch-happen/node_modules/ms</property>
+            <property name="cdx:npm:package:path">node_modules/make-fetch-happen/node_modules/ms</property>
           </properties>
         </component>
       </components>
@@ -20242,7 +20242,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/make-iterator</property>
+        <property name="cdx:npm:package:path">node_modules/make-iterator</property>
       </properties>
     </component>
     <component type="library" bom-ref="make-plural@6.2.2">
@@ -20278,7 +20278,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/make-plural</property>
+        <property name="cdx:npm:package:path">node_modules/make-plural</property>
       </properties>
     </component>
     <component type="library" bom-ref="map-cache@0.2.2">
@@ -20314,7 +20314,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/map-cache</property>
+        <property name="cdx:npm:package:path">node_modules/map-cache</property>
       </properties>
     </component>
     <component type="library" bom-ref="map-visit@1.0.0">
@@ -20350,7 +20350,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/map-visit</property>
+        <property name="cdx:npm:package:path">node_modules/map-visit</property>
       </properties>
     </component>
     <component type="library" bom-ref="marsdb@0.6.11">
@@ -20378,7 +20378,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/marsdb</property>
+        <property name="cdx:npm:package:path">node_modules/marsdb</property>
       </properties>
     </component>
     <component type="library" bom-ref="math-interval-parser@2.0.1">
@@ -20406,7 +20406,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/math-interval-parser</property>
+        <property name="cdx:npm:package:path">node_modules/math-interval-parser</property>
       </properties>
     </component>
     <component type="library" bom-ref="media-typer@0.3.0">
@@ -20434,7 +20434,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/media-typer</property>
+        <property name="cdx:npm:package:path">node_modules/media-typer</property>
       </properties>
     </component>
     <component type="library" bom-ref="merge-descriptors@1.0.1">
@@ -20462,7 +20462,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/merge-descriptors</property>
+        <property name="cdx:npm:package:path">node_modules/merge-descriptors</property>
       </properties>
     </component>
     <component type="library" bom-ref="messageformat-formatters@2.0.1">
@@ -20494,7 +20494,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/messageformat-formatters</property>
+        <property name="cdx:npm:package:path">node_modules/messageformat-formatters</property>
       </properties>
     </component>
     <component type="library" bom-ref="messageformat-parser@4.1.3">
@@ -20525,7 +20525,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/messageformat-parser</property>
+        <property name="cdx:npm:package:path">node_modules/messageformat-parser</property>
       </properties>
     </component>
     <component type="library" bom-ref="messageformat@2.3.0">
@@ -20557,7 +20557,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/messageformat</property>
+        <property name="cdx:npm:package:path">node_modules/messageformat</property>
       </properties>
       <components>
         <component type="library" bom-ref="messageformat@2.3.0|make-plural@4.3.0">
@@ -20593,7 +20593,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/messageformat/node_modules/make-plural</property>
+            <property name="cdx:npm:package:path">node_modules/messageformat/node_modules/make-plural</property>
           </properties>
         </component>
       </components>
@@ -20622,7 +20622,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/methods</property>
+        <property name="cdx:npm:package:path">node_modules/methods</property>
       </properties>
     </component>
     <component type="library" bom-ref="micromatch@3.1.10">
@@ -20658,7 +20658,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/micromatch</property>
+        <property name="cdx:npm:package:path">node_modules/micromatch</property>
       </properties>
     </component>
     <component type="library" bom-ref="mime-db@1.52.0">
@@ -20685,7 +20685,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/mime-db</property>
+        <property name="cdx:npm:package:path">node_modules/mime-db</property>
       </properties>
     </component>
     <component type="library" bom-ref="mime-types@2.1.35">
@@ -20712,7 +20712,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/mime-types</property>
+        <property name="cdx:npm:package:path">node_modules/mime-types</property>
       </properties>
     </component>
     <component type="library" bom-ref="mime@1.6.0">
@@ -20740,7 +20740,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/mime</property>
+        <property name="cdx:npm:package:path">node_modules/mime</property>
       </properties>
     </component>
     <component type="library" bom-ref="mimic-response@1.0.1">
@@ -20768,7 +20768,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/mimic-response</property>
+        <property name="cdx:npm:package:path">node_modules/mimic-response</property>
       </properties>
     </component>
     <component type="library" bom-ref="minimatch@5.1.0">
@@ -20796,7 +20796,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/minimatch</property>
+        <property name="cdx:npm:package:path">node_modules/minimatch</property>
       </properties>
     </component>
     <component type="library" bom-ref="minimist@1.2.7">
@@ -20828,7 +20828,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/minimist</property>
+        <property name="cdx:npm:package:path">node_modules/minimist</property>
       </properties>
     </component>
     <component type="library" bom-ref="minipass-collect@1.0.2">
@@ -20852,7 +20852,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/minipass-collect</property>
+        <property name="cdx:npm:package:path">node_modules/minipass-collect</property>
       </properties>
     </component>
     <component type="library" bom-ref="minipass-fetch@1.4.1">
@@ -20879,7 +20879,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/minipass-fetch</property>
+        <property name="cdx:npm:package:path">node_modules/minipass-fetch</property>
       </properties>
     </component>
     <component type="library" bom-ref="minipass-flush@1.0.5">
@@ -20907,7 +20907,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/minipass-flush</property>
+        <property name="cdx:npm:package:path">node_modules/minipass-flush</property>
       </properties>
     </component>
     <component type="library" bom-ref="minipass-pipeline@1.2.4">
@@ -20931,7 +20931,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/minipass-pipeline</property>
+        <property name="cdx:npm:package:path">node_modules/minipass-pipeline</property>
       </properties>
     </component>
     <component type="library" bom-ref="minipass-sized@1.0.3">
@@ -20959,7 +20959,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/minipass-sized</property>
+        <property name="cdx:npm:package:path">node_modules/minipass-sized</property>
       </properties>
     </component>
     <component type="library" bom-ref="minipass@3.3.4">
@@ -20987,7 +20987,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/minipass</property>
+        <property name="cdx:npm:package:path">node_modules/minipass</property>
       </properties>
     </component>
     <component type="library" bom-ref="minizlib@2.1.2">
@@ -21015,7 +21015,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/minizlib</property>
+        <property name="cdx:npm:package:path">node_modules/minizlib</property>
       </properties>
     </component>
     <component type="library" bom-ref="mixin-deep@1.3.2">
@@ -21051,7 +21051,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/mixin-deep</property>
+        <property name="cdx:npm:package:path">node_modules/mixin-deep</property>
       </properties>
     </component>
     <component type="library" bom-ref="mkdirp-classic@0.5.3">
@@ -21087,7 +21087,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/mkdirp-classic</property>
+        <property name="cdx:npm:package:path">node_modules/mkdirp-classic</property>
       </properties>
     </component>
     <component type="library" bom-ref="mkdirp@1.0.4">
@@ -21114,7 +21114,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/mkdirp</property>
+        <property name="cdx:npm:package:path">node_modules/mkdirp</property>
       </properties>
     </component>
     <component type="library" bom-ref="moment-timezone@0.5.38">
@@ -21150,7 +21150,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/moment-timezone</property>
+        <property name="cdx:npm:package:path">node_modules/moment-timezone</property>
       </properties>
     </component>
     <component type="library" bom-ref="moment@2.29.4">
@@ -21186,7 +21186,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/moment</property>
+        <property name="cdx:npm:package:path">node_modules/moment</property>
       </properties>
     </component>
     <component type="library" bom-ref="morgan@1.10.0">
@@ -21213,7 +21213,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/morgan</property>
+        <property name="cdx:npm:package:path">node_modules/morgan</property>
       </properties>
       <components>
         <component type="library" bom-ref="morgan@1.10.0|on-finished@2.3.0">
@@ -21240,7 +21240,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/morgan/node_modules/on-finished</property>
+            <property name="cdx:npm:package:path">node_modules/morgan/node_modules/on-finished</property>
           </properties>
         </component>
       </components>
@@ -21278,7 +21278,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/mout</property>
+        <property name="cdx:npm:package:path">node_modules/mout</property>
       </properties>
     </component>
     <component type="library" bom-ref="ms@2.0.0">
@@ -21305,7 +21305,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/ms</property>
+        <property name="cdx:npm:package:path">node_modules/ms</property>
       </properties>
     </component>
     <component type="library" bom-ref="multer@1.4.4">
@@ -21332,7 +21332,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/multer</property>
+        <property name="cdx:npm:package:path">node_modules/multer</property>
       </properties>
       <components>
         <component type="library" bom-ref="multer@1.4.4|mkdirp@0.5.6">
@@ -21360,7 +21360,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/multer/node_modules/mkdirp</property>
+            <property name="cdx:npm:package:path">node_modules/multer/node_modules/mkdirp</property>
           </properties>
         </component>
       </components>
@@ -21394,7 +21394,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/mustache</property>
+        <property name="cdx:npm:package:path">node_modules/mustache</property>
       </properties>
     </component>
     <component type="library" bom-ref="nan@2.17.0">
@@ -21421,7 +21421,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/nan</property>
+        <property name="cdx:npm:package:path">node_modules/nan</property>
       </properties>
     </component>
     <component type="library" bom-ref="nanomatch@1.2.13">
@@ -21457,7 +21457,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/nanomatch</property>
+        <property name="cdx:npm:package:path">node_modules/nanomatch</property>
       </properties>
     </component>
     <component type="library" bom-ref="napi-build-utils@1.0.2">
@@ -21493,7 +21493,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/napi-build-utils</property>
+        <property name="cdx:npm:package:path">node_modules/napi-build-utils</property>
       </properties>
     </component>
     <component type="library" bom-ref="needle@2.9.1">
@@ -21521,7 +21521,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/needle</property>
+        <property name="cdx:npm:package:path">node_modules/needle</property>
       </properties>
       <components>
         <component type="library" bom-ref="needle@2.9.1|debug@3.2.7">
@@ -21549,7 +21549,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/needle/node_modules/debug</property>
+            <property name="cdx:npm:package:path">node_modules/needle/node_modules/debug</property>
           </properties>
         </component>
         <component type="library" bom-ref="needle@2.9.1|ms@2.1.3">
@@ -21576,7 +21576,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/needle/node_modules/ms</property>
+            <property name="cdx:npm:package:path">node_modules/needle/node_modules/ms</property>
           </properties>
         </component>
       </components>
@@ -21605,7 +21605,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/negotiator</property>
+        <property name="cdx:npm:package:path">node_modules/negotiator</property>
       </properties>
     </component>
     <component type="library" bom-ref="neo-async@2.6.2">
@@ -21632,7 +21632,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/neo-async</property>
+        <property name="cdx:npm:package:path">node_modules/neo-async</property>
       </properties>
     </component>
     <component type="library" bom-ref="node-abi@2.30.1">
@@ -21668,7 +21668,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/node-abi</property>
+        <property name="cdx:npm:package:path">node_modules/node-abi</property>
       </properties>
       <components>
         <component type="library" bom-ref="node-abi@2.30.1|semver@5.7.1">
@@ -21695,7 +21695,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/node-abi/node_modules/semver</property>
+            <property name="cdx:npm:package:path">node_modules/node-abi/node_modules/semver</property>
           </properties>
         </component>
       </components>
@@ -21732,7 +21732,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/node-addon-api</property>
+        <property name="cdx:npm:package:path">node_modules/node-addon-api</property>
       </properties>
     </component>
     <component type="library" bom-ref="node-fetch@2.6.7">
@@ -21768,7 +21768,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/node-fetch</property>
+        <property name="cdx:npm:package:path">node_modules/node-fetch</property>
       </properties>
     </component>
     <component type="library" bom-ref="node-gyp@8.4.1">
@@ -21796,7 +21796,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/node-gyp</property>
+        <property name="cdx:npm:package:path">node_modules/node-gyp</property>
       </properties>
       <components>
         <component type="library" bom-ref="node-gyp@8.4.1|ansi-regex@5.0.1">
@@ -21824,7 +21824,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/node-gyp/node_modules/ansi-regex</property>
+            <property name="cdx:npm:package:path">node_modules/node-gyp/node_modules/ansi-regex</property>
           </properties>
         </component>
         <component type="library" bom-ref="node-gyp@8.4.1|are-we-there-yet@3.0.1">
@@ -21860,7 +21860,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/node-gyp/node_modules/are-we-there-yet</property>
+            <property name="cdx:npm:package:path">node_modules/node-gyp/node_modules/are-we-there-yet</property>
           </properties>
         </component>
         <component type="library" bom-ref="node-gyp@8.4.1|gauge@4.0.4">
@@ -21896,7 +21896,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/node-gyp/node_modules/gauge</property>
+            <property name="cdx:npm:package:path">node_modules/node-gyp/node_modules/gauge</property>
           </properties>
         </component>
         <component type="library" bom-ref="node-gyp@8.4.1|is-fullwidth-code-point@3.0.0">
@@ -21924,7 +21924,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/node-gyp/node_modules/is-fullwidth-code-point</property>
+            <property name="cdx:npm:package:path">node_modules/node-gyp/node_modules/is-fullwidth-code-point</property>
           </properties>
         </component>
         <component type="library" bom-ref="node-gyp@8.4.1|nopt@5.0.0">
@@ -21952,7 +21952,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/node-gyp/node_modules/nopt</property>
+            <property name="cdx:npm:package:path">node_modules/node-gyp/node_modules/nopt</property>
           </properties>
         </component>
         <component type="library" bom-ref="node-gyp@8.4.1|npmlog@6.0.2">
@@ -21980,7 +21980,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/node-gyp/node_modules/npmlog</property>
+            <property name="cdx:npm:package:path">node_modules/node-gyp/node_modules/npmlog</property>
           </properties>
         </component>
         <component type="library" bom-ref="node-gyp@8.4.1|readable-stream@3.6.0">
@@ -22007,7 +22007,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/node-gyp/node_modules/readable-stream</property>
+            <property name="cdx:npm:package:path">node_modules/node-gyp/node_modules/readable-stream</property>
           </properties>
         </component>
         <component type="library" bom-ref="node-gyp@8.4.1|string-width@4.2.3">
@@ -22035,7 +22035,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/node-gyp/node_modules/string-width</property>
+            <property name="cdx:npm:package:path">node_modules/node-gyp/node_modules/string-width</property>
           </properties>
         </component>
         <component type="library" bom-ref="node-gyp@8.4.1|strip-ansi@6.0.1">
@@ -22063,7 +22063,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/node-gyp/node_modules/strip-ansi</property>
+            <property name="cdx:npm:package:path">node_modules/node-gyp/node_modules/strip-ansi</property>
           </properties>
         </component>
       </components>
@@ -22093,7 +22093,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/node-pre-gyp</property>
+        <property name="cdx:npm:package:path">node_modules/node-pre-gyp</property>
       </properties>
       <components>
         <component type="library" bom-ref="node-pre-gyp@0.15.0|chownr@1.1.4">
@@ -22121,7 +22121,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/node-pre-gyp/node_modules/chownr</property>
+            <property name="cdx:npm:package:path">node_modules/node-pre-gyp/node_modules/chownr</property>
           </properties>
         </component>
         <component type="library" bom-ref="node-pre-gyp@0.15.0|fs-minipass@1.2.7">
@@ -22157,7 +22157,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/node-pre-gyp/node_modules/fs-minipass</property>
+            <property name="cdx:npm:package:path">node_modules/node-pre-gyp/node_modules/fs-minipass</property>
           </properties>
         </component>
         <component type="library" bom-ref="node-pre-gyp@0.15.0|minipass@2.9.0">
@@ -22185,7 +22185,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/node-pre-gyp/node_modules/minipass</property>
+            <property name="cdx:npm:package:path">node_modules/node-pre-gyp/node_modules/minipass</property>
           </properties>
         </component>
         <component type="library" bom-ref="node-pre-gyp@0.15.0|minizlib@1.3.3">
@@ -22213,7 +22213,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/node-pre-gyp/node_modules/minizlib</property>
+            <property name="cdx:npm:package:path">node_modules/node-pre-gyp/node_modules/minizlib</property>
           </properties>
         </component>
         <component type="library" bom-ref="node-pre-gyp@0.15.0|mkdirp@0.5.6">
@@ -22241,7 +22241,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/node-pre-gyp/node_modules/mkdirp</property>
+            <property name="cdx:npm:package:path">node_modules/node-pre-gyp/node_modules/mkdirp</property>
           </properties>
         </component>
         <component type="library" bom-ref="node-pre-gyp@0.15.0|nopt@4.0.3">
@@ -22269,7 +22269,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/node-pre-gyp/node_modules/nopt</property>
+            <property name="cdx:npm:package:path">node_modules/node-pre-gyp/node_modules/nopt</property>
           </properties>
         </component>
         <component type="library" bom-ref="node-pre-gyp@0.15.0|rimraf@2.7.1">
@@ -22297,7 +22297,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/node-pre-gyp/node_modules/rimraf</property>
+            <property name="cdx:npm:package:path">node_modules/node-pre-gyp/node_modules/rimraf</property>
           </properties>
         </component>
         <component type="library" bom-ref="node-pre-gyp@0.15.0|safe-buffer@5.2.1">
@@ -22333,7 +22333,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/node-pre-gyp/node_modules/safe-buffer</property>
+            <property name="cdx:npm:package:path">node_modules/node-pre-gyp/node_modules/safe-buffer</property>
           </properties>
         </component>
         <component type="library" bom-ref="node-pre-gyp@0.15.0|semver@5.7.1">
@@ -22360,7 +22360,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/node-pre-gyp/node_modules/semver</property>
+            <property name="cdx:npm:package:path">node_modules/node-pre-gyp/node_modules/semver</property>
           </properties>
         </component>
         <component type="library" bom-ref="node-pre-gyp@0.15.0|tar@4.4.19">
@@ -22388,7 +22388,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/node-pre-gyp/node_modules/tar</property>
+            <property name="cdx:npm:package:path">node_modules/node-pre-gyp/node_modules/tar</property>
           </properties>
         </component>
         <component type="library" bom-ref="node-pre-gyp@0.15.0|yallist@3.1.1">
@@ -22416,7 +22416,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/node-pre-gyp/node_modules/yallist</property>
+            <property name="cdx:npm:package:path">node_modules/node-pre-gyp/node_modules/yallist</property>
           </properties>
         </component>
       </components>
@@ -22445,7 +22445,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/noop-logger</property>
+        <property name="cdx:npm:package:path">node_modules/noop-logger</property>
       </properties>
     </component>
     <component type="library" bom-ref="nopt@3.0.6">
@@ -22473,7 +22473,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/nopt</property>
+        <property name="cdx:npm:package:path">node_modules/nopt</property>
       </properties>
     </component>
     <component type="library" bom-ref="normalize-package-data@2.5.0">
@@ -22501,7 +22501,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/normalize-package-data</property>
+        <property name="cdx:npm:package:path">node_modules/normalize-package-data</property>
       </properties>
       <components>
         <component type="library" bom-ref="normalize-package-data@2.5.0|semver@5.7.1">
@@ -22528,7 +22528,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/normalize-package-data/node_modules/semver</property>
+            <property name="cdx:npm:package:path">node_modules/normalize-package-data/node_modules/semver</property>
           </properties>
         </component>
       </components>
@@ -22566,7 +22566,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/normalize-path</property>
+        <property name="cdx:npm:package:path">node_modules/normalize-path</property>
       </properties>
     </component>
     <component type="library" bom-ref="normalize-url@2.0.1">
@@ -22594,7 +22594,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/normalize-url</property>
+        <property name="cdx:npm:package:path">node_modules/normalize-url</property>
       </properties>
     </component>
     <component type="library" bom-ref="notevil@1.3.3">
@@ -22626,7 +22626,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/notevil</property>
+        <property name="cdx:npm:package:path">node_modules/notevil</property>
       </properties>
       <components>
         <component type="library" bom-ref="notevil@1.3.3|esprima@1.0.4">
@@ -22658,7 +22658,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/notevil/node_modules/esprima</property>
+            <property name="cdx:npm:package:path">node_modules/notevil/node_modules/esprima</property>
           </properties>
         </component>
       </components>
@@ -22688,7 +22688,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/npm-bundled</property>
+        <property name="cdx:npm:package:path">node_modules/npm-bundled</property>
       </properties>
     </component>
     <component type="library" bom-ref="npm-normalize-package-bin@1.0.1">
@@ -22716,7 +22716,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/npm-normalize-package-bin</property>
+        <property name="cdx:npm:package:path">node_modules/npm-normalize-package-bin</property>
       </properties>
     </component>
     <component type="library" bom-ref="npm-packlist@1.4.8">
@@ -22752,7 +22752,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/npm-packlist</property>
+        <property name="cdx:npm:package:path">node_modules/npm-packlist</property>
       </properties>
     </component>
     <component type="library" bom-ref="npmlog@4.1.2">
@@ -22780,7 +22780,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/npmlog</property>
+        <property name="cdx:npm:package:path">node_modules/npmlog</property>
       </properties>
     </component>
     <component type="library" bom-ref="number-is-nan@1.0.1">
@@ -22808,7 +22808,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/number-is-nan</property>
+        <property name="cdx:npm:package:path">node_modules/number-is-nan</property>
       </properties>
     </component>
     <component type="library" bom-ref="oauth-sign@0.9.0">
@@ -22836,7 +22836,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/oauth-sign</property>
+        <property name="cdx:npm:package:path">node_modules/oauth-sign</property>
       </properties>
     </component>
     <component type="library" bom-ref="object-assign@4.1.1">
@@ -22864,7 +22864,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/object-assign</property>
+        <property name="cdx:npm:package:path">node_modules/object-assign</property>
       </properties>
     </component>
     <component type="library" bom-ref="object-copy@0.1.0">
@@ -22900,7 +22900,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/object-copy</property>
+        <property name="cdx:npm:package:path">node_modules/object-copy</property>
       </properties>
       <components>
         <component type="library" bom-ref="object-copy@0.1.0|define-property@0.2.5">
@@ -22936,7 +22936,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/object-copy/node_modules/define-property</property>
+            <property name="cdx:npm:package:path">node_modules/object-copy/node_modules/define-property</property>
           </properties>
         </component>
         <component type="library" bom-ref="object-copy@0.1.0|is-accessor-descriptor@0.1.6">
@@ -22972,7 +22972,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/object-copy/node_modules/is-accessor-descriptor</property>
+            <property name="cdx:npm:package:path">node_modules/object-copy/node_modules/is-accessor-descriptor</property>
           </properties>
         </component>
         <component type="library" bom-ref="object-copy@0.1.0|is-data-descriptor@0.1.4">
@@ -23008,7 +23008,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/object-copy/node_modules/is-data-descriptor</property>
+            <property name="cdx:npm:package:path">node_modules/object-copy/node_modules/is-data-descriptor</property>
           </properties>
         </component>
         <component type="library" bom-ref="object-copy@0.1.0|is-descriptor@0.1.6">
@@ -23044,7 +23044,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/object-copy/node_modules/is-descriptor</property>
+            <property name="cdx:npm:package:path">node_modules/object-copy/node_modules/is-descriptor</property>
           </properties>
           <components>
             <component type="library" bom-ref="object-copy@0.1.0|is-descriptor@0.1.6|kind-of@5.1.0">
@@ -23080,7 +23080,7 @@
                 </reference>
               </externalReferences>
               <properties>
-                <property name="cdx:npm:package:installPath">node_modules/object-copy/node_modules/is-descriptor/node_modules/kind-of</property>
+                <property name="cdx:npm:package:path">node_modules/object-copy/node_modules/is-descriptor/node_modules/kind-of</property>
               </properties>
             </component>
           </components>
@@ -23118,7 +23118,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/object-copy/node_modules/kind-of</property>
+            <property name="cdx:npm:package:path">node_modules/object-copy/node_modules/kind-of</property>
           </properties>
         </component>
       </components>
@@ -23152,7 +23152,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/object-inspect</property>
+        <property name="cdx:npm:package:path">node_modules/object-inspect</property>
       </properties>
     </component>
     <component type="library" bom-ref="object-is@1.1.5">
@@ -23188,7 +23188,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/object-is</property>
+        <property name="cdx:npm:package:path">node_modules/object-is</property>
       </properties>
     </component>
     <component type="library" bom-ref="object-keys@1.1.1">
@@ -23216,7 +23216,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/object-keys</property>
+        <property name="cdx:npm:package:path">node_modules/object-keys</property>
       </properties>
     </component>
     <component type="library" bom-ref="object-visit@1.0.1">
@@ -23252,7 +23252,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/object-visit</property>
+        <property name="cdx:npm:package:path">node_modules/object-visit</property>
       </properties>
     </component>
     <component type="library" bom-ref="object.assign@4.1.4">
@@ -23280,7 +23280,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/object.assign</property>
+        <property name="cdx:npm:package:path">node_modules/object.assign</property>
       </properties>
     </component>
     <component type="library" bom-ref="object.defaults@1.1.0">
@@ -23316,7 +23316,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/object.defaults</property>
+        <property name="cdx:npm:package:path">node_modules/object.defaults</property>
       </properties>
     </component>
     <component type="library" bom-ref="object.map@1.0.1">
@@ -23352,7 +23352,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/object.map</property>
+        <property name="cdx:npm:package:path">node_modules/object.map</property>
       </properties>
     </component>
     <component type="library" bom-ref="object.pick@1.3.0">
@@ -23388,7 +23388,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/object.pick</property>
+        <property name="cdx:npm:package:path">node_modules/object.pick</property>
       </properties>
     </component>
     <component type="library" bom-ref="on-finished@2.4.1">
@@ -23415,7 +23415,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/on-finished</property>
+        <property name="cdx:npm:package:path">node_modules/on-finished</property>
       </properties>
     </component>
     <component type="library" bom-ref="on-headers@1.0.2">
@@ -23443,7 +23443,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/on-headers</property>
+        <property name="cdx:npm:package:path">node_modules/on-headers</property>
       </properties>
     </component>
     <component type="library" bom-ref="once@1.4.0">
@@ -23471,7 +23471,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/once</property>
+        <property name="cdx:npm:package:path">node_modules/once</property>
       </properties>
     </component>
     <component type="library" bom-ref="one-time@1.0.0">
@@ -23499,7 +23499,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/one-time</property>
+        <property name="cdx:npm:package:path">node_modules/one-time</property>
       </properties>
     </component>
     <component type="library" bom-ref="opentype.js@0.7.3">
@@ -23527,7 +23527,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/opentype.js</property>
+        <property name="cdx:npm:package:path">node_modules/opentype.js</property>
       </properties>
     </component>
     <component type="library" bom-ref="optionator@0.8.3">
@@ -23563,7 +23563,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/optionator</property>
+        <property name="cdx:npm:package:path">node_modules/optionator</property>
       </properties>
     </component>
     <component type="library" bom-ref="os-homedir@1.0.2">
@@ -23591,7 +23591,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/os-homedir</property>
+        <property name="cdx:npm:package:path">node_modules/os-homedir</property>
       </properties>
     </component>
     <component type="library" bom-ref="os-tmpdir@1.0.2">
@@ -23619,7 +23619,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/os-tmpdir</property>
+        <property name="cdx:npm:package:path">node_modules/os-tmpdir</property>
       </properties>
     </component>
     <component type="library" bom-ref="osenv@0.1.5">
@@ -23647,7 +23647,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/osenv</property>
+        <property name="cdx:npm:package:path">node_modules/osenv</property>
       </properties>
     </component>
     <component type="library" bom-ref="otplib@12.0.1">
@@ -23679,7 +23679,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/otplib</property>
+        <property name="cdx:npm:package:path">node_modules/otplib</property>
       </properties>
     </component>
     <component type="library" bom-ref="p-cancelable@0.4.1">
@@ -23707,7 +23707,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/p-cancelable</property>
+        <property name="cdx:npm:package:path">node_modules/p-cancelable</property>
       </properties>
     </component>
     <component type="library" bom-ref="p-event@2.3.1">
@@ -23735,7 +23735,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/p-event</property>
+        <property name="cdx:npm:package:path">node_modules/p-event</property>
       </properties>
     </component>
     <component type="library" bom-ref="p-finally@1.0.0">
@@ -23763,7 +23763,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/p-finally</property>
+        <property name="cdx:npm:package:path">node_modules/p-finally</property>
       </properties>
     </component>
     <component type="library" bom-ref="p-is-promise@1.1.0">
@@ -23791,7 +23791,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/p-is-promise</property>
+        <property name="cdx:npm:package:path">node_modules/p-is-promise</property>
       </properties>
     </component>
     <component type="library" bom-ref="p-limit@2.3.0">
@@ -23819,7 +23819,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/p-limit</property>
+        <property name="cdx:npm:package:path">node_modules/p-limit</property>
       </properties>
     </component>
     <component type="library" bom-ref="p-locate@3.0.0">
@@ -23847,7 +23847,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/p-locate</property>
+        <property name="cdx:npm:package:path">node_modules/p-locate</property>
       </properties>
     </component>
     <component type="library" bom-ref="p-map@4.0.0">
@@ -23875,7 +23875,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/p-map</property>
+        <property name="cdx:npm:package:path">node_modules/p-map</property>
       </properties>
     </component>
     <component type="library" bom-ref="p-timeout@2.0.1">
@@ -23903,7 +23903,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/p-timeout</property>
+        <property name="cdx:npm:package:path">node_modules/p-timeout</property>
       </properties>
     </component>
     <component type="library" bom-ref="p-try@2.2.0">
@@ -23931,7 +23931,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/p-try</property>
+        <property name="cdx:npm:package:path">node_modules/p-try</property>
       </properties>
     </component>
     <component type="library" bom-ref="pako@0.2.9">
@@ -23962,7 +23962,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/pako</property>
+        <property name="cdx:npm:package:path">node_modules/pako</property>
       </properties>
     </component>
     <component type="library" bom-ref="parse-filepath@1.0.2">
@@ -23998,7 +23998,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/parse-filepath</property>
+        <property name="cdx:npm:package:path">node_modules/parse-filepath</property>
       </properties>
     </component>
     <component type="library" bom-ref="parse-json@4.0.0">
@@ -24026,7 +24026,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/parse-json</property>
+        <property name="cdx:npm:package:path">node_modules/parse-json</property>
       </properties>
     </component>
     <component type="library" bom-ref="parse-passwd@1.0.0">
@@ -24062,7 +24062,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/parse-passwd</property>
+        <property name="cdx:npm:package:path">node_modules/parse-passwd</property>
       </properties>
     </component>
     <component type="library" bom-ref="parseurl@1.3.3">
@@ -24089,7 +24089,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/parseurl</property>
+        <property name="cdx:npm:package:path">node_modules/parseurl</property>
       </properties>
     </component>
     <component type="library" bom-ref="pascalcase@0.1.1">
@@ -24125,7 +24125,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/pascalcase</property>
+        <property name="cdx:npm:package:path">node_modules/pascalcase</property>
       </properties>
     </component>
     <component type="library" bom-ref="path-exists@3.0.0">
@@ -24153,7 +24153,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/path-exists</property>
+        <property name="cdx:npm:package:path">node_modules/path-exists</property>
       </properties>
     </component>
     <component type="library" bom-ref="path-is-absolute@1.0.1">
@@ -24181,7 +24181,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/path-is-absolute</property>
+        <property name="cdx:npm:package:path">node_modules/path-is-absolute</property>
       </properties>
     </component>
     <component type="library" bom-ref="path-parse@1.0.7">
@@ -24217,7 +24217,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/path-parse</property>
+        <property name="cdx:npm:package:path">node_modules/path-parse</property>
       </properties>
     </component>
     <component type="library" bom-ref="path-root-regex@0.1.2">
@@ -24253,7 +24253,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/path-root-regex</property>
+        <property name="cdx:npm:package:path">node_modules/path-root-regex</property>
       </properties>
     </component>
     <component type="library" bom-ref="path-root@0.1.1">
@@ -24289,7 +24289,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/path-root</property>
+        <property name="cdx:npm:package:path">node_modules/path-root</property>
       </properties>
     </component>
     <component type="library" bom-ref="path-to-regexp@0.1.7">
@@ -24316,7 +24316,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/path-to-regexp</property>
+        <property name="cdx:npm:package:path">node_modules/path-to-regexp</property>
       </properties>
     </component>
     <component type="library" bom-ref="pdfkit@0.11.0">
@@ -24352,7 +24352,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/pdfkit</property>
+        <property name="cdx:npm:package:path">node_modules/pdfkit</property>
       </properties>
     </component>
     <component type="library" bom-ref="peek-readable@4.1.0">
@@ -24384,7 +24384,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/peek-readable</property>
+        <property name="cdx:npm:package:path">node_modules/peek-readable</property>
       </properties>
     </component>
     <component type="library" bom-ref="pend@1.2.0">
@@ -24416,7 +24416,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/pend</property>
+        <property name="cdx:npm:package:path">node_modules/pend</property>
       </properties>
     </component>
     <component type="library" bom-ref="performance-now@2.1.0">
@@ -24452,7 +24452,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/performance-now</property>
+        <property name="cdx:npm:package:path">node_modules/performance-now</property>
       </properties>
     </component>
     <component type="library" bom-ref="pg-connection-string@2.5.0">
@@ -24488,7 +24488,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/pg-connection-string</property>
+        <property name="cdx:npm:package:path">node_modules/pg-connection-string</property>
       </properties>
     </component>
     <component type="library" bom-ref="picomatch@2.3.1">
@@ -24524,7 +24524,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/picomatch</property>
+        <property name="cdx:npm:package:path">node_modules/picomatch</property>
       </properties>
     </component>
     <component type="library" bom-ref="pify@4.0.1">
@@ -24552,7 +24552,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/pify</property>
+        <property name="cdx:npm:package:path">node_modules/pify</property>
       </properties>
     </component>
     <component type="library" bom-ref="pinkie-promise@2.0.1">
@@ -24580,7 +24580,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/pinkie-promise</property>
+        <property name="cdx:npm:package:path">node_modules/pinkie-promise</property>
       </properties>
     </component>
     <component type="library" bom-ref="pinkie@2.0.4">
@@ -24608,7 +24608,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/pinkie</property>
+        <property name="cdx:npm:package:path">node_modules/pinkie</property>
       </properties>
     </component>
     <component type="library" bom-ref="png-js@1.0.0">
@@ -24635,7 +24635,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/png-js</property>
+        <property name="cdx:npm:package:path">node_modules/png-js</property>
       </properties>
     </component>
     <component type="library" bom-ref="portscanner@2.2.0">
@@ -24670,7 +24670,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/portscanner</property>
+        <property name="cdx:npm:package:path">node_modules/portscanner</property>
       </properties>
     </component>
     <component type="library" bom-ref="posix-character-classes@0.1.1">
@@ -24706,7 +24706,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/posix-character-classes</property>
+        <property name="cdx:npm:package:path">node_modules/posix-character-classes</property>
       </properties>
     </component>
     <component type="library" bom-ref="prebuild-install@5.3.6">
@@ -24742,7 +24742,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/prebuild-install</property>
+        <property name="cdx:npm:package:path">node_modules/prebuild-install</property>
       </properties>
     </component>
     <component type="library" bom-ref="prelude-ls@1.1.2">
@@ -24779,7 +24779,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/prelude-ls</property>
+        <property name="cdx:npm:package:path">node_modules/prelude-ls</property>
       </properties>
     </component>
     <component type="library" bom-ref="prepend-http@2.0.0">
@@ -24807,7 +24807,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/prepend-http</property>
+        <property name="cdx:npm:package:path">node_modules/prepend-http</property>
       </properties>
     </component>
     <component type="library" bom-ref="pretty-bytes@4.0.2">
@@ -24835,7 +24835,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/pretty-bytes</property>
+        <property name="cdx:npm:package:path">node_modules/pretty-bytes</property>
       </properties>
     </component>
     <component type="library" bom-ref="process-nextick-args@2.0.1">
@@ -24870,7 +24870,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/process-nextick-args</property>
+        <property name="cdx:npm:package:path">node_modules/process-nextick-args</property>
       </properties>
     </component>
     <component type="library" bom-ref="prom-client@12.0.0">
@@ -24898,7 +24898,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/prom-client</property>
+        <property name="cdx:npm:package:path">node_modules/prom-client</property>
       </properties>
     </component>
     <component type="library" bom-ref="promise-inflight@1.0.1">
@@ -24934,7 +24934,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/promise-inflight</property>
+        <property name="cdx:npm:package:path">node_modules/promise-inflight</property>
       </properties>
     </component>
     <component type="library" bom-ref="promise-retry@2.0.1">
@@ -24966,7 +24966,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/promise-retry</property>
+        <property name="cdx:npm:package:path">node_modules/promise-retry</property>
       </properties>
       <components>
         <component type="library" bom-ref="promise-retry@2.0.1|err-code@2.0.3">
@@ -24998,7 +24998,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/promise-retry/node_modules/err-code</property>
+            <property name="cdx:npm:package:path">node_modules/promise-retry/node_modules/err-code</property>
           </properties>
         </component>
         <component type="library" bom-ref="promise-retry@2.0.1|retry@0.12.0">
@@ -25030,7 +25030,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/promise-retry/node_modules/retry</property>
+            <property name="cdx:npm:package:path">node_modules/promise-retry/node_modules/retry</property>
           </properties>
         </component>
       </components>
@@ -25060,7 +25060,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/promise</property>
+        <property name="cdx:npm:package:path">node_modules/promise</property>
       </properties>
     </component>
     <component type="library" bom-ref="proper-lockfile@1.2.0">
@@ -25092,7 +25092,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/proper-lockfile</property>
+        <property name="cdx:npm:package:path">node_modules/proper-lockfile</property>
       </properties>
     </component>
     <component type="library" bom-ref="proxy-addr@2.0.7">
@@ -25120,7 +25120,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/proxy-addr</property>
+        <property name="cdx:npm:package:path">node_modules/proxy-addr</property>
       </properties>
     </component>
     <component type="library" bom-ref="psl@1.9.0">
@@ -25144,7 +25144,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/psl</property>
+        <property name="cdx:npm:package:path">node_modules/psl</property>
       </properties>
     </component>
     <component type="library" bom-ref="pug-attrs@3.0.0">
@@ -25172,7 +25172,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/pug-attrs</property>
+        <property name="cdx:npm:package:path">node_modules/pug-attrs</property>
       </properties>
     </component>
     <component type="library" bom-ref="pug-code-gen@3.0.2">
@@ -25200,7 +25200,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/pug-code-gen</property>
+        <property name="cdx:npm:package:path">node_modules/pug-code-gen</property>
       </properties>
     </component>
     <component type="library" bom-ref="pug-error@2.0.0">
@@ -25228,7 +25228,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/pug-error</property>
+        <property name="cdx:npm:package:path">node_modules/pug-error</property>
       </properties>
     </component>
     <component type="library" bom-ref="pug-filters@4.0.0">
@@ -25256,7 +25256,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/pug-filters</property>
+        <property name="cdx:npm:package:path">node_modules/pug-filters</property>
       </properties>
     </component>
     <component type="library" bom-ref="pug-lexer@5.0.1">
@@ -25284,7 +25284,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/pug-lexer</property>
+        <property name="cdx:npm:package:path">node_modules/pug-lexer</property>
       </properties>
     </component>
     <component type="library" bom-ref="pug-linker@4.0.0">
@@ -25312,7 +25312,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/pug-linker</property>
+        <property name="cdx:npm:package:path">node_modules/pug-linker</property>
       </properties>
     </component>
     <component type="library" bom-ref="pug-load@3.0.0">
@@ -25340,7 +25340,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/pug-load</property>
+        <property name="cdx:npm:package:path">node_modules/pug-load</property>
       </properties>
     </component>
     <component type="library" bom-ref="pug-parser@6.0.0">
@@ -25368,7 +25368,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/pug-parser</property>
+        <property name="cdx:npm:package:path">node_modules/pug-parser</property>
       </properties>
     </component>
     <component type="library" bom-ref="pug-runtime@3.0.1">
@@ -25396,7 +25396,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/pug-runtime</property>
+        <property name="cdx:npm:package:path">node_modules/pug-runtime</property>
       </properties>
     </component>
     <component type="library" bom-ref="pug-strip-comments@2.0.0">
@@ -25424,7 +25424,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/pug-strip-comments</property>
+        <property name="cdx:npm:package:path">node_modules/pug-strip-comments</property>
       </properties>
     </component>
     <component type="library" bom-ref="pug-walk@2.0.0">
@@ -25452,7 +25452,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/pug-walk</property>
+        <property name="cdx:npm:package:path">node_modules/pug-walk</property>
       </properties>
     </component>
     <component type="library" bom-ref="pug@3.0.2">
@@ -25484,7 +25484,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/pug</property>
+        <property name="cdx:npm:package:path">node_modules/pug</property>
       </properties>
     </component>
     <component type="library" bom-ref="pump@3.0.0">
@@ -25512,7 +25512,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/pump</property>
+        <property name="cdx:npm:package:path">node_modules/pump</property>
       </properties>
     </component>
     <component type="library" bom-ref="punycode@2.1.1">
@@ -25548,7 +25548,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/punycode</property>
+        <property name="cdx:npm:package:path">node_modules/punycode</property>
       </properties>
     </component>
     <component type="library" bom-ref="qs@6.11.0">
@@ -25579,7 +25579,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/qs</property>
+        <property name="cdx:npm:package:path">node_modules/qs</property>
       </properties>
     </component>
     <component type="library" bom-ref="query-string@5.1.1">
@@ -25607,7 +25607,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/query-string</property>
+        <property name="cdx:npm:package:path">node_modules/query-string</property>
       </properties>
     </component>
     <component type="library" bom-ref="range_check@2.0.4">
@@ -25635,7 +25635,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/range_check</property>
+        <property name="cdx:npm:package:path">node_modules/range_check</property>
       </properties>
     </component>
     <component type="library" bom-ref="range-parser@1.2.1">
@@ -25663,7 +25663,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/range-parser</property>
+        <property name="cdx:npm:package:path">node_modules/range-parser</property>
       </properties>
     </component>
     <component type="library" bom-ref="raw-body@2.5.1">
@@ -25691,7 +25691,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/raw-body</property>
+        <property name="cdx:npm:package:path">node_modules/raw-body</property>
       </properties>
     </component>
     <component type="library" bom-ref="rc@1.2.8">
@@ -25717,7 +25717,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/rc</property>
+        <property name="cdx:npm:package:path">node_modules/rc</property>
       </properties>
     </component>
     <component type="library" bom-ref="read-pkg@4.0.1">
@@ -25745,7 +25745,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/read-pkg</property>
+        <property name="cdx:npm:package:path">node_modules/read-pkg</property>
       </properties>
       <components>
         <component type="library" bom-ref="read-pkg@4.0.1|pify@3.0.0">
@@ -25773,7 +25773,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/read-pkg/node_modules/pify</property>
+            <property name="cdx:npm:package:path">node_modules/read-pkg/node_modules/pify</property>
           </properties>
         </component>
       </components>
@@ -25802,7 +25802,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/readable-stream</property>
+        <property name="cdx:npm:package:path">node_modules/readable-stream</property>
       </properties>
       <components>
         <component type="library" bom-ref="readable-stream@2.3.7|isarray@1.0.0">
@@ -25834,7 +25834,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/readable-stream/node_modules/isarray</property>
+            <property name="cdx:npm:package:path">node_modules/readable-stream/node_modules/isarray</property>
           </properties>
         </component>
       </components>
@@ -25868,7 +25868,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/readable-web-to-node-stream</property>
+        <property name="cdx:npm:package:path">node_modules/readable-web-to-node-stream</property>
       </properties>
       <components>
         <component type="library" bom-ref="readable-web-to-node-stream@3.0.2|readable-stream@3.6.0">
@@ -25895,7 +25895,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/readable-web-to-node-stream/node_modules/readable-stream</property>
+            <property name="cdx:npm:package:path">node_modules/readable-web-to-node-stream/node_modules/readable-stream</property>
           </properties>
         </component>
       </components>
@@ -25933,7 +25933,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/readdirp</property>
+        <property name="cdx:npm:package:path">node_modules/readdirp</property>
       </properties>
     </component>
     <component type="library" bom-ref="rechoir@0.7.1">
@@ -25961,7 +25961,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/rechoir</property>
+        <property name="cdx:npm:package:path">node_modules/rechoir</property>
       </properties>
     </component>
     <component type="library" bom-ref="regex-not@1.0.2">
@@ -25997,7 +25997,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/regex-not</property>
+        <property name="cdx:npm:package:path">node_modules/regex-not</property>
       </properties>
     </component>
     <component type="library" bom-ref="regexp.prototype.flags@1.4.3">
@@ -26025,7 +26025,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/regexp.prototype.flags</property>
+        <property name="cdx:npm:package:path">node_modules/regexp.prototype.flags</property>
       </properties>
     </component>
     <component type="library" bom-ref="remove-trailing-separator@1.1.0">
@@ -26061,7 +26061,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/remove-trailing-separator</property>
+        <property name="cdx:npm:package:path">node_modules/remove-trailing-separator</property>
       </properties>
     </component>
     <component type="library" bom-ref="repeat-element@1.1.4">
@@ -26097,7 +26097,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/repeat-element</property>
+        <property name="cdx:npm:package:path">node_modules/repeat-element</property>
       </properties>
     </component>
     <component type="library" bom-ref="repeat-string@1.6.1">
@@ -26133,7 +26133,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/repeat-string</property>
+        <property name="cdx:npm:package:path">node_modules/repeat-string</property>
       </properties>
     </component>
     <component type="library" bom-ref="replace@1.2.2">
@@ -26161,7 +26161,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/replace</property>
+        <property name="cdx:npm:package:path">node_modules/replace</property>
       </properties>
       <components>
         <component type="library" bom-ref="replace@1.2.2|ansi-regex@5.0.1">
@@ -26189,7 +26189,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/replace/node_modules/ansi-regex</property>
+            <property name="cdx:npm:package:path">node_modules/replace/node_modules/ansi-regex</property>
           </properties>
         </component>
         <component type="library" bom-ref="replace@1.2.2|ansi-styles@4.3.0">
@@ -26217,7 +26217,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/replace/node_modules/ansi-styles</property>
+            <property name="cdx:npm:package:path">node_modules/replace/node_modules/ansi-styles</property>
           </properties>
         </component>
         <component type="library" bom-ref="replace@1.2.2|brace-expansion@1.1.11">
@@ -26249,7 +26249,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/replace/node_modules/brace-expansion</property>
+            <property name="cdx:npm:package:path">node_modules/replace/node_modules/brace-expansion</property>
           </properties>
         </component>
         <component type="library" bom-ref="replace@1.2.2|cliui@6.0.0">
@@ -26277,7 +26277,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/replace/node_modules/cliui</property>
+            <property name="cdx:npm:package:path">node_modules/replace/node_modules/cliui</property>
           </properties>
         </component>
         <component type="library" bom-ref="replace@1.2.2|color-convert@2.0.1">
@@ -26305,7 +26305,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/replace/node_modules/color-convert</property>
+            <property name="cdx:npm:package:path">node_modules/replace/node_modules/color-convert</property>
           </properties>
         </component>
         <component type="library" bom-ref="replace@1.2.2|color-name@1.1.4">
@@ -26337,7 +26337,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/replace/node_modules/color-name</property>
+            <property name="cdx:npm:package:path">node_modules/replace/node_modules/color-name</property>
           </properties>
         </component>
         <component type="library" bom-ref="replace@1.2.2|find-up@4.1.0">
@@ -26365,7 +26365,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/replace/node_modules/find-up</property>
+            <property name="cdx:npm:package:path">node_modules/replace/node_modules/find-up</property>
           </properties>
         </component>
         <component type="library" bom-ref="replace@1.2.2|is-fullwidth-code-point@3.0.0">
@@ -26393,7 +26393,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/replace/node_modules/is-fullwidth-code-point</property>
+            <property name="cdx:npm:package:path">node_modules/replace/node_modules/is-fullwidth-code-point</property>
           </properties>
         </component>
         <component type="library" bom-ref="replace@1.2.2|locate-path@5.0.0">
@@ -26421,7 +26421,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/replace/node_modules/locate-path</property>
+            <property name="cdx:npm:package:path">node_modules/replace/node_modules/locate-path</property>
           </properties>
         </component>
         <component type="library" bom-ref="replace@1.2.2|minimatch@3.0.5">
@@ -26449,7 +26449,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/replace/node_modules/minimatch</property>
+            <property name="cdx:npm:package:path">node_modules/replace/node_modules/minimatch</property>
           </properties>
         </component>
         <component type="library" bom-ref="replace@1.2.2|p-locate@4.1.0">
@@ -26477,7 +26477,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/replace/node_modules/p-locate</property>
+            <property name="cdx:npm:package:path">node_modules/replace/node_modules/p-locate</property>
           </properties>
         </component>
         <component type="library" bom-ref="replace@1.2.2|path-exists@4.0.0">
@@ -26505,7 +26505,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/replace/node_modules/path-exists</property>
+            <property name="cdx:npm:package:path">node_modules/replace/node_modules/path-exists</property>
           </properties>
         </component>
         <component type="library" bom-ref="replace@1.2.2|string-width@4.2.3">
@@ -26533,7 +26533,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/replace/node_modules/string-width</property>
+            <property name="cdx:npm:package:path">node_modules/replace/node_modules/string-width</property>
           </properties>
         </component>
         <component type="library" bom-ref="replace@1.2.2|strip-ansi@6.0.1">
@@ -26561,7 +26561,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/replace/node_modules/strip-ansi</property>
+            <property name="cdx:npm:package:path">node_modules/replace/node_modules/strip-ansi</property>
           </properties>
         </component>
         <component type="library" bom-ref="replace@1.2.2|wrap-ansi@6.2.0">
@@ -26589,7 +26589,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/replace/node_modules/wrap-ansi</property>
+            <property name="cdx:npm:package:path">node_modules/replace/node_modules/wrap-ansi</property>
           </properties>
         </component>
         <component type="library" bom-ref="replace@1.2.2|yargs-parser@18.1.3">
@@ -26617,7 +26617,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/replace/node_modules/yargs-parser</property>
+            <property name="cdx:npm:package:path">node_modules/replace/node_modules/yargs-parser</property>
           </properties>
         </component>
         <component type="library" bom-ref="replace@1.2.2|yargs@15.4.1">
@@ -26648,7 +26648,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/replace/node_modules/yargs</property>
+            <property name="cdx:npm:package:path">node_modules/replace/node_modules/yargs</property>
           </properties>
         </component>
       </components>
@@ -26682,7 +26682,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/request</property>
+        <property name="cdx:npm:package:path">node_modules/request</property>
       </properties>
       <components>
         <component type="library" bom-ref="request@2.88.2|qs@6.5.3">
@@ -26713,7 +26713,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/request/node_modules/qs</property>
+            <property name="cdx:npm:package:path">node_modules/request/node_modules/qs</property>
           </properties>
         </component>
       </components>
@@ -26751,7 +26751,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/require-directory</property>
+        <property name="cdx:npm:package:path">node_modules/require-directory</property>
       </properties>
     </component>
     <component type="library" bom-ref="require-main-filename@2.0.0">
@@ -26787,7 +26787,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/require-main-filename</property>
+        <property name="cdx:npm:package:path">node_modules/require-main-filename</property>
       </properties>
     </component>
     <component type="library" bom-ref="resolve-dir@1.0.1">
@@ -26823,7 +26823,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/resolve-dir</property>
+        <property name="cdx:npm:package:path">node_modules/resolve-dir</property>
       </properties>
     </component>
     <component type="library" bom-ref="resolve-url@0.2.1">
@@ -26851,7 +26851,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/resolve-url</property>
+        <property name="cdx:npm:package:path">node_modules/resolve-url</property>
       </properties>
     </component>
     <component type="library" bom-ref="resolve@1.22.1">
@@ -26879,7 +26879,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/resolve</property>
+        <property name="cdx:npm:package:path">node_modules/resolve</property>
       </properties>
     </component>
     <component type="library" bom-ref="responselike@1.0.2">
@@ -26907,7 +26907,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/responselike</property>
+        <property name="cdx:npm:package:path">node_modules/responselike</property>
       </properties>
     </component>
     <component type="library" bom-ref="restructure@2.0.1">
@@ -26943,7 +26943,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/restructure</property>
+        <property name="cdx:npm:package:path">node_modules/restructure</property>
       </properties>
     </component>
     <component type="library" bom-ref="ret@0.1.15">
@@ -26971,7 +26971,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/ret</property>
+        <property name="cdx:npm:package:path">node_modules/ret</property>
       </properties>
     </component>
     <component type="library" bom-ref="retry-as-promised@6.1.0">
@@ -27007,7 +27007,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/retry-as-promised</property>
+        <property name="cdx:npm:package:path">node_modules/retry-as-promised</property>
       </properties>
     </component>
     <component type="library" bom-ref="retry@0.10.1">
@@ -27039,7 +27039,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/retry</property>
+        <property name="cdx:npm:package:path">node_modules/retry</property>
       </properties>
     </component>
     <component type="library" bom-ref="rimraf@3.0.2">
@@ -27067,7 +27067,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/rimraf</property>
+        <property name="cdx:npm:package:path">node_modules/rimraf</property>
       </properties>
     </component>
     <component type="library" bom-ref="rxjs@6.6.7">
@@ -27103,7 +27103,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/rxjs</property>
+        <property name="cdx:npm:package:path">node_modules/rxjs</property>
       </properties>
       <components>
         <component type="library" bom-ref="rxjs@6.6.7|tslib@1.14.1">
@@ -27139,7 +27139,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/rxjs/node_modules/tslib</property>
+            <property name="cdx:npm:package:path">node_modules/rxjs/node_modules/tslib</property>
           </properties>
         </component>
       </components>
@@ -27177,7 +27177,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/safe-buffer</property>
+        <property name="cdx:npm:package:path">node_modules/safe-buffer</property>
       </properties>
     </component>
     <component type="library" bom-ref="safe-regex@1.1.0">
@@ -27209,7 +27209,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/safe-regex</property>
+        <property name="cdx:npm:package:path">node_modules/safe-regex</property>
       </properties>
     </component>
     <component type="library" bom-ref="safe-stable-stringify@2.4.1">
@@ -27245,7 +27245,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/safe-stable-stringify</property>
+        <property name="cdx:npm:package:path">node_modules/safe-stable-stringify</property>
       </properties>
     </component>
     <component type="library" bom-ref="safer-buffer@2.1.2">
@@ -27277,7 +27277,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/safer-buffer</property>
+        <property name="cdx:npm:package:path">node_modules/safer-buffer</property>
       </properties>
     </component>
     <component type="library" bom-ref="samsam@1.1.2">
@@ -27304,7 +27304,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/samsam</property>
+        <property name="cdx:npm:package:path">node_modules/samsam</property>
       </properties>
     </component>
     <component type="library" bom-ref="sanitize-filename@1.6.3">
@@ -27328,7 +27328,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/sanitize-filename</property>
+        <property name="cdx:npm:package:path">node_modules/sanitize-filename</property>
       </properties>
     </component>
     <component type="library" bom-ref="sanitize-html@1.4.2">
@@ -27356,7 +27356,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/sanitize-html</property>
+        <property name="cdx:npm:package:path">node_modules/sanitize-html</property>
       </properties>
       <components>
         <component type="library" bom-ref="sanitize-html@1.4.2|lodash@2.4.2">
@@ -27392,7 +27392,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/sanitize-html/node_modules/lodash</property>
+            <property name="cdx:npm:package:path">node_modules/sanitize-html/node_modules/lodash</property>
           </properties>
         </component>
       </components>
@@ -27422,7 +27422,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/sax</property>
+        <property name="cdx:npm:package:path">node_modules/sax</property>
       </properties>
     </component>
     <component type="library" bom-ref="seek-bzip@1.0.6">
@@ -27449,7 +27449,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/seek-bzip</property>
+        <property name="cdx:npm:package:path">node_modules/seek-bzip</property>
       </properties>
     </component>
     <component type="library" bom-ref="semver@7.3.8">
@@ -27477,7 +27477,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/semver</property>
+        <property name="cdx:npm:package:path">node_modules/semver</property>
       </properties>
     </component>
     <component type="library" bom-ref="send@0.18.0">
@@ -27505,7 +27505,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/send</property>
+        <property name="cdx:npm:package:path">node_modules/send</property>
       </properties>
       <components>
         <component type="library" bom-ref="send@0.18.0|ms@2.1.3">
@@ -27532,7 +27532,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/send/node_modules/ms</property>
+            <property name="cdx:npm:package:path">node_modules/send/node_modules/ms</property>
           </properties>
         </component>
       </components>
@@ -27562,7 +27562,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/sequelize-pool</property>
+        <property name="cdx:npm:package:path">node_modules/sequelize-pool</property>
       </properties>
     </component>
     <component type="library" bom-ref="sequelize@6.25.3">
@@ -27597,7 +27597,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/sequelize</property>
+        <property name="cdx:npm:package:path">node_modules/sequelize</property>
       </properties>
       <components>
         <component type="library" bom-ref="sequelize@6.25.3|debug@4.3.4">
@@ -27625,7 +27625,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/sequelize/node_modules/debug</property>
+            <property name="cdx:npm:package:path">node_modules/sequelize/node_modules/debug</property>
           </properties>
         </component>
         <component type="library" bom-ref="sequelize@6.25.3|ms@2.1.2">
@@ -27652,7 +27652,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/sequelize/node_modules/ms</property>
+            <property name="cdx:npm:package:path">node_modules/sequelize/node_modules/ms</property>
           </properties>
         </component>
         <component type="library" bom-ref="sequelize@6.25.3|uuid@8.3.2">
@@ -27679,7 +27679,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/sequelize/node_modules/uuid</property>
+            <property name="cdx:npm:package:path">node_modules/sequelize/node_modules/uuid</property>
           </properties>
         </component>
       </components>
@@ -27709,7 +27709,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/serve-index</property>
+        <property name="cdx:npm:package:path">node_modules/serve-index</property>
       </properties>
       <components>
         <component type="library" bom-ref="serve-index@1.9.1|depd@1.1.2">
@@ -27737,7 +27737,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/serve-index/node_modules/depd</property>
+            <property name="cdx:npm:package:path">node_modules/serve-index/node_modules/depd</property>
           </properties>
         </component>
         <component type="library" bom-ref="serve-index@1.9.1|http-errors@1.6.3">
@@ -27765,7 +27765,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/serve-index/node_modules/http-errors</property>
+            <property name="cdx:npm:package:path">node_modules/serve-index/node_modules/http-errors</property>
           </properties>
         </component>
         <component type="library" bom-ref="serve-index@1.9.1|inherits@2.0.3">
@@ -27792,7 +27792,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/serve-index/node_modules/inherits</property>
+            <property name="cdx:npm:package:path">node_modules/serve-index/node_modules/inherits</property>
           </properties>
         </component>
         <component type="library" bom-ref="serve-index@1.9.1|setprototypeof@1.1.0">
@@ -27828,7 +27828,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/serve-index/node_modules/setprototypeof</property>
+            <property name="cdx:npm:package:path">node_modules/serve-index/node_modules/setprototypeof</property>
           </properties>
         </component>
         <component type="library" bom-ref="serve-index@1.9.1|statuses@1.5.0">
@@ -27855,7 +27855,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/serve-index/node_modules/statuses</property>
+            <property name="cdx:npm:package:path">node_modules/serve-index/node_modules/statuses</property>
           </properties>
         </component>
       </components>
@@ -27885,7 +27885,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/serve-static</property>
+        <property name="cdx:npm:package:path">node_modules/serve-static</property>
       </properties>
     </component>
     <component type="library" bom-ref="set-blocking@2.0.0">
@@ -27921,7 +27921,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/set-blocking</property>
+        <property name="cdx:npm:package:path">node_modules/set-blocking</property>
       </properties>
     </component>
     <component type="library" bom-ref="set-value@2.0.1">
@@ -27957,7 +27957,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/set-value</property>
+        <property name="cdx:npm:package:path">node_modules/set-value</property>
       </properties>
       <components>
         <component type="library" bom-ref="set-value@2.0.1|extend-shallow@2.0.1">
@@ -27993,7 +27993,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/set-value/node_modules/extend-shallow</property>
+            <property name="cdx:npm:package:path">node_modules/set-value/node_modules/extend-shallow</property>
           </properties>
         </component>
         <component type="library" bom-ref="set-value@2.0.1|is-extendable@0.1.1">
@@ -28029,7 +28029,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/set-value/node_modules/is-extendable</property>
+            <property name="cdx:npm:package:path">node_modules/set-value/node_modules/is-extendable</property>
           </properties>
         </component>
       </components>
@@ -28059,7 +28059,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/setimmediate</property>
+        <property name="cdx:npm:package:path">node_modules/setimmediate</property>
       </properties>
     </component>
     <component type="library" bom-ref="setprototypeof@1.2.0">
@@ -28095,7 +28095,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/setprototypeof</property>
+        <property name="cdx:npm:package:path">node_modules/setprototypeof</property>
       </properties>
     </component>
     <component type="library" bom-ref="side-channel@1.0.4">
@@ -28131,7 +28131,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/side-channel</property>
+        <property name="cdx:npm:package:path">node_modules/side-channel</property>
       </properties>
     </component>
     <component type="library" bom-ref="signal-exit@3.0.7">
@@ -28167,7 +28167,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/signal-exit</property>
+        <property name="cdx:npm:package:path">node_modules/signal-exit</property>
       </properties>
     </component>
     <component type="library" bom-ref="simple-concat@1.0.1">
@@ -28203,7 +28203,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/simple-concat</property>
+        <property name="cdx:npm:package:path">node_modules/simple-concat</property>
       </properties>
     </component>
     <component type="library" bom-ref="simple-get@3.1.1">
@@ -28239,7 +28239,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/simple-get</property>
+        <property name="cdx:npm:package:path">node_modules/simple-get</property>
       </properties>
       <components>
         <component type="library" bom-ref="simple-get@3.1.1|decompress-response@4.2.1">
@@ -28267,7 +28267,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/simple-get/node_modules/decompress-response</property>
+            <property name="cdx:npm:package:path">node_modules/simple-get/node_modules/decompress-response</property>
           </properties>
         </component>
         <component type="library" bom-ref="simple-get@3.1.1|mimic-response@2.1.0">
@@ -28295,7 +28295,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/simple-get/node_modules/mimic-response</property>
+            <property name="cdx:npm:package:path">node_modules/simple-get/node_modules/mimic-response</property>
           </properties>
         </component>
       </components>
@@ -28325,7 +28325,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/simple-swizzle</property>
+        <property name="cdx:npm:package:path">node_modules/simple-swizzle</property>
       </properties>
       <components>
         <component type="library" bom-ref="simple-swizzle@0.2.2|is-arrayish@0.3.2">
@@ -28353,7 +28353,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/simple-swizzle/node_modules/is-arrayish</property>
+            <property name="cdx:npm:package:path">node_modules/simple-swizzle/node_modules/is-arrayish</property>
           </properties>
         </component>
       </components>
@@ -28391,7 +28391,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/sinon</property>
+        <property name="cdx:npm:package:path">node_modules/sinon</property>
       </properties>
     </component>
     <component type="library" bom-ref="smart-buffer@4.2.0">
@@ -28427,7 +28427,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/smart-buffer</property>
+        <property name="cdx:npm:package:path">node_modules/smart-buffer</property>
       </properties>
     </component>
     <component type="library" bom-ref="snapdragon-node@2.1.1">
@@ -28463,7 +28463,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/snapdragon-node</property>
+        <property name="cdx:npm:package:path">node_modules/snapdragon-node</property>
       </properties>
       <components>
         <component type="library" bom-ref="snapdragon-node@2.1.1|define-property@1.0.0">
@@ -28499,7 +28499,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/snapdragon-node/node_modules/define-property</property>
+            <property name="cdx:npm:package:path">node_modules/snapdragon-node/node_modules/define-property</property>
           </properties>
         </component>
       </components>
@@ -28537,7 +28537,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/snapdragon-util</property>
+        <property name="cdx:npm:package:path">node_modules/snapdragon-util</property>
       </properties>
       <components>
         <component type="library" bom-ref="snapdragon-util@3.0.1|kind-of@3.2.2">
@@ -28573,7 +28573,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/snapdragon-util/node_modules/kind-of</property>
+            <property name="cdx:npm:package:path">node_modules/snapdragon-util/node_modules/kind-of</property>
           </properties>
         </component>
       </components>
@@ -28611,7 +28611,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/snapdragon</property>
+        <property name="cdx:npm:package:path">node_modules/snapdragon</property>
       </properties>
       <components>
         <component type="library" bom-ref="snapdragon@0.8.2|define-property@0.2.5">
@@ -28647,7 +28647,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/snapdragon/node_modules/define-property</property>
+            <property name="cdx:npm:package:path">node_modules/snapdragon/node_modules/define-property</property>
           </properties>
         </component>
         <component type="library" bom-ref="snapdragon@0.8.2|extend-shallow@2.0.1">
@@ -28683,7 +28683,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/snapdragon/node_modules/extend-shallow</property>
+            <property name="cdx:npm:package:path">node_modules/snapdragon/node_modules/extend-shallow</property>
           </properties>
         </component>
         <component type="library" bom-ref="snapdragon@0.8.2|is-accessor-descriptor@0.1.6">
@@ -28719,7 +28719,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/snapdragon/node_modules/is-accessor-descriptor</property>
+            <property name="cdx:npm:package:path">node_modules/snapdragon/node_modules/is-accessor-descriptor</property>
           </properties>
           <components>
             <component type="library" bom-ref="snapdragon@0.8.2|is-accessor-descriptor@0.1.6|kind-of@3.2.2">
@@ -28755,7 +28755,7 @@
                 </reference>
               </externalReferences>
               <properties>
-                <property name="cdx:npm:package:installPath">node_modules/snapdragon/node_modules/is-accessor-descriptor/node_modules/kind-of</property>
+                <property name="cdx:npm:package:path">node_modules/snapdragon/node_modules/is-accessor-descriptor/node_modules/kind-of</property>
               </properties>
             </component>
           </components>
@@ -28793,7 +28793,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/snapdragon/node_modules/is-data-descriptor</property>
+            <property name="cdx:npm:package:path">node_modules/snapdragon/node_modules/is-data-descriptor</property>
           </properties>
           <components>
             <component type="library" bom-ref="snapdragon@0.8.2|is-data-descriptor@0.1.4|kind-of@3.2.2">
@@ -28829,7 +28829,7 @@
                 </reference>
               </externalReferences>
               <properties>
-                <property name="cdx:npm:package:installPath">node_modules/snapdragon/node_modules/is-data-descriptor/node_modules/kind-of</property>
+                <property name="cdx:npm:package:path">node_modules/snapdragon/node_modules/is-data-descriptor/node_modules/kind-of</property>
               </properties>
             </component>
           </components>
@@ -28867,7 +28867,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/snapdragon/node_modules/is-descriptor</property>
+            <property name="cdx:npm:package:path">node_modules/snapdragon/node_modules/is-descriptor</property>
           </properties>
         </component>
         <component type="library" bom-ref="snapdragon@0.8.2|is-extendable@0.1.1">
@@ -28903,7 +28903,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/snapdragon/node_modules/is-extendable</property>
+            <property name="cdx:npm:package:path">node_modules/snapdragon/node_modules/is-extendable</property>
           </properties>
         </component>
         <component type="library" bom-ref="snapdragon@0.8.2|kind-of@5.1.0">
@@ -28939,7 +28939,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/snapdragon/node_modules/kind-of</property>
+            <property name="cdx:npm:package:path">node_modules/snapdragon/node_modules/kind-of</property>
           </properties>
         </component>
         <component type="library" bom-ref="snapdragon@0.8.2|source-map@0.5.7">
@@ -28971,7 +28971,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/snapdragon/node_modules/source-map</property>
+            <property name="cdx:npm:package:path">node_modules/snapdragon/node_modules/source-map</property>
           </properties>
         </component>
       </components>
@@ -29000,7 +29000,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/socket.io-adapter</property>
+        <property name="cdx:npm:package:path">node_modules/socket.io-adapter</property>
       </properties>
     </component>
     <component type="library" bom-ref="socket.io-parser@4.0.5">
@@ -29027,7 +29027,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/socket.io-parser</property>
+        <property name="cdx:npm:package:path">node_modules/socket.io-parser</property>
       </properties>
       <components>
         <component type="library" bom-ref="socket.io-parser@4.0.5|debug@4.3.4">
@@ -29055,7 +29055,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/socket.io-parser/node_modules/debug</property>
+            <property name="cdx:npm:package:path">node_modules/socket.io-parser/node_modules/debug</property>
           </properties>
         </component>
         <component type="library" bom-ref="socket.io-parser@4.0.5|ms@2.1.2">
@@ -29082,7 +29082,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/socket.io-parser/node_modules/ms</property>
+            <property name="cdx:npm:package:path">node_modules/socket.io-parser/node_modules/ms</property>
           </properties>
         </component>
       </components>
@@ -29111,7 +29111,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/socket.io</property>
+        <property name="cdx:npm:package:path">node_modules/socket.io</property>
       </properties>
       <components>
         <component type="library" bom-ref="socket.io@3.1.2|debug@4.3.4">
@@ -29139,7 +29139,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/socket.io/node_modules/debug</property>
+            <property name="cdx:npm:package:path">node_modules/socket.io/node_modules/debug</property>
           </properties>
         </component>
         <component type="library" bom-ref="socket.io@3.1.2|ms@2.1.2">
@@ -29166,7 +29166,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/socket.io/node_modules/ms</property>
+            <property name="cdx:npm:package:path">node_modules/socket.io/node_modules/ms</property>
           </properties>
         </component>
       </components>
@@ -29204,7 +29204,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/socks-proxy-agent</property>
+        <property name="cdx:npm:package:path">node_modules/socks-proxy-agent</property>
       </properties>
       <components>
         <component type="library" bom-ref="socks-proxy-agent@6.2.1|debug@4.3.4">
@@ -29232,7 +29232,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/socks-proxy-agent/node_modules/debug</property>
+            <property name="cdx:npm:package:path">node_modules/socks-proxy-agent/node_modules/debug</property>
           </properties>
         </component>
         <component type="library" bom-ref="socks-proxy-agent@6.2.1|ms@2.1.2">
@@ -29259,7 +29259,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/socks-proxy-agent/node_modules/ms</property>
+            <property name="cdx:npm:package:path">node_modules/socks-proxy-agent/node_modules/ms</property>
           </properties>
         </component>
       </components>
@@ -29297,7 +29297,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/socks</property>
+        <property name="cdx:npm:package:path">node_modules/socks</property>
       </properties>
       <components>
         <component type="library" bom-ref="socks@2.7.1|ip@2.0.0">
@@ -29328,7 +29328,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/socks/node_modules/ip</property>
+            <property name="cdx:npm:package:path">node_modules/socks/node_modules/ip</property>
           </properties>
         </component>
       </components>
@@ -29358,7 +29358,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/sort-keys-length</property>
+        <property name="cdx:npm:package:path">node_modules/sort-keys-length</property>
       </properties>
       <components>
         <component type="library" bom-ref="sort-keys-length@1.0.1|sort-keys@1.1.2">
@@ -29386,7 +29386,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/sort-keys-length/node_modules/sort-keys</property>
+            <property name="cdx:npm:package:path">node_modules/sort-keys-length/node_modules/sort-keys</property>
           </properties>
         </component>
       </components>
@@ -29416,7 +29416,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/sort-keys</property>
+        <property name="cdx:npm:package:path">node_modules/sort-keys</property>
       </properties>
     </component>
     <component type="library" bom-ref="source-map-resolve@0.5.3">
@@ -29444,7 +29444,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/source-map-resolve</property>
+        <property name="cdx:npm:package:path">node_modules/source-map-resolve</property>
       </properties>
     </component>
     <component type="library" bom-ref="source-map-support@0.5.21">
@@ -29475,7 +29475,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/source-map-support</property>
+        <property name="cdx:npm:package:path">node_modules/source-map-support</property>
       </properties>
     </component>
     <component type="library" bom-ref="source-map-url@0.4.1">
@@ -29503,7 +29503,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/source-map-url</property>
+        <property name="cdx:npm:package:path">node_modules/source-map-url</property>
       </properties>
     </component>
     <component type="library" bom-ref="source-map@0.6.1">
@@ -29535,7 +29535,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/source-map</property>
+        <property name="cdx:npm:package:path">node_modules/source-map</property>
       </properties>
     </component>
     <component type="library" bom-ref="spawn-command@0.0.2-1">
@@ -29563,7 +29563,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/spawn-command</property>
+        <property name="cdx:npm:package:path">node_modules/spawn-command</property>
       </properties>
     </component>
     <component type="library" bom-ref="spdx-correct@3.1.1">
@@ -29591,7 +29591,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/spdx-correct</property>
+        <property name="cdx:npm:package:path">node_modules/spdx-correct</property>
       </properties>
     </component>
     <component type="library" bom-ref="spdx-exceptions@2.3.0">
@@ -29619,7 +29619,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/spdx-exceptions</property>
+        <property name="cdx:npm:package:path">node_modules/spdx-exceptions</property>
       </properties>
     </component>
     <component type="library" bom-ref="spdx-expression-parse@3.0.1">
@@ -29647,7 +29647,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/spdx-expression-parse</property>
+        <property name="cdx:npm:package:path">node_modules/spdx-expression-parse</property>
       </properties>
     </component>
     <component type="library" bom-ref="spdx-license-ids@3.0.12">
@@ -29675,7 +29675,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/spdx-license-ids</property>
+        <property name="cdx:npm:package:path">node_modules/spdx-license-ids</property>
       </properties>
     </component>
     <component type="library" bom-ref="split-string@3.1.0">
@@ -29711,7 +29711,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/split-string</property>
+        <property name="cdx:npm:package:path">node_modules/split-string</property>
       </properties>
     </component>
     <component type="library" bom-ref="sprintf-js@1.1.2">
@@ -29739,7 +29739,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/sprintf-js</property>
+        <property name="cdx:npm:package:path">node_modules/sprintf-js</property>
       </properties>
     </component>
     <component type="library" bom-ref="sqlite3@5.1.2">
@@ -29771,7 +29771,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/sqlite3</property>
+        <property name="cdx:npm:package:path">node_modules/sqlite3</property>
       </properties>
     </component>
     <component type="library" bom-ref="sshpk@1.17.0">
@@ -29807,7 +29807,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/sshpk</property>
+        <property name="cdx:npm:package:path">node_modules/sshpk</property>
       </properties>
     </component>
     <component type="library" bom-ref="ssri@8.0.1">
@@ -29835,7 +29835,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/ssri</property>
+        <property name="cdx:npm:package:path">node_modules/ssri</property>
       </properties>
     </component>
     <component type="library" bom-ref="stack-trace@0.0.10">
@@ -29867,7 +29867,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/stack-trace</property>
+        <property name="cdx:npm:package:path">node_modules/stack-trace</property>
       </properties>
     </component>
     <component type="library" bom-ref="static-extend@0.1.2">
@@ -29903,7 +29903,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/static-extend</property>
+        <property name="cdx:npm:package:path">node_modules/static-extend</property>
       </properties>
       <components>
         <component type="library" bom-ref="static-extend@0.1.2|define-property@0.2.5">
@@ -29939,7 +29939,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/static-extend/node_modules/define-property</property>
+            <property name="cdx:npm:package:path">node_modules/static-extend/node_modules/define-property</property>
           </properties>
         </component>
         <component type="library" bom-ref="static-extend@0.1.2|is-accessor-descriptor@0.1.6">
@@ -29975,7 +29975,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/static-extend/node_modules/is-accessor-descriptor</property>
+            <property name="cdx:npm:package:path">node_modules/static-extend/node_modules/is-accessor-descriptor</property>
           </properties>
           <components>
             <component type="library" bom-ref="static-extend@0.1.2|is-accessor-descriptor@0.1.6|kind-of@3.2.2">
@@ -30011,7 +30011,7 @@
                 </reference>
               </externalReferences>
               <properties>
-                <property name="cdx:npm:package:installPath">node_modules/static-extend/node_modules/is-accessor-descriptor/node_modules/kind-of</property>
+                <property name="cdx:npm:package:path">node_modules/static-extend/node_modules/is-accessor-descriptor/node_modules/kind-of</property>
               </properties>
             </component>
           </components>
@@ -30049,7 +30049,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/static-extend/node_modules/is-data-descriptor</property>
+            <property name="cdx:npm:package:path">node_modules/static-extend/node_modules/is-data-descriptor</property>
           </properties>
           <components>
             <component type="library" bom-ref="static-extend@0.1.2|is-data-descriptor@0.1.4|kind-of@3.2.2">
@@ -30085,7 +30085,7 @@
                 </reference>
               </externalReferences>
               <properties>
-                <property name="cdx:npm:package:installPath">node_modules/static-extend/node_modules/is-data-descriptor/node_modules/kind-of</property>
+                <property name="cdx:npm:package:path">node_modules/static-extend/node_modules/is-data-descriptor/node_modules/kind-of</property>
               </properties>
             </component>
           </components>
@@ -30123,7 +30123,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/static-extend/node_modules/is-descriptor</property>
+            <property name="cdx:npm:package:path">node_modules/static-extend/node_modules/is-descriptor</property>
           </properties>
         </component>
         <component type="library" bom-ref="static-extend@0.1.2|kind-of@5.1.0">
@@ -30159,7 +30159,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/static-extend/node_modules/kind-of</property>
+            <property name="cdx:npm:package:path">node_modules/static-extend/node_modules/kind-of</property>
           </properties>
         </component>
       </components>
@@ -30188,7 +30188,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/statuses</property>
+        <property name="cdx:npm:package:path">node_modules/statuses</property>
       </properties>
     </component>
     <component type="library" bom-ref="stream-buffers@2.2.0">
@@ -30216,7 +30216,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/stream-buffers</property>
+        <property name="cdx:npm:package:path">node_modules/stream-buffers</property>
       </properties>
     </component>
     <component type="library" bom-ref="streamsearch@0.1.2">
@@ -30245,7 +30245,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/streamsearch</property>
+        <property name="cdx:npm:package:path">node_modules/streamsearch</property>
       </properties>
     </component>
     <component type="library" bom-ref="strict-uri-encode@1.1.0">
@@ -30273,7 +30273,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/strict-uri-encode</property>
+        <property name="cdx:npm:package:path">node_modules/strict-uri-encode</property>
       </properties>
     </component>
     <component type="library" bom-ref="string_decoder@1.1.1">
@@ -30304,7 +30304,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/string_decoder</property>
+        <property name="cdx:npm:package:path">node_modules/string_decoder</property>
       </properties>
     </component>
     <component type="library" bom-ref="string-width@1.0.2">
@@ -30332,7 +30332,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/string-width</property>
+        <property name="cdx:npm:package:path">node_modules/string-width</property>
       </properties>
     </component>
     <component type="library" bom-ref="string.fromcodepoint@0.2.1">
@@ -30369,7 +30369,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/string.fromcodepoint</property>
+        <property name="cdx:npm:package:path">node_modules/string.fromcodepoint</property>
       </properties>
     </component>
     <component type="library" bom-ref="string.prototype.codepointat@0.2.1">
@@ -30405,7 +30405,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/string.prototype.codepointat</property>
+        <property name="cdx:npm:package:path">node_modules/string.prototype.codepointat</property>
       </properties>
     </component>
     <component type="library" bom-ref="strip-ansi@3.0.1">
@@ -30433,7 +30433,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/strip-ansi</property>
+        <property name="cdx:npm:package:path">node_modules/strip-ansi</property>
       </properties>
     </component>
     <component type="library" bom-ref="strip-bom@3.0.0">
@@ -30461,7 +30461,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/strip-bom</property>
+        <property name="cdx:npm:package:path">node_modules/strip-bom</property>
       </properties>
     </component>
     <component type="library" bom-ref="strip-dirs@2.1.0">
@@ -30489,7 +30489,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/strip-dirs</property>
+        <property name="cdx:npm:package:path">node_modules/strip-dirs</property>
       </properties>
     </component>
     <component type="library" bom-ref="strip-json-comments@2.0.1">
@@ -30517,7 +30517,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/strip-json-comments</property>
+        <property name="cdx:npm:package:path">node_modules/strip-json-comments</property>
       </properties>
     </component>
     <component type="library" bom-ref="strip-outer@1.0.1">
@@ -30545,7 +30545,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/strip-outer</property>
+        <property name="cdx:npm:package:path">node_modules/strip-outer</property>
       </properties>
     </component>
     <component type="library" bom-ref="strtok3@6.3.0">
@@ -30577,7 +30577,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/strtok3</property>
+        <property name="cdx:npm:package:path">node_modules/strtok3</property>
       </properties>
     </component>
     <component type="library" bom-ref="supports-color@5.5.0">
@@ -30605,7 +30605,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/supports-color</property>
+        <property name="cdx:npm:package:path">node_modules/supports-color</property>
       </properties>
     </component>
     <component type="library" bom-ref="supports-preserve-symlinks-flag@1.0.0">
@@ -30641,7 +30641,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/supports-preserve-symlinks-flag</property>
+        <property name="cdx:npm:package:path">node_modules/supports-preserve-symlinks-flag</property>
       </properties>
     </component>
     <component type="library" bom-ref="svg-captcha@1.4.0">
@@ -30677,7 +30677,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/svg-captcha</property>
+        <property name="cdx:npm:package:path">node_modules/svg-captcha</property>
       </properties>
     </component>
     <component type="library" bom-ref="swagger-ui-dist@4.15.2">
@@ -30699,7 +30699,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/swagger-ui-dist</property>
+        <property name="cdx:npm:package:path">node_modules/swagger-ui-dist</property>
       </properties>
     </component>
     <component type="library" bom-ref="swagger-ui-express@4.5.0">
@@ -30731,7 +30731,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/swagger-ui-express</property>
+        <property name="cdx:npm:package:path">node_modules/swagger-ui-express</property>
       </properties>
     </component>
     <component type="library" bom-ref="tar-fs@2.1.1">
@@ -30767,7 +30767,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/tar-fs</property>
+        <property name="cdx:npm:package:path">node_modules/tar-fs</property>
       </properties>
       <components>
         <component type="library" bom-ref="tar-fs@2.1.1|bl@4.1.0">
@@ -30798,7 +30798,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/tar-fs/node_modules/bl</property>
+            <property name="cdx:npm:package:path">node_modules/tar-fs/node_modules/bl</property>
           </properties>
         </component>
         <component type="library" bom-ref="tar-fs@2.1.1|chownr@1.1.4">
@@ -30826,7 +30826,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/tar-fs/node_modules/chownr</property>
+            <property name="cdx:npm:package:path">node_modules/tar-fs/node_modules/chownr</property>
           </properties>
         </component>
         <component type="library" bom-ref="tar-fs@2.1.1|readable-stream@3.6.0">
@@ -30853,7 +30853,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/tar-fs/node_modules/readable-stream</property>
+            <property name="cdx:npm:package:path">node_modules/tar-fs/node_modules/readable-stream</property>
           </properties>
         </component>
         <component type="library" bom-ref="tar-fs@2.1.1|tar-stream@2.2.0">
@@ -30889,7 +30889,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/tar-fs/node_modules/tar-stream</property>
+            <property name="cdx:npm:package:path">node_modules/tar-fs/node_modules/tar-stream</property>
           </properties>
         </component>
       </components>
@@ -30927,7 +30927,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/tar-stream</property>
+        <property name="cdx:npm:package:path">node_modules/tar-stream</property>
       </properties>
     </component>
     <component type="library" bom-ref="tar@6.1.12">
@@ -30955,7 +30955,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/tar</property>
+        <property name="cdx:npm:package:path">node_modules/tar</property>
       </properties>
     </component>
     <component type="library" bom-ref="tdigest@0.1.2">
@@ -30991,7 +30991,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/tdigest</property>
+        <property name="cdx:npm:package:path">node_modules/tdigest</property>
       </properties>
     </component>
     <component type="library" bom-ref="text-hex@1.0.0">
@@ -31027,7 +31027,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/text-hex</property>
+        <property name="cdx:npm:package:path">node_modules/text-hex</property>
       </properties>
     </component>
     <component type="library" bom-ref="thirty-two@1.0.2">
@@ -31050,7 +31050,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/thirty-two</property>
+        <property name="cdx:npm:package:path">node_modules/thirty-two</property>
       </properties>
     </component>
     <component type="library" bom-ref="through@2.3.8">
@@ -31082,7 +31082,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/through</property>
+        <property name="cdx:npm:package:path">node_modules/through</property>
       </properties>
     </component>
     <component type="library" bom-ref="timed-out@4.0.1">
@@ -31110,7 +31110,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/timed-out</property>
+        <property name="cdx:npm:package:path">node_modules/timed-out</property>
       </properties>
     </component>
     <component type="library" bom-ref="tiny-inflate@1.0.3">
@@ -31146,7 +31146,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/tiny-inflate</property>
+        <property name="cdx:npm:package:path">node_modules/tiny-inflate</property>
       </properties>
     </component>
     <component type="library" bom-ref="to-buffer@1.1.1">
@@ -31182,7 +31182,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/to-buffer</property>
+        <property name="cdx:npm:package:path">node_modules/to-buffer</property>
       </properties>
     </component>
     <component type="library" bom-ref="to-fast-properties@2.0.0">
@@ -31210,7 +31210,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/to-fast-properties</property>
+        <property name="cdx:npm:package:path">node_modules/to-fast-properties</property>
       </properties>
     </component>
     <component type="library" bom-ref="to-object-path@0.3.0">
@@ -31246,7 +31246,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/to-object-path</property>
+        <property name="cdx:npm:package:path">node_modules/to-object-path</property>
       </properties>
       <components>
         <component type="library" bom-ref="to-object-path@0.3.0|kind-of@3.2.2">
@@ -31282,7 +31282,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/to-object-path/node_modules/kind-of</property>
+            <property name="cdx:npm:package:path">node_modules/to-object-path/node_modules/kind-of</property>
           </properties>
         </component>
       </components>
@@ -31320,7 +31320,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/to-regex-range</property>
+        <property name="cdx:npm:package:path">node_modules/to-regex-range</property>
       </properties>
     </component>
     <component type="library" bom-ref="to-regex@3.0.2">
@@ -31356,7 +31356,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/to-regex</property>
+        <property name="cdx:npm:package:path">node_modules/to-regex</property>
       </properties>
     </component>
     <component type="library" bom-ref="toidentifier@1.0.1">
@@ -31384,7 +31384,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/toidentifier</property>
+        <property name="cdx:npm:package:path">node_modules/toidentifier</property>
       </properties>
     </component>
     <component type="library" bom-ref="token-stream@1.0.0">
@@ -31412,7 +31412,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/token-stream</property>
+        <property name="cdx:npm:package:path">node_modules/token-stream</property>
       </properties>
     </component>
     <component type="library" bom-ref="token-types@4.2.1">
@@ -31444,7 +31444,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/token-types</property>
+        <property name="cdx:npm:package:path">node_modules/token-types</property>
       </properties>
     </component>
     <component type="library" bom-ref="toposort-class@1.0.1">
@@ -31471,7 +31471,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/toposort-class</property>
+        <property name="cdx:npm:package:path">node_modules/toposort-class</property>
       </properties>
     </component>
     <component type="library" bom-ref="tough-cookie@2.5.0">
@@ -31507,7 +31507,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/tough-cookie</property>
+        <property name="cdx:npm:package:path">node_modules/tough-cookie</property>
       </properties>
     </component>
     <component type="library" bom-ref="tr46@0.0.3">
@@ -31543,7 +31543,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/tr46</property>
+        <property name="cdx:npm:package:path">node_modules/tr46</property>
       </properties>
     </component>
     <component type="library" bom-ref="traverse@0.3.9">
@@ -31571,7 +31571,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/traverse</property>
+        <property name="cdx:npm:package:path">node_modules/traverse</property>
       </properties>
     </component>
     <component type="library" bom-ref="tree-kill@1.2.2">
@@ -31603,7 +31603,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/tree-kill</property>
+        <property name="cdx:npm:package:path">node_modules/tree-kill</property>
       </properties>
     </component>
     <component type="library" bom-ref="trim-repeated@1.0.0">
@@ -31631,7 +31631,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/trim-repeated</property>
+        <property name="cdx:npm:package:path">node_modules/trim-repeated</property>
       </properties>
     </component>
     <component type="library" bom-ref="triple-beam@1.3.0">
@@ -31667,7 +31667,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/triple-beam</property>
+        <property name="cdx:npm:package:path">node_modules/triple-beam</property>
       </properties>
     </component>
     <component type="library" bom-ref="truncate-utf8-bytes@1.0.2">
@@ -31703,7 +31703,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/truncate-utf8-bytes</property>
+        <property name="cdx:npm:package:path">node_modules/truncate-utf8-bytes</property>
       </properties>
     </component>
     <component type="library" bom-ref="ts-node-dev@1.1.8">
@@ -31730,7 +31730,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/ts-node-dev</property>
+        <property name="cdx:npm:package:path">node_modules/ts-node-dev</property>
       </properties>
       <components>
         <component type="library" bom-ref="ts-node-dev@1.1.8|rimraf@2.7.1">
@@ -31758,7 +31758,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/ts-node-dev/node_modules/rimraf</property>
+            <property name="cdx:npm:package:path">node_modules/ts-node-dev/node_modules/rimraf</property>
           </properties>
         </component>
       </components>
@@ -31796,7 +31796,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/ts-node</property>
+        <property name="cdx:npm:package:path">node_modules/ts-node</property>
       </properties>
     </component>
     <component type="library" bom-ref="tsconfig@7.0.0">
@@ -31832,7 +31832,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/tsconfig</property>
+        <property name="cdx:npm:package:path">node_modules/tsconfig</property>
       </properties>
     </component>
     <component type="library" bom-ref="tslib@2.4.1">
@@ -31868,7 +31868,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/tslib</property>
+        <property name="cdx:npm:package:path">node_modules/tslib</property>
       </properties>
     </component>
     <component type="library" bom-ref="tunnel-agent@0.6.0">
@@ -31896,7 +31896,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/tunnel-agent</property>
+        <property name="cdx:npm:package:path">node_modules/tunnel-agent</property>
       </properties>
     </component>
     <component type="library" bom-ref="tweetnacl@0.14.5">
@@ -31932,7 +31932,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/tweetnacl</property>
+        <property name="cdx:npm:package:path">node_modules/tweetnacl</property>
       </properties>
     </component>
     <component type="library" bom-ref="type-check@0.3.2">
@@ -31968,7 +31968,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/type-check</property>
+        <property name="cdx:npm:package:path">node_modules/type-check</property>
       </properties>
     </component>
     <component type="library" bom-ref="type-is@1.6.18">
@@ -31995,7 +31995,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/type-is</property>
+        <property name="cdx:npm:package:path">node_modules/type-is</property>
       </properties>
     </component>
     <component type="library" bom-ref="typecast@0.0.1">
@@ -32022,7 +32022,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/typecast</property>
+        <property name="cdx:npm:package:path">node_modules/typecast</property>
       </properties>
     </component>
     <component type="library" bom-ref="typedarray@0.0.6">
@@ -32054,7 +32054,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/typedarray</property>
+        <property name="cdx:npm:package:path">node_modules/typedarray</property>
       </properties>
     </component>
     <component type="library" bom-ref="typescript@4.8.4">
@@ -32090,7 +32090,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/typescript</property>
+        <property name="cdx:npm:package:path">node_modules/typescript</property>
       </properties>
     </component>
     <component type="library" bom-ref="uglify-js@3.17.4">
@@ -32118,7 +32118,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/uglify-js</property>
+        <property name="cdx:npm:package:path">node_modules/uglify-js</property>
       </properties>
     </component>
     <component type="library" bom-ref="unbzip2-stream@1.4.3">
@@ -32150,7 +32150,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/unbzip2-stream</property>
+        <property name="cdx:npm:package:path">node_modules/unbzip2-stream</property>
       </properties>
     </component>
     <component type="library" bom-ref="unc-path-regex@0.1.2">
@@ -32186,7 +32186,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/unc-path-regex</property>
+        <property name="cdx:npm:package:path">node_modules/unc-path-regex</property>
       </properties>
     </component>
     <component type="library" bom-ref="underscore.string@3.3.6">
@@ -32221,7 +32221,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/underscore.string</property>
+        <property name="cdx:npm:package:path">node_modules/underscore.string</property>
       </properties>
     </component>
     <component type="library" bom-ref="unicode-properties@1.4.1">
@@ -32257,7 +32257,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/unicode-properties</property>
+        <property name="cdx:npm:package:path">node_modules/unicode-properties</property>
       </properties>
     </component>
     <component type="library" bom-ref="unicode-trie@2.0.0">
@@ -32293,7 +32293,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/unicode-trie</property>
+        <property name="cdx:npm:package:path">node_modules/unicode-trie</property>
       </properties>
     </component>
     <component type="library" bom-ref="union-value@1.0.1">
@@ -32329,7 +32329,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/union-value</property>
+        <property name="cdx:npm:package:path">node_modules/union-value</property>
       </properties>
       <components>
         <component type="library" bom-ref="union-value@1.0.1|is-extendable@0.1.1">
@@ -32365,7 +32365,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/union-value/node_modules/is-extendable</property>
+            <property name="cdx:npm:package:path">node_modules/union-value/node_modules/is-extendable</property>
           </properties>
         </component>
       </components>
@@ -32403,7 +32403,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/unique-filename</property>
+        <property name="cdx:npm:package:path">node_modules/unique-filename</property>
       </properties>
     </component>
     <component type="library" bom-ref="unique-slug@2.0.2">
@@ -32431,7 +32431,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/unique-slug</property>
+        <property name="cdx:npm:package:path">node_modules/unique-slug</property>
       </properties>
     </component>
     <component type="library" bom-ref="unit-compare@1.0.1">
@@ -32467,7 +32467,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/unit-compare</property>
+        <property name="cdx:npm:package:path">node_modules/unit-compare</property>
       </properties>
     </component>
     <component type="library" bom-ref="universalify@2.0.0">
@@ -32503,7 +32503,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/universalify</property>
+        <property name="cdx:npm:package:path">node_modules/universalify</property>
       </properties>
     </component>
     <component type="library" bom-ref="unpipe@1.0.0">
@@ -32531,7 +32531,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/unpipe</property>
+        <property name="cdx:npm:package:path">node_modules/unpipe</property>
       </properties>
     </component>
     <component type="library" bom-ref="unset-value@1.0.0">
@@ -32567,7 +32567,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/unset-value</property>
+        <property name="cdx:npm:package:path">node_modules/unset-value</property>
       </properties>
       <components>
         <component type="library" bom-ref="unset-value@1.0.0|has-value@0.3.1">
@@ -32603,7 +32603,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/unset-value/node_modules/has-value</property>
+            <property name="cdx:npm:package:path">node_modules/unset-value/node_modules/has-value</property>
           </properties>
           <components>
             <component type="library" bom-ref="unset-value@1.0.0|has-value@0.3.1|isobject@2.1.0">
@@ -32639,7 +32639,7 @@
                 </reference>
               </externalReferences>
               <properties>
-                <property name="cdx:npm:package:installPath">node_modules/unset-value/node_modules/has-value/node_modules/isobject</property>
+                <property name="cdx:npm:package:path">node_modules/unset-value/node_modules/has-value/node_modules/isobject</property>
               </properties>
             </component>
           </components>
@@ -32677,7 +32677,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/unset-value/node_modules/has-values</property>
+            <property name="cdx:npm:package:path">node_modules/unset-value/node_modules/has-values</property>
           </properties>
         </component>
         <component type="library" bom-ref="unset-value@1.0.0|isarray@1.0.0">
@@ -32709,7 +32709,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/unset-value/node_modules/isarray</property>
+            <property name="cdx:npm:package:path">node_modules/unset-value/node_modules/isarray</property>
           </properties>
         </component>
       </components>
@@ -32739,7 +32739,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/untildify</property>
+        <property name="cdx:npm:package:path">node_modules/untildify</property>
       </properties>
     </component>
     <component type="library" bom-ref="unzipper@0.9.15">
@@ -32767,7 +32767,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/unzipper</property>
+        <property name="cdx:npm:package:path">node_modules/unzipper</property>
       </properties>
       <components>
         <component type="library" bom-ref="unzipper@0.9.15|bluebird@3.4.7">
@@ -32803,7 +32803,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/unzipper/node_modules/bluebird</property>
+            <property name="cdx:npm:package:path">node_modules/unzipper/node_modules/bluebird</property>
           </properties>
         </component>
       </components>
@@ -32841,7 +32841,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/uri-js</property>
+        <property name="cdx:npm:package:path">node_modules/uri-js</property>
       </properties>
     </component>
     <component type="library" bom-ref="urix@0.1.0">
@@ -32869,7 +32869,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/urix</property>
+        <property name="cdx:npm:package:path">node_modules/urix</property>
       </properties>
     </component>
     <component type="library" bom-ref="url-parse-lax@3.0.0">
@@ -32897,7 +32897,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/url-parse-lax</property>
+        <property name="cdx:npm:package:path">node_modules/url-parse-lax</property>
       </properties>
     </component>
     <component type="library" bom-ref="url-to-options@1.0.1">
@@ -32925,7 +32925,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/url-to-options</property>
+        <property name="cdx:npm:package:path">node_modules/url-to-options</property>
       </properties>
     </component>
     <component type="library" bom-ref="use@3.1.1">
@@ -32961,7 +32961,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/use</property>
+        <property name="cdx:npm:package:path">node_modules/use</property>
       </properties>
     </component>
     <component type="library" bom-ref="utf8-byte-length@1.0.4">
@@ -32997,7 +32997,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/utf8-byte-length</property>
+        <property name="cdx:npm:package:path">node_modules/utf8-byte-length</property>
       </properties>
     </component>
     <component type="library" bom-ref="util-deprecate@1.0.2">
@@ -33033,7 +33033,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/util-deprecate</property>
+        <property name="cdx:npm:package:path">node_modules/util-deprecate</property>
       </properties>
     </component>
     <component type="library" bom-ref="util@0.12.5">
@@ -33065,7 +33065,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/util</property>
+        <property name="cdx:npm:package:path">node_modules/util</property>
       </properties>
     </component>
     <component type="library" bom-ref="utils-merge@1.0.1">
@@ -33101,7 +33101,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/utils-merge</property>
+        <property name="cdx:npm:package:path">node_modules/utils-merge</property>
       </properties>
     </component>
     <component type="library" bom-ref="uuid@3.4.0">
@@ -33128,7 +33128,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/uuid</property>
+        <property name="cdx:npm:package:path">node_modules/uuid</property>
       </properties>
     </component>
     <component type="library" bom-ref="v8flags@3.2.0">
@@ -33156,7 +33156,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/v8flags</property>
+        <property name="cdx:npm:package:path">node_modules/v8flags</property>
       </properties>
     </component>
     <component type="library" bom-ref="validate-npm-package-license@3.0.4">
@@ -33184,7 +33184,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/validate-npm-package-license</property>
+        <property name="cdx:npm:package:path">node_modules/validate-npm-package-license</property>
       </properties>
     </component>
     <component type="library" bom-ref="validate@4.5.1">
@@ -33212,7 +33212,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/validate</property>
+        <property name="cdx:npm:package:path">node_modules/validate</property>
       </properties>
     </component>
     <component type="library" bom-ref="validator@13.7.0">
@@ -33248,7 +33248,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/validator</property>
+        <property name="cdx:npm:package:path">node_modules/validator</property>
       </properties>
     </component>
     <component type="library" bom-ref="vary@1.1.2">
@@ -33276,7 +33276,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/vary</property>
+        <property name="cdx:npm:package:path">node_modules/vary</property>
       </properties>
     </component>
     <component type="library" bom-ref="verror@1.10.0">
@@ -33303,7 +33303,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/verror</property>
+        <property name="cdx:npm:package:path">node_modules/verror</property>
       </properties>
       <components>
         <component type="library" bom-ref="verror@1.10.0|core-util-is@1.0.2">
@@ -33335,7 +33335,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/verror/node_modules/core-util-is</property>
+            <property name="cdx:npm:package:path">node_modules/verror/node_modules/core-util-is</property>
           </properties>
         </component>
       </components>
@@ -33365,7 +33365,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/vm2</property>
+        <property name="cdx:npm:package:path">node_modules/vm2</property>
       </properties>
       <components>
         <component type="library" bom-ref="vm2@3.9.11|acorn@8.8.1">
@@ -33396,7 +33396,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/vm2/node_modules/acorn</property>
+            <property name="cdx:npm:package:path">node_modules/vm2/node_modules/acorn</property>
           </properties>
         </component>
       </components>
@@ -33434,7 +33434,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/void-elements</property>
+        <property name="cdx:npm:package:path">node_modules/void-elements</property>
       </properties>
     </component>
     <component type="library" bom-ref="walk@2.3.15">
@@ -33468,7 +33468,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/walk</property>
+        <property name="cdx:npm:package:path">node_modules/walk</property>
       </properties>
     </component>
     <component type="library" bom-ref="walkdir@0.0.11">
@@ -33500,7 +33500,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/walkdir</property>
+        <property name="cdx:npm:package:path">node_modules/walkdir</property>
       </properties>
     </component>
     <component type="library" bom-ref="webidl-conversions@3.0.1">
@@ -33528,7 +33528,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/webidl-conversions</property>
+        <property name="cdx:npm:package:path">node_modules/webidl-conversions</property>
       </properties>
     </component>
     <component type="library" bom-ref="whatwg-url@5.0.0">
@@ -33556,7 +33556,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/whatwg-url</property>
+        <property name="cdx:npm:package:path">node_modules/whatwg-url</property>
       </properties>
     </component>
     <component type="library" bom-ref="which-boxed-primitive@1.0.2">
@@ -33592,7 +33592,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/which-boxed-primitive</property>
+        <property name="cdx:npm:package:path">node_modules/which-boxed-primitive</property>
       </properties>
     </component>
     <component type="library" bom-ref="which-collection@1.0.1">
@@ -33628,7 +33628,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/which-collection</property>
+        <property name="cdx:npm:package:path">node_modules/which-collection</property>
       </properties>
     </component>
     <component type="library" bom-ref="which-module@2.0.0">
@@ -33664,7 +33664,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/which-module</property>
+        <property name="cdx:npm:package:path">node_modules/which-module</property>
       </properties>
     </component>
     <component type="library" bom-ref="which-pm-runs@1.1.0">
@@ -33700,7 +33700,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/which-pm-runs</property>
+        <property name="cdx:npm:package:path">node_modules/which-pm-runs</property>
       </properties>
     </component>
     <component type="library" bom-ref="which-typed-array@1.1.9">
@@ -33728,7 +33728,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/which-typed-array</property>
+        <property name="cdx:npm:package:path">node_modules/which-typed-array</property>
       </properties>
     </component>
     <component type="library" bom-ref="which@2.0.2">
@@ -33756,7 +33756,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/which</property>
+        <property name="cdx:npm:package:path">node_modules/which</property>
       </properties>
     </component>
     <component type="library" bom-ref="wide-align@1.1.5">
@@ -33784,7 +33784,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/wide-align</property>
+        <property name="cdx:npm:package:path">node_modules/wide-align</property>
       </properties>
     </component>
     <component type="library" bom-ref="winston-transport@4.5.0">
@@ -33816,7 +33816,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/winston-transport</property>
+        <property name="cdx:npm:package:path">node_modules/winston-transport</property>
       </properties>
       <components>
         <component type="library" bom-ref="winston-transport@4.5.0|readable-stream@3.6.0">
@@ -33843,7 +33843,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/winston-transport/node_modules/readable-stream</property>
+            <property name="cdx:npm:package:path">node_modules/winston-transport/node_modules/readable-stream</property>
           </properties>
         </component>
       </components>
@@ -33873,7 +33873,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/winston</property>
+        <property name="cdx:npm:package:path">node_modules/winston</property>
       </properties>
       <components>
         <component type="library" bom-ref="winston@3.8.2|async@3.2.4">
@@ -33909,7 +33909,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/winston/node_modules/async</property>
+            <property name="cdx:npm:package:path">node_modules/winston/node_modules/async</property>
           </properties>
         </component>
         <component type="library" bom-ref="winston@3.8.2|is-stream@2.0.1">
@@ -33937,7 +33937,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/winston/node_modules/is-stream</property>
+            <property name="cdx:npm:package:path">node_modules/winston/node_modules/is-stream</property>
           </properties>
         </component>
         <component type="library" bom-ref="winston@3.8.2|readable-stream@3.6.0">
@@ -33964,7 +33964,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/winston/node_modules/readable-stream</property>
+            <property name="cdx:npm:package:path">node_modules/winston/node_modules/readable-stream</property>
           </properties>
         </component>
       </components>
@@ -33994,7 +33994,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/with</property>
+        <property name="cdx:npm:package:path">node_modules/with</property>
       </properties>
     </component>
     <component type="library" bom-ref="wkx@0.5.0">
@@ -34022,7 +34022,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/wkx</property>
+        <property name="cdx:npm:package:path">node_modules/wkx</property>
       </properties>
     </component>
     <component type="library" bom-ref="word-wrap@1.2.3">
@@ -34058,7 +34058,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/word-wrap</property>
+        <property name="cdx:npm:package:path">node_modules/word-wrap</property>
       </properties>
     </component>
     <component type="library" bom-ref="wordwrap@0.0.3">
@@ -34086,7 +34086,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/wordwrap</property>
+        <property name="cdx:npm:package:path">node_modules/wordwrap</property>
       </properties>
     </component>
     <component type="library" bom-ref="wrap-ansi@5.1.0">
@@ -34114,7 +34114,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/wrap-ansi</property>
+        <property name="cdx:npm:package:path">node_modules/wrap-ansi</property>
       </properties>
       <components>
         <component type="library" bom-ref="wrap-ansi@5.1.0|ansi-regex@4.1.1">
@@ -34142,7 +34142,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/wrap-ansi/node_modules/ansi-regex</property>
+            <property name="cdx:npm:package:path">node_modules/wrap-ansi/node_modules/ansi-regex</property>
           </properties>
         </component>
         <component type="library" bom-ref="wrap-ansi@5.1.0|emoji-regex@7.0.3">
@@ -34178,7 +34178,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/wrap-ansi/node_modules/emoji-regex</property>
+            <property name="cdx:npm:package:path">node_modules/wrap-ansi/node_modules/emoji-regex</property>
           </properties>
         </component>
         <component type="library" bom-ref="wrap-ansi@5.1.0|is-fullwidth-code-point@2.0.0">
@@ -34206,7 +34206,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/wrap-ansi/node_modules/is-fullwidth-code-point</property>
+            <property name="cdx:npm:package:path">node_modules/wrap-ansi/node_modules/is-fullwidth-code-point</property>
           </properties>
         </component>
         <component type="library" bom-ref="wrap-ansi@5.1.0|string-width@3.1.0">
@@ -34234,7 +34234,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/wrap-ansi/node_modules/string-width</property>
+            <property name="cdx:npm:package:path">node_modules/wrap-ansi/node_modules/string-width</property>
           </properties>
         </component>
         <component type="library" bom-ref="wrap-ansi@5.1.0|strip-ansi@5.2.0">
@@ -34262,7 +34262,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/wrap-ansi/node_modules/strip-ansi</property>
+            <property name="cdx:npm:package:path">node_modules/wrap-ansi/node_modules/strip-ansi</property>
           </properties>
         </component>
       </components>
@@ -34300,7 +34300,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/wrappy</property>
+        <property name="cdx:npm:package:path">node_modules/wrappy</property>
       </properties>
     </component>
     <component type="library" bom-ref="ws@7.4.6">
@@ -34336,7 +34336,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/ws</property>
+        <property name="cdx:npm:package:path">node_modules/ws</property>
       </properties>
     </component>
     <component type="library" bom-ref="xtend@4.0.2">
@@ -34372,7 +34372,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/xtend</property>
+        <property name="cdx:npm:package:path">node_modules/xtend</property>
       </properties>
     </component>
     <component type="library" bom-ref="y18n@4.0.3">
@@ -34404,7 +34404,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/y18n</property>
+        <property name="cdx:npm:package:path">node_modules/y18n</property>
       </properties>
     </component>
     <component type="library" bom-ref="yallist@4.0.0">
@@ -34432,7 +34432,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/yallist</property>
+        <property name="cdx:npm:package:path">node_modules/yallist</property>
       </properties>
     </component>
     <component type="library" bom-ref="yaml-schema-validator@1.2.3">
@@ -34460,7 +34460,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/yaml-schema-validator</property>
+        <property name="cdx:npm:package:path">node_modules/yaml-schema-validator</property>
       </properties>
     </component>
     <component type="library" bom-ref="yargs-parser@13.1.2">
@@ -34484,7 +34484,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/yargs-parser</property>
+        <property name="cdx:npm:package:path">node_modules/yargs-parser</property>
       </properties>
     </component>
     <component type="library" bom-ref="yargs@13.3.2">
@@ -34515,7 +34515,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/yargs</property>
+        <property name="cdx:npm:package:path">node_modules/yargs</property>
       </properties>
       <components>
         <component type="library" bom-ref="yargs@13.3.2|ansi-regex@4.1.1">
@@ -34543,7 +34543,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/yargs/node_modules/ansi-regex</property>
+            <property name="cdx:npm:package:path">node_modules/yargs/node_modules/ansi-regex</property>
           </properties>
         </component>
         <component type="library" bom-ref="yargs@13.3.2|emoji-regex@7.0.3">
@@ -34579,7 +34579,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/yargs/node_modules/emoji-regex</property>
+            <property name="cdx:npm:package:path">node_modules/yargs/node_modules/emoji-regex</property>
           </properties>
         </component>
         <component type="library" bom-ref="yargs@13.3.2|is-fullwidth-code-point@2.0.0">
@@ -34607,7 +34607,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/yargs/node_modules/is-fullwidth-code-point</property>
+            <property name="cdx:npm:package:path">node_modules/yargs/node_modules/is-fullwidth-code-point</property>
           </properties>
         </component>
         <component type="library" bom-ref="yargs@13.3.2|string-width@3.1.0">
@@ -34635,7 +34635,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/yargs/node_modules/string-width</property>
+            <property name="cdx:npm:package:path">node_modules/yargs/node_modules/string-width</property>
           </properties>
         </component>
         <component type="library" bom-ref="yargs@13.3.2|strip-ansi@5.2.0">
@@ -34663,7 +34663,7 @@
             </reference>
           </externalReferences>
           <properties>
-            <property name="cdx:npm:package:installPath">node_modules/yargs/node_modules/strip-ansi</property>
+            <property name="cdx:npm:package:path">node_modules/yargs/node_modules/strip-ansi</property>
           </properties>
         </component>
       </components>
@@ -34701,7 +34701,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/yauzl</property>
+        <property name="cdx:npm:package:path">node_modules/yauzl</property>
       </properties>
     </component>
     <component type="library" bom-ref="yn@3.1.1">
@@ -34729,7 +34729,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/yn</property>
+        <property name="cdx:npm:package:path">node_modules/yn</property>
       </properties>
     </component>
     <component type="library" bom-ref="z85@0.0.2">
@@ -34765,7 +34765,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/z85</property>
+        <property name="cdx:npm:package:path">node_modules/z85</property>
       </properties>
     </component>
     <component type="library" bom-ref="zip-stream@1.2.0">
@@ -34801,7 +34801,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/zip-stream</property>
+        <property name="cdx:npm:package:path">node_modules/zip-stream</property>
       </properties>
     </component>
     <component type="library" bom-ref="zlibjs@0.3.1">
@@ -34833,7 +34833,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/zlibjs</property>
+        <property name="cdx:npm:package:path">node_modules/zlibjs</property>
       </properties>
     </component>
   </components>

--- a/demo/local-dependencies/example-results/bom.1.2.json
+++ b/demo/local-dependencies/example-results/bom.1.2.json
@@ -8,7 +8,7 @@
       {
         "vendor": "@cyclonedx",
         "name": "cyclonedx-npm",
-        "version": "1.4.0"
+        "version": "1.4.1"
       }
     ],
     "component": {

--- a/demo/local-dependencies/example-results/bom.1.2.xml
+++ b/demo/local-dependencies/example-results/bom.1.2.xml
@@ -5,7 +5,7 @@
       <tool>
         <vendor>@cyclonedx</vendor>
         <name>cyclonedx-npm</name>
-        <version>1.4.0</version>
+        <version>1.4.1</version>
       </tool>
     </tools>
     <component type="application" bom-ref="demo-local-deps@0.0.0">

--- a/demo/local-dependencies/example-results/bom.1.3.json
+++ b/demo/local-dependencies/example-results/bom.1.3.json
@@ -8,7 +8,7 @@
       {
         "vendor": "@cyclonedx",
         "name": "cyclonedx-npm",
-        "version": "1.4.0"
+        "version": "1.4.1"
       }
     ],
     "component": {
@@ -26,6 +26,10 @@
       ],
       "purl": "pkg:npm/demo-local-deps@0.0.0",
       "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
         {
           "name": "cdx:npm:package:private",
           "value": "true"
@@ -57,6 +61,10 @@
       ],
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-a"
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -78,6 +86,10 @@
       "purl": "pkg:npm/my-local-b-off@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-b-off"
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -98,6 +110,10 @@
       ],
       "purl": "pkg:npm/my-noname@0.0.0",
       "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-noname"
+        },
         {
           "name": "cdx:npm:package:private",
           "value": "true"

--- a/demo/local-dependencies/example-results/bom.1.3.json
+++ b/demo/local-dependencies/example-results/bom.1.3.json
@@ -27,7 +27,7 @@
       "purl": "pkg:npm/demo-local-deps@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -61,7 +61,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-a"
         },
         {
@@ -86,7 +86,7 @@
       "purl": "pkg:npm/my-local-b-off@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-b-off"
         },
         {
@@ -111,7 +111,7 @@
       "purl": "pkg:npm/my-noname@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-noname"
         },
         {

--- a/demo/local-dependencies/example-results/bom.1.3.xml
+++ b/demo/local-dependencies/example-results/bom.1.3.xml
@@ -5,7 +5,7 @@
       <tool>
         <vendor>@cyclonedx</vendor>
         <name>cyclonedx-npm</name>
-        <version>1.4.0</version>
+        <version>1.4.1</version>
       </tool>
     </tools>
     <component type="application" bom-ref="demo-local-deps@0.0.0">
@@ -19,6 +19,7 @@
       </licenses>
       <purl>pkg:npm/demo-local-deps@0.0.0</purl>
       <properties>
+        <property name="cdx:npm:package:installPath"/>
         <property name="cdx:npm:package:private">true</property>
       </properties>
     </component>
@@ -41,6 +42,7 @@
         </reference>
       </externalReferences>
       <properties>
+        <property name="cdx:npm:package:installPath">node_modules/my-local-a</property>
         <property name="cdx:npm:package:private">true</property>
       </properties>
     </component>
@@ -55,6 +57,7 @@
       </licenses>
       <purl>pkg:npm/my-local-b-off@0.0.0</purl>
       <properties>
+        <property name="cdx:npm:package:installPath">node_modules/my-local-b-off</property>
         <property name="cdx:npm:package:private">true</property>
       </properties>
     </component>
@@ -69,6 +72,7 @@
       </licenses>
       <purl>pkg:npm/my-noname@0.0.0</purl>
       <properties>
+        <property name="cdx:npm:package:installPath">node_modules/my-noname</property>
         <property name="cdx:npm:package:private">true</property>
       </properties>
     </component>

--- a/demo/local-dependencies/example-results/bom.1.3.xml
+++ b/demo/local-dependencies/example-results/bom.1.3.xml
@@ -19,7 +19,7 @@
       </licenses>
       <purl>pkg:npm/demo-local-deps@0.0.0</purl>
       <properties>
-        <property name="cdx:npm:package:installPath"/>
+        <property name="cdx:npm:package:path"/>
         <property name="cdx:npm:package:private">true</property>
       </properties>
     </component>
@@ -42,7 +42,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/my-local-a</property>
+        <property name="cdx:npm:package:path">node_modules/my-local-a</property>
         <property name="cdx:npm:package:private">true</property>
       </properties>
     </component>
@@ -57,7 +57,7 @@
       </licenses>
       <purl>pkg:npm/my-local-b-off@0.0.0</purl>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/my-local-b-off</property>
+        <property name="cdx:npm:package:path">node_modules/my-local-b-off</property>
         <property name="cdx:npm:package:private">true</property>
       </properties>
     </component>
@@ -72,7 +72,7 @@
       </licenses>
       <purl>pkg:npm/my-noname@0.0.0</purl>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/my-noname</property>
+        <property name="cdx:npm:package:path">node_modules/my-noname</property>
         <property name="cdx:npm:package:private">true</property>
       </properties>
     </component>

--- a/demo/local-dependencies/example-results/bom.1.4.json
+++ b/demo/local-dependencies/example-results/bom.1.4.json
@@ -8,7 +8,7 @@
       {
         "vendor": "@cyclonedx",
         "name": "cyclonedx-npm",
-        "version": "1.4.0",
+        "version": "1.4.1",
         "externalReferences": [
           {
             "url": "https://github.com/CycloneDX/cyclonedx-node-npm/issues",
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-local-deps@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -74,6 +78,10 @@
       ],
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-a"
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -95,6 +103,10 @@
       "purl": "pkg:npm/my-local-b-off@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-b-off"
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -115,6 +127,10 @@
       ],
       "purl": "pkg:npm/my-noname@0.0.0",
       "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-noname"
+        },
         {
           "name": "cdx:npm:package:private",
           "value": "true"

--- a/demo/local-dependencies/example-results/bom.1.4.json
+++ b/demo/local-dependencies/example-results/bom.1.4.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-local-deps@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -78,7 +78,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-a"
         },
         {
@@ -103,7 +103,7 @@
       "purl": "pkg:npm/my-local-b-off@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-b-off"
         },
         {
@@ -128,7 +128,7 @@
       "purl": "pkg:npm/my-noname@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-noname"
         },
         {

--- a/demo/local-dependencies/example-results/bom.1.4.xml
+++ b/demo/local-dependencies/example-results/bom.1.4.xml
@@ -5,7 +5,7 @@
       <tool>
         <vendor>@cyclonedx</vendor>
         <name>cyclonedx-npm</name>
-        <version>1.4.0</version>
+        <version>1.4.1</version>
         <externalReferences>
           <reference type="issue-tracker">
             <url>https://github.com/CycloneDX/cyclonedx-node-npm/issues</url>
@@ -33,6 +33,7 @@
       </licenses>
       <purl>pkg:npm/demo-local-deps@0.0.0</purl>
       <properties>
+        <property name="cdx:npm:package:installPath"/>
         <property name="cdx:npm:package:private">true</property>
       </properties>
     </component>
@@ -55,6 +56,7 @@
         </reference>
       </externalReferences>
       <properties>
+        <property name="cdx:npm:package:installPath">node_modules/my-local-a</property>
         <property name="cdx:npm:package:private">true</property>
       </properties>
     </component>
@@ -69,6 +71,7 @@
       </licenses>
       <purl>pkg:npm/my-local-b-off@0.0.0</purl>
       <properties>
+        <property name="cdx:npm:package:installPath">node_modules/my-local-b-off</property>
         <property name="cdx:npm:package:private">true</property>
       </properties>
     </component>
@@ -83,6 +86,7 @@
       </licenses>
       <purl>pkg:npm/my-noname@0.0.0</purl>
       <properties>
+        <property name="cdx:npm:package:installPath">node_modules/my-noname</property>
         <property name="cdx:npm:package:private">true</property>
       </properties>
     </component>

--- a/demo/local-dependencies/example-results/bom.1.4.xml
+++ b/demo/local-dependencies/example-results/bom.1.4.xml
@@ -33,7 +33,7 @@
       </licenses>
       <purl>pkg:npm/demo-local-deps@0.0.0</purl>
       <properties>
-        <property name="cdx:npm:package:installPath"/>
+        <property name="cdx:npm:package:path"/>
         <property name="cdx:npm:package:private">true</property>
       </properties>
     </component>
@@ -56,7 +56,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/my-local-a</property>
+        <property name="cdx:npm:package:path">node_modules/my-local-a</property>
         <property name="cdx:npm:package:private">true</property>
       </properties>
     </component>
@@ -71,7 +71,7 @@
       </licenses>
       <purl>pkg:npm/my-local-b-off@0.0.0</purl>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/my-local-b-off</property>
+        <property name="cdx:npm:package:path">node_modules/my-local-b-off</property>
         <property name="cdx:npm:package:private">true</property>
       </properties>
     </component>
@@ -86,7 +86,7 @@
       </licenses>
       <purl>pkg:npm/my-noname@0.0.0</purl>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/my-noname</property>
+        <property name="cdx:npm:package:path">node_modules/my-noname</property>
         <property name="cdx:npm:package:private">true</property>
       </properties>
     </component>

--- a/demo/local-workspaces/example-results/bom.1.2.json
+++ b/demo/local-workspaces/example-results/bom.1.2.json
@@ -8,7 +8,7 @@
       {
         "vendor": "@cyclonedx",
         "name": "cyclonedx-npm",
-        "version": "1.4.0"
+        "version": "1.4.1"
       }
     ],
     "component": {

--- a/demo/local-workspaces/example-results/bom.1.2.xml
+++ b/demo/local-workspaces/example-results/bom.1.2.xml
@@ -5,7 +5,7 @@
       <tool>
         <vendor>@cyclonedx</vendor>
         <name>cyclonedx-npm</name>
-        <version>1.4.0</version>
+        <version>1.4.1</version>
       </tool>
     </tools>
     <component type="application" bom-ref="demo-workspaces@0.0.0">

--- a/demo/local-workspaces/example-results/bom.1.3.json
+++ b/demo/local-workspaces/example-results/bom.1.3.json
@@ -8,7 +8,7 @@
       {
         "vendor": "@cyclonedx",
         "name": "cyclonedx-npm",
-        "version": "1.4.0"
+        "version": "1.4.1"
       }
     ],
     "component": {
@@ -26,6 +26,10 @@
       ],
       "purl": "pkg:npm/demo-workspaces@0.0.0",
       "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
         {
           "name": "cdx:npm:package:private",
           "value": "true"
@@ -57,6 +61,10 @@
       ],
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-a"
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -77,6 +85,10 @@
       ],
       "purl": "pkg:npm/my-local-b-off@0.0.0",
       "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-b-off"
+        },
         {
           "name": "cdx:npm:package:private",
           "value": "true"
@@ -105,6 +117,10 @@
         }
       ],
       "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-c"
+        },
         {
           "name": "cdx:npm:package:private",
           "value": "true"

--- a/demo/local-workspaces/example-results/bom.1.3.json
+++ b/demo/local-workspaces/example-results/bom.1.3.json
@@ -27,7 +27,7 @@
       "purl": "pkg:npm/demo-workspaces@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -61,7 +61,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-a"
         },
         {
@@ -86,7 +86,7 @@
       "purl": "pkg:npm/my-local-b-off@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-b-off"
         },
         {
@@ -118,7 +118,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-c"
         },
         {

--- a/demo/local-workspaces/example-results/bom.1.3.xml
+++ b/demo/local-workspaces/example-results/bom.1.3.xml
@@ -5,7 +5,7 @@
       <tool>
         <vendor>@cyclonedx</vendor>
         <name>cyclonedx-npm</name>
-        <version>1.4.0</version>
+        <version>1.4.1</version>
       </tool>
     </tools>
     <component type="application" bom-ref="demo-workspaces@0.0.0">
@@ -19,6 +19,7 @@
       </licenses>
       <purl>pkg:npm/demo-workspaces@0.0.0</purl>
       <properties>
+        <property name="cdx:npm:package:installPath"/>
         <property name="cdx:npm:package:private">true</property>
       </properties>
     </component>
@@ -41,6 +42,7 @@
         </reference>
       </externalReferences>
       <properties>
+        <property name="cdx:npm:package:installPath">node_modules/my-local-a</property>
         <property name="cdx:npm:package:private">true</property>
       </properties>
     </component>
@@ -55,6 +57,7 @@
       </licenses>
       <purl>pkg:npm/my-local-b-off@0.0.0</purl>
       <properties>
+        <property name="cdx:npm:package:installPath">node_modules/my-local-b-off</property>
         <property name="cdx:npm:package:private">true</property>
       </properties>
     </component>
@@ -75,6 +78,7 @@
         </reference>
       </externalReferences>
       <properties>
+        <property name="cdx:npm:package:installPath">node_modules/my-local-c</property>
         <property name="cdx:npm:package:private">true</property>
       </properties>
     </component>

--- a/demo/local-workspaces/example-results/bom.1.3.xml
+++ b/demo/local-workspaces/example-results/bom.1.3.xml
@@ -19,7 +19,7 @@
       </licenses>
       <purl>pkg:npm/demo-workspaces@0.0.0</purl>
       <properties>
-        <property name="cdx:npm:package:installPath"/>
+        <property name="cdx:npm:package:path"/>
         <property name="cdx:npm:package:private">true</property>
       </properties>
     </component>
@@ -42,7 +42,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/my-local-a</property>
+        <property name="cdx:npm:package:path">node_modules/my-local-a</property>
         <property name="cdx:npm:package:private">true</property>
       </properties>
     </component>
@@ -57,7 +57,7 @@
       </licenses>
       <purl>pkg:npm/my-local-b-off@0.0.0</purl>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/my-local-b-off</property>
+        <property name="cdx:npm:package:path">node_modules/my-local-b-off</property>
         <property name="cdx:npm:package:private">true</property>
       </properties>
     </component>
@@ -78,7 +78,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/my-local-c</property>
+        <property name="cdx:npm:package:path">node_modules/my-local-c</property>
         <property name="cdx:npm:package:private">true</property>
       </properties>
     </component>

--- a/demo/local-workspaces/example-results/bom.1.4.json
+++ b/demo/local-workspaces/example-results/bom.1.4.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-workspaces@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -78,7 +78,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-a"
         },
         {
@@ -103,7 +103,7 @@
       "purl": "pkg:npm/my-local-b-off@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-b-off"
         },
         {
@@ -135,7 +135,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-c"
         },
         {

--- a/demo/local-workspaces/example-results/bom.1.4.json
+++ b/demo/local-workspaces/example-results/bom.1.4.json
@@ -8,7 +8,7 @@
       {
         "vendor": "@cyclonedx",
         "name": "cyclonedx-npm",
-        "version": "1.4.0",
+        "version": "1.4.1",
         "externalReferences": [
           {
             "url": "https://github.com/CycloneDX/cyclonedx-node-npm/issues",
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-workspaces@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -74,6 +78,10 @@
       ],
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-a"
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -94,6 +102,10 @@
       ],
       "purl": "pkg:npm/my-local-b-off@0.0.0",
       "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-b-off"
+        },
         {
           "name": "cdx:npm:package:private",
           "value": "true"
@@ -122,6 +134,10 @@
         }
       ],
       "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-c"
+        },
         {
           "name": "cdx:npm:package:private",
           "value": "true"

--- a/demo/local-workspaces/example-results/bom.1.4.xml
+++ b/demo/local-workspaces/example-results/bom.1.4.xml
@@ -5,7 +5,7 @@
       <tool>
         <vendor>@cyclonedx</vendor>
         <name>cyclonedx-npm</name>
-        <version>1.4.0</version>
+        <version>1.4.1</version>
         <externalReferences>
           <reference type="issue-tracker">
             <url>https://github.com/CycloneDX/cyclonedx-node-npm/issues</url>
@@ -33,6 +33,7 @@
       </licenses>
       <purl>pkg:npm/demo-workspaces@0.0.0</purl>
       <properties>
+        <property name="cdx:npm:package:installPath"/>
         <property name="cdx:npm:package:private">true</property>
       </properties>
     </component>
@@ -55,6 +56,7 @@
         </reference>
       </externalReferences>
       <properties>
+        <property name="cdx:npm:package:installPath">node_modules/my-local-a</property>
         <property name="cdx:npm:package:private">true</property>
       </properties>
     </component>
@@ -69,6 +71,7 @@
       </licenses>
       <purl>pkg:npm/my-local-b-off@0.0.0</purl>
       <properties>
+        <property name="cdx:npm:package:installPath">node_modules/my-local-b-off</property>
         <property name="cdx:npm:package:private">true</property>
       </properties>
     </component>
@@ -89,6 +92,7 @@
         </reference>
       </externalReferences>
       <properties>
+        <property name="cdx:npm:package:installPath">node_modules/my-local-c</property>
         <property name="cdx:npm:package:private">true</property>
       </properties>
     </component>

--- a/demo/local-workspaces/example-results/bom.1.4.xml
+++ b/demo/local-workspaces/example-results/bom.1.4.xml
@@ -33,7 +33,7 @@
       </licenses>
       <purl>pkg:npm/demo-workspaces@0.0.0</purl>
       <properties>
-        <property name="cdx:npm:package:installPath"/>
+        <property name="cdx:npm:package:path"/>
         <property name="cdx:npm:package:private">true</property>
       </properties>
     </component>
@@ -56,7 +56,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/my-local-a</property>
+        <property name="cdx:npm:package:path">node_modules/my-local-a</property>
         <property name="cdx:npm:package:private">true</property>
       </properties>
     </component>
@@ -71,7 +71,7 @@
       </licenses>
       <purl>pkg:npm/my-local-b-off@0.0.0</purl>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/my-local-b-off</property>
+        <property name="cdx:npm:package:path">node_modules/my-local-b-off</property>
         <property name="cdx:npm:package:private">true</property>
       </properties>
     </component>
@@ -92,7 +92,7 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:npm:package:installPath">node_modules/my-local-c</property>
+        <property name="cdx:npm:package:path">node_modules/my-local-c</property>
         <property name="cdx:npm:package:private">true</property>
       </properties>
     </component>

--- a/src/builders.ts
+++ b/src/builders.ts
@@ -19,8 +19,7 @@ Copyright (c) OWASP Foundation. All Rights Reserved.
 
 import { Builders, Enums, Factories, Models } from '@cyclonedx/cyclonedx-library'
 import { PackageURL } from 'packageurl-js'
-import { relative as relativePathPosix } from 'path/posix'
-import { relative as relativePathWin } from 'path/win32'
+import * as path from 'path'
 
 import { makeNpmRunner, runFunc } from './npmRunner'
 import { PropertyNames, PropertyValueBool } from './properties'
@@ -468,8 +467,8 @@ export class BomBuilder {
     }
     // do not depend on `node:path.relative()` -- this would be runtime-dependent, not input-dependent
     const [relativePath, dirSep] = rootPath[0] === '/'
-      ? [relativePathPosix, '/']
-      : [relativePathWin, '\\']
+      ? [path.posix.relative, '/']
+      : [path.win32.relative, '\\']
     for (const component of components) {
       for (const property of component.properties) {
         if (property.name !== PropertyNames.PackageInstallPath) {

--- a/src/properties.ts
+++ b/src/properties.ts
@@ -18,16 +18,21 @@ Copyright (c) OWASP Foundation. All Rights Reserved.
 */
 
 /**
+ * CDX properties' names - specific to this very tool.
  * @see {@link https://github.com/CycloneDX/cyclonedx-property-taxonomy/blob/main/cdx/npm.md npm property taxonomy}
  */
-
 export const enum PropertyNames {
   PackageBundled = 'cdx:npm:package:bundled',
   PackageExtraneous = 'cdx:npm:package:extraneous',
   PackagePrivate = 'cdx:npm:package:private',
   PackageDevelopment = 'cdx:npm:package:development',
+  PackageInstallPath = 'cdx:npm:package:installPath',
 }
 
+/**
+ * CDX properties' values' boolean representation - specific to this very tool.
+ * @see {@link https://github.com/CycloneDX/cyclonedx-property-taxonomy/blob/main/cdx/npm.md npm property taxonomy}
+ */
 export const enum PropertyValueBool {
   True = 'true',
   False = 'false',

--- a/src/properties.ts
+++ b/src/properties.ts
@@ -26,7 +26,7 @@ export const enum PropertyNames {
   PackageExtraneous = 'cdx:npm:package:extraneous',
   PackagePrivate = 'cdx:npm:package:private',
   PackageDevelopment = 'cdx:npm:package:development',
-  PackageInstallPath = 'cdx:npm:package:installPath',
+  PackageInstallPath = 'cdx:npm:package:path',
 }
 
 /**

--- a/tests/_data/sbom_demo-results/bundled-dependencies_npm6_node14_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bundled-dependencies_npm6_node14_macos-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-bundled-deps@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -94,6 +98,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bundle-dependencies"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -136,6 +146,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/ansi-regex"
             }
           ]
         },
@@ -180,6 +194,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/builtin-modules"
             }
           ]
         },
@@ -224,6 +242,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/camelcase"
             }
           ]
         },
@@ -268,6 +290,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/cliui"
             }
           ]
         },
@@ -312,6 +338,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/code-point-at"
             }
           ]
         },
@@ -356,6 +386,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/decamelize"
             }
           ]
         },
@@ -399,6 +433,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/error-ex"
             }
           ]
         },
@@ -443,6 +481,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/escape-string-regexp"
             }
           ]
         },
@@ -487,6 +529,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/find-up"
             }
           ]
         },
@@ -530,6 +576,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/graceful-fs"
             }
           ]
         },
@@ -574,6 +624,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/hosted-git-info"
             }
           ]
         },
@@ -618,6 +672,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/invert-kv"
             }
           ]
         },
@@ -662,6 +720,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-arrayish"
             }
           ]
         },
@@ -706,6 +768,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-builtin-module"
             }
           ]
         },
@@ -750,6 +816,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-fullwidth-code-point"
             }
           ]
         },
@@ -794,6 +864,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-utf8"
             }
           ]
         },
@@ -838,6 +912,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lcid"
             }
           ]
         },
@@ -882,6 +960,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/load-json-file"
             }
           ]
         },
@@ -926,6 +1008,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lodash.assign"
             }
           ]
         },
@@ -970,6 +1056,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lodash.keys"
             }
           ]
         },
@@ -1014,6 +1104,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lodash.rest"
             }
           ]
         },
@@ -1058,6 +1152,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/normalize-package-data"
             }
           ]
         },
@@ -1102,6 +1200,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/number-is-nan"
             }
           ]
         },
@@ -1146,6 +1248,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/object-assign"
             }
           ]
         },
@@ -1190,6 +1296,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/os-locale"
             }
           ]
         },
@@ -1234,6 +1344,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/parse-json"
             }
           ]
         },
@@ -1278,6 +1392,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/path-exists"
             }
           ]
         },
@@ -1322,6 +1440,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/path-type"
             }
           ]
         },
@@ -1366,6 +1488,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pify"
             }
           ]
         },
@@ -1410,6 +1536,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pinkie-promise"
             }
           ]
         },
@@ -1454,6 +1584,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pinkie"
             }
           ]
         },
@@ -1498,6 +1632,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pkg-conf"
             }
           ]
         },
@@ -1542,6 +1680,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/read-pkg-up"
             }
           ]
         },
@@ -1586,6 +1728,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/read-pkg"
             }
           ]
         },
@@ -1630,6 +1776,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/require-main-filename"
             }
           ]
         },
@@ -1673,6 +1823,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/semver"
             }
           ]
         },
@@ -1717,6 +1871,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-correct"
             }
           ]
         },
@@ -1761,6 +1919,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-exceptions"
             }
           ]
         },
@@ -1803,6 +1965,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-expression-parse"
             }
           ]
         },
@@ -1847,6 +2013,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-license-ids"
             }
           ]
         },
@@ -1891,6 +2061,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/string-width"
             }
           ]
         },
@@ -1935,6 +2109,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/strip-ansi"
             }
           ]
         },
@@ -1979,6 +2157,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/strip-bom"
             }
           ]
         },
@@ -2023,6 +2205,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/symbol"
             }
           ]
         },
@@ -2067,6 +2253,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/validate-npm-package-license"
             }
           ]
         },
@@ -2111,6 +2301,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/window-size"
             }
           ]
         },
@@ -2155,6 +2349,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/wrap-ansi"
             }
           ]
         },
@@ -2199,6 +2397,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/y18n"
             }
           ]
         },
@@ -2243,6 +2445,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/yargs-parser"
             }
           ]
         },
@@ -2286,6 +2492,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/yargs"
             }
           ]
         }

--- a/tests/_data/sbom_demo-results/bundled-dependencies_npm6_node14_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bundled-dependencies_npm6_node14_macos-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-bundled-deps@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -100,7 +100,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bundle-dependencies"
         }
       ],
@@ -148,7 +148,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/ansi-regex"
             }
           ]
@@ -196,7 +196,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/builtin-modules"
             }
           ]
@@ -244,7 +244,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/camelcase"
             }
           ]
@@ -292,7 +292,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/cliui"
             }
           ]
@@ -340,7 +340,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/code-point-at"
             }
           ]
@@ -388,7 +388,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/decamelize"
             }
           ]
@@ -435,7 +435,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/error-ex"
             }
           ]
@@ -483,7 +483,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/escape-string-regexp"
             }
           ]
@@ -531,7 +531,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/find-up"
             }
           ]
@@ -578,7 +578,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/graceful-fs"
             }
           ]
@@ -626,7 +626,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/hosted-git-info"
             }
           ]
@@ -674,7 +674,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/invert-kv"
             }
           ]
@@ -722,7 +722,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-arrayish"
             }
           ]
@@ -770,7 +770,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-builtin-module"
             }
           ]
@@ -818,7 +818,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -866,7 +866,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-utf8"
             }
           ]
@@ -914,7 +914,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lcid"
             }
           ]
@@ -962,7 +962,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/load-json-file"
             }
           ]
@@ -1010,7 +1010,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lodash.assign"
             }
           ]
@@ -1058,7 +1058,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lodash.keys"
             }
           ]
@@ -1106,7 +1106,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lodash.rest"
             }
           ]
@@ -1154,7 +1154,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/normalize-package-data"
             }
           ]
@@ -1202,7 +1202,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/number-is-nan"
             }
           ]
@@ -1250,7 +1250,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/object-assign"
             }
           ]
@@ -1298,7 +1298,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/os-locale"
             }
           ]
@@ -1346,7 +1346,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/parse-json"
             }
           ]
@@ -1394,7 +1394,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/path-exists"
             }
           ]
@@ -1442,7 +1442,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/path-type"
             }
           ]
@@ -1490,7 +1490,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pify"
             }
           ]
@@ -1538,7 +1538,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pinkie-promise"
             }
           ]
@@ -1586,7 +1586,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pinkie"
             }
           ]
@@ -1634,7 +1634,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pkg-conf"
             }
           ]
@@ -1682,7 +1682,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/read-pkg-up"
             }
           ]
@@ -1730,7 +1730,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/read-pkg"
             }
           ]
@@ -1778,7 +1778,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/require-main-filename"
             }
           ]
@@ -1825,7 +1825,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/semver"
             }
           ]
@@ -1873,7 +1873,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-correct"
             }
           ]
@@ -1921,7 +1921,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-exceptions"
             }
           ]
@@ -1967,7 +1967,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-expression-parse"
             }
           ]
@@ -2015,7 +2015,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-license-ids"
             }
           ]
@@ -2063,7 +2063,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/string-width"
             }
           ]
@@ -2111,7 +2111,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/strip-ansi"
             }
           ]
@@ -2159,7 +2159,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/strip-bom"
             }
           ]
@@ -2207,7 +2207,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/symbol"
             }
           ]
@@ -2255,7 +2255,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/validate-npm-package-license"
             }
           ]
@@ -2303,7 +2303,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/window-size"
             }
           ]
@@ -2351,7 +2351,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/wrap-ansi"
             }
           ]
@@ -2399,7 +2399,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/y18n"
             }
           ]
@@ -2447,7 +2447,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/yargs-parser"
             }
           ]
@@ -2494,7 +2494,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/yargs"
             }
           ]

--- a/tests/_data/sbom_demo-results/bundled-dependencies_npm6_node14_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bundled-dependencies_npm6_node14_ubuntu-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-bundled-deps@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -94,6 +98,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bundle-dependencies"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -136,6 +146,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/ansi-regex"
             }
           ]
         },
@@ -180,6 +194,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/builtin-modules"
             }
           ]
         },
@@ -224,6 +242,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/camelcase"
             }
           ]
         },
@@ -268,6 +290,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/cliui"
             }
           ]
         },
@@ -312,6 +338,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/code-point-at"
             }
           ]
         },
@@ -356,6 +386,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/decamelize"
             }
           ]
         },
@@ -399,6 +433,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/error-ex"
             }
           ]
         },
@@ -443,6 +481,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/escape-string-regexp"
             }
           ]
         },
@@ -487,6 +529,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/find-up"
             }
           ]
         },
@@ -530,6 +576,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/graceful-fs"
             }
           ]
         },
@@ -574,6 +624,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/hosted-git-info"
             }
           ]
         },
@@ -618,6 +672,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/invert-kv"
             }
           ]
         },
@@ -662,6 +720,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-arrayish"
             }
           ]
         },
@@ -706,6 +768,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-builtin-module"
             }
           ]
         },
@@ -750,6 +816,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-fullwidth-code-point"
             }
           ]
         },
@@ -794,6 +864,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-utf8"
             }
           ]
         },
@@ -838,6 +912,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lcid"
             }
           ]
         },
@@ -882,6 +960,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/load-json-file"
             }
           ]
         },
@@ -926,6 +1008,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lodash.assign"
             }
           ]
         },
@@ -970,6 +1056,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lodash.keys"
             }
           ]
         },
@@ -1014,6 +1104,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lodash.rest"
             }
           ]
         },
@@ -1058,6 +1152,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/normalize-package-data"
             }
           ]
         },
@@ -1102,6 +1200,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/number-is-nan"
             }
           ]
         },
@@ -1146,6 +1248,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/object-assign"
             }
           ]
         },
@@ -1190,6 +1296,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/os-locale"
             }
           ]
         },
@@ -1234,6 +1344,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/parse-json"
             }
           ]
         },
@@ -1278,6 +1392,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/path-exists"
             }
           ]
         },
@@ -1322,6 +1440,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/path-type"
             }
           ]
         },
@@ -1366,6 +1488,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pify"
             }
           ]
         },
@@ -1410,6 +1536,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pinkie-promise"
             }
           ]
         },
@@ -1454,6 +1584,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pinkie"
             }
           ]
         },
@@ -1498,6 +1632,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pkg-conf"
             }
           ]
         },
@@ -1542,6 +1680,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/read-pkg-up"
             }
           ]
         },
@@ -1586,6 +1728,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/read-pkg"
             }
           ]
         },
@@ -1630,6 +1776,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/require-main-filename"
             }
           ]
         },
@@ -1673,6 +1823,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/semver"
             }
           ]
         },
@@ -1717,6 +1871,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-correct"
             }
           ]
         },
@@ -1761,6 +1919,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-exceptions"
             }
           ]
         },
@@ -1803,6 +1965,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-expression-parse"
             }
           ]
         },
@@ -1847,6 +2013,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-license-ids"
             }
           ]
         },
@@ -1891,6 +2061,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/string-width"
             }
           ]
         },
@@ -1935,6 +2109,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/strip-ansi"
             }
           ]
         },
@@ -1979,6 +2157,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/strip-bom"
             }
           ]
         },
@@ -2023,6 +2205,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/symbol"
             }
           ]
         },
@@ -2067,6 +2253,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/validate-npm-package-license"
             }
           ]
         },
@@ -2111,6 +2301,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/window-size"
             }
           ]
         },
@@ -2155,6 +2349,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/wrap-ansi"
             }
           ]
         },
@@ -2199,6 +2397,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/y18n"
             }
           ]
         },
@@ -2243,6 +2445,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/yargs-parser"
             }
           ]
         },
@@ -2286,6 +2492,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/yargs"
             }
           ]
         }

--- a/tests/_data/sbom_demo-results/bundled-dependencies_npm6_node14_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bundled-dependencies_npm6_node14_ubuntu-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-bundled-deps@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -100,7 +100,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bundle-dependencies"
         }
       ],
@@ -148,7 +148,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/ansi-regex"
             }
           ]
@@ -196,7 +196,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/builtin-modules"
             }
           ]
@@ -244,7 +244,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/camelcase"
             }
           ]
@@ -292,7 +292,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/cliui"
             }
           ]
@@ -340,7 +340,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/code-point-at"
             }
           ]
@@ -388,7 +388,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/decamelize"
             }
           ]
@@ -435,7 +435,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/error-ex"
             }
           ]
@@ -483,7 +483,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/escape-string-regexp"
             }
           ]
@@ -531,7 +531,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/find-up"
             }
           ]
@@ -578,7 +578,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/graceful-fs"
             }
           ]
@@ -626,7 +626,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/hosted-git-info"
             }
           ]
@@ -674,7 +674,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/invert-kv"
             }
           ]
@@ -722,7 +722,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-arrayish"
             }
           ]
@@ -770,7 +770,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-builtin-module"
             }
           ]
@@ -818,7 +818,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -866,7 +866,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-utf8"
             }
           ]
@@ -914,7 +914,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lcid"
             }
           ]
@@ -962,7 +962,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/load-json-file"
             }
           ]
@@ -1010,7 +1010,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lodash.assign"
             }
           ]
@@ -1058,7 +1058,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lodash.keys"
             }
           ]
@@ -1106,7 +1106,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lodash.rest"
             }
           ]
@@ -1154,7 +1154,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/normalize-package-data"
             }
           ]
@@ -1202,7 +1202,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/number-is-nan"
             }
           ]
@@ -1250,7 +1250,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/object-assign"
             }
           ]
@@ -1298,7 +1298,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/os-locale"
             }
           ]
@@ -1346,7 +1346,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/parse-json"
             }
           ]
@@ -1394,7 +1394,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/path-exists"
             }
           ]
@@ -1442,7 +1442,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/path-type"
             }
           ]
@@ -1490,7 +1490,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pify"
             }
           ]
@@ -1538,7 +1538,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pinkie-promise"
             }
           ]
@@ -1586,7 +1586,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pinkie"
             }
           ]
@@ -1634,7 +1634,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pkg-conf"
             }
           ]
@@ -1682,7 +1682,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/read-pkg-up"
             }
           ]
@@ -1730,7 +1730,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/read-pkg"
             }
           ]
@@ -1778,7 +1778,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/require-main-filename"
             }
           ]
@@ -1825,7 +1825,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/semver"
             }
           ]
@@ -1873,7 +1873,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-correct"
             }
           ]
@@ -1921,7 +1921,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-exceptions"
             }
           ]
@@ -1967,7 +1967,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-expression-parse"
             }
           ]
@@ -2015,7 +2015,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-license-ids"
             }
           ]
@@ -2063,7 +2063,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/string-width"
             }
           ]
@@ -2111,7 +2111,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/strip-ansi"
             }
           ]
@@ -2159,7 +2159,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/strip-bom"
             }
           ]
@@ -2207,7 +2207,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/symbol"
             }
           ]
@@ -2255,7 +2255,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/validate-npm-package-license"
             }
           ]
@@ -2303,7 +2303,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/window-size"
             }
           ]
@@ -2351,7 +2351,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/wrap-ansi"
             }
           ]
@@ -2399,7 +2399,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/y18n"
             }
           ]
@@ -2447,7 +2447,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/yargs-parser"
             }
           ]
@@ -2494,7 +2494,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/yargs"
             }
           ]

--- a/tests/_data/sbom_demo-results/bundled-dependencies_npm6_node14_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bundled-dependencies_npm6_node14_windows-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-bundled-deps@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -94,6 +98,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bundle-dependencies"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -136,6 +146,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\ansi-regex"
             }
           ]
         },
@@ -180,6 +194,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\builtin-modules"
             }
           ]
         },
@@ -224,6 +242,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\camelcase"
             }
           ]
         },
@@ -268,6 +290,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\cliui"
             }
           ]
         },
@@ -312,6 +338,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\code-point-at"
             }
           ]
         },
@@ -356,6 +386,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\decamelize"
             }
           ]
         },
@@ -399,6 +433,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\error-ex"
             }
           ]
         },
@@ -443,6 +481,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\escape-string-regexp"
             }
           ]
         },
@@ -487,6 +529,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\find-up"
             }
           ]
         },
@@ -530,6 +576,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\graceful-fs"
             }
           ]
         },
@@ -574,6 +624,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\hosted-git-info"
             }
           ]
         },
@@ -618,6 +672,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\invert-kv"
             }
           ]
         },
@@ -662,6 +720,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\is-arrayish"
             }
           ]
         },
@@ -706,6 +768,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\is-builtin-module"
             }
           ]
         },
@@ -750,6 +816,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\is-fullwidth-code-point"
             }
           ]
         },
@@ -794,6 +864,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\is-utf8"
             }
           ]
         },
@@ -838,6 +912,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\lcid"
             }
           ]
         },
@@ -882,6 +960,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\load-json-file"
             }
           ]
         },
@@ -926,6 +1008,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\lodash.assign"
             }
           ]
         },
@@ -970,6 +1056,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\lodash.keys"
             }
           ]
         },
@@ -1014,6 +1104,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\lodash.rest"
             }
           ]
         },
@@ -1058,6 +1152,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\normalize-package-data"
             }
           ]
         },
@@ -1102,6 +1200,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\number-is-nan"
             }
           ]
         },
@@ -1146,6 +1248,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\object-assign"
             }
           ]
         },
@@ -1190,6 +1296,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\os-locale"
             }
           ]
         },
@@ -1234,6 +1344,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\parse-json"
             }
           ]
         },
@@ -1278,6 +1392,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\path-exists"
             }
           ]
         },
@@ -1322,6 +1440,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\path-type"
             }
           ]
         },
@@ -1366,6 +1488,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\pify"
             }
           ]
         },
@@ -1410,6 +1536,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\pinkie-promise"
             }
           ]
         },
@@ -1454,6 +1584,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\pinkie"
             }
           ]
         },
@@ -1498,6 +1632,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\pkg-conf"
             }
           ]
         },
@@ -1542,6 +1680,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\read-pkg-up"
             }
           ]
         },
@@ -1586,6 +1728,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\read-pkg"
             }
           ]
         },
@@ -1630,6 +1776,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\require-main-filename"
             }
           ]
         },
@@ -1673,6 +1823,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\semver"
             }
           ]
         },
@@ -1717,6 +1871,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\spdx-correct"
             }
           ]
         },
@@ -1761,6 +1919,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\spdx-exceptions"
             }
           ]
         },
@@ -1803,6 +1965,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\spdx-expression-parse"
             }
           ]
         },
@@ -1847,6 +2013,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\spdx-license-ids"
             }
           ]
         },
@@ -1891,6 +2061,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\string-width"
             }
           ]
         },
@@ -1935,6 +2109,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\strip-ansi"
             }
           ]
         },
@@ -1979,6 +2157,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\strip-bom"
             }
           ]
         },
@@ -2023,6 +2205,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\symbol"
             }
           ]
         },
@@ -2067,6 +2253,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\validate-npm-package-license"
             }
           ]
         },
@@ -2111,6 +2301,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\window-size"
             }
           ]
         },
@@ -2155,6 +2349,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\wrap-ansi"
             }
           ]
         },
@@ -2199,6 +2397,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\y18n"
             }
           ]
         },
@@ -2243,6 +2445,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\yargs-parser"
             }
           ]
         },
@@ -2286,6 +2492,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\yargs"
             }
           ]
         }

--- a/tests/_data/sbom_demo-results/bundled-dependencies_npm6_node14_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bundled-dependencies_npm6_node14_windows-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-bundled-deps@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -100,7 +100,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bundle-dependencies"
         }
       ],
@@ -148,7 +148,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\ansi-regex"
             }
           ]
@@ -196,7 +196,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\builtin-modules"
             }
           ]
@@ -244,7 +244,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\camelcase"
             }
           ]
@@ -292,7 +292,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\cliui"
             }
           ]
@@ -340,7 +340,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\code-point-at"
             }
           ]
@@ -388,7 +388,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\decamelize"
             }
           ]
@@ -435,7 +435,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\error-ex"
             }
           ]
@@ -483,7 +483,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\escape-string-regexp"
             }
           ]
@@ -531,7 +531,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\find-up"
             }
           ]
@@ -578,7 +578,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\graceful-fs"
             }
           ]
@@ -626,7 +626,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\hosted-git-info"
             }
           ]
@@ -674,7 +674,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\invert-kv"
             }
           ]
@@ -722,7 +722,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\is-arrayish"
             }
           ]
@@ -770,7 +770,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\is-builtin-module"
             }
           ]
@@ -818,7 +818,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\is-fullwidth-code-point"
             }
           ]
@@ -866,7 +866,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\is-utf8"
             }
           ]
@@ -914,7 +914,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\lcid"
             }
           ]
@@ -962,7 +962,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\load-json-file"
             }
           ]
@@ -1010,7 +1010,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\lodash.assign"
             }
           ]
@@ -1058,7 +1058,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\lodash.keys"
             }
           ]
@@ -1106,7 +1106,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\lodash.rest"
             }
           ]
@@ -1154,7 +1154,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\normalize-package-data"
             }
           ]
@@ -1202,7 +1202,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\number-is-nan"
             }
           ]
@@ -1250,7 +1250,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\object-assign"
             }
           ]
@@ -1298,7 +1298,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\os-locale"
             }
           ]
@@ -1346,7 +1346,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\parse-json"
             }
           ]
@@ -1394,7 +1394,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\path-exists"
             }
           ]
@@ -1442,7 +1442,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\path-type"
             }
           ]
@@ -1490,7 +1490,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\pify"
             }
           ]
@@ -1538,7 +1538,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\pinkie-promise"
             }
           ]
@@ -1586,7 +1586,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\pinkie"
             }
           ]
@@ -1634,7 +1634,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\pkg-conf"
             }
           ]
@@ -1682,7 +1682,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\read-pkg-up"
             }
           ]
@@ -1730,7 +1730,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\read-pkg"
             }
           ]
@@ -1778,7 +1778,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\require-main-filename"
             }
           ]
@@ -1825,7 +1825,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\semver"
             }
           ]
@@ -1873,7 +1873,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\spdx-correct"
             }
           ]
@@ -1921,7 +1921,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\spdx-exceptions"
             }
           ]
@@ -1967,7 +1967,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\spdx-expression-parse"
             }
           ]
@@ -2015,7 +2015,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\spdx-license-ids"
             }
           ]
@@ -2063,7 +2063,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\string-width"
             }
           ]
@@ -2111,7 +2111,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\strip-ansi"
             }
           ]
@@ -2159,7 +2159,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\strip-bom"
             }
           ]
@@ -2207,7 +2207,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\symbol"
             }
           ]
@@ -2255,7 +2255,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\validate-npm-package-license"
             }
           ]
@@ -2303,7 +2303,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\window-size"
             }
           ]
@@ -2351,7 +2351,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\wrap-ansi"
             }
           ]
@@ -2399,7 +2399,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\y18n"
             }
           ]
@@ -2447,7 +2447,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\yargs-parser"
             }
           ]
@@ -2494,7 +2494,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\yargs"
             }
           ]

--- a/tests/_data/sbom_demo-results/bundled-dependencies_npm6_node16_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bundled-dependencies_npm6_node16_macos-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-bundled-deps@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -94,6 +98,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bundle-dependencies"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -136,6 +146,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/ansi-regex"
             }
           ]
         },
@@ -180,6 +194,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/builtin-modules"
             }
           ]
         },
@@ -224,6 +242,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/camelcase"
             }
           ]
         },
@@ -268,6 +290,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/cliui"
             }
           ]
         },
@@ -312,6 +338,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/code-point-at"
             }
           ]
         },
@@ -356,6 +386,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/decamelize"
             }
           ]
         },
@@ -399,6 +433,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/error-ex"
             }
           ]
         },
@@ -443,6 +481,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/escape-string-regexp"
             }
           ]
         },
@@ -487,6 +529,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/find-up"
             }
           ]
         },
@@ -530,6 +576,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/graceful-fs"
             }
           ]
         },
@@ -574,6 +624,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/hosted-git-info"
             }
           ]
         },
@@ -618,6 +672,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/invert-kv"
             }
           ]
         },
@@ -662,6 +720,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-arrayish"
             }
           ]
         },
@@ -706,6 +768,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-builtin-module"
             }
           ]
         },
@@ -750,6 +816,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-fullwidth-code-point"
             }
           ]
         },
@@ -794,6 +864,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-utf8"
             }
           ]
         },
@@ -838,6 +912,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lcid"
             }
           ]
         },
@@ -882,6 +960,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/load-json-file"
             }
           ]
         },
@@ -926,6 +1008,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lodash.assign"
             }
           ]
         },
@@ -970,6 +1056,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lodash.keys"
             }
           ]
         },
@@ -1014,6 +1104,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lodash.rest"
             }
           ]
         },
@@ -1058,6 +1152,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/normalize-package-data"
             }
           ]
         },
@@ -1102,6 +1200,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/number-is-nan"
             }
           ]
         },
@@ -1146,6 +1248,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/object-assign"
             }
           ]
         },
@@ -1190,6 +1296,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/os-locale"
             }
           ]
         },
@@ -1234,6 +1344,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/parse-json"
             }
           ]
         },
@@ -1278,6 +1392,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/path-exists"
             }
           ]
         },
@@ -1322,6 +1440,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/path-type"
             }
           ]
         },
@@ -1366,6 +1488,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pify"
             }
           ]
         },
@@ -1410,6 +1536,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pinkie-promise"
             }
           ]
         },
@@ -1454,6 +1584,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pinkie"
             }
           ]
         },
@@ -1498,6 +1632,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pkg-conf"
             }
           ]
         },
@@ -1542,6 +1680,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/read-pkg-up"
             }
           ]
         },
@@ -1586,6 +1728,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/read-pkg"
             }
           ]
         },
@@ -1630,6 +1776,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/require-main-filename"
             }
           ]
         },
@@ -1673,6 +1823,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/semver"
             }
           ]
         },
@@ -1717,6 +1871,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-correct"
             }
           ]
         },
@@ -1761,6 +1919,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-exceptions"
             }
           ]
         },
@@ -1803,6 +1965,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-expression-parse"
             }
           ]
         },
@@ -1847,6 +2013,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-license-ids"
             }
           ]
         },
@@ -1891,6 +2061,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/string-width"
             }
           ]
         },
@@ -1935,6 +2109,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/strip-ansi"
             }
           ]
         },
@@ -1979,6 +2157,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/strip-bom"
             }
           ]
         },
@@ -2023,6 +2205,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/symbol"
             }
           ]
         },
@@ -2067,6 +2253,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/validate-npm-package-license"
             }
           ]
         },
@@ -2111,6 +2301,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/window-size"
             }
           ]
         },
@@ -2155,6 +2349,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/wrap-ansi"
             }
           ]
         },
@@ -2199,6 +2397,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/y18n"
             }
           ]
         },
@@ -2243,6 +2445,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/yargs-parser"
             }
           ]
         },
@@ -2286,6 +2492,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/yargs"
             }
           ]
         }

--- a/tests/_data/sbom_demo-results/bundled-dependencies_npm6_node16_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bundled-dependencies_npm6_node16_macos-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-bundled-deps@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -100,7 +100,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bundle-dependencies"
         }
       ],
@@ -148,7 +148,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/ansi-regex"
             }
           ]
@@ -196,7 +196,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/builtin-modules"
             }
           ]
@@ -244,7 +244,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/camelcase"
             }
           ]
@@ -292,7 +292,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/cliui"
             }
           ]
@@ -340,7 +340,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/code-point-at"
             }
           ]
@@ -388,7 +388,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/decamelize"
             }
           ]
@@ -435,7 +435,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/error-ex"
             }
           ]
@@ -483,7 +483,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/escape-string-regexp"
             }
           ]
@@ -531,7 +531,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/find-up"
             }
           ]
@@ -578,7 +578,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/graceful-fs"
             }
           ]
@@ -626,7 +626,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/hosted-git-info"
             }
           ]
@@ -674,7 +674,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/invert-kv"
             }
           ]
@@ -722,7 +722,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-arrayish"
             }
           ]
@@ -770,7 +770,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-builtin-module"
             }
           ]
@@ -818,7 +818,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -866,7 +866,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-utf8"
             }
           ]
@@ -914,7 +914,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lcid"
             }
           ]
@@ -962,7 +962,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/load-json-file"
             }
           ]
@@ -1010,7 +1010,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lodash.assign"
             }
           ]
@@ -1058,7 +1058,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lodash.keys"
             }
           ]
@@ -1106,7 +1106,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lodash.rest"
             }
           ]
@@ -1154,7 +1154,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/normalize-package-data"
             }
           ]
@@ -1202,7 +1202,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/number-is-nan"
             }
           ]
@@ -1250,7 +1250,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/object-assign"
             }
           ]
@@ -1298,7 +1298,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/os-locale"
             }
           ]
@@ -1346,7 +1346,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/parse-json"
             }
           ]
@@ -1394,7 +1394,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/path-exists"
             }
           ]
@@ -1442,7 +1442,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/path-type"
             }
           ]
@@ -1490,7 +1490,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pify"
             }
           ]
@@ -1538,7 +1538,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pinkie-promise"
             }
           ]
@@ -1586,7 +1586,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pinkie"
             }
           ]
@@ -1634,7 +1634,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pkg-conf"
             }
           ]
@@ -1682,7 +1682,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/read-pkg-up"
             }
           ]
@@ -1730,7 +1730,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/read-pkg"
             }
           ]
@@ -1778,7 +1778,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/require-main-filename"
             }
           ]
@@ -1825,7 +1825,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/semver"
             }
           ]
@@ -1873,7 +1873,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-correct"
             }
           ]
@@ -1921,7 +1921,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-exceptions"
             }
           ]
@@ -1967,7 +1967,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-expression-parse"
             }
           ]
@@ -2015,7 +2015,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-license-ids"
             }
           ]
@@ -2063,7 +2063,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/string-width"
             }
           ]
@@ -2111,7 +2111,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/strip-ansi"
             }
           ]
@@ -2159,7 +2159,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/strip-bom"
             }
           ]
@@ -2207,7 +2207,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/symbol"
             }
           ]
@@ -2255,7 +2255,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/validate-npm-package-license"
             }
           ]
@@ -2303,7 +2303,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/window-size"
             }
           ]
@@ -2351,7 +2351,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/wrap-ansi"
             }
           ]
@@ -2399,7 +2399,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/y18n"
             }
           ]
@@ -2447,7 +2447,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/yargs-parser"
             }
           ]
@@ -2494,7 +2494,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/yargs"
             }
           ]

--- a/tests/_data/sbom_demo-results/bundled-dependencies_npm6_node16_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bundled-dependencies_npm6_node16_ubuntu-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-bundled-deps@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -94,6 +98,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bundle-dependencies"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -136,6 +146,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/ansi-regex"
             }
           ]
         },
@@ -180,6 +194,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/builtin-modules"
             }
           ]
         },
@@ -224,6 +242,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/camelcase"
             }
           ]
         },
@@ -268,6 +290,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/cliui"
             }
           ]
         },
@@ -312,6 +338,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/code-point-at"
             }
           ]
         },
@@ -356,6 +386,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/decamelize"
             }
           ]
         },
@@ -399,6 +433,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/error-ex"
             }
           ]
         },
@@ -443,6 +481,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/escape-string-regexp"
             }
           ]
         },
@@ -487,6 +529,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/find-up"
             }
           ]
         },
@@ -530,6 +576,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/graceful-fs"
             }
           ]
         },
@@ -574,6 +624,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/hosted-git-info"
             }
           ]
         },
@@ -618,6 +672,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/invert-kv"
             }
           ]
         },
@@ -662,6 +720,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-arrayish"
             }
           ]
         },
@@ -706,6 +768,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-builtin-module"
             }
           ]
         },
@@ -750,6 +816,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-fullwidth-code-point"
             }
           ]
         },
@@ -794,6 +864,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-utf8"
             }
           ]
         },
@@ -838,6 +912,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lcid"
             }
           ]
         },
@@ -882,6 +960,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/load-json-file"
             }
           ]
         },
@@ -926,6 +1008,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lodash.assign"
             }
           ]
         },
@@ -970,6 +1056,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lodash.keys"
             }
           ]
         },
@@ -1014,6 +1104,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lodash.rest"
             }
           ]
         },
@@ -1058,6 +1152,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/normalize-package-data"
             }
           ]
         },
@@ -1102,6 +1200,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/number-is-nan"
             }
           ]
         },
@@ -1146,6 +1248,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/object-assign"
             }
           ]
         },
@@ -1190,6 +1296,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/os-locale"
             }
           ]
         },
@@ -1234,6 +1344,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/parse-json"
             }
           ]
         },
@@ -1278,6 +1392,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/path-exists"
             }
           ]
         },
@@ -1322,6 +1440,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/path-type"
             }
           ]
         },
@@ -1366,6 +1488,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pify"
             }
           ]
         },
@@ -1410,6 +1536,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pinkie-promise"
             }
           ]
         },
@@ -1454,6 +1584,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pinkie"
             }
           ]
         },
@@ -1498,6 +1632,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pkg-conf"
             }
           ]
         },
@@ -1542,6 +1680,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/read-pkg-up"
             }
           ]
         },
@@ -1586,6 +1728,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/read-pkg"
             }
           ]
         },
@@ -1630,6 +1776,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/require-main-filename"
             }
           ]
         },
@@ -1673,6 +1823,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/semver"
             }
           ]
         },
@@ -1717,6 +1871,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-correct"
             }
           ]
         },
@@ -1761,6 +1919,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-exceptions"
             }
           ]
         },
@@ -1803,6 +1965,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-expression-parse"
             }
           ]
         },
@@ -1847,6 +2013,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-license-ids"
             }
           ]
         },
@@ -1891,6 +2061,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/string-width"
             }
           ]
         },
@@ -1935,6 +2109,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/strip-ansi"
             }
           ]
         },
@@ -1979,6 +2157,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/strip-bom"
             }
           ]
         },
@@ -2023,6 +2205,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/symbol"
             }
           ]
         },
@@ -2067,6 +2253,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/validate-npm-package-license"
             }
           ]
         },
@@ -2111,6 +2301,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/window-size"
             }
           ]
         },
@@ -2155,6 +2349,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/wrap-ansi"
             }
           ]
         },
@@ -2199,6 +2397,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/y18n"
             }
           ]
         },
@@ -2243,6 +2445,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/yargs-parser"
             }
           ]
         },
@@ -2286,6 +2492,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/yargs"
             }
           ]
         }

--- a/tests/_data/sbom_demo-results/bundled-dependencies_npm6_node16_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bundled-dependencies_npm6_node16_ubuntu-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-bundled-deps@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -100,7 +100,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bundle-dependencies"
         }
       ],
@@ -148,7 +148,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/ansi-regex"
             }
           ]
@@ -196,7 +196,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/builtin-modules"
             }
           ]
@@ -244,7 +244,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/camelcase"
             }
           ]
@@ -292,7 +292,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/cliui"
             }
           ]
@@ -340,7 +340,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/code-point-at"
             }
           ]
@@ -388,7 +388,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/decamelize"
             }
           ]
@@ -435,7 +435,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/error-ex"
             }
           ]
@@ -483,7 +483,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/escape-string-regexp"
             }
           ]
@@ -531,7 +531,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/find-up"
             }
           ]
@@ -578,7 +578,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/graceful-fs"
             }
           ]
@@ -626,7 +626,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/hosted-git-info"
             }
           ]
@@ -674,7 +674,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/invert-kv"
             }
           ]
@@ -722,7 +722,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-arrayish"
             }
           ]
@@ -770,7 +770,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-builtin-module"
             }
           ]
@@ -818,7 +818,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -866,7 +866,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-utf8"
             }
           ]
@@ -914,7 +914,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lcid"
             }
           ]
@@ -962,7 +962,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/load-json-file"
             }
           ]
@@ -1010,7 +1010,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lodash.assign"
             }
           ]
@@ -1058,7 +1058,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lodash.keys"
             }
           ]
@@ -1106,7 +1106,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lodash.rest"
             }
           ]
@@ -1154,7 +1154,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/normalize-package-data"
             }
           ]
@@ -1202,7 +1202,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/number-is-nan"
             }
           ]
@@ -1250,7 +1250,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/object-assign"
             }
           ]
@@ -1298,7 +1298,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/os-locale"
             }
           ]
@@ -1346,7 +1346,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/parse-json"
             }
           ]
@@ -1394,7 +1394,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/path-exists"
             }
           ]
@@ -1442,7 +1442,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/path-type"
             }
           ]
@@ -1490,7 +1490,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pify"
             }
           ]
@@ -1538,7 +1538,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pinkie-promise"
             }
           ]
@@ -1586,7 +1586,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pinkie"
             }
           ]
@@ -1634,7 +1634,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pkg-conf"
             }
           ]
@@ -1682,7 +1682,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/read-pkg-up"
             }
           ]
@@ -1730,7 +1730,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/read-pkg"
             }
           ]
@@ -1778,7 +1778,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/require-main-filename"
             }
           ]
@@ -1825,7 +1825,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/semver"
             }
           ]
@@ -1873,7 +1873,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-correct"
             }
           ]
@@ -1921,7 +1921,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-exceptions"
             }
           ]
@@ -1967,7 +1967,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-expression-parse"
             }
           ]
@@ -2015,7 +2015,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-license-ids"
             }
           ]
@@ -2063,7 +2063,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/string-width"
             }
           ]
@@ -2111,7 +2111,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/strip-ansi"
             }
           ]
@@ -2159,7 +2159,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/strip-bom"
             }
           ]
@@ -2207,7 +2207,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/symbol"
             }
           ]
@@ -2255,7 +2255,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/validate-npm-package-license"
             }
           ]
@@ -2303,7 +2303,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/window-size"
             }
           ]
@@ -2351,7 +2351,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/wrap-ansi"
             }
           ]
@@ -2399,7 +2399,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/y18n"
             }
           ]
@@ -2447,7 +2447,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/yargs-parser"
             }
           ]
@@ -2494,7 +2494,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/yargs"
             }
           ]

--- a/tests/_data/sbom_demo-results/bundled-dependencies_npm6_node16_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bundled-dependencies_npm6_node16_windows-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-bundled-deps@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -94,6 +98,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bundle-dependencies"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -136,6 +146,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\ansi-regex"
             }
           ]
         },
@@ -180,6 +194,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\builtin-modules"
             }
           ]
         },
@@ -224,6 +242,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\camelcase"
             }
           ]
         },
@@ -268,6 +290,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\cliui"
             }
           ]
         },
@@ -312,6 +338,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\code-point-at"
             }
           ]
         },
@@ -356,6 +386,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\decamelize"
             }
           ]
         },
@@ -399,6 +433,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\error-ex"
             }
           ]
         },
@@ -443,6 +481,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\escape-string-regexp"
             }
           ]
         },
@@ -487,6 +529,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\find-up"
             }
           ]
         },
@@ -530,6 +576,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\graceful-fs"
             }
           ]
         },
@@ -574,6 +624,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\hosted-git-info"
             }
           ]
         },
@@ -618,6 +672,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\invert-kv"
             }
           ]
         },
@@ -662,6 +720,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\is-arrayish"
             }
           ]
         },
@@ -706,6 +768,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\is-builtin-module"
             }
           ]
         },
@@ -750,6 +816,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\is-fullwidth-code-point"
             }
           ]
         },
@@ -794,6 +864,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\is-utf8"
             }
           ]
         },
@@ -838,6 +912,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\lcid"
             }
           ]
         },
@@ -882,6 +960,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\load-json-file"
             }
           ]
         },
@@ -926,6 +1008,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\lodash.assign"
             }
           ]
         },
@@ -970,6 +1056,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\lodash.keys"
             }
           ]
         },
@@ -1014,6 +1104,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\lodash.rest"
             }
           ]
         },
@@ -1058,6 +1152,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\normalize-package-data"
             }
           ]
         },
@@ -1102,6 +1200,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\number-is-nan"
             }
           ]
         },
@@ -1146,6 +1248,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\object-assign"
             }
           ]
         },
@@ -1190,6 +1296,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\os-locale"
             }
           ]
         },
@@ -1234,6 +1344,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\parse-json"
             }
           ]
         },
@@ -1278,6 +1392,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\path-exists"
             }
           ]
         },
@@ -1322,6 +1440,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\path-type"
             }
           ]
         },
@@ -1366,6 +1488,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\pify"
             }
           ]
         },
@@ -1410,6 +1536,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\pinkie-promise"
             }
           ]
         },
@@ -1454,6 +1584,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\pinkie"
             }
           ]
         },
@@ -1498,6 +1632,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\pkg-conf"
             }
           ]
         },
@@ -1542,6 +1680,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\read-pkg-up"
             }
           ]
         },
@@ -1586,6 +1728,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\read-pkg"
             }
           ]
         },
@@ -1630,6 +1776,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\require-main-filename"
             }
           ]
         },
@@ -1673,6 +1823,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\semver"
             }
           ]
         },
@@ -1717,6 +1871,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\spdx-correct"
             }
           ]
         },
@@ -1761,6 +1919,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\spdx-exceptions"
             }
           ]
         },
@@ -1803,6 +1965,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\spdx-expression-parse"
             }
           ]
         },
@@ -1847,6 +2013,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\spdx-license-ids"
             }
           ]
         },
@@ -1891,6 +2061,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\string-width"
             }
           ]
         },
@@ -1935,6 +2109,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\strip-ansi"
             }
           ]
         },
@@ -1979,6 +2157,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\strip-bom"
             }
           ]
         },
@@ -2023,6 +2205,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\symbol"
             }
           ]
         },
@@ -2067,6 +2253,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\validate-npm-package-license"
             }
           ]
         },
@@ -2111,6 +2301,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\window-size"
             }
           ]
         },
@@ -2155,6 +2349,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\wrap-ansi"
             }
           ]
         },
@@ -2199,6 +2397,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\y18n"
             }
           ]
         },
@@ -2243,6 +2445,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\yargs-parser"
             }
           ]
         },
@@ -2286,6 +2492,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\yargs"
             }
           ]
         }

--- a/tests/_data/sbom_demo-results/bundled-dependencies_npm6_node16_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bundled-dependencies_npm6_node16_windows-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-bundled-deps@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -100,7 +100,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bundle-dependencies"
         }
       ],
@@ -148,7 +148,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\ansi-regex"
             }
           ]
@@ -196,7 +196,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\builtin-modules"
             }
           ]
@@ -244,7 +244,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\camelcase"
             }
           ]
@@ -292,7 +292,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\cliui"
             }
           ]
@@ -340,7 +340,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\code-point-at"
             }
           ]
@@ -388,7 +388,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\decamelize"
             }
           ]
@@ -435,7 +435,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\error-ex"
             }
           ]
@@ -483,7 +483,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\escape-string-regexp"
             }
           ]
@@ -531,7 +531,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\find-up"
             }
           ]
@@ -578,7 +578,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\graceful-fs"
             }
           ]
@@ -626,7 +626,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\hosted-git-info"
             }
           ]
@@ -674,7 +674,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\invert-kv"
             }
           ]
@@ -722,7 +722,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\is-arrayish"
             }
           ]
@@ -770,7 +770,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\is-builtin-module"
             }
           ]
@@ -818,7 +818,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\is-fullwidth-code-point"
             }
           ]
@@ -866,7 +866,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\is-utf8"
             }
           ]
@@ -914,7 +914,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\lcid"
             }
           ]
@@ -962,7 +962,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\load-json-file"
             }
           ]
@@ -1010,7 +1010,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\lodash.assign"
             }
           ]
@@ -1058,7 +1058,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\lodash.keys"
             }
           ]
@@ -1106,7 +1106,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\lodash.rest"
             }
           ]
@@ -1154,7 +1154,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\normalize-package-data"
             }
           ]
@@ -1202,7 +1202,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\number-is-nan"
             }
           ]
@@ -1250,7 +1250,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\object-assign"
             }
           ]
@@ -1298,7 +1298,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\os-locale"
             }
           ]
@@ -1346,7 +1346,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\parse-json"
             }
           ]
@@ -1394,7 +1394,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\path-exists"
             }
           ]
@@ -1442,7 +1442,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\path-type"
             }
           ]
@@ -1490,7 +1490,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\pify"
             }
           ]
@@ -1538,7 +1538,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\pinkie-promise"
             }
           ]
@@ -1586,7 +1586,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\pinkie"
             }
           ]
@@ -1634,7 +1634,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\pkg-conf"
             }
           ]
@@ -1682,7 +1682,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\read-pkg-up"
             }
           ]
@@ -1730,7 +1730,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\read-pkg"
             }
           ]
@@ -1778,7 +1778,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\require-main-filename"
             }
           ]
@@ -1825,7 +1825,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\semver"
             }
           ]
@@ -1873,7 +1873,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\spdx-correct"
             }
           ]
@@ -1921,7 +1921,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\spdx-exceptions"
             }
           ]
@@ -1967,7 +1967,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\spdx-expression-parse"
             }
           ]
@@ -2015,7 +2015,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\spdx-license-ids"
             }
           ]
@@ -2063,7 +2063,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\string-width"
             }
           ]
@@ -2111,7 +2111,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\strip-ansi"
             }
           ]
@@ -2159,7 +2159,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\strip-bom"
             }
           ]
@@ -2207,7 +2207,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\symbol"
             }
           ]
@@ -2255,7 +2255,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\validate-npm-package-license"
             }
           ]
@@ -2303,7 +2303,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\window-size"
             }
           ]
@@ -2351,7 +2351,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\wrap-ansi"
             }
           ]
@@ -2399,7 +2399,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\y18n"
             }
           ]
@@ -2447,7 +2447,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\yargs-parser"
             }
           ]
@@ -2494,7 +2494,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\yargs"
             }
           ]

--- a/tests/_data/sbom_demo-results/bundled-dependencies_npm6_node18_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bundled-dependencies_npm6_node18_macos-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-bundled-deps@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -94,6 +98,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bundle-dependencies"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -136,6 +146,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/ansi-regex"
             }
           ]
         },
@@ -180,6 +194,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/builtin-modules"
             }
           ]
         },
@@ -224,6 +242,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/camelcase"
             }
           ]
         },
@@ -268,6 +290,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/cliui"
             }
           ]
         },
@@ -312,6 +338,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/code-point-at"
             }
           ]
         },
@@ -356,6 +386,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/decamelize"
             }
           ]
         },
@@ -399,6 +433,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/error-ex"
             }
           ]
         },
@@ -443,6 +481,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/escape-string-regexp"
             }
           ]
         },
@@ -487,6 +529,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/find-up"
             }
           ]
         },
@@ -530,6 +576,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/graceful-fs"
             }
           ]
         },
@@ -574,6 +624,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/hosted-git-info"
             }
           ]
         },
@@ -618,6 +672,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/invert-kv"
             }
           ]
         },
@@ -662,6 +720,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-arrayish"
             }
           ]
         },
@@ -706,6 +768,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-builtin-module"
             }
           ]
         },
@@ -750,6 +816,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-fullwidth-code-point"
             }
           ]
         },
@@ -794,6 +864,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-utf8"
             }
           ]
         },
@@ -838,6 +912,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lcid"
             }
           ]
         },
@@ -882,6 +960,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/load-json-file"
             }
           ]
         },
@@ -926,6 +1008,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lodash.assign"
             }
           ]
         },
@@ -970,6 +1056,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lodash.keys"
             }
           ]
         },
@@ -1014,6 +1104,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lodash.rest"
             }
           ]
         },
@@ -1058,6 +1152,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/normalize-package-data"
             }
           ]
         },
@@ -1102,6 +1200,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/number-is-nan"
             }
           ]
         },
@@ -1146,6 +1248,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/object-assign"
             }
           ]
         },
@@ -1190,6 +1296,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/os-locale"
             }
           ]
         },
@@ -1234,6 +1344,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/parse-json"
             }
           ]
         },
@@ -1278,6 +1392,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/path-exists"
             }
           ]
         },
@@ -1322,6 +1440,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/path-type"
             }
           ]
         },
@@ -1366,6 +1488,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pify"
             }
           ]
         },
@@ -1410,6 +1536,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pinkie-promise"
             }
           ]
         },
@@ -1454,6 +1584,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pinkie"
             }
           ]
         },
@@ -1498,6 +1632,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pkg-conf"
             }
           ]
         },
@@ -1542,6 +1680,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/read-pkg-up"
             }
           ]
         },
@@ -1586,6 +1728,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/read-pkg"
             }
           ]
         },
@@ -1630,6 +1776,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/require-main-filename"
             }
           ]
         },
@@ -1673,6 +1823,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/semver"
             }
           ]
         },
@@ -1717,6 +1871,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-correct"
             }
           ]
         },
@@ -1761,6 +1919,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-exceptions"
             }
           ]
         },
@@ -1803,6 +1965,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-expression-parse"
             }
           ]
         },
@@ -1847,6 +2013,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-license-ids"
             }
           ]
         },
@@ -1891,6 +2061,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/string-width"
             }
           ]
         },
@@ -1935,6 +2109,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/strip-ansi"
             }
           ]
         },
@@ -1979,6 +2157,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/strip-bom"
             }
           ]
         },
@@ -2023,6 +2205,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/symbol"
             }
           ]
         },
@@ -2067,6 +2253,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/validate-npm-package-license"
             }
           ]
         },
@@ -2111,6 +2301,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/window-size"
             }
           ]
         },
@@ -2155,6 +2349,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/wrap-ansi"
             }
           ]
         },
@@ -2199,6 +2397,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/y18n"
             }
           ]
         },
@@ -2243,6 +2445,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/yargs-parser"
             }
           ]
         },
@@ -2286,6 +2492,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/yargs"
             }
           ]
         }

--- a/tests/_data/sbom_demo-results/bundled-dependencies_npm6_node18_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bundled-dependencies_npm6_node18_macos-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-bundled-deps@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -100,7 +100,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bundle-dependencies"
         }
       ],
@@ -148,7 +148,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/ansi-regex"
             }
           ]
@@ -196,7 +196,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/builtin-modules"
             }
           ]
@@ -244,7 +244,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/camelcase"
             }
           ]
@@ -292,7 +292,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/cliui"
             }
           ]
@@ -340,7 +340,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/code-point-at"
             }
           ]
@@ -388,7 +388,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/decamelize"
             }
           ]
@@ -435,7 +435,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/error-ex"
             }
           ]
@@ -483,7 +483,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/escape-string-regexp"
             }
           ]
@@ -531,7 +531,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/find-up"
             }
           ]
@@ -578,7 +578,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/graceful-fs"
             }
           ]
@@ -626,7 +626,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/hosted-git-info"
             }
           ]
@@ -674,7 +674,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/invert-kv"
             }
           ]
@@ -722,7 +722,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-arrayish"
             }
           ]
@@ -770,7 +770,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-builtin-module"
             }
           ]
@@ -818,7 +818,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -866,7 +866,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-utf8"
             }
           ]
@@ -914,7 +914,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lcid"
             }
           ]
@@ -962,7 +962,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/load-json-file"
             }
           ]
@@ -1010,7 +1010,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lodash.assign"
             }
           ]
@@ -1058,7 +1058,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lodash.keys"
             }
           ]
@@ -1106,7 +1106,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lodash.rest"
             }
           ]
@@ -1154,7 +1154,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/normalize-package-data"
             }
           ]
@@ -1202,7 +1202,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/number-is-nan"
             }
           ]
@@ -1250,7 +1250,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/object-assign"
             }
           ]
@@ -1298,7 +1298,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/os-locale"
             }
           ]
@@ -1346,7 +1346,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/parse-json"
             }
           ]
@@ -1394,7 +1394,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/path-exists"
             }
           ]
@@ -1442,7 +1442,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/path-type"
             }
           ]
@@ -1490,7 +1490,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pify"
             }
           ]
@@ -1538,7 +1538,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pinkie-promise"
             }
           ]
@@ -1586,7 +1586,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pinkie"
             }
           ]
@@ -1634,7 +1634,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pkg-conf"
             }
           ]
@@ -1682,7 +1682,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/read-pkg-up"
             }
           ]
@@ -1730,7 +1730,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/read-pkg"
             }
           ]
@@ -1778,7 +1778,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/require-main-filename"
             }
           ]
@@ -1825,7 +1825,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/semver"
             }
           ]
@@ -1873,7 +1873,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-correct"
             }
           ]
@@ -1921,7 +1921,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-exceptions"
             }
           ]
@@ -1967,7 +1967,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-expression-parse"
             }
           ]
@@ -2015,7 +2015,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-license-ids"
             }
           ]
@@ -2063,7 +2063,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/string-width"
             }
           ]
@@ -2111,7 +2111,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/strip-ansi"
             }
           ]
@@ -2159,7 +2159,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/strip-bom"
             }
           ]
@@ -2207,7 +2207,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/symbol"
             }
           ]
@@ -2255,7 +2255,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/validate-npm-package-license"
             }
           ]
@@ -2303,7 +2303,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/window-size"
             }
           ]
@@ -2351,7 +2351,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/wrap-ansi"
             }
           ]
@@ -2399,7 +2399,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/y18n"
             }
           ]
@@ -2447,7 +2447,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/yargs-parser"
             }
           ]
@@ -2494,7 +2494,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/yargs"
             }
           ]

--- a/tests/_data/sbom_demo-results/bundled-dependencies_npm6_node18_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bundled-dependencies_npm6_node18_ubuntu-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-bundled-deps@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -94,6 +98,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bundle-dependencies"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -136,6 +146,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/ansi-regex"
             }
           ]
         },
@@ -180,6 +194,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/builtin-modules"
             }
           ]
         },
@@ -224,6 +242,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/camelcase"
             }
           ]
         },
@@ -268,6 +290,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/cliui"
             }
           ]
         },
@@ -312,6 +338,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/code-point-at"
             }
           ]
         },
@@ -356,6 +386,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/decamelize"
             }
           ]
         },
@@ -399,6 +433,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/error-ex"
             }
           ]
         },
@@ -443,6 +481,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/escape-string-regexp"
             }
           ]
         },
@@ -487,6 +529,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/find-up"
             }
           ]
         },
@@ -530,6 +576,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/graceful-fs"
             }
           ]
         },
@@ -574,6 +624,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/hosted-git-info"
             }
           ]
         },
@@ -618,6 +672,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/invert-kv"
             }
           ]
         },
@@ -662,6 +720,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-arrayish"
             }
           ]
         },
@@ -706,6 +768,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-builtin-module"
             }
           ]
         },
@@ -750,6 +816,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-fullwidth-code-point"
             }
           ]
         },
@@ -794,6 +864,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-utf8"
             }
           ]
         },
@@ -838,6 +912,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lcid"
             }
           ]
         },
@@ -882,6 +960,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/load-json-file"
             }
           ]
         },
@@ -926,6 +1008,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lodash.assign"
             }
           ]
         },
@@ -970,6 +1056,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lodash.keys"
             }
           ]
         },
@@ -1014,6 +1104,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lodash.rest"
             }
           ]
         },
@@ -1058,6 +1152,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/normalize-package-data"
             }
           ]
         },
@@ -1102,6 +1200,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/number-is-nan"
             }
           ]
         },
@@ -1146,6 +1248,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/object-assign"
             }
           ]
         },
@@ -1190,6 +1296,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/os-locale"
             }
           ]
         },
@@ -1234,6 +1344,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/parse-json"
             }
           ]
         },
@@ -1278,6 +1392,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/path-exists"
             }
           ]
         },
@@ -1322,6 +1440,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/path-type"
             }
           ]
         },
@@ -1366,6 +1488,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pify"
             }
           ]
         },
@@ -1410,6 +1536,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pinkie-promise"
             }
           ]
         },
@@ -1454,6 +1584,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pinkie"
             }
           ]
         },
@@ -1498,6 +1632,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pkg-conf"
             }
           ]
         },
@@ -1542,6 +1680,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/read-pkg-up"
             }
           ]
         },
@@ -1586,6 +1728,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/read-pkg"
             }
           ]
         },
@@ -1630,6 +1776,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/require-main-filename"
             }
           ]
         },
@@ -1673,6 +1823,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/semver"
             }
           ]
         },
@@ -1717,6 +1871,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-correct"
             }
           ]
         },
@@ -1761,6 +1919,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-exceptions"
             }
           ]
         },
@@ -1803,6 +1965,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-expression-parse"
             }
           ]
         },
@@ -1847,6 +2013,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-license-ids"
             }
           ]
         },
@@ -1891,6 +2061,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/string-width"
             }
           ]
         },
@@ -1935,6 +2109,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/strip-ansi"
             }
           ]
         },
@@ -1979,6 +2157,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/strip-bom"
             }
           ]
         },
@@ -2023,6 +2205,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/symbol"
             }
           ]
         },
@@ -2067,6 +2253,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/validate-npm-package-license"
             }
           ]
         },
@@ -2111,6 +2301,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/window-size"
             }
           ]
         },
@@ -2155,6 +2349,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/wrap-ansi"
             }
           ]
         },
@@ -2199,6 +2397,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/y18n"
             }
           ]
         },
@@ -2243,6 +2445,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/yargs-parser"
             }
           ]
         },
@@ -2286,6 +2492,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/yargs"
             }
           ]
         }

--- a/tests/_data/sbom_demo-results/bundled-dependencies_npm6_node18_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bundled-dependencies_npm6_node18_ubuntu-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-bundled-deps@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -100,7 +100,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bundle-dependencies"
         }
       ],
@@ -148,7 +148,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/ansi-regex"
             }
           ]
@@ -196,7 +196,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/builtin-modules"
             }
           ]
@@ -244,7 +244,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/camelcase"
             }
           ]
@@ -292,7 +292,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/cliui"
             }
           ]
@@ -340,7 +340,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/code-point-at"
             }
           ]
@@ -388,7 +388,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/decamelize"
             }
           ]
@@ -435,7 +435,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/error-ex"
             }
           ]
@@ -483,7 +483,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/escape-string-regexp"
             }
           ]
@@ -531,7 +531,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/find-up"
             }
           ]
@@ -578,7 +578,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/graceful-fs"
             }
           ]
@@ -626,7 +626,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/hosted-git-info"
             }
           ]
@@ -674,7 +674,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/invert-kv"
             }
           ]
@@ -722,7 +722,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-arrayish"
             }
           ]
@@ -770,7 +770,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-builtin-module"
             }
           ]
@@ -818,7 +818,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -866,7 +866,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-utf8"
             }
           ]
@@ -914,7 +914,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lcid"
             }
           ]
@@ -962,7 +962,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/load-json-file"
             }
           ]
@@ -1010,7 +1010,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lodash.assign"
             }
           ]
@@ -1058,7 +1058,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lodash.keys"
             }
           ]
@@ -1106,7 +1106,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lodash.rest"
             }
           ]
@@ -1154,7 +1154,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/normalize-package-data"
             }
           ]
@@ -1202,7 +1202,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/number-is-nan"
             }
           ]
@@ -1250,7 +1250,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/object-assign"
             }
           ]
@@ -1298,7 +1298,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/os-locale"
             }
           ]
@@ -1346,7 +1346,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/parse-json"
             }
           ]
@@ -1394,7 +1394,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/path-exists"
             }
           ]
@@ -1442,7 +1442,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/path-type"
             }
           ]
@@ -1490,7 +1490,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pify"
             }
           ]
@@ -1538,7 +1538,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pinkie-promise"
             }
           ]
@@ -1586,7 +1586,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pinkie"
             }
           ]
@@ -1634,7 +1634,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pkg-conf"
             }
           ]
@@ -1682,7 +1682,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/read-pkg-up"
             }
           ]
@@ -1730,7 +1730,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/read-pkg"
             }
           ]
@@ -1778,7 +1778,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/require-main-filename"
             }
           ]
@@ -1825,7 +1825,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/semver"
             }
           ]
@@ -1873,7 +1873,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-correct"
             }
           ]
@@ -1921,7 +1921,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-exceptions"
             }
           ]
@@ -1967,7 +1967,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-expression-parse"
             }
           ]
@@ -2015,7 +2015,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-license-ids"
             }
           ]
@@ -2063,7 +2063,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/string-width"
             }
           ]
@@ -2111,7 +2111,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/strip-ansi"
             }
           ]
@@ -2159,7 +2159,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/strip-bom"
             }
           ]
@@ -2207,7 +2207,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/symbol"
             }
           ]
@@ -2255,7 +2255,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/validate-npm-package-license"
             }
           ]
@@ -2303,7 +2303,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/window-size"
             }
           ]
@@ -2351,7 +2351,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/wrap-ansi"
             }
           ]
@@ -2399,7 +2399,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/y18n"
             }
           ]
@@ -2447,7 +2447,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/yargs-parser"
             }
           ]
@@ -2494,7 +2494,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/yargs"
             }
           ]

--- a/tests/_data/sbom_demo-results/bundled-dependencies_npm6_node18_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bundled-dependencies_npm6_node18_windows-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-bundled-deps@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -94,6 +98,12 @@
           "comment": "as detected from PackageJson property \"homepage\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bundle-dependencies"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -136,6 +146,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\ansi-regex"
             }
           ]
         },
@@ -180,6 +194,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\builtin-modules"
             }
           ]
         },
@@ -224,6 +242,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\camelcase"
             }
           ]
         },
@@ -268,6 +290,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\cliui"
             }
           ]
         },
@@ -312,6 +338,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\code-point-at"
             }
           ]
         },
@@ -356,6 +386,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\decamelize"
             }
           ]
         },
@@ -399,6 +433,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\error-ex"
             }
           ]
         },
@@ -443,6 +481,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\escape-string-regexp"
             }
           ]
         },
@@ -487,6 +529,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\find-up"
             }
           ]
         },
@@ -530,6 +576,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\graceful-fs"
             }
           ]
         },
@@ -574,6 +624,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\hosted-git-info"
             }
           ]
         },
@@ -618,6 +672,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\invert-kv"
             }
           ]
         },
@@ -662,6 +720,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\is-arrayish"
             }
           ]
         },
@@ -706,6 +768,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\is-builtin-module"
             }
           ]
         },
@@ -750,6 +816,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\is-fullwidth-code-point"
             }
           ]
         },
@@ -794,6 +864,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\is-utf8"
             }
           ]
         },
@@ -838,6 +912,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\lcid"
             }
           ]
         },
@@ -882,6 +960,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\load-json-file"
             }
           ]
         },
@@ -926,6 +1008,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\lodash.assign"
             }
           ]
         },
@@ -970,6 +1056,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\lodash.keys"
             }
           ]
         },
@@ -1014,6 +1104,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\lodash.rest"
             }
           ]
         },
@@ -1058,6 +1152,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\normalize-package-data"
             }
           ]
         },
@@ -1102,6 +1200,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\number-is-nan"
             }
           ]
         },
@@ -1146,6 +1248,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\object-assign"
             }
           ]
         },
@@ -1190,6 +1296,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\os-locale"
             }
           ]
         },
@@ -1234,6 +1344,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\parse-json"
             }
           ]
         },
@@ -1278,6 +1392,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\path-exists"
             }
           ]
         },
@@ -1322,6 +1440,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\path-type"
             }
           ]
         },
@@ -1366,6 +1488,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\pify"
             }
           ]
         },
@@ -1410,6 +1536,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\pinkie-promise"
             }
           ]
         },
@@ -1454,6 +1584,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\pinkie"
             }
           ]
         },
@@ -1498,6 +1632,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\pkg-conf"
             }
           ]
         },
@@ -1542,6 +1680,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\read-pkg-up"
             }
           ]
         },
@@ -1586,6 +1728,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\read-pkg"
             }
           ]
         },
@@ -1630,6 +1776,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\require-main-filename"
             }
           ]
         },
@@ -1673,6 +1823,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\semver"
             }
           ]
         },
@@ -1717,6 +1871,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\spdx-correct"
             }
           ]
         },
@@ -1761,6 +1919,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\spdx-exceptions"
             }
           ]
         },
@@ -1803,6 +1965,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\spdx-expression-parse"
             }
           ]
         },
@@ -1847,6 +2013,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\spdx-license-ids"
             }
           ]
         },
@@ -1891,6 +2061,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\string-width"
             }
           ]
         },
@@ -1935,6 +2109,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\strip-ansi"
             }
           ]
         },
@@ -1979,6 +2157,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\strip-bom"
             }
           ]
         },
@@ -2023,6 +2205,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\symbol"
             }
           ]
         },
@@ -2067,6 +2253,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\validate-npm-package-license"
             }
           ]
         },
@@ -2111,6 +2301,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\window-size"
             }
           ]
         },
@@ -2155,6 +2349,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\wrap-ansi"
             }
           ]
         },
@@ -2199,6 +2397,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\y18n"
             }
           ]
         },
@@ -2243,6 +2445,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\yargs-parser"
             }
           ]
         },
@@ -2286,6 +2492,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\yargs"
             }
           ]
         }

--- a/tests/_data/sbom_demo-results/bundled-dependencies_npm6_node18_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bundled-dependencies_npm6_node18_windows-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-bundled-deps@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -100,7 +100,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bundle-dependencies"
         }
       ],
@@ -148,7 +148,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\ansi-regex"
             }
           ]
@@ -196,7 +196,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\builtin-modules"
             }
           ]
@@ -244,7 +244,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\camelcase"
             }
           ]
@@ -292,7 +292,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\cliui"
             }
           ]
@@ -340,7 +340,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\code-point-at"
             }
           ]
@@ -388,7 +388,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\decamelize"
             }
           ]
@@ -435,7 +435,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\error-ex"
             }
           ]
@@ -483,7 +483,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\escape-string-regexp"
             }
           ]
@@ -531,7 +531,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\find-up"
             }
           ]
@@ -578,7 +578,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\graceful-fs"
             }
           ]
@@ -626,7 +626,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\hosted-git-info"
             }
           ]
@@ -674,7 +674,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\invert-kv"
             }
           ]
@@ -722,7 +722,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\is-arrayish"
             }
           ]
@@ -770,7 +770,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\is-builtin-module"
             }
           ]
@@ -818,7 +818,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\is-fullwidth-code-point"
             }
           ]
@@ -866,7 +866,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\is-utf8"
             }
           ]
@@ -914,7 +914,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\lcid"
             }
           ]
@@ -962,7 +962,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\load-json-file"
             }
           ]
@@ -1010,7 +1010,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\lodash.assign"
             }
           ]
@@ -1058,7 +1058,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\lodash.keys"
             }
           ]
@@ -1106,7 +1106,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\lodash.rest"
             }
           ]
@@ -1154,7 +1154,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\normalize-package-data"
             }
           ]
@@ -1202,7 +1202,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\number-is-nan"
             }
           ]
@@ -1250,7 +1250,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\object-assign"
             }
           ]
@@ -1298,7 +1298,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\os-locale"
             }
           ]
@@ -1346,7 +1346,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\parse-json"
             }
           ]
@@ -1394,7 +1394,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\path-exists"
             }
           ]
@@ -1442,7 +1442,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\path-type"
             }
           ]
@@ -1490,7 +1490,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\pify"
             }
           ]
@@ -1538,7 +1538,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\pinkie-promise"
             }
           ]
@@ -1586,7 +1586,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\pinkie"
             }
           ]
@@ -1634,7 +1634,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\pkg-conf"
             }
           ]
@@ -1682,7 +1682,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\read-pkg-up"
             }
           ]
@@ -1730,7 +1730,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\read-pkg"
             }
           ]
@@ -1778,7 +1778,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\require-main-filename"
             }
           ]
@@ -1825,7 +1825,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\semver"
             }
           ]
@@ -1873,7 +1873,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\spdx-correct"
             }
           ]
@@ -1921,7 +1921,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\spdx-exceptions"
             }
           ]
@@ -1967,7 +1967,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\spdx-expression-parse"
             }
           ]
@@ -2015,7 +2015,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\spdx-license-ids"
             }
           ]
@@ -2063,7 +2063,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\string-width"
             }
           ]
@@ -2111,7 +2111,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\strip-ansi"
             }
           ]
@@ -2159,7 +2159,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\strip-bom"
             }
           ]
@@ -2207,7 +2207,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\symbol"
             }
           ]
@@ -2255,7 +2255,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\validate-npm-package-license"
             }
           ]
@@ -2303,7 +2303,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\window-size"
             }
           ]
@@ -2351,7 +2351,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\wrap-ansi"
             }
           ]
@@ -2399,7 +2399,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\y18n"
             }
           ]
@@ -2447,7 +2447,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\yargs-parser"
             }
           ]
@@ -2494,7 +2494,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\yargs"
             }
           ]

--- a/tests/_data/sbom_demo-results/bundled-dependencies_npm7_node14_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bundled-dependencies_npm7_node14_macos-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-bundled-deps@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -76,7 +76,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bundle-dependencies"
         }
       ],
@@ -100,7 +100,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/ansi-regex"
             }
           ]
@@ -124,7 +124,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/builtin-modules"
             }
           ]
@@ -148,7 +148,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/camelcase"
             }
           ]
@@ -172,7 +172,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/cliui"
             }
           ]
@@ -196,7 +196,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/code-point-at"
             }
           ]
@@ -220,7 +220,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/decamelize"
             }
           ]
@@ -244,7 +244,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/error-ex"
             }
           ]
@@ -268,7 +268,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/escape-string-regexp"
             }
           ]
@@ -292,7 +292,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/find-up"
             }
           ]
@@ -316,7 +316,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/graceful-fs"
             }
           ]
@@ -340,7 +340,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/hosted-git-info"
             }
           ]
@@ -364,7 +364,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/invert-kv"
             }
           ]
@@ -388,7 +388,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-arrayish"
             }
           ]
@@ -412,7 +412,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-builtin-module"
             }
           ]
@@ -436,7 +436,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -460,7 +460,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-utf8"
             }
           ]
@@ -484,7 +484,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lcid"
             }
           ]
@@ -508,7 +508,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/load-json-file"
             }
           ]
@@ -532,7 +532,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lodash.assign"
             }
           ]
@@ -556,7 +556,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lodash.keys"
             }
           ]
@@ -580,7 +580,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lodash.rest"
             }
           ]
@@ -604,7 +604,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/normalize-package-data"
             }
           ]
@@ -628,7 +628,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/number-is-nan"
             }
           ]
@@ -652,7 +652,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/object-assign"
             }
           ]
@@ -676,7 +676,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/os-locale"
             }
           ]
@@ -700,7 +700,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/parse-json"
             }
           ]
@@ -724,7 +724,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/path-exists"
             }
           ]
@@ -748,7 +748,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/path-type"
             }
           ]
@@ -772,7 +772,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pify"
             }
           ]
@@ -796,7 +796,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pinkie-promise"
             }
           ]
@@ -820,7 +820,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pinkie"
             }
           ]
@@ -844,7 +844,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pkg-conf"
             }
           ]
@@ -868,7 +868,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/read-pkg-up"
             }
           ]
@@ -892,7 +892,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/read-pkg"
             }
           ]
@@ -916,7 +916,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/require-main-filename"
             }
           ]
@@ -940,7 +940,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/semver"
             }
           ]
@@ -964,7 +964,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-correct"
             }
           ]
@@ -988,7 +988,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-exceptions"
             }
           ]
@@ -1010,7 +1010,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-expression-parse"
             }
           ]
@@ -1034,7 +1034,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-license-ids"
             }
           ]
@@ -1058,7 +1058,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/string-width"
             }
           ]
@@ -1082,7 +1082,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/strip-ansi"
             }
           ]
@@ -1106,7 +1106,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/strip-bom"
             }
           ]
@@ -1130,7 +1130,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/symbol"
             }
           ]
@@ -1154,7 +1154,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/validate-npm-package-license"
             }
           ]
@@ -1178,7 +1178,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/window-size"
             }
           ]
@@ -1202,7 +1202,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/wrap-ansi"
             }
           ]
@@ -1226,7 +1226,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/y18n"
             }
           ]
@@ -1250,7 +1250,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/yargs-parser"
             }
           ]
@@ -1274,7 +1274,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/yargs"
             }
           ]

--- a/tests/_data/sbom_demo-results/bundled-dependencies_npm7_node14_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bundled-dependencies_npm7_node14_macos-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-bundled-deps@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -70,6 +74,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bundle-dependencies"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -88,6 +98,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/ansi-regex"
             }
           ]
         },
@@ -108,6 +122,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/builtin-modules"
             }
           ]
         },
@@ -128,6 +146,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/camelcase"
             }
           ]
         },
@@ -148,6 +170,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/cliui"
             }
           ]
         },
@@ -168,6 +194,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/code-point-at"
             }
           ]
         },
@@ -188,6 +218,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/decamelize"
             }
           ]
         },
@@ -208,6 +242,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/error-ex"
             }
           ]
         },
@@ -228,6 +266,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/escape-string-regexp"
             }
           ]
         },
@@ -248,6 +290,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/find-up"
             }
           ]
         },
@@ -268,6 +314,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/graceful-fs"
             }
           ]
         },
@@ -288,6 +338,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/hosted-git-info"
             }
           ]
         },
@@ -308,6 +362,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/invert-kv"
             }
           ]
         },
@@ -328,6 +386,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-arrayish"
             }
           ]
         },
@@ -348,6 +410,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-builtin-module"
             }
           ]
         },
@@ -368,6 +434,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-fullwidth-code-point"
             }
           ]
         },
@@ -388,6 +458,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-utf8"
             }
           ]
         },
@@ -408,6 +482,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lcid"
             }
           ]
         },
@@ -428,6 +506,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/load-json-file"
             }
           ]
         },
@@ -448,6 +530,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lodash.assign"
             }
           ]
         },
@@ -468,6 +554,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lodash.keys"
             }
           ]
         },
@@ -488,6 +578,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lodash.rest"
             }
           ]
         },
@@ -508,6 +602,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/normalize-package-data"
             }
           ]
         },
@@ -528,6 +626,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/number-is-nan"
             }
           ]
         },
@@ -548,6 +650,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/object-assign"
             }
           ]
         },
@@ -568,6 +674,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/os-locale"
             }
           ]
         },
@@ -588,6 +698,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/parse-json"
             }
           ]
         },
@@ -608,6 +722,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/path-exists"
             }
           ]
         },
@@ -628,6 +746,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/path-type"
             }
           ]
         },
@@ -648,6 +770,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pify"
             }
           ]
         },
@@ -668,6 +794,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pinkie-promise"
             }
           ]
         },
@@ -688,6 +818,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pinkie"
             }
           ]
         },
@@ -708,6 +842,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pkg-conf"
             }
           ]
         },
@@ -728,6 +866,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/read-pkg-up"
             }
           ]
         },
@@ -748,6 +890,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/read-pkg"
             }
           ]
         },
@@ -768,6 +914,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/require-main-filename"
             }
           ]
         },
@@ -788,6 +938,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/semver"
             }
           ]
         },
@@ -808,6 +962,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-correct"
             }
           ]
         },
@@ -828,6 +986,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-exceptions"
             }
           ]
         },
@@ -846,6 +1008,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-expression-parse"
             }
           ]
         },
@@ -866,6 +1032,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-license-ids"
             }
           ]
         },
@@ -886,6 +1056,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/string-width"
             }
           ]
         },
@@ -906,6 +1080,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/strip-ansi"
             }
           ]
         },
@@ -926,6 +1104,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/strip-bom"
             }
           ]
         },
@@ -946,6 +1128,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/symbol"
             }
           ]
         },
@@ -966,6 +1152,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/validate-npm-package-license"
             }
           ]
         },
@@ -986,6 +1176,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/window-size"
             }
           ]
         },
@@ -1006,6 +1200,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/wrap-ansi"
             }
           ]
         },
@@ -1026,6 +1224,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/y18n"
             }
           ]
         },
@@ -1046,6 +1248,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/yargs-parser"
             }
           ]
         },
@@ -1066,6 +1272,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/yargs"
             }
           ]
         }

--- a/tests/_data/sbom_demo-results/bundled-dependencies_npm7_node14_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bundled-dependencies_npm7_node14_ubuntu-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-bundled-deps@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -76,7 +76,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bundle-dependencies"
         }
       ],
@@ -100,7 +100,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/ansi-regex"
             }
           ]
@@ -124,7 +124,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/builtin-modules"
             }
           ]
@@ -148,7 +148,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/camelcase"
             }
           ]
@@ -172,7 +172,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/cliui"
             }
           ]
@@ -196,7 +196,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/code-point-at"
             }
           ]
@@ -220,7 +220,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/decamelize"
             }
           ]
@@ -244,7 +244,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/error-ex"
             }
           ]
@@ -268,7 +268,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/escape-string-regexp"
             }
           ]
@@ -292,7 +292,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/find-up"
             }
           ]
@@ -316,7 +316,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/graceful-fs"
             }
           ]
@@ -340,7 +340,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/hosted-git-info"
             }
           ]
@@ -364,7 +364,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/invert-kv"
             }
           ]
@@ -388,7 +388,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-arrayish"
             }
           ]
@@ -412,7 +412,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-builtin-module"
             }
           ]
@@ -436,7 +436,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -460,7 +460,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-utf8"
             }
           ]
@@ -484,7 +484,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lcid"
             }
           ]
@@ -508,7 +508,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/load-json-file"
             }
           ]
@@ -532,7 +532,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lodash.assign"
             }
           ]
@@ -556,7 +556,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lodash.keys"
             }
           ]
@@ -580,7 +580,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lodash.rest"
             }
           ]
@@ -604,7 +604,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/normalize-package-data"
             }
           ]
@@ -628,7 +628,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/number-is-nan"
             }
           ]
@@ -652,7 +652,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/object-assign"
             }
           ]
@@ -676,7 +676,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/os-locale"
             }
           ]
@@ -700,7 +700,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/parse-json"
             }
           ]
@@ -724,7 +724,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/path-exists"
             }
           ]
@@ -748,7 +748,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/path-type"
             }
           ]
@@ -772,7 +772,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pify"
             }
           ]
@@ -796,7 +796,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pinkie-promise"
             }
           ]
@@ -820,7 +820,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pinkie"
             }
           ]
@@ -844,7 +844,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pkg-conf"
             }
           ]
@@ -868,7 +868,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/read-pkg-up"
             }
           ]
@@ -892,7 +892,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/read-pkg"
             }
           ]
@@ -916,7 +916,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/require-main-filename"
             }
           ]
@@ -940,7 +940,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/semver"
             }
           ]
@@ -964,7 +964,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-correct"
             }
           ]
@@ -988,7 +988,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-exceptions"
             }
           ]
@@ -1010,7 +1010,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-expression-parse"
             }
           ]
@@ -1034,7 +1034,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-license-ids"
             }
           ]
@@ -1058,7 +1058,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/string-width"
             }
           ]
@@ -1082,7 +1082,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/strip-ansi"
             }
           ]
@@ -1106,7 +1106,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/strip-bom"
             }
           ]
@@ -1130,7 +1130,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/symbol"
             }
           ]
@@ -1154,7 +1154,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/validate-npm-package-license"
             }
           ]
@@ -1178,7 +1178,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/window-size"
             }
           ]
@@ -1202,7 +1202,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/wrap-ansi"
             }
           ]
@@ -1226,7 +1226,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/y18n"
             }
           ]
@@ -1250,7 +1250,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/yargs-parser"
             }
           ]
@@ -1274,7 +1274,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/yargs"
             }
           ]

--- a/tests/_data/sbom_demo-results/bundled-dependencies_npm7_node14_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bundled-dependencies_npm7_node14_ubuntu-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-bundled-deps@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -70,6 +74,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bundle-dependencies"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -88,6 +98,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/ansi-regex"
             }
           ]
         },
@@ -108,6 +122,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/builtin-modules"
             }
           ]
         },
@@ -128,6 +146,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/camelcase"
             }
           ]
         },
@@ -148,6 +170,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/cliui"
             }
           ]
         },
@@ -168,6 +194,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/code-point-at"
             }
           ]
         },
@@ -188,6 +218,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/decamelize"
             }
           ]
         },
@@ -208,6 +242,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/error-ex"
             }
           ]
         },
@@ -228,6 +266,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/escape-string-regexp"
             }
           ]
         },
@@ -248,6 +290,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/find-up"
             }
           ]
         },
@@ -268,6 +314,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/graceful-fs"
             }
           ]
         },
@@ -288,6 +338,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/hosted-git-info"
             }
           ]
         },
@@ -308,6 +362,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/invert-kv"
             }
           ]
         },
@@ -328,6 +386,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-arrayish"
             }
           ]
         },
@@ -348,6 +410,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-builtin-module"
             }
           ]
         },
@@ -368,6 +434,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-fullwidth-code-point"
             }
           ]
         },
@@ -388,6 +458,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-utf8"
             }
           ]
         },
@@ -408,6 +482,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lcid"
             }
           ]
         },
@@ -428,6 +506,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/load-json-file"
             }
           ]
         },
@@ -448,6 +530,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lodash.assign"
             }
           ]
         },
@@ -468,6 +554,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lodash.keys"
             }
           ]
         },
@@ -488,6 +578,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lodash.rest"
             }
           ]
         },
@@ -508,6 +602,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/normalize-package-data"
             }
           ]
         },
@@ -528,6 +626,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/number-is-nan"
             }
           ]
         },
@@ -548,6 +650,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/object-assign"
             }
           ]
         },
@@ -568,6 +674,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/os-locale"
             }
           ]
         },
@@ -588,6 +698,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/parse-json"
             }
           ]
         },
@@ -608,6 +722,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/path-exists"
             }
           ]
         },
@@ -628,6 +746,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/path-type"
             }
           ]
         },
@@ -648,6 +770,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pify"
             }
           ]
         },
@@ -668,6 +794,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pinkie-promise"
             }
           ]
         },
@@ -688,6 +818,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pinkie"
             }
           ]
         },
@@ -708,6 +842,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pkg-conf"
             }
           ]
         },
@@ -728,6 +866,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/read-pkg-up"
             }
           ]
         },
@@ -748,6 +890,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/read-pkg"
             }
           ]
         },
@@ -768,6 +914,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/require-main-filename"
             }
           ]
         },
@@ -788,6 +938,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/semver"
             }
           ]
         },
@@ -808,6 +962,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-correct"
             }
           ]
         },
@@ -828,6 +986,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-exceptions"
             }
           ]
         },
@@ -846,6 +1008,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-expression-parse"
             }
           ]
         },
@@ -866,6 +1032,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-license-ids"
             }
           ]
         },
@@ -886,6 +1056,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/string-width"
             }
           ]
         },
@@ -906,6 +1080,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/strip-ansi"
             }
           ]
         },
@@ -926,6 +1104,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/strip-bom"
             }
           ]
         },
@@ -946,6 +1128,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/symbol"
             }
           ]
         },
@@ -966,6 +1152,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/validate-npm-package-license"
             }
           ]
         },
@@ -986,6 +1176,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/window-size"
             }
           ]
         },
@@ -1006,6 +1200,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/wrap-ansi"
             }
           ]
         },
@@ -1026,6 +1224,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/y18n"
             }
           ]
         },
@@ -1046,6 +1248,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/yargs-parser"
             }
           ]
         },
@@ -1066,6 +1272,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/yargs"
             }
           ]
         }

--- a/tests/_data/sbom_demo-results/bundled-dependencies_npm7_node14_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bundled-dependencies_npm7_node14_windows-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-bundled-deps@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -70,6 +74,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bundle-dependencies"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -88,6 +98,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\ansi-regex"
             }
           ]
         },
@@ -108,6 +122,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\builtin-modules"
             }
           ]
         },
@@ -128,6 +146,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\camelcase"
             }
           ]
         },
@@ -148,6 +170,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\cliui"
             }
           ]
         },
@@ -168,6 +194,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\code-point-at"
             }
           ]
         },
@@ -188,6 +218,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\decamelize"
             }
           ]
         },
@@ -208,6 +242,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\error-ex"
             }
           ]
         },
@@ -228,6 +266,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\escape-string-regexp"
             }
           ]
         },
@@ -248,6 +290,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\find-up"
             }
           ]
         },
@@ -268,6 +314,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\graceful-fs"
             }
           ]
         },
@@ -288,6 +338,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\hosted-git-info"
             }
           ]
         },
@@ -308,6 +362,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\invert-kv"
             }
           ]
         },
@@ -328,6 +386,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\is-arrayish"
             }
           ]
         },
@@ -348,6 +410,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\is-builtin-module"
             }
           ]
         },
@@ -368,6 +434,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\is-fullwidth-code-point"
             }
           ]
         },
@@ -388,6 +458,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\is-utf8"
             }
           ]
         },
@@ -408,6 +482,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\lcid"
             }
           ]
         },
@@ -428,6 +506,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\load-json-file"
             }
           ]
         },
@@ -448,6 +530,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\lodash.assign"
             }
           ]
         },
@@ -468,6 +554,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\lodash.keys"
             }
           ]
         },
@@ -488,6 +578,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\lodash.rest"
             }
           ]
         },
@@ -508,6 +602,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\normalize-package-data"
             }
           ]
         },
@@ -528,6 +626,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\number-is-nan"
             }
           ]
         },
@@ -548,6 +650,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\object-assign"
             }
           ]
         },
@@ -568,6 +674,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\os-locale"
             }
           ]
         },
@@ -588,6 +698,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\parse-json"
             }
           ]
         },
@@ -608,6 +722,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\path-exists"
             }
           ]
         },
@@ -628,6 +746,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\path-type"
             }
           ]
         },
@@ -648,6 +770,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\pify"
             }
           ]
         },
@@ -668,6 +794,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\pinkie-promise"
             }
           ]
         },
@@ -688,6 +818,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\pinkie"
             }
           ]
         },
@@ -708,6 +842,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\pkg-conf"
             }
           ]
         },
@@ -728,6 +866,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\read-pkg-up"
             }
           ]
         },
@@ -748,6 +890,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\read-pkg"
             }
           ]
         },
@@ -768,6 +914,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\require-main-filename"
             }
           ]
         },
@@ -788,6 +938,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\semver"
             }
           ]
         },
@@ -808,6 +962,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\spdx-correct"
             }
           ]
         },
@@ -828,6 +986,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\spdx-exceptions"
             }
           ]
         },
@@ -846,6 +1008,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\spdx-expression-parse"
             }
           ]
         },
@@ -866,6 +1032,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\spdx-license-ids"
             }
           ]
         },
@@ -886,6 +1056,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\string-width"
             }
           ]
         },
@@ -906,6 +1080,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\strip-ansi"
             }
           ]
         },
@@ -926,6 +1104,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\strip-bom"
             }
           ]
         },
@@ -946,6 +1128,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\symbol"
             }
           ]
         },
@@ -966,6 +1152,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\validate-npm-package-license"
             }
           ]
         },
@@ -986,6 +1176,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\window-size"
             }
           ]
         },
@@ -1006,6 +1200,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\wrap-ansi"
             }
           ]
         },
@@ -1026,6 +1224,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\y18n"
             }
           ]
         },
@@ -1046,6 +1248,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\yargs-parser"
             }
           ]
         },
@@ -1066,6 +1272,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\yargs"
             }
           ]
         }

--- a/tests/_data/sbom_demo-results/bundled-dependencies_npm7_node14_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bundled-dependencies_npm7_node14_windows-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-bundled-deps@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -76,7 +76,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bundle-dependencies"
         }
       ],
@@ -100,7 +100,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\ansi-regex"
             }
           ]
@@ -124,7 +124,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\builtin-modules"
             }
           ]
@@ -148,7 +148,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\camelcase"
             }
           ]
@@ -172,7 +172,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\cliui"
             }
           ]
@@ -196,7 +196,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\code-point-at"
             }
           ]
@@ -220,7 +220,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\decamelize"
             }
           ]
@@ -244,7 +244,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\error-ex"
             }
           ]
@@ -268,7 +268,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\escape-string-regexp"
             }
           ]
@@ -292,7 +292,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\find-up"
             }
           ]
@@ -316,7 +316,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\graceful-fs"
             }
           ]
@@ -340,7 +340,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\hosted-git-info"
             }
           ]
@@ -364,7 +364,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\invert-kv"
             }
           ]
@@ -388,7 +388,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\is-arrayish"
             }
           ]
@@ -412,7 +412,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\is-builtin-module"
             }
           ]
@@ -436,7 +436,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\is-fullwidth-code-point"
             }
           ]
@@ -460,7 +460,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\is-utf8"
             }
           ]
@@ -484,7 +484,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\lcid"
             }
           ]
@@ -508,7 +508,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\load-json-file"
             }
           ]
@@ -532,7 +532,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\lodash.assign"
             }
           ]
@@ -556,7 +556,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\lodash.keys"
             }
           ]
@@ -580,7 +580,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\lodash.rest"
             }
           ]
@@ -604,7 +604,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\normalize-package-data"
             }
           ]
@@ -628,7 +628,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\number-is-nan"
             }
           ]
@@ -652,7 +652,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\object-assign"
             }
           ]
@@ -676,7 +676,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\os-locale"
             }
           ]
@@ -700,7 +700,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\parse-json"
             }
           ]
@@ -724,7 +724,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\path-exists"
             }
           ]
@@ -748,7 +748,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\path-type"
             }
           ]
@@ -772,7 +772,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\pify"
             }
           ]
@@ -796,7 +796,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\pinkie-promise"
             }
           ]
@@ -820,7 +820,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\pinkie"
             }
           ]
@@ -844,7 +844,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\pkg-conf"
             }
           ]
@@ -868,7 +868,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\read-pkg-up"
             }
           ]
@@ -892,7 +892,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\read-pkg"
             }
           ]
@@ -916,7 +916,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\require-main-filename"
             }
           ]
@@ -940,7 +940,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\semver"
             }
           ]
@@ -964,7 +964,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\spdx-correct"
             }
           ]
@@ -988,7 +988,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\spdx-exceptions"
             }
           ]
@@ -1010,7 +1010,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\spdx-expression-parse"
             }
           ]
@@ -1034,7 +1034,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\spdx-license-ids"
             }
           ]
@@ -1058,7 +1058,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\string-width"
             }
           ]
@@ -1082,7 +1082,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\strip-ansi"
             }
           ]
@@ -1106,7 +1106,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\strip-bom"
             }
           ]
@@ -1130,7 +1130,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\symbol"
             }
           ]
@@ -1154,7 +1154,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\validate-npm-package-license"
             }
           ]
@@ -1178,7 +1178,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\window-size"
             }
           ]
@@ -1202,7 +1202,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\wrap-ansi"
             }
           ]
@@ -1226,7 +1226,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\y18n"
             }
           ]
@@ -1250,7 +1250,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\yargs-parser"
             }
           ]
@@ -1274,7 +1274,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\yargs"
             }
           ]

--- a/tests/_data/sbom_demo-results/bundled-dependencies_npm7_node16_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bundled-dependencies_npm7_node16_macos-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-bundled-deps@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -76,7 +76,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bundle-dependencies"
         }
       ],
@@ -100,7 +100,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/ansi-regex"
             }
           ]
@@ -124,7 +124,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/builtin-modules"
             }
           ]
@@ -148,7 +148,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/camelcase"
             }
           ]
@@ -172,7 +172,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/cliui"
             }
           ]
@@ -196,7 +196,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/code-point-at"
             }
           ]
@@ -220,7 +220,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/decamelize"
             }
           ]
@@ -244,7 +244,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/error-ex"
             }
           ]
@@ -268,7 +268,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/escape-string-regexp"
             }
           ]
@@ -292,7 +292,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/find-up"
             }
           ]
@@ -316,7 +316,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/graceful-fs"
             }
           ]
@@ -340,7 +340,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/hosted-git-info"
             }
           ]
@@ -364,7 +364,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/invert-kv"
             }
           ]
@@ -388,7 +388,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-arrayish"
             }
           ]
@@ -412,7 +412,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-builtin-module"
             }
           ]
@@ -436,7 +436,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -460,7 +460,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-utf8"
             }
           ]
@@ -484,7 +484,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lcid"
             }
           ]
@@ -508,7 +508,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/load-json-file"
             }
           ]
@@ -532,7 +532,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lodash.assign"
             }
           ]
@@ -556,7 +556,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lodash.keys"
             }
           ]
@@ -580,7 +580,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lodash.rest"
             }
           ]
@@ -604,7 +604,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/normalize-package-data"
             }
           ]
@@ -628,7 +628,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/number-is-nan"
             }
           ]
@@ -652,7 +652,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/object-assign"
             }
           ]
@@ -676,7 +676,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/os-locale"
             }
           ]
@@ -700,7 +700,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/parse-json"
             }
           ]
@@ -724,7 +724,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/path-exists"
             }
           ]
@@ -748,7 +748,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/path-type"
             }
           ]
@@ -772,7 +772,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pify"
             }
           ]
@@ -796,7 +796,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pinkie-promise"
             }
           ]
@@ -820,7 +820,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pinkie"
             }
           ]
@@ -844,7 +844,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pkg-conf"
             }
           ]
@@ -868,7 +868,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/read-pkg-up"
             }
           ]
@@ -892,7 +892,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/read-pkg"
             }
           ]
@@ -916,7 +916,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/require-main-filename"
             }
           ]
@@ -940,7 +940,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/semver"
             }
           ]
@@ -964,7 +964,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-correct"
             }
           ]
@@ -988,7 +988,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-exceptions"
             }
           ]
@@ -1010,7 +1010,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-expression-parse"
             }
           ]
@@ -1034,7 +1034,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-license-ids"
             }
           ]
@@ -1058,7 +1058,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/string-width"
             }
           ]
@@ -1082,7 +1082,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/strip-ansi"
             }
           ]
@@ -1106,7 +1106,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/strip-bom"
             }
           ]
@@ -1130,7 +1130,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/symbol"
             }
           ]
@@ -1154,7 +1154,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/validate-npm-package-license"
             }
           ]
@@ -1178,7 +1178,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/window-size"
             }
           ]
@@ -1202,7 +1202,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/wrap-ansi"
             }
           ]
@@ -1226,7 +1226,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/y18n"
             }
           ]
@@ -1250,7 +1250,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/yargs-parser"
             }
           ]
@@ -1274,7 +1274,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/yargs"
             }
           ]

--- a/tests/_data/sbom_demo-results/bundled-dependencies_npm7_node16_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bundled-dependencies_npm7_node16_macos-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-bundled-deps@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -70,6 +74,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bundle-dependencies"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -88,6 +98,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/ansi-regex"
             }
           ]
         },
@@ -108,6 +122,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/builtin-modules"
             }
           ]
         },
@@ -128,6 +146,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/camelcase"
             }
           ]
         },
@@ -148,6 +170,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/cliui"
             }
           ]
         },
@@ -168,6 +194,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/code-point-at"
             }
           ]
         },
@@ -188,6 +218,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/decamelize"
             }
           ]
         },
@@ -208,6 +242,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/error-ex"
             }
           ]
         },
@@ -228,6 +266,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/escape-string-regexp"
             }
           ]
         },
@@ -248,6 +290,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/find-up"
             }
           ]
         },
@@ -268,6 +314,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/graceful-fs"
             }
           ]
         },
@@ -288,6 +338,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/hosted-git-info"
             }
           ]
         },
@@ -308,6 +362,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/invert-kv"
             }
           ]
         },
@@ -328,6 +386,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-arrayish"
             }
           ]
         },
@@ -348,6 +410,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-builtin-module"
             }
           ]
         },
@@ -368,6 +434,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-fullwidth-code-point"
             }
           ]
         },
@@ -388,6 +458,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-utf8"
             }
           ]
         },
@@ -408,6 +482,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lcid"
             }
           ]
         },
@@ -428,6 +506,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/load-json-file"
             }
           ]
         },
@@ -448,6 +530,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lodash.assign"
             }
           ]
         },
@@ -468,6 +554,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lodash.keys"
             }
           ]
         },
@@ -488,6 +578,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lodash.rest"
             }
           ]
         },
@@ -508,6 +602,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/normalize-package-data"
             }
           ]
         },
@@ -528,6 +626,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/number-is-nan"
             }
           ]
         },
@@ -548,6 +650,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/object-assign"
             }
           ]
         },
@@ -568,6 +674,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/os-locale"
             }
           ]
         },
@@ -588,6 +698,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/parse-json"
             }
           ]
         },
@@ -608,6 +722,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/path-exists"
             }
           ]
         },
@@ -628,6 +746,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/path-type"
             }
           ]
         },
@@ -648,6 +770,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pify"
             }
           ]
         },
@@ -668,6 +794,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pinkie-promise"
             }
           ]
         },
@@ -688,6 +818,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pinkie"
             }
           ]
         },
@@ -708,6 +842,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pkg-conf"
             }
           ]
         },
@@ -728,6 +866,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/read-pkg-up"
             }
           ]
         },
@@ -748,6 +890,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/read-pkg"
             }
           ]
         },
@@ -768,6 +914,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/require-main-filename"
             }
           ]
         },
@@ -788,6 +938,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/semver"
             }
           ]
         },
@@ -808,6 +962,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-correct"
             }
           ]
         },
@@ -828,6 +986,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-exceptions"
             }
           ]
         },
@@ -846,6 +1008,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-expression-parse"
             }
           ]
         },
@@ -866,6 +1032,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-license-ids"
             }
           ]
         },
@@ -886,6 +1056,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/string-width"
             }
           ]
         },
@@ -906,6 +1080,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/strip-ansi"
             }
           ]
         },
@@ -926,6 +1104,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/strip-bom"
             }
           ]
         },
@@ -946,6 +1128,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/symbol"
             }
           ]
         },
@@ -966,6 +1152,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/validate-npm-package-license"
             }
           ]
         },
@@ -986,6 +1176,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/window-size"
             }
           ]
         },
@@ -1006,6 +1200,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/wrap-ansi"
             }
           ]
         },
@@ -1026,6 +1224,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/y18n"
             }
           ]
         },
@@ -1046,6 +1248,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/yargs-parser"
             }
           ]
         },
@@ -1066,6 +1272,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/yargs"
             }
           ]
         }

--- a/tests/_data/sbom_demo-results/bundled-dependencies_npm7_node16_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bundled-dependencies_npm7_node16_ubuntu-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-bundled-deps@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -76,7 +76,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bundle-dependencies"
         }
       ],
@@ -100,7 +100,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/ansi-regex"
             }
           ]
@@ -124,7 +124,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/builtin-modules"
             }
           ]
@@ -148,7 +148,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/camelcase"
             }
           ]
@@ -172,7 +172,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/cliui"
             }
           ]
@@ -196,7 +196,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/code-point-at"
             }
           ]
@@ -220,7 +220,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/decamelize"
             }
           ]
@@ -244,7 +244,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/error-ex"
             }
           ]
@@ -268,7 +268,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/escape-string-regexp"
             }
           ]
@@ -292,7 +292,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/find-up"
             }
           ]
@@ -316,7 +316,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/graceful-fs"
             }
           ]
@@ -340,7 +340,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/hosted-git-info"
             }
           ]
@@ -364,7 +364,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/invert-kv"
             }
           ]
@@ -388,7 +388,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-arrayish"
             }
           ]
@@ -412,7 +412,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-builtin-module"
             }
           ]
@@ -436,7 +436,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -460,7 +460,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-utf8"
             }
           ]
@@ -484,7 +484,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lcid"
             }
           ]
@@ -508,7 +508,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/load-json-file"
             }
           ]
@@ -532,7 +532,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lodash.assign"
             }
           ]
@@ -556,7 +556,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lodash.keys"
             }
           ]
@@ -580,7 +580,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lodash.rest"
             }
           ]
@@ -604,7 +604,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/normalize-package-data"
             }
           ]
@@ -628,7 +628,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/number-is-nan"
             }
           ]
@@ -652,7 +652,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/object-assign"
             }
           ]
@@ -676,7 +676,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/os-locale"
             }
           ]
@@ -700,7 +700,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/parse-json"
             }
           ]
@@ -724,7 +724,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/path-exists"
             }
           ]
@@ -748,7 +748,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/path-type"
             }
           ]
@@ -772,7 +772,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pify"
             }
           ]
@@ -796,7 +796,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pinkie-promise"
             }
           ]
@@ -820,7 +820,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pinkie"
             }
           ]
@@ -844,7 +844,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pkg-conf"
             }
           ]
@@ -868,7 +868,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/read-pkg-up"
             }
           ]
@@ -892,7 +892,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/read-pkg"
             }
           ]
@@ -916,7 +916,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/require-main-filename"
             }
           ]
@@ -940,7 +940,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/semver"
             }
           ]
@@ -964,7 +964,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-correct"
             }
           ]
@@ -988,7 +988,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-exceptions"
             }
           ]
@@ -1010,7 +1010,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-expression-parse"
             }
           ]
@@ -1034,7 +1034,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-license-ids"
             }
           ]
@@ -1058,7 +1058,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/string-width"
             }
           ]
@@ -1082,7 +1082,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/strip-ansi"
             }
           ]
@@ -1106,7 +1106,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/strip-bom"
             }
           ]
@@ -1130,7 +1130,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/symbol"
             }
           ]
@@ -1154,7 +1154,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/validate-npm-package-license"
             }
           ]
@@ -1178,7 +1178,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/window-size"
             }
           ]
@@ -1202,7 +1202,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/wrap-ansi"
             }
           ]
@@ -1226,7 +1226,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/y18n"
             }
           ]
@@ -1250,7 +1250,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/yargs-parser"
             }
           ]
@@ -1274,7 +1274,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/yargs"
             }
           ]

--- a/tests/_data/sbom_demo-results/bundled-dependencies_npm7_node16_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bundled-dependencies_npm7_node16_ubuntu-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-bundled-deps@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -70,6 +74,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bundle-dependencies"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -88,6 +98,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/ansi-regex"
             }
           ]
         },
@@ -108,6 +122,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/builtin-modules"
             }
           ]
         },
@@ -128,6 +146,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/camelcase"
             }
           ]
         },
@@ -148,6 +170,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/cliui"
             }
           ]
         },
@@ -168,6 +194,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/code-point-at"
             }
           ]
         },
@@ -188,6 +218,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/decamelize"
             }
           ]
         },
@@ -208,6 +242,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/error-ex"
             }
           ]
         },
@@ -228,6 +266,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/escape-string-regexp"
             }
           ]
         },
@@ -248,6 +290,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/find-up"
             }
           ]
         },
@@ -268,6 +314,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/graceful-fs"
             }
           ]
         },
@@ -288,6 +338,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/hosted-git-info"
             }
           ]
         },
@@ -308,6 +362,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/invert-kv"
             }
           ]
         },
@@ -328,6 +386,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-arrayish"
             }
           ]
         },
@@ -348,6 +410,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-builtin-module"
             }
           ]
         },
@@ -368,6 +434,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-fullwidth-code-point"
             }
           ]
         },
@@ -388,6 +458,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-utf8"
             }
           ]
         },
@@ -408,6 +482,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lcid"
             }
           ]
         },
@@ -428,6 +506,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/load-json-file"
             }
           ]
         },
@@ -448,6 +530,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lodash.assign"
             }
           ]
         },
@@ -468,6 +554,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lodash.keys"
             }
           ]
         },
@@ -488,6 +578,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lodash.rest"
             }
           ]
         },
@@ -508,6 +602,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/normalize-package-data"
             }
           ]
         },
@@ -528,6 +626,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/number-is-nan"
             }
           ]
         },
@@ -548,6 +650,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/object-assign"
             }
           ]
         },
@@ -568,6 +674,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/os-locale"
             }
           ]
         },
@@ -588,6 +698,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/parse-json"
             }
           ]
         },
@@ -608,6 +722,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/path-exists"
             }
           ]
         },
@@ -628,6 +746,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/path-type"
             }
           ]
         },
@@ -648,6 +770,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pify"
             }
           ]
         },
@@ -668,6 +794,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pinkie-promise"
             }
           ]
         },
@@ -688,6 +818,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pinkie"
             }
           ]
         },
@@ -708,6 +842,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pkg-conf"
             }
           ]
         },
@@ -728,6 +866,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/read-pkg-up"
             }
           ]
         },
@@ -748,6 +890,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/read-pkg"
             }
           ]
         },
@@ -768,6 +914,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/require-main-filename"
             }
           ]
         },
@@ -788,6 +938,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/semver"
             }
           ]
         },
@@ -808,6 +962,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-correct"
             }
           ]
         },
@@ -828,6 +986,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-exceptions"
             }
           ]
         },
@@ -846,6 +1008,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-expression-parse"
             }
           ]
         },
@@ -866,6 +1032,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-license-ids"
             }
           ]
         },
@@ -886,6 +1056,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/string-width"
             }
           ]
         },
@@ -906,6 +1080,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/strip-ansi"
             }
           ]
         },
@@ -926,6 +1104,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/strip-bom"
             }
           ]
         },
@@ -946,6 +1128,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/symbol"
             }
           ]
         },
@@ -966,6 +1152,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/validate-npm-package-license"
             }
           ]
         },
@@ -986,6 +1176,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/window-size"
             }
           ]
         },
@@ -1006,6 +1200,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/wrap-ansi"
             }
           ]
         },
@@ -1026,6 +1224,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/y18n"
             }
           ]
         },
@@ -1046,6 +1248,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/yargs-parser"
             }
           ]
         },
@@ -1066,6 +1272,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/yargs"
             }
           ]
         }

--- a/tests/_data/sbom_demo-results/bundled-dependencies_npm7_node16_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bundled-dependencies_npm7_node16_windows-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-bundled-deps@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -70,6 +74,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bundle-dependencies"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -88,6 +98,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\ansi-regex"
             }
           ]
         },
@@ -108,6 +122,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\builtin-modules"
             }
           ]
         },
@@ -128,6 +146,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\camelcase"
             }
           ]
         },
@@ -148,6 +170,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\cliui"
             }
           ]
         },
@@ -168,6 +194,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\code-point-at"
             }
           ]
         },
@@ -188,6 +218,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\decamelize"
             }
           ]
         },
@@ -208,6 +242,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\error-ex"
             }
           ]
         },
@@ -228,6 +266,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\escape-string-regexp"
             }
           ]
         },
@@ -248,6 +290,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\find-up"
             }
           ]
         },
@@ -268,6 +314,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\graceful-fs"
             }
           ]
         },
@@ -288,6 +338,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\hosted-git-info"
             }
           ]
         },
@@ -308,6 +362,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\invert-kv"
             }
           ]
         },
@@ -328,6 +386,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\is-arrayish"
             }
           ]
         },
@@ -348,6 +410,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\is-builtin-module"
             }
           ]
         },
@@ -368,6 +434,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\is-fullwidth-code-point"
             }
           ]
         },
@@ -388,6 +458,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\is-utf8"
             }
           ]
         },
@@ -408,6 +482,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\lcid"
             }
           ]
         },
@@ -428,6 +506,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\load-json-file"
             }
           ]
         },
@@ -448,6 +530,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\lodash.assign"
             }
           ]
         },
@@ -468,6 +554,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\lodash.keys"
             }
           ]
         },
@@ -488,6 +578,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\lodash.rest"
             }
           ]
         },
@@ -508,6 +602,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\normalize-package-data"
             }
           ]
         },
@@ -528,6 +626,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\number-is-nan"
             }
           ]
         },
@@ -548,6 +650,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\object-assign"
             }
           ]
         },
@@ -568,6 +674,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\os-locale"
             }
           ]
         },
@@ -588,6 +698,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\parse-json"
             }
           ]
         },
@@ -608,6 +722,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\path-exists"
             }
           ]
         },
@@ -628,6 +746,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\path-type"
             }
           ]
         },
@@ -648,6 +770,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\pify"
             }
           ]
         },
@@ -668,6 +794,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\pinkie-promise"
             }
           ]
         },
@@ -688,6 +818,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\pinkie"
             }
           ]
         },
@@ -708,6 +842,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\pkg-conf"
             }
           ]
         },
@@ -728,6 +866,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\read-pkg-up"
             }
           ]
         },
@@ -748,6 +890,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\read-pkg"
             }
           ]
         },
@@ -768,6 +914,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\require-main-filename"
             }
           ]
         },
@@ -788,6 +938,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\semver"
             }
           ]
         },
@@ -808,6 +962,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\spdx-correct"
             }
           ]
         },
@@ -828,6 +986,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\spdx-exceptions"
             }
           ]
         },
@@ -846,6 +1008,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\spdx-expression-parse"
             }
           ]
         },
@@ -866,6 +1032,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\spdx-license-ids"
             }
           ]
         },
@@ -886,6 +1056,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\string-width"
             }
           ]
         },
@@ -906,6 +1080,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\strip-ansi"
             }
           ]
         },
@@ -926,6 +1104,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\strip-bom"
             }
           ]
         },
@@ -946,6 +1128,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\symbol"
             }
           ]
         },
@@ -966,6 +1152,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\validate-npm-package-license"
             }
           ]
         },
@@ -986,6 +1176,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\window-size"
             }
           ]
         },
@@ -1006,6 +1200,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\wrap-ansi"
             }
           ]
         },
@@ -1026,6 +1224,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\y18n"
             }
           ]
         },
@@ -1046,6 +1248,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\yargs-parser"
             }
           ]
         },
@@ -1066,6 +1272,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\yargs"
             }
           ]
         }

--- a/tests/_data/sbom_demo-results/bundled-dependencies_npm7_node16_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bundled-dependencies_npm7_node16_windows-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-bundled-deps@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -76,7 +76,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bundle-dependencies"
         }
       ],
@@ -100,7 +100,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\ansi-regex"
             }
           ]
@@ -124,7 +124,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\builtin-modules"
             }
           ]
@@ -148,7 +148,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\camelcase"
             }
           ]
@@ -172,7 +172,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\cliui"
             }
           ]
@@ -196,7 +196,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\code-point-at"
             }
           ]
@@ -220,7 +220,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\decamelize"
             }
           ]
@@ -244,7 +244,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\error-ex"
             }
           ]
@@ -268,7 +268,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\escape-string-regexp"
             }
           ]
@@ -292,7 +292,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\find-up"
             }
           ]
@@ -316,7 +316,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\graceful-fs"
             }
           ]
@@ -340,7 +340,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\hosted-git-info"
             }
           ]
@@ -364,7 +364,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\invert-kv"
             }
           ]
@@ -388,7 +388,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\is-arrayish"
             }
           ]
@@ -412,7 +412,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\is-builtin-module"
             }
           ]
@@ -436,7 +436,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\is-fullwidth-code-point"
             }
           ]
@@ -460,7 +460,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\is-utf8"
             }
           ]
@@ -484,7 +484,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\lcid"
             }
           ]
@@ -508,7 +508,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\load-json-file"
             }
           ]
@@ -532,7 +532,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\lodash.assign"
             }
           ]
@@ -556,7 +556,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\lodash.keys"
             }
           ]
@@ -580,7 +580,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\lodash.rest"
             }
           ]
@@ -604,7 +604,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\normalize-package-data"
             }
           ]
@@ -628,7 +628,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\number-is-nan"
             }
           ]
@@ -652,7 +652,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\object-assign"
             }
           ]
@@ -676,7 +676,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\os-locale"
             }
           ]
@@ -700,7 +700,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\parse-json"
             }
           ]
@@ -724,7 +724,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\path-exists"
             }
           ]
@@ -748,7 +748,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\path-type"
             }
           ]
@@ -772,7 +772,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\pify"
             }
           ]
@@ -796,7 +796,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\pinkie-promise"
             }
           ]
@@ -820,7 +820,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\pinkie"
             }
           ]
@@ -844,7 +844,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\pkg-conf"
             }
           ]
@@ -868,7 +868,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\read-pkg-up"
             }
           ]
@@ -892,7 +892,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\read-pkg"
             }
           ]
@@ -916,7 +916,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\require-main-filename"
             }
           ]
@@ -940,7 +940,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\semver"
             }
           ]
@@ -964,7 +964,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\spdx-correct"
             }
           ]
@@ -988,7 +988,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\spdx-exceptions"
             }
           ]
@@ -1010,7 +1010,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\spdx-expression-parse"
             }
           ]
@@ -1034,7 +1034,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\spdx-license-ids"
             }
           ]
@@ -1058,7 +1058,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\string-width"
             }
           ]
@@ -1082,7 +1082,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\strip-ansi"
             }
           ]
@@ -1106,7 +1106,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\strip-bom"
             }
           ]
@@ -1130,7 +1130,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\symbol"
             }
           ]
@@ -1154,7 +1154,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\validate-npm-package-license"
             }
           ]
@@ -1178,7 +1178,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\window-size"
             }
           ]
@@ -1202,7 +1202,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\wrap-ansi"
             }
           ]
@@ -1226,7 +1226,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\y18n"
             }
           ]
@@ -1250,7 +1250,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\yargs-parser"
             }
           ]
@@ -1274,7 +1274,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\yargs"
             }
           ]

--- a/tests/_data/sbom_demo-results/bundled-dependencies_npm7_node18_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bundled-dependencies_npm7_node18_macos-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-bundled-deps@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -76,7 +76,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bundle-dependencies"
         }
       ],
@@ -100,7 +100,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/ansi-regex"
             }
           ]
@@ -124,7 +124,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/builtin-modules"
             }
           ]
@@ -148,7 +148,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/camelcase"
             }
           ]
@@ -172,7 +172,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/cliui"
             }
           ]
@@ -196,7 +196,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/code-point-at"
             }
           ]
@@ -220,7 +220,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/decamelize"
             }
           ]
@@ -244,7 +244,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/error-ex"
             }
           ]
@@ -268,7 +268,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/escape-string-regexp"
             }
           ]
@@ -292,7 +292,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/find-up"
             }
           ]
@@ -316,7 +316,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/graceful-fs"
             }
           ]
@@ -340,7 +340,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/hosted-git-info"
             }
           ]
@@ -364,7 +364,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/invert-kv"
             }
           ]
@@ -388,7 +388,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-arrayish"
             }
           ]
@@ -412,7 +412,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-builtin-module"
             }
           ]
@@ -436,7 +436,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -460,7 +460,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-utf8"
             }
           ]
@@ -484,7 +484,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lcid"
             }
           ]
@@ -508,7 +508,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/load-json-file"
             }
           ]
@@ -532,7 +532,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lodash.assign"
             }
           ]
@@ -556,7 +556,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lodash.keys"
             }
           ]
@@ -580,7 +580,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lodash.rest"
             }
           ]
@@ -604,7 +604,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/normalize-package-data"
             }
           ]
@@ -628,7 +628,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/number-is-nan"
             }
           ]
@@ -652,7 +652,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/object-assign"
             }
           ]
@@ -676,7 +676,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/os-locale"
             }
           ]
@@ -700,7 +700,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/parse-json"
             }
           ]
@@ -724,7 +724,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/path-exists"
             }
           ]
@@ -748,7 +748,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/path-type"
             }
           ]
@@ -772,7 +772,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pify"
             }
           ]
@@ -796,7 +796,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pinkie-promise"
             }
           ]
@@ -820,7 +820,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pinkie"
             }
           ]
@@ -844,7 +844,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pkg-conf"
             }
           ]
@@ -868,7 +868,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/read-pkg-up"
             }
           ]
@@ -892,7 +892,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/read-pkg"
             }
           ]
@@ -916,7 +916,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/require-main-filename"
             }
           ]
@@ -940,7 +940,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/semver"
             }
           ]
@@ -964,7 +964,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-correct"
             }
           ]
@@ -988,7 +988,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-exceptions"
             }
           ]
@@ -1010,7 +1010,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-expression-parse"
             }
           ]
@@ -1034,7 +1034,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-license-ids"
             }
           ]
@@ -1058,7 +1058,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/string-width"
             }
           ]
@@ -1082,7 +1082,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/strip-ansi"
             }
           ]
@@ -1106,7 +1106,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/strip-bom"
             }
           ]
@@ -1130,7 +1130,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/symbol"
             }
           ]
@@ -1154,7 +1154,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/validate-npm-package-license"
             }
           ]
@@ -1178,7 +1178,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/window-size"
             }
           ]
@@ -1202,7 +1202,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/wrap-ansi"
             }
           ]
@@ -1226,7 +1226,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/y18n"
             }
           ]
@@ -1250,7 +1250,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/yargs-parser"
             }
           ]
@@ -1274,7 +1274,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/yargs"
             }
           ]

--- a/tests/_data/sbom_demo-results/bundled-dependencies_npm7_node18_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bundled-dependencies_npm7_node18_macos-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-bundled-deps@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -70,6 +74,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bundle-dependencies"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -88,6 +98,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/ansi-regex"
             }
           ]
         },
@@ -108,6 +122,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/builtin-modules"
             }
           ]
         },
@@ -128,6 +146,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/camelcase"
             }
           ]
         },
@@ -148,6 +170,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/cliui"
             }
           ]
         },
@@ -168,6 +194,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/code-point-at"
             }
           ]
         },
@@ -188,6 +218,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/decamelize"
             }
           ]
         },
@@ -208,6 +242,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/error-ex"
             }
           ]
         },
@@ -228,6 +266,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/escape-string-regexp"
             }
           ]
         },
@@ -248,6 +290,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/find-up"
             }
           ]
         },
@@ -268,6 +314,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/graceful-fs"
             }
           ]
         },
@@ -288,6 +338,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/hosted-git-info"
             }
           ]
         },
@@ -308,6 +362,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/invert-kv"
             }
           ]
         },
@@ -328,6 +386,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-arrayish"
             }
           ]
         },
@@ -348,6 +410,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-builtin-module"
             }
           ]
         },
@@ -368,6 +434,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-fullwidth-code-point"
             }
           ]
         },
@@ -388,6 +458,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-utf8"
             }
           ]
         },
@@ -408,6 +482,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lcid"
             }
           ]
         },
@@ -428,6 +506,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/load-json-file"
             }
           ]
         },
@@ -448,6 +530,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lodash.assign"
             }
           ]
         },
@@ -468,6 +554,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lodash.keys"
             }
           ]
         },
@@ -488,6 +578,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lodash.rest"
             }
           ]
         },
@@ -508,6 +602,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/normalize-package-data"
             }
           ]
         },
@@ -528,6 +626,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/number-is-nan"
             }
           ]
         },
@@ -548,6 +650,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/object-assign"
             }
           ]
         },
@@ -568,6 +674,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/os-locale"
             }
           ]
         },
@@ -588,6 +698,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/parse-json"
             }
           ]
         },
@@ -608,6 +722,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/path-exists"
             }
           ]
         },
@@ -628,6 +746,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/path-type"
             }
           ]
         },
@@ -648,6 +770,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pify"
             }
           ]
         },
@@ -668,6 +794,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pinkie-promise"
             }
           ]
         },
@@ -688,6 +818,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pinkie"
             }
           ]
         },
@@ -708,6 +842,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pkg-conf"
             }
           ]
         },
@@ -728,6 +866,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/read-pkg-up"
             }
           ]
         },
@@ -748,6 +890,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/read-pkg"
             }
           ]
         },
@@ -768,6 +914,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/require-main-filename"
             }
           ]
         },
@@ -788,6 +938,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/semver"
             }
           ]
         },
@@ -808,6 +962,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-correct"
             }
           ]
         },
@@ -828,6 +986,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-exceptions"
             }
           ]
         },
@@ -846,6 +1008,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-expression-parse"
             }
           ]
         },
@@ -866,6 +1032,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-license-ids"
             }
           ]
         },
@@ -886,6 +1056,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/string-width"
             }
           ]
         },
@@ -906,6 +1080,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/strip-ansi"
             }
           ]
         },
@@ -926,6 +1104,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/strip-bom"
             }
           ]
         },
@@ -946,6 +1128,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/symbol"
             }
           ]
         },
@@ -966,6 +1152,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/validate-npm-package-license"
             }
           ]
         },
@@ -986,6 +1176,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/window-size"
             }
           ]
         },
@@ -1006,6 +1200,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/wrap-ansi"
             }
           ]
         },
@@ -1026,6 +1224,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/y18n"
             }
           ]
         },
@@ -1046,6 +1248,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/yargs-parser"
             }
           ]
         },
@@ -1066,6 +1272,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/yargs"
             }
           ]
         }

--- a/tests/_data/sbom_demo-results/bundled-dependencies_npm7_node18_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bundled-dependencies_npm7_node18_ubuntu-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-bundled-deps@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -76,7 +76,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bundle-dependencies"
         }
       ],
@@ -100,7 +100,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/ansi-regex"
             }
           ]
@@ -124,7 +124,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/builtin-modules"
             }
           ]
@@ -148,7 +148,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/camelcase"
             }
           ]
@@ -172,7 +172,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/cliui"
             }
           ]
@@ -196,7 +196,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/code-point-at"
             }
           ]
@@ -220,7 +220,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/decamelize"
             }
           ]
@@ -244,7 +244,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/error-ex"
             }
           ]
@@ -268,7 +268,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/escape-string-regexp"
             }
           ]
@@ -292,7 +292,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/find-up"
             }
           ]
@@ -316,7 +316,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/graceful-fs"
             }
           ]
@@ -340,7 +340,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/hosted-git-info"
             }
           ]
@@ -364,7 +364,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/invert-kv"
             }
           ]
@@ -388,7 +388,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-arrayish"
             }
           ]
@@ -412,7 +412,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-builtin-module"
             }
           ]
@@ -436,7 +436,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -460,7 +460,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-utf8"
             }
           ]
@@ -484,7 +484,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lcid"
             }
           ]
@@ -508,7 +508,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/load-json-file"
             }
           ]
@@ -532,7 +532,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lodash.assign"
             }
           ]
@@ -556,7 +556,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lodash.keys"
             }
           ]
@@ -580,7 +580,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lodash.rest"
             }
           ]
@@ -604,7 +604,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/normalize-package-data"
             }
           ]
@@ -628,7 +628,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/number-is-nan"
             }
           ]
@@ -652,7 +652,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/object-assign"
             }
           ]
@@ -676,7 +676,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/os-locale"
             }
           ]
@@ -700,7 +700,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/parse-json"
             }
           ]
@@ -724,7 +724,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/path-exists"
             }
           ]
@@ -748,7 +748,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/path-type"
             }
           ]
@@ -772,7 +772,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pify"
             }
           ]
@@ -796,7 +796,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pinkie-promise"
             }
           ]
@@ -820,7 +820,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pinkie"
             }
           ]
@@ -844,7 +844,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pkg-conf"
             }
           ]
@@ -868,7 +868,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/read-pkg-up"
             }
           ]
@@ -892,7 +892,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/read-pkg"
             }
           ]
@@ -916,7 +916,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/require-main-filename"
             }
           ]
@@ -940,7 +940,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/semver"
             }
           ]
@@ -964,7 +964,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-correct"
             }
           ]
@@ -988,7 +988,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-exceptions"
             }
           ]
@@ -1010,7 +1010,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-expression-parse"
             }
           ]
@@ -1034,7 +1034,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-license-ids"
             }
           ]
@@ -1058,7 +1058,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/string-width"
             }
           ]
@@ -1082,7 +1082,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/strip-ansi"
             }
           ]
@@ -1106,7 +1106,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/strip-bom"
             }
           ]
@@ -1130,7 +1130,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/symbol"
             }
           ]
@@ -1154,7 +1154,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/validate-npm-package-license"
             }
           ]
@@ -1178,7 +1178,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/window-size"
             }
           ]
@@ -1202,7 +1202,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/wrap-ansi"
             }
           ]
@@ -1226,7 +1226,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/y18n"
             }
           ]
@@ -1250,7 +1250,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/yargs-parser"
             }
           ]
@@ -1274,7 +1274,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/yargs"
             }
           ]

--- a/tests/_data/sbom_demo-results/bundled-dependencies_npm7_node18_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bundled-dependencies_npm7_node18_ubuntu-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-bundled-deps@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -70,6 +74,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bundle-dependencies"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -88,6 +98,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/ansi-regex"
             }
           ]
         },
@@ -108,6 +122,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/builtin-modules"
             }
           ]
         },
@@ -128,6 +146,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/camelcase"
             }
           ]
         },
@@ -148,6 +170,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/cliui"
             }
           ]
         },
@@ -168,6 +194,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/code-point-at"
             }
           ]
         },
@@ -188,6 +218,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/decamelize"
             }
           ]
         },
@@ -208,6 +242,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/error-ex"
             }
           ]
         },
@@ -228,6 +266,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/escape-string-regexp"
             }
           ]
         },
@@ -248,6 +290,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/find-up"
             }
           ]
         },
@@ -268,6 +314,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/graceful-fs"
             }
           ]
         },
@@ -288,6 +338,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/hosted-git-info"
             }
           ]
         },
@@ -308,6 +362,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/invert-kv"
             }
           ]
         },
@@ -328,6 +386,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-arrayish"
             }
           ]
         },
@@ -348,6 +410,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-builtin-module"
             }
           ]
         },
@@ -368,6 +434,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-fullwidth-code-point"
             }
           ]
         },
@@ -388,6 +458,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-utf8"
             }
           ]
         },
@@ -408,6 +482,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lcid"
             }
           ]
         },
@@ -428,6 +506,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/load-json-file"
             }
           ]
         },
@@ -448,6 +530,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lodash.assign"
             }
           ]
         },
@@ -468,6 +554,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lodash.keys"
             }
           ]
         },
@@ -488,6 +578,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lodash.rest"
             }
           ]
         },
@@ -508,6 +602,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/normalize-package-data"
             }
           ]
         },
@@ -528,6 +626,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/number-is-nan"
             }
           ]
         },
@@ -548,6 +650,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/object-assign"
             }
           ]
         },
@@ -568,6 +674,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/os-locale"
             }
           ]
         },
@@ -588,6 +698,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/parse-json"
             }
           ]
         },
@@ -608,6 +722,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/path-exists"
             }
           ]
         },
@@ -628,6 +746,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/path-type"
             }
           ]
         },
@@ -648,6 +770,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pify"
             }
           ]
         },
@@ -668,6 +794,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pinkie-promise"
             }
           ]
         },
@@ -688,6 +818,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pinkie"
             }
           ]
         },
@@ -708,6 +842,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pkg-conf"
             }
           ]
         },
@@ -728,6 +866,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/read-pkg-up"
             }
           ]
         },
@@ -748,6 +890,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/read-pkg"
             }
           ]
         },
@@ -768,6 +914,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/require-main-filename"
             }
           ]
         },
@@ -788,6 +938,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/semver"
             }
           ]
         },
@@ -808,6 +962,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-correct"
             }
           ]
         },
@@ -828,6 +986,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-exceptions"
             }
           ]
         },
@@ -846,6 +1008,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-expression-parse"
             }
           ]
         },
@@ -866,6 +1032,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-license-ids"
             }
           ]
         },
@@ -886,6 +1056,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/string-width"
             }
           ]
         },
@@ -906,6 +1080,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/strip-ansi"
             }
           ]
         },
@@ -926,6 +1104,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/strip-bom"
             }
           ]
         },
@@ -946,6 +1128,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/symbol"
             }
           ]
         },
@@ -966,6 +1152,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/validate-npm-package-license"
             }
           ]
         },
@@ -986,6 +1176,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/window-size"
             }
           ]
         },
@@ -1006,6 +1200,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/wrap-ansi"
             }
           ]
         },
@@ -1026,6 +1224,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/y18n"
             }
           ]
         },
@@ -1046,6 +1248,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/yargs-parser"
             }
           ]
         },
@@ -1066,6 +1272,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/yargs"
             }
           ]
         }

--- a/tests/_data/sbom_demo-results/bundled-dependencies_npm7_node18_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bundled-dependencies_npm7_node18_windows-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-bundled-deps@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -70,6 +74,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bundle-dependencies"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -88,6 +98,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\ansi-regex"
             }
           ]
         },
@@ -108,6 +122,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\builtin-modules"
             }
           ]
         },
@@ -128,6 +146,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\camelcase"
             }
           ]
         },
@@ -148,6 +170,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\cliui"
             }
           ]
         },
@@ -168,6 +194,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\code-point-at"
             }
           ]
         },
@@ -188,6 +218,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\decamelize"
             }
           ]
         },
@@ -208,6 +242,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\error-ex"
             }
           ]
         },
@@ -228,6 +266,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\escape-string-regexp"
             }
           ]
         },
@@ -248,6 +290,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\find-up"
             }
           ]
         },
@@ -268,6 +314,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\graceful-fs"
             }
           ]
         },
@@ -288,6 +338,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\hosted-git-info"
             }
           ]
         },
@@ -308,6 +362,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\invert-kv"
             }
           ]
         },
@@ -328,6 +386,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\is-arrayish"
             }
           ]
         },
@@ -348,6 +410,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\is-builtin-module"
             }
           ]
         },
@@ -368,6 +434,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\is-fullwidth-code-point"
             }
           ]
         },
@@ -388,6 +458,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\is-utf8"
             }
           ]
         },
@@ -408,6 +482,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\lcid"
             }
           ]
         },
@@ -428,6 +506,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\load-json-file"
             }
           ]
         },
@@ -448,6 +530,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\lodash.assign"
             }
           ]
         },
@@ -468,6 +554,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\lodash.keys"
             }
           ]
         },
@@ -488,6 +578,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\lodash.rest"
             }
           ]
         },
@@ -508,6 +602,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\normalize-package-data"
             }
           ]
         },
@@ -528,6 +626,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\number-is-nan"
             }
           ]
         },
@@ -548,6 +650,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\object-assign"
             }
           ]
         },
@@ -568,6 +674,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\os-locale"
             }
           ]
         },
@@ -588,6 +698,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\parse-json"
             }
           ]
         },
@@ -608,6 +722,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\path-exists"
             }
           ]
         },
@@ -628,6 +746,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\path-type"
             }
           ]
         },
@@ -648,6 +770,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\pify"
             }
           ]
         },
@@ -668,6 +794,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\pinkie-promise"
             }
           ]
         },
@@ -688,6 +818,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\pinkie"
             }
           ]
         },
@@ -708,6 +842,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\pkg-conf"
             }
           ]
         },
@@ -728,6 +866,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\read-pkg-up"
             }
           ]
         },
@@ -748,6 +890,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\read-pkg"
             }
           ]
         },
@@ -768,6 +914,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\require-main-filename"
             }
           ]
         },
@@ -788,6 +938,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\semver"
             }
           ]
         },
@@ -808,6 +962,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\spdx-correct"
             }
           ]
         },
@@ -828,6 +986,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\spdx-exceptions"
             }
           ]
         },
@@ -846,6 +1008,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\spdx-expression-parse"
             }
           ]
         },
@@ -866,6 +1032,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\spdx-license-ids"
             }
           ]
         },
@@ -886,6 +1056,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\string-width"
             }
           ]
         },
@@ -906,6 +1080,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\strip-ansi"
             }
           ]
         },
@@ -926,6 +1104,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\strip-bom"
             }
           ]
         },
@@ -946,6 +1128,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\symbol"
             }
           ]
         },
@@ -966,6 +1152,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\validate-npm-package-license"
             }
           ]
         },
@@ -986,6 +1176,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\window-size"
             }
           ]
         },
@@ -1006,6 +1200,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\wrap-ansi"
             }
           ]
         },
@@ -1026,6 +1224,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\y18n"
             }
           ]
         },
@@ -1046,6 +1248,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\yargs-parser"
             }
           ]
         },
@@ -1066,6 +1272,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\yargs"
             }
           ]
         }

--- a/tests/_data/sbom_demo-results/bundled-dependencies_npm7_node18_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bundled-dependencies_npm7_node18_windows-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-bundled-deps@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -76,7 +76,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bundle-dependencies"
         }
       ],
@@ -100,7 +100,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\ansi-regex"
             }
           ]
@@ -124,7 +124,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\builtin-modules"
             }
           ]
@@ -148,7 +148,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\camelcase"
             }
           ]
@@ -172,7 +172,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\cliui"
             }
           ]
@@ -196,7 +196,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\code-point-at"
             }
           ]
@@ -220,7 +220,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\decamelize"
             }
           ]
@@ -244,7 +244,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\error-ex"
             }
           ]
@@ -268,7 +268,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\escape-string-regexp"
             }
           ]
@@ -292,7 +292,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\find-up"
             }
           ]
@@ -316,7 +316,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\graceful-fs"
             }
           ]
@@ -340,7 +340,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\hosted-git-info"
             }
           ]
@@ -364,7 +364,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\invert-kv"
             }
           ]
@@ -388,7 +388,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\is-arrayish"
             }
           ]
@@ -412,7 +412,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\is-builtin-module"
             }
           ]
@@ -436,7 +436,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\is-fullwidth-code-point"
             }
           ]
@@ -460,7 +460,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\is-utf8"
             }
           ]
@@ -484,7 +484,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\lcid"
             }
           ]
@@ -508,7 +508,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\load-json-file"
             }
           ]
@@ -532,7 +532,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\lodash.assign"
             }
           ]
@@ -556,7 +556,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\lodash.keys"
             }
           ]
@@ -580,7 +580,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\lodash.rest"
             }
           ]
@@ -604,7 +604,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\normalize-package-data"
             }
           ]
@@ -628,7 +628,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\number-is-nan"
             }
           ]
@@ -652,7 +652,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\object-assign"
             }
           ]
@@ -676,7 +676,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\os-locale"
             }
           ]
@@ -700,7 +700,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\parse-json"
             }
           ]
@@ -724,7 +724,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\path-exists"
             }
           ]
@@ -748,7 +748,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\path-type"
             }
           ]
@@ -772,7 +772,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\pify"
             }
           ]
@@ -796,7 +796,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\pinkie-promise"
             }
           ]
@@ -820,7 +820,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\pinkie"
             }
           ]
@@ -844,7 +844,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\pkg-conf"
             }
           ]
@@ -868,7 +868,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\read-pkg-up"
             }
           ]
@@ -892,7 +892,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\read-pkg"
             }
           ]
@@ -916,7 +916,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\require-main-filename"
             }
           ]
@@ -940,7 +940,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\semver"
             }
           ]
@@ -964,7 +964,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\spdx-correct"
             }
           ]
@@ -988,7 +988,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\spdx-exceptions"
             }
           ]
@@ -1010,7 +1010,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\spdx-expression-parse"
             }
           ]
@@ -1034,7 +1034,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\spdx-license-ids"
             }
           ]
@@ -1058,7 +1058,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\string-width"
             }
           ]
@@ -1082,7 +1082,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\strip-ansi"
             }
           ]
@@ -1106,7 +1106,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\strip-bom"
             }
           ]
@@ -1130,7 +1130,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\symbol"
             }
           ]
@@ -1154,7 +1154,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\validate-npm-package-license"
             }
           ]
@@ -1178,7 +1178,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\window-size"
             }
           ]
@@ -1202,7 +1202,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\wrap-ansi"
             }
           ]
@@ -1226,7 +1226,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\y18n"
             }
           ]
@@ -1250,7 +1250,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\yargs-parser"
             }
           ]
@@ -1274,7 +1274,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\yargs"
             }
           ]

--- a/tests/_data/sbom_demo-results/bundled-dependencies_npm8_node14_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bundled-dependencies_npm8_node14_macos-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-bundled-deps@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -76,7 +76,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bundle-dependencies"
         }
       ],
@@ -100,7 +100,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/ansi-regex"
             }
           ]
@@ -124,7 +124,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/builtin-modules"
             }
           ]
@@ -148,7 +148,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/camelcase"
             }
           ]
@@ -172,7 +172,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/cliui"
             }
           ]
@@ -196,7 +196,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/code-point-at"
             }
           ]
@@ -220,7 +220,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/decamelize"
             }
           ]
@@ -244,7 +244,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/error-ex"
             }
           ]
@@ -268,7 +268,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/escape-string-regexp"
             }
           ]
@@ -292,7 +292,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/find-up"
             }
           ]
@@ -316,7 +316,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/graceful-fs"
             }
           ]
@@ -340,7 +340,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/hosted-git-info"
             }
           ]
@@ -364,7 +364,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/invert-kv"
             }
           ]
@@ -388,7 +388,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-arrayish"
             }
           ]
@@ -412,7 +412,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-builtin-module"
             }
           ]
@@ -436,7 +436,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -460,7 +460,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-utf8"
             }
           ]
@@ -484,7 +484,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lcid"
             }
           ]
@@ -508,7 +508,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/load-json-file"
             }
           ]
@@ -532,7 +532,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lodash.assign"
             }
           ]
@@ -556,7 +556,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lodash.keys"
             }
           ]
@@ -580,7 +580,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lodash.rest"
             }
           ]
@@ -604,7 +604,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/normalize-package-data"
             }
           ]
@@ -628,7 +628,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/number-is-nan"
             }
           ]
@@ -652,7 +652,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/object-assign"
             }
           ]
@@ -676,7 +676,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/os-locale"
             }
           ]
@@ -700,7 +700,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/parse-json"
             }
           ]
@@ -724,7 +724,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/path-exists"
             }
           ]
@@ -748,7 +748,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/path-type"
             }
           ]
@@ -772,7 +772,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pify"
             }
           ]
@@ -796,7 +796,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pinkie-promise"
             }
           ]
@@ -820,7 +820,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pinkie"
             }
           ]
@@ -844,7 +844,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pkg-conf"
             }
           ]
@@ -868,7 +868,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/read-pkg-up"
             }
           ]
@@ -892,7 +892,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/read-pkg"
             }
           ]
@@ -916,7 +916,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/require-main-filename"
             }
           ]
@@ -940,7 +940,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/semver"
             }
           ]
@@ -964,7 +964,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-correct"
             }
           ]
@@ -988,7 +988,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-exceptions"
             }
           ]
@@ -1010,7 +1010,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-expression-parse"
             }
           ]
@@ -1034,7 +1034,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-license-ids"
             }
           ]
@@ -1058,7 +1058,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/string-width"
             }
           ]
@@ -1082,7 +1082,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/strip-ansi"
             }
           ]
@@ -1106,7 +1106,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/strip-bom"
             }
           ]
@@ -1130,7 +1130,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/symbol"
             }
           ]
@@ -1154,7 +1154,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/validate-npm-package-license"
             }
           ]
@@ -1178,7 +1178,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/window-size"
             }
           ]
@@ -1202,7 +1202,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/wrap-ansi"
             }
           ]
@@ -1226,7 +1226,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/y18n"
             }
           ]
@@ -1250,7 +1250,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/yargs-parser"
             }
           ]
@@ -1274,7 +1274,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/yargs"
             }
           ]

--- a/tests/_data/sbom_demo-results/bundled-dependencies_npm8_node14_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bundled-dependencies_npm8_node14_macos-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-bundled-deps@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -70,6 +74,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bundle-dependencies"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -88,6 +98,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/ansi-regex"
             }
           ]
         },
@@ -108,6 +122,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/builtin-modules"
             }
           ]
         },
@@ -128,6 +146,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/camelcase"
             }
           ]
         },
@@ -148,6 +170,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/cliui"
             }
           ]
         },
@@ -168,6 +194,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/code-point-at"
             }
           ]
         },
@@ -188,6 +218,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/decamelize"
             }
           ]
         },
@@ -208,6 +242,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/error-ex"
             }
           ]
         },
@@ -228,6 +266,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/escape-string-regexp"
             }
           ]
         },
@@ -248,6 +290,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/find-up"
             }
           ]
         },
@@ -268,6 +314,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/graceful-fs"
             }
           ]
         },
@@ -288,6 +338,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/hosted-git-info"
             }
           ]
         },
@@ -308,6 +362,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/invert-kv"
             }
           ]
         },
@@ -328,6 +386,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-arrayish"
             }
           ]
         },
@@ -348,6 +410,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-builtin-module"
             }
           ]
         },
@@ -368,6 +434,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-fullwidth-code-point"
             }
           ]
         },
@@ -388,6 +458,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-utf8"
             }
           ]
         },
@@ -408,6 +482,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lcid"
             }
           ]
         },
@@ -428,6 +506,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/load-json-file"
             }
           ]
         },
@@ -448,6 +530,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lodash.assign"
             }
           ]
         },
@@ -468,6 +554,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lodash.keys"
             }
           ]
         },
@@ -488,6 +578,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lodash.rest"
             }
           ]
         },
@@ -508,6 +602,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/normalize-package-data"
             }
           ]
         },
@@ -528,6 +626,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/number-is-nan"
             }
           ]
         },
@@ -548,6 +650,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/object-assign"
             }
           ]
         },
@@ -568,6 +674,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/os-locale"
             }
           ]
         },
@@ -588,6 +698,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/parse-json"
             }
           ]
         },
@@ -608,6 +722,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/path-exists"
             }
           ]
         },
@@ -628,6 +746,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/path-type"
             }
           ]
         },
@@ -648,6 +770,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pify"
             }
           ]
         },
@@ -668,6 +794,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pinkie-promise"
             }
           ]
         },
@@ -688,6 +818,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pinkie"
             }
           ]
         },
@@ -708,6 +842,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pkg-conf"
             }
           ]
         },
@@ -728,6 +866,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/read-pkg-up"
             }
           ]
         },
@@ -748,6 +890,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/read-pkg"
             }
           ]
         },
@@ -768,6 +914,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/require-main-filename"
             }
           ]
         },
@@ -788,6 +938,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/semver"
             }
           ]
         },
@@ -808,6 +962,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-correct"
             }
           ]
         },
@@ -828,6 +986,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-exceptions"
             }
           ]
         },
@@ -846,6 +1008,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-expression-parse"
             }
           ]
         },
@@ -866,6 +1032,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-license-ids"
             }
           ]
         },
@@ -886,6 +1056,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/string-width"
             }
           ]
         },
@@ -906,6 +1080,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/strip-ansi"
             }
           ]
         },
@@ -926,6 +1104,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/strip-bom"
             }
           ]
         },
@@ -946,6 +1128,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/symbol"
             }
           ]
         },
@@ -966,6 +1152,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/validate-npm-package-license"
             }
           ]
         },
@@ -986,6 +1176,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/window-size"
             }
           ]
         },
@@ -1006,6 +1200,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/wrap-ansi"
             }
           ]
         },
@@ -1026,6 +1224,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/y18n"
             }
           ]
         },
@@ -1046,6 +1248,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/yargs-parser"
             }
           ]
         },
@@ -1066,6 +1272,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/yargs"
             }
           ]
         }

--- a/tests/_data/sbom_demo-results/bundled-dependencies_npm8_node14_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bundled-dependencies_npm8_node14_ubuntu-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-bundled-deps@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -76,7 +76,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bundle-dependencies"
         }
       ],
@@ -100,7 +100,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/ansi-regex"
             }
           ]
@@ -124,7 +124,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/builtin-modules"
             }
           ]
@@ -148,7 +148,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/camelcase"
             }
           ]
@@ -172,7 +172,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/cliui"
             }
           ]
@@ -196,7 +196,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/code-point-at"
             }
           ]
@@ -220,7 +220,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/decamelize"
             }
           ]
@@ -244,7 +244,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/error-ex"
             }
           ]
@@ -268,7 +268,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/escape-string-regexp"
             }
           ]
@@ -292,7 +292,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/find-up"
             }
           ]
@@ -316,7 +316,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/graceful-fs"
             }
           ]
@@ -340,7 +340,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/hosted-git-info"
             }
           ]
@@ -364,7 +364,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/invert-kv"
             }
           ]
@@ -388,7 +388,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-arrayish"
             }
           ]
@@ -412,7 +412,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-builtin-module"
             }
           ]
@@ -436,7 +436,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -460,7 +460,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-utf8"
             }
           ]
@@ -484,7 +484,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lcid"
             }
           ]
@@ -508,7 +508,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/load-json-file"
             }
           ]
@@ -532,7 +532,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lodash.assign"
             }
           ]
@@ -556,7 +556,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lodash.keys"
             }
           ]
@@ -580,7 +580,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lodash.rest"
             }
           ]
@@ -604,7 +604,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/normalize-package-data"
             }
           ]
@@ -628,7 +628,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/number-is-nan"
             }
           ]
@@ -652,7 +652,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/object-assign"
             }
           ]
@@ -676,7 +676,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/os-locale"
             }
           ]
@@ -700,7 +700,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/parse-json"
             }
           ]
@@ -724,7 +724,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/path-exists"
             }
           ]
@@ -748,7 +748,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/path-type"
             }
           ]
@@ -772,7 +772,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pify"
             }
           ]
@@ -796,7 +796,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pinkie-promise"
             }
           ]
@@ -820,7 +820,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pinkie"
             }
           ]
@@ -844,7 +844,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pkg-conf"
             }
           ]
@@ -868,7 +868,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/read-pkg-up"
             }
           ]
@@ -892,7 +892,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/read-pkg"
             }
           ]
@@ -916,7 +916,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/require-main-filename"
             }
           ]
@@ -940,7 +940,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/semver"
             }
           ]
@@ -964,7 +964,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-correct"
             }
           ]
@@ -988,7 +988,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-exceptions"
             }
           ]
@@ -1010,7 +1010,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-expression-parse"
             }
           ]
@@ -1034,7 +1034,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-license-ids"
             }
           ]
@@ -1058,7 +1058,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/string-width"
             }
           ]
@@ -1082,7 +1082,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/strip-ansi"
             }
           ]
@@ -1106,7 +1106,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/strip-bom"
             }
           ]
@@ -1130,7 +1130,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/symbol"
             }
           ]
@@ -1154,7 +1154,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/validate-npm-package-license"
             }
           ]
@@ -1178,7 +1178,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/window-size"
             }
           ]
@@ -1202,7 +1202,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/wrap-ansi"
             }
           ]
@@ -1226,7 +1226,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/y18n"
             }
           ]
@@ -1250,7 +1250,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/yargs-parser"
             }
           ]
@@ -1274,7 +1274,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/yargs"
             }
           ]

--- a/tests/_data/sbom_demo-results/bundled-dependencies_npm8_node14_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bundled-dependencies_npm8_node14_ubuntu-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-bundled-deps@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -70,6 +74,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bundle-dependencies"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -88,6 +98,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/ansi-regex"
             }
           ]
         },
@@ -108,6 +122,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/builtin-modules"
             }
           ]
         },
@@ -128,6 +146,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/camelcase"
             }
           ]
         },
@@ -148,6 +170,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/cliui"
             }
           ]
         },
@@ -168,6 +194,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/code-point-at"
             }
           ]
         },
@@ -188,6 +218,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/decamelize"
             }
           ]
         },
@@ -208,6 +242,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/error-ex"
             }
           ]
         },
@@ -228,6 +266,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/escape-string-regexp"
             }
           ]
         },
@@ -248,6 +290,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/find-up"
             }
           ]
         },
@@ -268,6 +314,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/graceful-fs"
             }
           ]
         },
@@ -288,6 +338,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/hosted-git-info"
             }
           ]
         },
@@ -308,6 +362,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/invert-kv"
             }
           ]
         },
@@ -328,6 +386,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-arrayish"
             }
           ]
         },
@@ -348,6 +410,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-builtin-module"
             }
           ]
         },
@@ -368,6 +434,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-fullwidth-code-point"
             }
           ]
         },
@@ -388,6 +458,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-utf8"
             }
           ]
         },
@@ -408,6 +482,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lcid"
             }
           ]
         },
@@ -428,6 +506,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/load-json-file"
             }
           ]
         },
@@ -448,6 +530,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lodash.assign"
             }
           ]
         },
@@ -468,6 +554,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lodash.keys"
             }
           ]
         },
@@ -488,6 +578,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lodash.rest"
             }
           ]
         },
@@ -508,6 +602,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/normalize-package-data"
             }
           ]
         },
@@ -528,6 +626,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/number-is-nan"
             }
           ]
         },
@@ -548,6 +650,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/object-assign"
             }
           ]
         },
@@ -568,6 +674,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/os-locale"
             }
           ]
         },
@@ -588,6 +698,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/parse-json"
             }
           ]
         },
@@ -608,6 +722,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/path-exists"
             }
           ]
         },
@@ -628,6 +746,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/path-type"
             }
           ]
         },
@@ -648,6 +770,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pify"
             }
           ]
         },
@@ -668,6 +794,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pinkie-promise"
             }
           ]
         },
@@ -688,6 +818,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pinkie"
             }
           ]
         },
@@ -708,6 +842,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pkg-conf"
             }
           ]
         },
@@ -728,6 +866,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/read-pkg-up"
             }
           ]
         },
@@ -748,6 +890,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/read-pkg"
             }
           ]
         },
@@ -768,6 +914,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/require-main-filename"
             }
           ]
         },
@@ -788,6 +938,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/semver"
             }
           ]
         },
@@ -808,6 +962,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-correct"
             }
           ]
         },
@@ -828,6 +986,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-exceptions"
             }
           ]
         },
@@ -846,6 +1008,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-expression-parse"
             }
           ]
         },
@@ -866,6 +1032,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-license-ids"
             }
           ]
         },
@@ -886,6 +1056,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/string-width"
             }
           ]
         },
@@ -906,6 +1080,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/strip-ansi"
             }
           ]
         },
@@ -926,6 +1104,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/strip-bom"
             }
           ]
         },
@@ -946,6 +1128,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/symbol"
             }
           ]
         },
@@ -966,6 +1152,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/validate-npm-package-license"
             }
           ]
         },
@@ -986,6 +1176,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/window-size"
             }
           ]
         },
@@ -1006,6 +1200,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/wrap-ansi"
             }
           ]
         },
@@ -1026,6 +1224,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/y18n"
             }
           ]
         },
@@ -1046,6 +1248,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/yargs-parser"
             }
           ]
         },
@@ -1066,6 +1272,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/yargs"
             }
           ]
         }

--- a/tests/_data/sbom_demo-results/bundled-dependencies_npm8_node14_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bundled-dependencies_npm8_node14_windows-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-bundled-deps@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -70,6 +74,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bundle-dependencies"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -88,6 +98,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\ansi-regex"
             }
           ]
         },
@@ -108,6 +122,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\builtin-modules"
             }
           ]
         },
@@ -128,6 +146,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\camelcase"
             }
           ]
         },
@@ -148,6 +170,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\cliui"
             }
           ]
         },
@@ -168,6 +194,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\code-point-at"
             }
           ]
         },
@@ -188,6 +218,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\decamelize"
             }
           ]
         },
@@ -208,6 +242,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\error-ex"
             }
           ]
         },
@@ -228,6 +266,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\escape-string-regexp"
             }
           ]
         },
@@ -248,6 +290,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\find-up"
             }
           ]
         },
@@ -268,6 +314,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\graceful-fs"
             }
           ]
         },
@@ -288,6 +338,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\hosted-git-info"
             }
           ]
         },
@@ -308,6 +362,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\invert-kv"
             }
           ]
         },
@@ -328,6 +386,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\is-arrayish"
             }
           ]
         },
@@ -348,6 +410,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\is-builtin-module"
             }
           ]
         },
@@ -368,6 +434,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\is-fullwidth-code-point"
             }
           ]
         },
@@ -388,6 +458,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\is-utf8"
             }
           ]
         },
@@ -408,6 +482,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\lcid"
             }
           ]
         },
@@ -428,6 +506,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\load-json-file"
             }
           ]
         },
@@ -448,6 +530,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\lodash.assign"
             }
           ]
         },
@@ -468,6 +554,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\lodash.keys"
             }
           ]
         },
@@ -488,6 +578,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\lodash.rest"
             }
           ]
         },
@@ -508,6 +602,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\normalize-package-data"
             }
           ]
         },
@@ -528,6 +626,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\number-is-nan"
             }
           ]
         },
@@ -548,6 +650,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\object-assign"
             }
           ]
         },
@@ -568,6 +674,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\os-locale"
             }
           ]
         },
@@ -588,6 +698,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\parse-json"
             }
           ]
         },
@@ -608,6 +722,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\path-exists"
             }
           ]
         },
@@ -628,6 +746,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\path-type"
             }
           ]
         },
@@ -648,6 +770,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\pify"
             }
           ]
         },
@@ -668,6 +794,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\pinkie-promise"
             }
           ]
         },
@@ -688,6 +818,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\pinkie"
             }
           ]
         },
@@ -708,6 +842,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\pkg-conf"
             }
           ]
         },
@@ -728,6 +866,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\read-pkg-up"
             }
           ]
         },
@@ -748,6 +890,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\read-pkg"
             }
           ]
         },
@@ -768,6 +914,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\require-main-filename"
             }
           ]
         },
@@ -788,6 +938,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\semver"
             }
           ]
         },
@@ -808,6 +962,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\spdx-correct"
             }
           ]
         },
@@ -828,6 +986,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\spdx-exceptions"
             }
           ]
         },
@@ -846,6 +1008,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\spdx-expression-parse"
             }
           ]
         },
@@ -866,6 +1032,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\spdx-license-ids"
             }
           ]
         },
@@ -886,6 +1056,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\string-width"
             }
           ]
         },
@@ -906,6 +1080,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\strip-ansi"
             }
           ]
         },
@@ -926,6 +1104,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\strip-bom"
             }
           ]
         },
@@ -946,6 +1128,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\symbol"
             }
           ]
         },
@@ -966,6 +1152,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\validate-npm-package-license"
             }
           ]
         },
@@ -986,6 +1176,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\window-size"
             }
           ]
         },
@@ -1006,6 +1200,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\wrap-ansi"
             }
           ]
         },
@@ -1026,6 +1224,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\y18n"
             }
           ]
         },
@@ -1046,6 +1248,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\yargs-parser"
             }
           ]
         },
@@ -1066,6 +1272,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\yargs"
             }
           ]
         }

--- a/tests/_data/sbom_demo-results/bundled-dependencies_npm8_node14_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bundled-dependencies_npm8_node14_windows-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-bundled-deps@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -76,7 +76,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bundle-dependencies"
         }
       ],
@@ -100,7 +100,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\ansi-regex"
             }
           ]
@@ -124,7 +124,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\builtin-modules"
             }
           ]
@@ -148,7 +148,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\camelcase"
             }
           ]
@@ -172,7 +172,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\cliui"
             }
           ]
@@ -196,7 +196,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\code-point-at"
             }
           ]
@@ -220,7 +220,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\decamelize"
             }
           ]
@@ -244,7 +244,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\error-ex"
             }
           ]
@@ -268,7 +268,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\escape-string-regexp"
             }
           ]
@@ -292,7 +292,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\find-up"
             }
           ]
@@ -316,7 +316,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\graceful-fs"
             }
           ]
@@ -340,7 +340,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\hosted-git-info"
             }
           ]
@@ -364,7 +364,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\invert-kv"
             }
           ]
@@ -388,7 +388,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\is-arrayish"
             }
           ]
@@ -412,7 +412,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\is-builtin-module"
             }
           ]
@@ -436,7 +436,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\is-fullwidth-code-point"
             }
           ]
@@ -460,7 +460,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\is-utf8"
             }
           ]
@@ -484,7 +484,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\lcid"
             }
           ]
@@ -508,7 +508,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\load-json-file"
             }
           ]
@@ -532,7 +532,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\lodash.assign"
             }
           ]
@@ -556,7 +556,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\lodash.keys"
             }
           ]
@@ -580,7 +580,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\lodash.rest"
             }
           ]
@@ -604,7 +604,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\normalize-package-data"
             }
           ]
@@ -628,7 +628,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\number-is-nan"
             }
           ]
@@ -652,7 +652,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\object-assign"
             }
           ]
@@ -676,7 +676,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\os-locale"
             }
           ]
@@ -700,7 +700,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\parse-json"
             }
           ]
@@ -724,7 +724,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\path-exists"
             }
           ]
@@ -748,7 +748,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\path-type"
             }
           ]
@@ -772,7 +772,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\pify"
             }
           ]
@@ -796,7 +796,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\pinkie-promise"
             }
           ]
@@ -820,7 +820,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\pinkie"
             }
           ]
@@ -844,7 +844,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\pkg-conf"
             }
           ]
@@ -868,7 +868,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\read-pkg-up"
             }
           ]
@@ -892,7 +892,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\read-pkg"
             }
           ]
@@ -916,7 +916,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\require-main-filename"
             }
           ]
@@ -940,7 +940,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\semver"
             }
           ]
@@ -964,7 +964,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\spdx-correct"
             }
           ]
@@ -988,7 +988,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\spdx-exceptions"
             }
           ]
@@ -1010,7 +1010,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\spdx-expression-parse"
             }
           ]
@@ -1034,7 +1034,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\spdx-license-ids"
             }
           ]
@@ -1058,7 +1058,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\string-width"
             }
           ]
@@ -1082,7 +1082,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\strip-ansi"
             }
           ]
@@ -1106,7 +1106,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\strip-bom"
             }
           ]
@@ -1130,7 +1130,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\symbol"
             }
           ]
@@ -1154,7 +1154,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\validate-npm-package-license"
             }
           ]
@@ -1178,7 +1178,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\window-size"
             }
           ]
@@ -1202,7 +1202,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\wrap-ansi"
             }
           ]
@@ -1226,7 +1226,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\y18n"
             }
           ]
@@ -1250,7 +1250,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\yargs-parser"
             }
           ]
@@ -1274,7 +1274,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\yargs"
             }
           ]

--- a/tests/_data/sbom_demo-results/bundled-dependencies_npm8_node16_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bundled-dependencies_npm8_node16_macos-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-bundled-deps@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -76,7 +76,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bundle-dependencies"
         }
       ],
@@ -100,7 +100,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/ansi-regex"
             }
           ]
@@ -124,7 +124,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/builtin-modules"
             }
           ]
@@ -148,7 +148,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/camelcase"
             }
           ]
@@ -172,7 +172,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/cliui"
             }
           ]
@@ -196,7 +196,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/code-point-at"
             }
           ]
@@ -220,7 +220,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/decamelize"
             }
           ]
@@ -244,7 +244,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/error-ex"
             }
           ]
@@ -268,7 +268,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/escape-string-regexp"
             }
           ]
@@ -292,7 +292,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/find-up"
             }
           ]
@@ -316,7 +316,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/graceful-fs"
             }
           ]
@@ -340,7 +340,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/hosted-git-info"
             }
           ]
@@ -364,7 +364,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/invert-kv"
             }
           ]
@@ -388,7 +388,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-arrayish"
             }
           ]
@@ -412,7 +412,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-builtin-module"
             }
           ]
@@ -436,7 +436,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -460,7 +460,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-utf8"
             }
           ]
@@ -484,7 +484,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lcid"
             }
           ]
@@ -508,7 +508,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/load-json-file"
             }
           ]
@@ -532,7 +532,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lodash.assign"
             }
           ]
@@ -556,7 +556,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lodash.keys"
             }
           ]
@@ -580,7 +580,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lodash.rest"
             }
           ]
@@ -604,7 +604,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/normalize-package-data"
             }
           ]
@@ -628,7 +628,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/number-is-nan"
             }
           ]
@@ -652,7 +652,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/object-assign"
             }
           ]
@@ -676,7 +676,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/os-locale"
             }
           ]
@@ -700,7 +700,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/parse-json"
             }
           ]
@@ -724,7 +724,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/path-exists"
             }
           ]
@@ -748,7 +748,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/path-type"
             }
           ]
@@ -772,7 +772,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pify"
             }
           ]
@@ -796,7 +796,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pinkie-promise"
             }
           ]
@@ -820,7 +820,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pinkie"
             }
           ]
@@ -844,7 +844,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pkg-conf"
             }
           ]
@@ -868,7 +868,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/read-pkg-up"
             }
           ]
@@ -892,7 +892,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/read-pkg"
             }
           ]
@@ -916,7 +916,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/require-main-filename"
             }
           ]
@@ -940,7 +940,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/semver"
             }
           ]
@@ -964,7 +964,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-correct"
             }
           ]
@@ -988,7 +988,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-exceptions"
             }
           ]
@@ -1010,7 +1010,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-expression-parse"
             }
           ]
@@ -1034,7 +1034,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-license-ids"
             }
           ]
@@ -1058,7 +1058,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/string-width"
             }
           ]
@@ -1082,7 +1082,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/strip-ansi"
             }
           ]
@@ -1106,7 +1106,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/strip-bom"
             }
           ]
@@ -1130,7 +1130,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/symbol"
             }
           ]
@@ -1154,7 +1154,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/validate-npm-package-license"
             }
           ]
@@ -1178,7 +1178,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/window-size"
             }
           ]
@@ -1202,7 +1202,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/wrap-ansi"
             }
           ]
@@ -1226,7 +1226,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/y18n"
             }
           ]
@@ -1250,7 +1250,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/yargs-parser"
             }
           ]
@@ -1274,7 +1274,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/yargs"
             }
           ]

--- a/tests/_data/sbom_demo-results/bundled-dependencies_npm8_node16_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bundled-dependencies_npm8_node16_macos-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-bundled-deps@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -70,6 +74,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bundle-dependencies"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -88,6 +98,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/ansi-regex"
             }
           ]
         },
@@ -108,6 +122,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/builtin-modules"
             }
           ]
         },
@@ -128,6 +146,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/camelcase"
             }
           ]
         },
@@ -148,6 +170,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/cliui"
             }
           ]
         },
@@ -168,6 +194,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/code-point-at"
             }
           ]
         },
@@ -188,6 +218,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/decamelize"
             }
           ]
         },
@@ -208,6 +242,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/error-ex"
             }
           ]
         },
@@ -228,6 +266,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/escape-string-regexp"
             }
           ]
         },
@@ -248,6 +290,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/find-up"
             }
           ]
         },
@@ -268,6 +314,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/graceful-fs"
             }
           ]
         },
@@ -288,6 +338,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/hosted-git-info"
             }
           ]
         },
@@ -308,6 +362,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/invert-kv"
             }
           ]
         },
@@ -328,6 +386,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-arrayish"
             }
           ]
         },
@@ -348,6 +410,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-builtin-module"
             }
           ]
         },
@@ -368,6 +434,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-fullwidth-code-point"
             }
           ]
         },
@@ -388,6 +458,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-utf8"
             }
           ]
         },
@@ -408,6 +482,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lcid"
             }
           ]
         },
@@ -428,6 +506,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/load-json-file"
             }
           ]
         },
@@ -448,6 +530,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lodash.assign"
             }
           ]
         },
@@ -468,6 +554,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lodash.keys"
             }
           ]
         },
@@ -488,6 +578,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lodash.rest"
             }
           ]
         },
@@ -508,6 +602,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/normalize-package-data"
             }
           ]
         },
@@ -528,6 +626,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/number-is-nan"
             }
           ]
         },
@@ -548,6 +650,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/object-assign"
             }
           ]
         },
@@ -568,6 +674,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/os-locale"
             }
           ]
         },
@@ -588,6 +698,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/parse-json"
             }
           ]
         },
@@ -608,6 +722,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/path-exists"
             }
           ]
         },
@@ -628,6 +746,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/path-type"
             }
           ]
         },
@@ -648,6 +770,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pify"
             }
           ]
         },
@@ -668,6 +794,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pinkie-promise"
             }
           ]
         },
@@ -688,6 +818,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pinkie"
             }
           ]
         },
@@ -708,6 +842,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pkg-conf"
             }
           ]
         },
@@ -728,6 +866,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/read-pkg-up"
             }
           ]
         },
@@ -748,6 +890,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/read-pkg"
             }
           ]
         },
@@ -768,6 +914,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/require-main-filename"
             }
           ]
         },
@@ -788,6 +938,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/semver"
             }
           ]
         },
@@ -808,6 +962,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-correct"
             }
           ]
         },
@@ -828,6 +986,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-exceptions"
             }
           ]
         },
@@ -846,6 +1008,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-expression-parse"
             }
           ]
         },
@@ -866,6 +1032,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-license-ids"
             }
           ]
         },
@@ -886,6 +1056,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/string-width"
             }
           ]
         },
@@ -906,6 +1080,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/strip-ansi"
             }
           ]
         },
@@ -926,6 +1104,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/strip-bom"
             }
           ]
         },
@@ -946,6 +1128,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/symbol"
             }
           ]
         },
@@ -966,6 +1152,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/validate-npm-package-license"
             }
           ]
         },
@@ -986,6 +1176,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/window-size"
             }
           ]
         },
@@ -1006,6 +1200,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/wrap-ansi"
             }
           ]
         },
@@ -1026,6 +1224,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/y18n"
             }
           ]
         },
@@ -1046,6 +1248,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/yargs-parser"
             }
           ]
         },
@@ -1066,6 +1272,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/yargs"
             }
           ]
         }

--- a/tests/_data/sbom_demo-results/bundled-dependencies_npm8_node16_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bundled-dependencies_npm8_node16_ubuntu-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-bundled-deps@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -76,7 +76,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bundle-dependencies"
         }
       ],
@@ -100,7 +100,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/ansi-regex"
             }
           ]
@@ -124,7 +124,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/builtin-modules"
             }
           ]
@@ -148,7 +148,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/camelcase"
             }
           ]
@@ -172,7 +172,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/cliui"
             }
           ]
@@ -196,7 +196,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/code-point-at"
             }
           ]
@@ -220,7 +220,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/decamelize"
             }
           ]
@@ -244,7 +244,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/error-ex"
             }
           ]
@@ -268,7 +268,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/escape-string-regexp"
             }
           ]
@@ -292,7 +292,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/find-up"
             }
           ]
@@ -316,7 +316,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/graceful-fs"
             }
           ]
@@ -340,7 +340,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/hosted-git-info"
             }
           ]
@@ -364,7 +364,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/invert-kv"
             }
           ]
@@ -388,7 +388,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-arrayish"
             }
           ]
@@ -412,7 +412,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-builtin-module"
             }
           ]
@@ -436,7 +436,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -460,7 +460,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-utf8"
             }
           ]
@@ -484,7 +484,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lcid"
             }
           ]
@@ -508,7 +508,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/load-json-file"
             }
           ]
@@ -532,7 +532,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lodash.assign"
             }
           ]
@@ -556,7 +556,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lodash.keys"
             }
           ]
@@ -580,7 +580,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lodash.rest"
             }
           ]
@@ -604,7 +604,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/normalize-package-data"
             }
           ]
@@ -628,7 +628,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/number-is-nan"
             }
           ]
@@ -652,7 +652,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/object-assign"
             }
           ]
@@ -676,7 +676,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/os-locale"
             }
           ]
@@ -700,7 +700,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/parse-json"
             }
           ]
@@ -724,7 +724,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/path-exists"
             }
           ]
@@ -748,7 +748,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/path-type"
             }
           ]
@@ -772,7 +772,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pify"
             }
           ]
@@ -796,7 +796,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pinkie-promise"
             }
           ]
@@ -820,7 +820,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pinkie"
             }
           ]
@@ -844,7 +844,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pkg-conf"
             }
           ]
@@ -868,7 +868,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/read-pkg-up"
             }
           ]
@@ -892,7 +892,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/read-pkg"
             }
           ]
@@ -916,7 +916,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/require-main-filename"
             }
           ]
@@ -940,7 +940,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/semver"
             }
           ]
@@ -964,7 +964,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-correct"
             }
           ]
@@ -988,7 +988,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-exceptions"
             }
           ]
@@ -1010,7 +1010,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-expression-parse"
             }
           ]
@@ -1034,7 +1034,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-license-ids"
             }
           ]
@@ -1058,7 +1058,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/string-width"
             }
           ]
@@ -1082,7 +1082,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/strip-ansi"
             }
           ]
@@ -1106,7 +1106,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/strip-bom"
             }
           ]
@@ -1130,7 +1130,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/symbol"
             }
           ]
@@ -1154,7 +1154,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/validate-npm-package-license"
             }
           ]
@@ -1178,7 +1178,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/window-size"
             }
           ]
@@ -1202,7 +1202,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/wrap-ansi"
             }
           ]
@@ -1226,7 +1226,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/y18n"
             }
           ]
@@ -1250,7 +1250,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/yargs-parser"
             }
           ]
@@ -1274,7 +1274,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/yargs"
             }
           ]

--- a/tests/_data/sbom_demo-results/bundled-dependencies_npm8_node16_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bundled-dependencies_npm8_node16_ubuntu-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-bundled-deps@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -70,6 +74,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bundle-dependencies"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -88,6 +98,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/ansi-regex"
             }
           ]
         },
@@ -108,6 +122,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/builtin-modules"
             }
           ]
         },
@@ -128,6 +146,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/camelcase"
             }
           ]
         },
@@ -148,6 +170,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/cliui"
             }
           ]
         },
@@ -168,6 +194,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/code-point-at"
             }
           ]
         },
@@ -188,6 +218,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/decamelize"
             }
           ]
         },
@@ -208,6 +242,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/error-ex"
             }
           ]
         },
@@ -228,6 +266,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/escape-string-regexp"
             }
           ]
         },
@@ -248,6 +290,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/find-up"
             }
           ]
         },
@@ -268,6 +314,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/graceful-fs"
             }
           ]
         },
@@ -288,6 +338,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/hosted-git-info"
             }
           ]
         },
@@ -308,6 +362,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/invert-kv"
             }
           ]
         },
@@ -328,6 +386,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-arrayish"
             }
           ]
         },
@@ -348,6 +410,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-builtin-module"
             }
           ]
         },
@@ -368,6 +434,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-fullwidth-code-point"
             }
           ]
         },
@@ -388,6 +458,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-utf8"
             }
           ]
         },
@@ -408,6 +482,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lcid"
             }
           ]
         },
@@ -428,6 +506,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/load-json-file"
             }
           ]
         },
@@ -448,6 +530,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lodash.assign"
             }
           ]
         },
@@ -468,6 +554,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lodash.keys"
             }
           ]
         },
@@ -488,6 +578,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lodash.rest"
             }
           ]
         },
@@ -508,6 +602,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/normalize-package-data"
             }
           ]
         },
@@ -528,6 +626,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/number-is-nan"
             }
           ]
         },
@@ -548,6 +650,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/object-assign"
             }
           ]
         },
@@ -568,6 +674,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/os-locale"
             }
           ]
         },
@@ -588,6 +698,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/parse-json"
             }
           ]
         },
@@ -608,6 +722,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/path-exists"
             }
           ]
         },
@@ -628,6 +746,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/path-type"
             }
           ]
         },
@@ -648,6 +770,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pify"
             }
           ]
         },
@@ -668,6 +794,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pinkie-promise"
             }
           ]
         },
@@ -688,6 +818,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pinkie"
             }
           ]
         },
@@ -708,6 +842,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pkg-conf"
             }
           ]
         },
@@ -728,6 +866,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/read-pkg-up"
             }
           ]
         },
@@ -748,6 +890,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/read-pkg"
             }
           ]
         },
@@ -768,6 +914,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/require-main-filename"
             }
           ]
         },
@@ -788,6 +938,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/semver"
             }
           ]
         },
@@ -808,6 +962,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-correct"
             }
           ]
         },
@@ -828,6 +986,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-exceptions"
             }
           ]
         },
@@ -846,6 +1008,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-expression-parse"
             }
           ]
         },
@@ -866,6 +1032,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-license-ids"
             }
           ]
         },
@@ -886,6 +1056,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/string-width"
             }
           ]
         },
@@ -906,6 +1080,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/strip-ansi"
             }
           ]
         },
@@ -926,6 +1104,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/strip-bom"
             }
           ]
         },
@@ -946,6 +1128,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/symbol"
             }
           ]
         },
@@ -966,6 +1152,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/validate-npm-package-license"
             }
           ]
         },
@@ -986,6 +1176,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/window-size"
             }
           ]
         },
@@ -1006,6 +1200,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/wrap-ansi"
             }
           ]
         },
@@ -1026,6 +1224,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/y18n"
             }
           ]
         },
@@ -1046,6 +1248,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/yargs-parser"
             }
           ]
         },
@@ -1066,6 +1272,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/yargs"
             }
           ]
         }

--- a/tests/_data/sbom_demo-results/bundled-dependencies_npm8_node16_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bundled-dependencies_npm8_node16_windows-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-bundled-deps@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -70,6 +74,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bundle-dependencies"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -88,6 +98,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\ansi-regex"
             }
           ]
         },
@@ -108,6 +122,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\builtin-modules"
             }
           ]
         },
@@ -128,6 +146,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\camelcase"
             }
           ]
         },
@@ -148,6 +170,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\cliui"
             }
           ]
         },
@@ -168,6 +194,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\code-point-at"
             }
           ]
         },
@@ -188,6 +218,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\decamelize"
             }
           ]
         },
@@ -208,6 +242,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\error-ex"
             }
           ]
         },
@@ -228,6 +266,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\escape-string-regexp"
             }
           ]
         },
@@ -248,6 +290,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\find-up"
             }
           ]
         },
@@ -268,6 +314,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\graceful-fs"
             }
           ]
         },
@@ -288,6 +338,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\hosted-git-info"
             }
           ]
         },
@@ -308,6 +362,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\invert-kv"
             }
           ]
         },
@@ -328,6 +386,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\is-arrayish"
             }
           ]
         },
@@ -348,6 +410,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\is-builtin-module"
             }
           ]
         },
@@ -368,6 +434,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\is-fullwidth-code-point"
             }
           ]
         },
@@ -388,6 +458,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\is-utf8"
             }
           ]
         },
@@ -408,6 +482,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\lcid"
             }
           ]
         },
@@ -428,6 +506,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\load-json-file"
             }
           ]
         },
@@ -448,6 +530,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\lodash.assign"
             }
           ]
         },
@@ -468,6 +554,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\lodash.keys"
             }
           ]
         },
@@ -488,6 +578,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\lodash.rest"
             }
           ]
         },
@@ -508,6 +602,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\normalize-package-data"
             }
           ]
         },
@@ -528,6 +626,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\number-is-nan"
             }
           ]
         },
@@ -548,6 +650,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\object-assign"
             }
           ]
         },
@@ -568,6 +674,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\os-locale"
             }
           ]
         },
@@ -588,6 +698,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\parse-json"
             }
           ]
         },
@@ -608,6 +722,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\path-exists"
             }
           ]
         },
@@ -628,6 +746,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\path-type"
             }
           ]
         },
@@ -648,6 +770,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\pify"
             }
           ]
         },
@@ -668,6 +794,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\pinkie-promise"
             }
           ]
         },
@@ -688,6 +818,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\pinkie"
             }
           ]
         },
@@ -708,6 +842,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\pkg-conf"
             }
           ]
         },
@@ -728,6 +866,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\read-pkg-up"
             }
           ]
         },
@@ -748,6 +890,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\read-pkg"
             }
           ]
         },
@@ -768,6 +914,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\require-main-filename"
             }
           ]
         },
@@ -788,6 +938,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\semver"
             }
           ]
         },
@@ -808,6 +962,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\spdx-correct"
             }
           ]
         },
@@ -828,6 +986,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\spdx-exceptions"
             }
           ]
         },
@@ -846,6 +1008,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\spdx-expression-parse"
             }
           ]
         },
@@ -866,6 +1032,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\spdx-license-ids"
             }
           ]
         },
@@ -886,6 +1056,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\string-width"
             }
           ]
         },
@@ -906,6 +1080,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\strip-ansi"
             }
           ]
         },
@@ -926,6 +1104,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\strip-bom"
             }
           ]
         },
@@ -946,6 +1128,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\symbol"
             }
           ]
         },
@@ -966,6 +1152,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\validate-npm-package-license"
             }
           ]
         },
@@ -986,6 +1176,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\window-size"
             }
           ]
         },
@@ -1006,6 +1200,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\wrap-ansi"
             }
           ]
         },
@@ -1026,6 +1224,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\y18n"
             }
           ]
         },
@@ -1046,6 +1248,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\yargs-parser"
             }
           ]
         },
@@ -1066,6 +1272,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\yargs"
             }
           ]
         }

--- a/tests/_data/sbom_demo-results/bundled-dependencies_npm8_node16_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bundled-dependencies_npm8_node16_windows-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-bundled-deps@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -76,7 +76,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bundle-dependencies"
         }
       ],
@@ -100,7 +100,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\ansi-regex"
             }
           ]
@@ -124,7 +124,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\builtin-modules"
             }
           ]
@@ -148,7 +148,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\camelcase"
             }
           ]
@@ -172,7 +172,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\cliui"
             }
           ]
@@ -196,7 +196,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\code-point-at"
             }
           ]
@@ -220,7 +220,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\decamelize"
             }
           ]
@@ -244,7 +244,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\error-ex"
             }
           ]
@@ -268,7 +268,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\escape-string-regexp"
             }
           ]
@@ -292,7 +292,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\find-up"
             }
           ]
@@ -316,7 +316,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\graceful-fs"
             }
           ]
@@ -340,7 +340,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\hosted-git-info"
             }
           ]
@@ -364,7 +364,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\invert-kv"
             }
           ]
@@ -388,7 +388,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\is-arrayish"
             }
           ]
@@ -412,7 +412,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\is-builtin-module"
             }
           ]
@@ -436,7 +436,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\is-fullwidth-code-point"
             }
           ]
@@ -460,7 +460,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\is-utf8"
             }
           ]
@@ -484,7 +484,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\lcid"
             }
           ]
@@ -508,7 +508,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\load-json-file"
             }
           ]
@@ -532,7 +532,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\lodash.assign"
             }
           ]
@@ -556,7 +556,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\lodash.keys"
             }
           ]
@@ -580,7 +580,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\lodash.rest"
             }
           ]
@@ -604,7 +604,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\normalize-package-data"
             }
           ]
@@ -628,7 +628,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\number-is-nan"
             }
           ]
@@ -652,7 +652,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\object-assign"
             }
           ]
@@ -676,7 +676,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\os-locale"
             }
           ]
@@ -700,7 +700,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\parse-json"
             }
           ]
@@ -724,7 +724,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\path-exists"
             }
           ]
@@ -748,7 +748,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\path-type"
             }
           ]
@@ -772,7 +772,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\pify"
             }
           ]
@@ -796,7 +796,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\pinkie-promise"
             }
           ]
@@ -820,7 +820,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\pinkie"
             }
           ]
@@ -844,7 +844,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\pkg-conf"
             }
           ]
@@ -868,7 +868,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\read-pkg-up"
             }
           ]
@@ -892,7 +892,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\read-pkg"
             }
           ]
@@ -916,7 +916,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\require-main-filename"
             }
           ]
@@ -940,7 +940,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\semver"
             }
           ]
@@ -964,7 +964,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\spdx-correct"
             }
           ]
@@ -988,7 +988,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\spdx-exceptions"
             }
           ]
@@ -1010,7 +1010,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\spdx-expression-parse"
             }
           ]
@@ -1034,7 +1034,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\spdx-license-ids"
             }
           ]
@@ -1058,7 +1058,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\string-width"
             }
           ]
@@ -1082,7 +1082,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\strip-ansi"
             }
           ]
@@ -1106,7 +1106,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\strip-bom"
             }
           ]
@@ -1130,7 +1130,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\symbol"
             }
           ]
@@ -1154,7 +1154,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\validate-npm-package-license"
             }
           ]
@@ -1178,7 +1178,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\window-size"
             }
           ]
@@ -1202,7 +1202,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\wrap-ansi"
             }
           ]
@@ -1226,7 +1226,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\y18n"
             }
           ]
@@ -1250,7 +1250,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\yargs-parser"
             }
           ]
@@ -1274,7 +1274,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\yargs"
             }
           ]

--- a/tests/_data/sbom_demo-results/bundled-dependencies_npm8_node18_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bundled-dependencies_npm8_node18_macos-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-bundled-deps@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -76,7 +76,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bundle-dependencies"
         }
       ],
@@ -100,7 +100,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/ansi-regex"
             }
           ]
@@ -124,7 +124,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/builtin-modules"
             }
           ]
@@ -148,7 +148,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/camelcase"
             }
           ]
@@ -172,7 +172,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/cliui"
             }
           ]
@@ -196,7 +196,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/code-point-at"
             }
           ]
@@ -220,7 +220,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/decamelize"
             }
           ]
@@ -244,7 +244,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/error-ex"
             }
           ]
@@ -268,7 +268,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/escape-string-regexp"
             }
           ]
@@ -292,7 +292,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/find-up"
             }
           ]
@@ -316,7 +316,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/graceful-fs"
             }
           ]
@@ -340,7 +340,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/hosted-git-info"
             }
           ]
@@ -364,7 +364,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/invert-kv"
             }
           ]
@@ -388,7 +388,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-arrayish"
             }
           ]
@@ -412,7 +412,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-builtin-module"
             }
           ]
@@ -436,7 +436,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -460,7 +460,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-utf8"
             }
           ]
@@ -484,7 +484,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lcid"
             }
           ]
@@ -508,7 +508,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/load-json-file"
             }
           ]
@@ -532,7 +532,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lodash.assign"
             }
           ]
@@ -556,7 +556,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lodash.keys"
             }
           ]
@@ -580,7 +580,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lodash.rest"
             }
           ]
@@ -604,7 +604,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/normalize-package-data"
             }
           ]
@@ -628,7 +628,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/number-is-nan"
             }
           ]
@@ -652,7 +652,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/object-assign"
             }
           ]
@@ -676,7 +676,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/os-locale"
             }
           ]
@@ -700,7 +700,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/parse-json"
             }
           ]
@@ -724,7 +724,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/path-exists"
             }
           ]
@@ -748,7 +748,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/path-type"
             }
           ]
@@ -772,7 +772,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pify"
             }
           ]
@@ -796,7 +796,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pinkie-promise"
             }
           ]
@@ -820,7 +820,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pinkie"
             }
           ]
@@ -844,7 +844,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pkg-conf"
             }
           ]
@@ -868,7 +868,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/read-pkg-up"
             }
           ]
@@ -892,7 +892,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/read-pkg"
             }
           ]
@@ -916,7 +916,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/require-main-filename"
             }
           ]
@@ -940,7 +940,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/semver"
             }
           ]
@@ -964,7 +964,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-correct"
             }
           ]
@@ -988,7 +988,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-exceptions"
             }
           ]
@@ -1010,7 +1010,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-expression-parse"
             }
           ]
@@ -1034,7 +1034,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-license-ids"
             }
           ]
@@ -1058,7 +1058,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/string-width"
             }
           ]
@@ -1082,7 +1082,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/strip-ansi"
             }
           ]
@@ -1106,7 +1106,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/strip-bom"
             }
           ]
@@ -1130,7 +1130,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/symbol"
             }
           ]
@@ -1154,7 +1154,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/validate-npm-package-license"
             }
           ]
@@ -1178,7 +1178,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/window-size"
             }
           ]
@@ -1202,7 +1202,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/wrap-ansi"
             }
           ]
@@ -1226,7 +1226,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/y18n"
             }
           ]
@@ -1250,7 +1250,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/yargs-parser"
             }
           ]
@@ -1274,7 +1274,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/yargs"
             }
           ]

--- a/tests/_data/sbom_demo-results/bundled-dependencies_npm8_node18_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bundled-dependencies_npm8_node18_macos-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-bundled-deps@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -70,6 +74,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bundle-dependencies"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -88,6 +98,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/ansi-regex"
             }
           ]
         },
@@ -108,6 +122,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/builtin-modules"
             }
           ]
         },
@@ -128,6 +146,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/camelcase"
             }
           ]
         },
@@ -148,6 +170,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/cliui"
             }
           ]
         },
@@ -168,6 +194,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/code-point-at"
             }
           ]
         },
@@ -188,6 +218,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/decamelize"
             }
           ]
         },
@@ -208,6 +242,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/error-ex"
             }
           ]
         },
@@ -228,6 +266,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/escape-string-regexp"
             }
           ]
         },
@@ -248,6 +290,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/find-up"
             }
           ]
         },
@@ -268,6 +314,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/graceful-fs"
             }
           ]
         },
@@ -288,6 +338,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/hosted-git-info"
             }
           ]
         },
@@ -308,6 +362,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/invert-kv"
             }
           ]
         },
@@ -328,6 +386,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-arrayish"
             }
           ]
         },
@@ -348,6 +410,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-builtin-module"
             }
           ]
         },
@@ -368,6 +434,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-fullwidth-code-point"
             }
           ]
         },
@@ -388,6 +458,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-utf8"
             }
           ]
         },
@@ -408,6 +482,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lcid"
             }
           ]
         },
@@ -428,6 +506,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/load-json-file"
             }
           ]
         },
@@ -448,6 +530,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lodash.assign"
             }
           ]
         },
@@ -468,6 +554,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lodash.keys"
             }
           ]
         },
@@ -488,6 +578,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lodash.rest"
             }
           ]
         },
@@ -508,6 +602,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/normalize-package-data"
             }
           ]
         },
@@ -528,6 +626,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/number-is-nan"
             }
           ]
         },
@@ -548,6 +650,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/object-assign"
             }
           ]
         },
@@ -568,6 +674,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/os-locale"
             }
           ]
         },
@@ -588,6 +698,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/parse-json"
             }
           ]
         },
@@ -608,6 +722,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/path-exists"
             }
           ]
         },
@@ -628,6 +746,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/path-type"
             }
           ]
         },
@@ -648,6 +770,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pify"
             }
           ]
         },
@@ -668,6 +794,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pinkie-promise"
             }
           ]
         },
@@ -688,6 +818,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pinkie"
             }
           ]
         },
@@ -708,6 +842,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pkg-conf"
             }
           ]
         },
@@ -728,6 +866,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/read-pkg-up"
             }
           ]
         },
@@ -748,6 +890,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/read-pkg"
             }
           ]
         },
@@ -768,6 +914,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/require-main-filename"
             }
           ]
         },
@@ -788,6 +938,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/semver"
             }
           ]
         },
@@ -808,6 +962,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-correct"
             }
           ]
         },
@@ -828,6 +986,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-exceptions"
             }
           ]
         },
@@ -846,6 +1008,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-expression-parse"
             }
           ]
         },
@@ -866,6 +1032,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-license-ids"
             }
           ]
         },
@@ -886,6 +1056,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/string-width"
             }
           ]
         },
@@ -906,6 +1080,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/strip-ansi"
             }
           ]
         },
@@ -926,6 +1104,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/strip-bom"
             }
           ]
         },
@@ -946,6 +1128,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/symbol"
             }
           ]
         },
@@ -966,6 +1152,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/validate-npm-package-license"
             }
           ]
         },
@@ -986,6 +1176,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/window-size"
             }
           ]
         },
@@ -1006,6 +1200,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/wrap-ansi"
             }
           ]
         },
@@ -1026,6 +1224,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/y18n"
             }
           ]
         },
@@ -1046,6 +1248,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/yargs-parser"
             }
           ]
         },
@@ -1066,6 +1272,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/yargs"
             }
           ]
         }

--- a/tests/_data/sbom_demo-results/bundled-dependencies_npm8_node18_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bundled-dependencies_npm8_node18_ubuntu-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-bundled-deps@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -76,7 +76,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bundle-dependencies"
         }
       ],
@@ -100,7 +100,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/ansi-regex"
             }
           ]
@@ -124,7 +124,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/builtin-modules"
             }
           ]
@@ -148,7 +148,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/camelcase"
             }
           ]
@@ -172,7 +172,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/cliui"
             }
           ]
@@ -196,7 +196,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/code-point-at"
             }
           ]
@@ -220,7 +220,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/decamelize"
             }
           ]
@@ -244,7 +244,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/error-ex"
             }
           ]
@@ -268,7 +268,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/escape-string-regexp"
             }
           ]
@@ -292,7 +292,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/find-up"
             }
           ]
@@ -316,7 +316,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/graceful-fs"
             }
           ]
@@ -340,7 +340,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/hosted-git-info"
             }
           ]
@@ -364,7 +364,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/invert-kv"
             }
           ]
@@ -388,7 +388,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-arrayish"
             }
           ]
@@ -412,7 +412,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-builtin-module"
             }
           ]
@@ -436,7 +436,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -460,7 +460,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-utf8"
             }
           ]
@@ -484,7 +484,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lcid"
             }
           ]
@@ -508,7 +508,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/load-json-file"
             }
           ]
@@ -532,7 +532,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lodash.assign"
             }
           ]
@@ -556,7 +556,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lodash.keys"
             }
           ]
@@ -580,7 +580,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lodash.rest"
             }
           ]
@@ -604,7 +604,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/normalize-package-data"
             }
           ]
@@ -628,7 +628,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/number-is-nan"
             }
           ]
@@ -652,7 +652,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/object-assign"
             }
           ]
@@ -676,7 +676,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/os-locale"
             }
           ]
@@ -700,7 +700,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/parse-json"
             }
           ]
@@ -724,7 +724,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/path-exists"
             }
           ]
@@ -748,7 +748,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/path-type"
             }
           ]
@@ -772,7 +772,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pify"
             }
           ]
@@ -796,7 +796,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pinkie-promise"
             }
           ]
@@ -820,7 +820,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pinkie"
             }
           ]
@@ -844,7 +844,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pkg-conf"
             }
           ]
@@ -868,7 +868,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/read-pkg-up"
             }
           ]
@@ -892,7 +892,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/read-pkg"
             }
           ]
@@ -916,7 +916,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/require-main-filename"
             }
           ]
@@ -940,7 +940,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/semver"
             }
           ]
@@ -964,7 +964,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-correct"
             }
           ]
@@ -988,7 +988,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-exceptions"
             }
           ]
@@ -1010,7 +1010,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-expression-parse"
             }
           ]
@@ -1034,7 +1034,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-license-ids"
             }
           ]
@@ -1058,7 +1058,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/string-width"
             }
           ]
@@ -1082,7 +1082,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/strip-ansi"
             }
           ]
@@ -1106,7 +1106,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/strip-bom"
             }
           ]
@@ -1130,7 +1130,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/symbol"
             }
           ]
@@ -1154,7 +1154,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/validate-npm-package-license"
             }
           ]
@@ -1178,7 +1178,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/window-size"
             }
           ]
@@ -1202,7 +1202,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/wrap-ansi"
             }
           ]
@@ -1226,7 +1226,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/y18n"
             }
           ]
@@ -1250,7 +1250,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/yargs-parser"
             }
           ]
@@ -1274,7 +1274,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/yargs"
             }
           ]

--- a/tests/_data/sbom_demo-results/bundled-dependencies_npm8_node18_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bundled-dependencies_npm8_node18_ubuntu-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-bundled-deps@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -70,6 +74,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bundle-dependencies"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -88,6 +98,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/ansi-regex"
             }
           ]
         },
@@ -108,6 +122,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/builtin-modules"
             }
           ]
         },
@@ -128,6 +146,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/camelcase"
             }
           ]
         },
@@ -148,6 +170,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/cliui"
             }
           ]
         },
@@ -168,6 +194,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/code-point-at"
             }
           ]
         },
@@ -188,6 +218,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/decamelize"
             }
           ]
         },
@@ -208,6 +242,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/error-ex"
             }
           ]
         },
@@ -228,6 +266,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/escape-string-regexp"
             }
           ]
         },
@@ -248,6 +290,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/find-up"
             }
           ]
         },
@@ -268,6 +314,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/graceful-fs"
             }
           ]
         },
@@ -288,6 +338,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/hosted-git-info"
             }
           ]
         },
@@ -308,6 +362,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/invert-kv"
             }
           ]
         },
@@ -328,6 +386,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-arrayish"
             }
           ]
         },
@@ -348,6 +410,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-builtin-module"
             }
           ]
         },
@@ -368,6 +434,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-fullwidth-code-point"
             }
           ]
         },
@@ -388,6 +458,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-utf8"
             }
           ]
         },
@@ -408,6 +482,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lcid"
             }
           ]
         },
@@ -428,6 +506,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/load-json-file"
             }
           ]
         },
@@ -448,6 +530,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lodash.assign"
             }
           ]
         },
@@ -468,6 +554,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lodash.keys"
             }
           ]
         },
@@ -488,6 +578,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lodash.rest"
             }
           ]
         },
@@ -508,6 +602,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/normalize-package-data"
             }
           ]
         },
@@ -528,6 +626,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/number-is-nan"
             }
           ]
         },
@@ -548,6 +650,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/object-assign"
             }
           ]
         },
@@ -568,6 +674,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/os-locale"
             }
           ]
         },
@@ -588,6 +698,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/parse-json"
             }
           ]
         },
@@ -608,6 +722,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/path-exists"
             }
           ]
         },
@@ -628,6 +746,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/path-type"
             }
           ]
         },
@@ -648,6 +770,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pify"
             }
           ]
         },
@@ -668,6 +794,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pinkie-promise"
             }
           ]
         },
@@ -688,6 +818,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pinkie"
             }
           ]
         },
@@ -708,6 +842,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pkg-conf"
             }
           ]
         },
@@ -728,6 +866,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/read-pkg-up"
             }
           ]
         },
@@ -748,6 +890,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/read-pkg"
             }
           ]
         },
@@ -768,6 +914,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/require-main-filename"
             }
           ]
         },
@@ -788,6 +938,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/semver"
             }
           ]
         },
@@ -808,6 +962,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-correct"
             }
           ]
         },
@@ -828,6 +986,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-exceptions"
             }
           ]
         },
@@ -846,6 +1008,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-expression-parse"
             }
           ]
         },
@@ -866,6 +1032,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-license-ids"
             }
           ]
         },
@@ -886,6 +1056,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/string-width"
             }
           ]
         },
@@ -906,6 +1080,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/strip-ansi"
             }
           ]
         },
@@ -926,6 +1104,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/strip-bom"
             }
           ]
         },
@@ -946,6 +1128,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/symbol"
             }
           ]
         },
@@ -966,6 +1152,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/validate-npm-package-license"
             }
           ]
         },
@@ -986,6 +1176,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/window-size"
             }
           ]
         },
@@ -1006,6 +1200,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/wrap-ansi"
             }
           ]
         },
@@ -1026,6 +1224,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/y18n"
             }
           ]
         },
@@ -1046,6 +1248,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/yargs-parser"
             }
           ]
         },
@@ -1066,6 +1272,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/yargs"
             }
           ]
         }

--- a/tests/_data/sbom_demo-results/bundled-dependencies_npm8_node18_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bundled-dependencies_npm8_node18_windows-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-bundled-deps@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -70,6 +74,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bundle-dependencies"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -88,6 +98,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\ansi-regex"
             }
           ]
         },
@@ -108,6 +122,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\builtin-modules"
             }
           ]
         },
@@ -128,6 +146,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\camelcase"
             }
           ]
         },
@@ -148,6 +170,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\cliui"
             }
           ]
         },
@@ -168,6 +194,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\code-point-at"
             }
           ]
         },
@@ -188,6 +218,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\decamelize"
             }
           ]
         },
@@ -208,6 +242,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\error-ex"
             }
           ]
         },
@@ -228,6 +266,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\escape-string-regexp"
             }
           ]
         },
@@ -248,6 +290,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\find-up"
             }
           ]
         },
@@ -268,6 +314,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\graceful-fs"
             }
           ]
         },
@@ -288,6 +338,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\hosted-git-info"
             }
           ]
         },
@@ -308,6 +362,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\invert-kv"
             }
           ]
         },
@@ -328,6 +386,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\is-arrayish"
             }
           ]
         },
@@ -348,6 +410,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\is-builtin-module"
             }
           ]
         },
@@ -368,6 +434,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\is-fullwidth-code-point"
             }
           ]
         },
@@ -388,6 +458,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\is-utf8"
             }
           ]
         },
@@ -408,6 +482,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\lcid"
             }
           ]
         },
@@ -428,6 +506,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\load-json-file"
             }
           ]
         },
@@ -448,6 +530,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\lodash.assign"
             }
           ]
         },
@@ -468,6 +554,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\lodash.keys"
             }
           ]
         },
@@ -488,6 +578,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\lodash.rest"
             }
           ]
         },
@@ -508,6 +602,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\normalize-package-data"
             }
           ]
         },
@@ -528,6 +626,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\number-is-nan"
             }
           ]
         },
@@ -548,6 +650,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\object-assign"
             }
           ]
         },
@@ -568,6 +674,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\os-locale"
             }
           ]
         },
@@ -588,6 +698,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\parse-json"
             }
           ]
         },
@@ -608,6 +722,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\path-exists"
             }
           ]
         },
@@ -628,6 +746,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\path-type"
             }
           ]
         },
@@ -648,6 +770,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\pify"
             }
           ]
         },
@@ -668,6 +794,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\pinkie-promise"
             }
           ]
         },
@@ -688,6 +818,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\pinkie"
             }
           ]
         },
@@ -708,6 +842,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\pkg-conf"
             }
           ]
         },
@@ -728,6 +866,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\read-pkg-up"
             }
           ]
         },
@@ -748,6 +890,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\read-pkg"
             }
           ]
         },
@@ -768,6 +914,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\require-main-filename"
             }
           ]
         },
@@ -788,6 +938,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\semver"
             }
           ]
         },
@@ -808,6 +962,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\spdx-correct"
             }
           ]
         },
@@ -828,6 +986,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\spdx-exceptions"
             }
           ]
         },
@@ -846,6 +1008,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\spdx-expression-parse"
             }
           ]
         },
@@ -866,6 +1032,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\spdx-license-ids"
             }
           ]
         },
@@ -886,6 +1056,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\string-width"
             }
           ]
         },
@@ -906,6 +1080,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\strip-ansi"
             }
           ]
         },
@@ -926,6 +1104,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\strip-bom"
             }
           ]
         },
@@ -946,6 +1128,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\symbol"
             }
           ]
         },
@@ -966,6 +1152,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\validate-npm-package-license"
             }
           ]
         },
@@ -986,6 +1176,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\window-size"
             }
           ]
         },
@@ -1006,6 +1200,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\wrap-ansi"
             }
           ]
         },
@@ -1026,6 +1224,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\y18n"
             }
           ]
         },
@@ -1046,6 +1248,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\yargs-parser"
             }
           ]
         },
@@ -1066,6 +1272,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\yargs"
             }
           ]
         }

--- a/tests/_data/sbom_demo-results/bundled-dependencies_npm8_node18_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bundled-dependencies_npm8_node18_windows-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-bundled-deps@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -76,7 +76,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bundle-dependencies"
         }
       ],
@@ -100,7 +100,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\ansi-regex"
             }
           ]
@@ -124,7 +124,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\builtin-modules"
             }
           ]
@@ -148,7 +148,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\camelcase"
             }
           ]
@@ -172,7 +172,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\cliui"
             }
           ]
@@ -196,7 +196,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\code-point-at"
             }
           ]
@@ -220,7 +220,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\decamelize"
             }
           ]
@@ -244,7 +244,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\error-ex"
             }
           ]
@@ -268,7 +268,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\escape-string-regexp"
             }
           ]
@@ -292,7 +292,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\find-up"
             }
           ]
@@ -316,7 +316,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\graceful-fs"
             }
           ]
@@ -340,7 +340,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\hosted-git-info"
             }
           ]
@@ -364,7 +364,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\invert-kv"
             }
           ]
@@ -388,7 +388,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\is-arrayish"
             }
           ]
@@ -412,7 +412,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\is-builtin-module"
             }
           ]
@@ -436,7 +436,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\is-fullwidth-code-point"
             }
           ]
@@ -460,7 +460,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\is-utf8"
             }
           ]
@@ -484,7 +484,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\lcid"
             }
           ]
@@ -508,7 +508,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\load-json-file"
             }
           ]
@@ -532,7 +532,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\lodash.assign"
             }
           ]
@@ -556,7 +556,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\lodash.keys"
             }
           ]
@@ -580,7 +580,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\lodash.rest"
             }
           ]
@@ -604,7 +604,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\normalize-package-data"
             }
           ]
@@ -628,7 +628,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\number-is-nan"
             }
           ]
@@ -652,7 +652,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\object-assign"
             }
           ]
@@ -676,7 +676,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\os-locale"
             }
           ]
@@ -700,7 +700,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\parse-json"
             }
           ]
@@ -724,7 +724,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\path-exists"
             }
           ]
@@ -748,7 +748,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\path-type"
             }
           ]
@@ -772,7 +772,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\pify"
             }
           ]
@@ -796,7 +796,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\pinkie-promise"
             }
           ]
@@ -820,7 +820,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\pinkie"
             }
           ]
@@ -844,7 +844,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\pkg-conf"
             }
           ]
@@ -868,7 +868,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\read-pkg-up"
             }
           ]
@@ -892,7 +892,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\read-pkg"
             }
           ]
@@ -916,7 +916,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\require-main-filename"
             }
           ]
@@ -940,7 +940,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\semver"
             }
           ]
@@ -964,7 +964,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\spdx-correct"
             }
           ]
@@ -988,7 +988,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\spdx-exceptions"
             }
           ]
@@ -1010,7 +1010,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\spdx-expression-parse"
             }
           ]
@@ -1034,7 +1034,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\spdx-license-ids"
             }
           ]
@@ -1058,7 +1058,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\string-width"
             }
           ]
@@ -1082,7 +1082,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\strip-ansi"
             }
           ]
@@ -1106,7 +1106,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\strip-bom"
             }
           ]
@@ -1130,7 +1130,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\symbol"
             }
           ]
@@ -1154,7 +1154,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\validate-npm-package-license"
             }
           ]
@@ -1178,7 +1178,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\window-size"
             }
           ]
@@ -1202,7 +1202,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\wrap-ansi"
             }
           ]
@@ -1226,7 +1226,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\y18n"
             }
           ]
@@ -1250,7 +1250,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\yargs-parser"
             }
           ]
@@ -1274,7 +1274,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\yargs"
             }
           ]

--- a/tests/_data/sbom_demo-results/bundled-dependencies_npm9_node16_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bundled-dependencies_npm9_node16_macos-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-bundled-deps@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -76,7 +76,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bundle-dependencies"
         }
       ],
@@ -100,7 +100,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/ansi-regex"
             }
           ]
@@ -124,7 +124,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/builtin-modules"
             }
           ]
@@ -148,7 +148,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/camelcase"
             }
           ]
@@ -172,7 +172,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/cliui"
             }
           ]
@@ -196,7 +196,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/code-point-at"
             }
           ]
@@ -220,7 +220,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/decamelize"
             }
           ]
@@ -244,7 +244,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/error-ex"
             }
           ]
@@ -268,7 +268,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/escape-string-regexp"
             }
           ]
@@ -292,7 +292,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/find-up"
             }
           ]
@@ -316,7 +316,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/graceful-fs"
             }
           ]
@@ -340,7 +340,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/hosted-git-info"
             }
           ]
@@ -364,7 +364,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/invert-kv"
             }
           ]
@@ -388,7 +388,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-arrayish"
             }
           ]
@@ -412,7 +412,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-builtin-module"
             }
           ]
@@ -436,7 +436,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -460,7 +460,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-utf8"
             }
           ]
@@ -484,7 +484,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lcid"
             }
           ]
@@ -508,7 +508,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/load-json-file"
             }
           ]
@@ -532,7 +532,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lodash.assign"
             }
           ]
@@ -556,7 +556,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lodash.keys"
             }
           ]
@@ -580,7 +580,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lodash.rest"
             }
           ]
@@ -604,7 +604,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/normalize-package-data"
             }
           ]
@@ -628,7 +628,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/number-is-nan"
             }
           ]
@@ -652,7 +652,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/object-assign"
             }
           ]
@@ -676,7 +676,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/os-locale"
             }
           ]
@@ -700,7 +700,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/parse-json"
             }
           ]
@@ -724,7 +724,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/path-exists"
             }
           ]
@@ -748,7 +748,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/path-type"
             }
           ]
@@ -772,7 +772,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pify"
             }
           ]
@@ -796,7 +796,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pinkie-promise"
             }
           ]
@@ -820,7 +820,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pinkie"
             }
           ]
@@ -844,7 +844,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pkg-conf"
             }
           ]
@@ -868,7 +868,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/read-pkg-up"
             }
           ]
@@ -892,7 +892,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/read-pkg"
             }
           ]
@@ -916,7 +916,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/require-main-filename"
             }
           ]
@@ -940,7 +940,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/semver"
             }
           ]
@@ -964,7 +964,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-correct"
             }
           ]
@@ -988,7 +988,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-exceptions"
             }
           ]
@@ -1010,7 +1010,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-expression-parse"
             }
           ]
@@ -1034,7 +1034,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-license-ids"
             }
           ]
@@ -1058,7 +1058,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/string-width"
             }
           ]
@@ -1082,7 +1082,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/strip-ansi"
             }
           ]
@@ -1106,7 +1106,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/strip-bom"
             }
           ]
@@ -1130,7 +1130,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/symbol"
             }
           ]
@@ -1154,7 +1154,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/validate-npm-package-license"
             }
           ]
@@ -1178,7 +1178,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/window-size"
             }
           ]
@@ -1202,7 +1202,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/wrap-ansi"
             }
           ]
@@ -1226,7 +1226,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/y18n"
             }
           ]
@@ -1250,7 +1250,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/yargs-parser"
             }
           ]
@@ -1274,7 +1274,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/yargs"
             }
           ]

--- a/tests/_data/sbom_demo-results/bundled-dependencies_npm9_node16_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bundled-dependencies_npm9_node16_macos-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-bundled-deps@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -70,6 +74,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bundle-dependencies"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -88,6 +98,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/ansi-regex"
             }
           ]
         },
@@ -108,6 +122,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/builtin-modules"
             }
           ]
         },
@@ -128,6 +146,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/camelcase"
             }
           ]
         },
@@ -148,6 +170,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/cliui"
             }
           ]
         },
@@ -168,6 +194,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/code-point-at"
             }
           ]
         },
@@ -188,6 +218,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/decamelize"
             }
           ]
         },
@@ -208,6 +242,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/error-ex"
             }
           ]
         },
@@ -228,6 +266,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/escape-string-regexp"
             }
           ]
         },
@@ -248,6 +290,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/find-up"
             }
           ]
         },
@@ -268,6 +314,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/graceful-fs"
             }
           ]
         },
@@ -288,6 +338,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/hosted-git-info"
             }
           ]
         },
@@ -308,6 +362,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/invert-kv"
             }
           ]
         },
@@ -328,6 +386,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-arrayish"
             }
           ]
         },
@@ -348,6 +410,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-builtin-module"
             }
           ]
         },
@@ -368,6 +434,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-fullwidth-code-point"
             }
           ]
         },
@@ -388,6 +458,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-utf8"
             }
           ]
         },
@@ -408,6 +482,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lcid"
             }
           ]
         },
@@ -428,6 +506,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/load-json-file"
             }
           ]
         },
@@ -448,6 +530,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lodash.assign"
             }
           ]
         },
@@ -468,6 +554,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lodash.keys"
             }
           ]
         },
@@ -488,6 +578,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lodash.rest"
             }
           ]
         },
@@ -508,6 +602,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/normalize-package-data"
             }
           ]
         },
@@ -528,6 +626,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/number-is-nan"
             }
           ]
         },
@@ -548,6 +650,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/object-assign"
             }
           ]
         },
@@ -568,6 +674,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/os-locale"
             }
           ]
         },
@@ -588,6 +698,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/parse-json"
             }
           ]
         },
@@ -608,6 +722,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/path-exists"
             }
           ]
         },
@@ -628,6 +746,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/path-type"
             }
           ]
         },
@@ -648,6 +770,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pify"
             }
           ]
         },
@@ -668,6 +794,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pinkie-promise"
             }
           ]
         },
@@ -688,6 +818,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pinkie"
             }
           ]
         },
@@ -708,6 +842,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pkg-conf"
             }
           ]
         },
@@ -728,6 +866,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/read-pkg-up"
             }
           ]
         },
@@ -748,6 +890,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/read-pkg"
             }
           ]
         },
@@ -768,6 +914,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/require-main-filename"
             }
           ]
         },
@@ -788,6 +938,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/semver"
             }
           ]
         },
@@ -808,6 +962,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-correct"
             }
           ]
         },
@@ -828,6 +986,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-exceptions"
             }
           ]
         },
@@ -846,6 +1008,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-expression-parse"
             }
           ]
         },
@@ -866,6 +1032,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-license-ids"
             }
           ]
         },
@@ -886,6 +1056,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/string-width"
             }
           ]
         },
@@ -906,6 +1080,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/strip-ansi"
             }
           ]
         },
@@ -926,6 +1104,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/strip-bom"
             }
           ]
         },
@@ -946,6 +1128,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/symbol"
             }
           ]
         },
@@ -966,6 +1152,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/validate-npm-package-license"
             }
           ]
         },
@@ -986,6 +1176,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/window-size"
             }
           ]
         },
@@ -1006,6 +1200,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/wrap-ansi"
             }
           ]
         },
@@ -1026,6 +1224,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/y18n"
             }
           ]
         },
@@ -1046,6 +1248,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/yargs-parser"
             }
           ]
         },
@@ -1066,6 +1272,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/yargs"
             }
           ]
         }

--- a/tests/_data/sbom_demo-results/bundled-dependencies_npm9_node16_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bundled-dependencies_npm9_node16_ubuntu-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-bundled-deps@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -76,7 +76,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bundle-dependencies"
         }
       ],
@@ -100,7 +100,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/ansi-regex"
             }
           ]
@@ -124,7 +124,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/builtin-modules"
             }
           ]
@@ -148,7 +148,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/camelcase"
             }
           ]
@@ -172,7 +172,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/cliui"
             }
           ]
@@ -196,7 +196,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/code-point-at"
             }
           ]
@@ -220,7 +220,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/decamelize"
             }
           ]
@@ -244,7 +244,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/error-ex"
             }
           ]
@@ -268,7 +268,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/escape-string-regexp"
             }
           ]
@@ -292,7 +292,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/find-up"
             }
           ]
@@ -316,7 +316,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/graceful-fs"
             }
           ]
@@ -340,7 +340,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/hosted-git-info"
             }
           ]
@@ -364,7 +364,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/invert-kv"
             }
           ]
@@ -388,7 +388,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-arrayish"
             }
           ]
@@ -412,7 +412,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-builtin-module"
             }
           ]
@@ -436,7 +436,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -460,7 +460,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-utf8"
             }
           ]
@@ -484,7 +484,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lcid"
             }
           ]
@@ -508,7 +508,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/load-json-file"
             }
           ]
@@ -532,7 +532,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lodash.assign"
             }
           ]
@@ -556,7 +556,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lodash.keys"
             }
           ]
@@ -580,7 +580,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lodash.rest"
             }
           ]
@@ -604,7 +604,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/normalize-package-data"
             }
           ]
@@ -628,7 +628,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/number-is-nan"
             }
           ]
@@ -652,7 +652,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/object-assign"
             }
           ]
@@ -676,7 +676,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/os-locale"
             }
           ]
@@ -700,7 +700,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/parse-json"
             }
           ]
@@ -724,7 +724,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/path-exists"
             }
           ]
@@ -748,7 +748,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/path-type"
             }
           ]
@@ -772,7 +772,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pify"
             }
           ]
@@ -796,7 +796,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pinkie-promise"
             }
           ]
@@ -820,7 +820,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pinkie"
             }
           ]
@@ -844,7 +844,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pkg-conf"
             }
           ]
@@ -868,7 +868,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/read-pkg-up"
             }
           ]
@@ -892,7 +892,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/read-pkg"
             }
           ]
@@ -916,7 +916,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/require-main-filename"
             }
           ]
@@ -940,7 +940,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/semver"
             }
           ]
@@ -964,7 +964,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-correct"
             }
           ]
@@ -988,7 +988,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-exceptions"
             }
           ]
@@ -1010,7 +1010,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-expression-parse"
             }
           ]
@@ -1034,7 +1034,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-license-ids"
             }
           ]
@@ -1058,7 +1058,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/string-width"
             }
           ]
@@ -1082,7 +1082,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/strip-ansi"
             }
           ]
@@ -1106,7 +1106,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/strip-bom"
             }
           ]
@@ -1130,7 +1130,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/symbol"
             }
           ]
@@ -1154,7 +1154,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/validate-npm-package-license"
             }
           ]
@@ -1178,7 +1178,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/window-size"
             }
           ]
@@ -1202,7 +1202,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/wrap-ansi"
             }
           ]
@@ -1226,7 +1226,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/y18n"
             }
           ]
@@ -1250,7 +1250,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/yargs-parser"
             }
           ]
@@ -1274,7 +1274,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/yargs"
             }
           ]

--- a/tests/_data/sbom_demo-results/bundled-dependencies_npm9_node16_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bundled-dependencies_npm9_node16_ubuntu-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-bundled-deps@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -70,6 +74,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bundle-dependencies"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -88,6 +98,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/ansi-regex"
             }
           ]
         },
@@ -108,6 +122,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/builtin-modules"
             }
           ]
         },
@@ -128,6 +146,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/camelcase"
             }
           ]
         },
@@ -148,6 +170,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/cliui"
             }
           ]
         },
@@ -168,6 +194,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/code-point-at"
             }
           ]
         },
@@ -188,6 +218,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/decamelize"
             }
           ]
         },
@@ -208,6 +242,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/error-ex"
             }
           ]
         },
@@ -228,6 +266,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/escape-string-regexp"
             }
           ]
         },
@@ -248,6 +290,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/find-up"
             }
           ]
         },
@@ -268,6 +314,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/graceful-fs"
             }
           ]
         },
@@ -288,6 +338,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/hosted-git-info"
             }
           ]
         },
@@ -308,6 +362,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/invert-kv"
             }
           ]
         },
@@ -328,6 +386,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-arrayish"
             }
           ]
         },
@@ -348,6 +410,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-builtin-module"
             }
           ]
         },
@@ -368,6 +434,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-fullwidth-code-point"
             }
           ]
         },
@@ -388,6 +458,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-utf8"
             }
           ]
         },
@@ -408,6 +482,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lcid"
             }
           ]
         },
@@ -428,6 +506,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/load-json-file"
             }
           ]
         },
@@ -448,6 +530,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lodash.assign"
             }
           ]
         },
@@ -468,6 +554,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lodash.keys"
             }
           ]
         },
@@ -488,6 +578,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lodash.rest"
             }
           ]
         },
@@ -508,6 +602,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/normalize-package-data"
             }
           ]
         },
@@ -528,6 +626,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/number-is-nan"
             }
           ]
         },
@@ -548,6 +650,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/object-assign"
             }
           ]
         },
@@ -568,6 +674,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/os-locale"
             }
           ]
         },
@@ -588,6 +698,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/parse-json"
             }
           ]
         },
@@ -608,6 +722,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/path-exists"
             }
           ]
         },
@@ -628,6 +746,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/path-type"
             }
           ]
         },
@@ -648,6 +770,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pify"
             }
           ]
         },
@@ -668,6 +794,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pinkie-promise"
             }
           ]
         },
@@ -688,6 +818,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pinkie"
             }
           ]
         },
@@ -708,6 +842,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pkg-conf"
             }
           ]
         },
@@ -728,6 +866,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/read-pkg-up"
             }
           ]
         },
@@ -748,6 +890,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/read-pkg"
             }
           ]
         },
@@ -768,6 +914,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/require-main-filename"
             }
           ]
         },
@@ -788,6 +938,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/semver"
             }
           ]
         },
@@ -808,6 +962,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-correct"
             }
           ]
         },
@@ -828,6 +986,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-exceptions"
             }
           ]
         },
@@ -846,6 +1008,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-expression-parse"
             }
           ]
         },
@@ -866,6 +1032,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-license-ids"
             }
           ]
         },
@@ -886,6 +1056,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/string-width"
             }
           ]
         },
@@ -906,6 +1080,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/strip-ansi"
             }
           ]
         },
@@ -926,6 +1104,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/strip-bom"
             }
           ]
         },
@@ -946,6 +1128,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/symbol"
             }
           ]
         },
@@ -966,6 +1152,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/validate-npm-package-license"
             }
           ]
         },
@@ -986,6 +1176,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/window-size"
             }
           ]
         },
@@ -1006,6 +1200,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/wrap-ansi"
             }
           ]
         },
@@ -1026,6 +1224,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/y18n"
             }
           ]
         },
@@ -1046,6 +1248,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/yargs-parser"
             }
           ]
         },
@@ -1066,6 +1272,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/yargs"
             }
           ]
         }

--- a/tests/_data/sbom_demo-results/bundled-dependencies_npm9_node16_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bundled-dependencies_npm9_node16_windows-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-bundled-deps@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -70,6 +74,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bundle-dependencies"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -88,6 +98,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\ansi-regex"
             }
           ]
         },
@@ -108,6 +122,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\builtin-modules"
             }
           ]
         },
@@ -128,6 +146,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\camelcase"
             }
           ]
         },
@@ -148,6 +170,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\cliui"
             }
           ]
         },
@@ -168,6 +194,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\code-point-at"
             }
           ]
         },
@@ -188,6 +218,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\decamelize"
             }
           ]
         },
@@ -208,6 +242,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\error-ex"
             }
           ]
         },
@@ -228,6 +266,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\escape-string-regexp"
             }
           ]
         },
@@ -248,6 +290,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\find-up"
             }
           ]
         },
@@ -268,6 +314,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\graceful-fs"
             }
           ]
         },
@@ -288,6 +338,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\hosted-git-info"
             }
           ]
         },
@@ -308,6 +362,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\invert-kv"
             }
           ]
         },
@@ -328,6 +386,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\is-arrayish"
             }
           ]
         },
@@ -348,6 +410,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\is-builtin-module"
             }
           ]
         },
@@ -368,6 +434,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\is-fullwidth-code-point"
             }
           ]
         },
@@ -388,6 +458,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\is-utf8"
             }
           ]
         },
@@ -408,6 +482,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\lcid"
             }
           ]
         },
@@ -428,6 +506,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\load-json-file"
             }
           ]
         },
@@ -448,6 +530,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\lodash.assign"
             }
           ]
         },
@@ -468,6 +554,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\lodash.keys"
             }
           ]
         },
@@ -488,6 +578,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\lodash.rest"
             }
           ]
         },
@@ -508,6 +602,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\normalize-package-data"
             }
           ]
         },
@@ -528,6 +626,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\number-is-nan"
             }
           ]
         },
@@ -548,6 +650,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\object-assign"
             }
           ]
         },
@@ -568,6 +674,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\os-locale"
             }
           ]
         },
@@ -588,6 +698,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\parse-json"
             }
           ]
         },
@@ -608,6 +722,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\path-exists"
             }
           ]
         },
@@ -628,6 +746,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\path-type"
             }
           ]
         },
@@ -648,6 +770,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\pify"
             }
           ]
         },
@@ -668,6 +794,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\pinkie-promise"
             }
           ]
         },
@@ -688,6 +818,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\pinkie"
             }
           ]
         },
@@ -708,6 +842,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\pkg-conf"
             }
           ]
         },
@@ -728,6 +866,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\read-pkg-up"
             }
           ]
         },
@@ -748,6 +890,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\read-pkg"
             }
           ]
         },
@@ -768,6 +914,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\require-main-filename"
             }
           ]
         },
@@ -788,6 +938,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\semver"
             }
           ]
         },
@@ -808,6 +962,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\spdx-correct"
             }
           ]
         },
@@ -828,6 +986,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\spdx-exceptions"
             }
           ]
         },
@@ -846,6 +1008,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\spdx-expression-parse"
             }
           ]
         },
@@ -866,6 +1032,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\spdx-license-ids"
             }
           ]
         },
@@ -886,6 +1056,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\string-width"
             }
           ]
         },
@@ -906,6 +1080,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\strip-ansi"
             }
           ]
         },
@@ -926,6 +1104,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\strip-bom"
             }
           ]
         },
@@ -946,6 +1128,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\symbol"
             }
           ]
         },
@@ -966,6 +1152,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\validate-npm-package-license"
             }
           ]
         },
@@ -986,6 +1176,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\window-size"
             }
           ]
         },
@@ -1006,6 +1200,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\wrap-ansi"
             }
           ]
         },
@@ -1026,6 +1224,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\y18n"
             }
           ]
         },
@@ -1046,6 +1248,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\yargs-parser"
             }
           ]
         },
@@ -1066,6 +1272,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\yargs"
             }
           ]
         }

--- a/tests/_data/sbom_demo-results/bundled-dependencies_npm9_node16_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bundled-dependencies_npm9_node16_windows-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-bundled-deps@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -76,7 +76,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bundle-dependencies"
         }
       ],
@@ -100,7 +100,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\ansi-regex"
             }
           ]
@@ -124,7 +124,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\builtin-modules"
             }
           ]
@@ -148,7 +148,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\camelcase"
             }
           ]
@@ -172,7 +172,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\cliui"
             }
           ]
@@ -196,7 +196,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\code-point-at"
             }
           ]
@@ -220,7 +220,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\decamelize"
             }
           ]
@@ -244,7 +244,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\error-ex"
             }
           ]
@@ -268,7 +268,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\escape-string-regexp"
             }
           ]
@@ -292,7 +292,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\find-up"
             }
           ]
@@ -316,7 +316,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\graceful-fs"
             }
           ]
@@ -340,7 +340,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\hosted-git-info"
             }
           ]
@@ -364,7 +364,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\invert-kv"
             }
           ]
@@ -388,7 +388,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\is-arrayish"
             }
           ]
@@ -412,7 +412,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\is-builtin-module"
             }
           ]
@@ -436,7 +436,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\is-fullwidth-code-point"
             }
           ]
@@ -460,7 +460,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\is-utf8"
             }
           ]
@@ -484,7 +484,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\lcid"
             }
           ]
@@ -508,7 +508,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\load-json-file"
             }
           ]
@@ -532,7 +532,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\lodash.assign"
             }
           ]
@@ -556,7 +556,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\lodash.keys"
             }
           ]
@@ -580,7 +580,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\lodash.rest"
             }
           ]
@@ -604,7 +604,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\normalize-package-data"
             }
           ]
@@ -628,7 +628,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\number-is-nan"
             }
           ]
@@ -652,7 +652,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\object-assign"
             }
           ]
@@ -676,7 +676,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\os-locale"
             }
           ]
@@ -700,7 +700,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\parse-json"
             }
           ]
@@ -724,7 +724,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\path-exists"
             }
           ]
@@ -748,7 +748,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\path-type"
             }
           ]
@@ -772,7 +772,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\pify"
             }
           ]
@@ -796,7 +796,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\pinkie-promise"
             }
           ]
@@ -820,7 +820,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\pinkie"
             }
           ]
@@ -844,7 +844,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\pkg-conf"
             }
           ]
@@ -868,7 +868,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\read-pkg-up"
             }
           ]
@@ -892,7 +892,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\read-pkg"
             }
           ]
@@ -916,7 +916,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\require-main-filename"
             }
           ]
@@ -940,7 +940,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\semver"
             }
           ]
@@ -964,7 +964,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\spdx-correct"
             }
           ]
@@ -988,7 +988,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\spdx-exceptions"
             }
           ]
@@ -1010,7 +1010,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\spdx-expression-parse"
             }
           ]
@@ -1034,7 +1034,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\spdx-license-ids"
             }
           ]
@@ -1058,7 +1058,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\string-width"
             }
           ]
@@ -1082,7 +1082,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\strip-ansi"
             }
           ]
@@ -1106,7 +1106,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\strip-bom"
             }
           ]
@@ -1130,7 +1130,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\symbol"
             }
           ]
@@ -1154,7 +1154,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\validate-npm-package-license"
             }
           ]
@@ -1178,7 +1178,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\window-size"
             }
           ]
@@ -1202,7 +1202,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\wrap-ansi"
             }
           ]
@@ -1226,7 +1226,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\y18n"
             }
           ]
@@ -1250,7 +1250,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\yargs-parser"
             }
           ]
@@ -1274,7 +1274,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\yargs"
             }
           ]

--- a/tests/_data/sbom_demo-results/bundled-dependencies_npm9_node18_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bundled-dependencies_npm9_node18_macos-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-bundled-deps@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -76,7 +76,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bundle-dependencies"
         }
       ],
@@ -100,7 +100,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/ansi-regex"
             }
           ]
@@ -124,7 +124,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/builtin-modules"
             }
           ]
@@ -148,7 +148,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/camelcase"
             }
           ]
@@ -172,7 +172,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/cliui"
             }
           ]
@@ -196,7 +196,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/code-point-at"
             }
           ]
@@ -220,7 +220,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/decamelize"
             }
           ]
@@ -244,7 +244,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/error-ex"
             }
           ]
@@ -268,7 +268,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/escape-string-regexp"
             }
           ]
@@ -292,7 +292,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/find-up"
             }
           ]
@@ -316,7 +316,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/graceful-fs"
             }
           ]
@@ -340,7 +340,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/hosted-git-info"
             }
           ]
@@ -364,7 +364,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/invert-kv"
             }
           ]
@@ -388,7 +388,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-arrayish"
             }
           ]
@@ -412,7 +412,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-builtin-module"
             }
           ]
@@ -436,7 +436,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -460,7 +460,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-utf8"
             }
           ]
@@ -484,7 +484,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lcid"
             }
           ]
@@ -508,7 +508,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/load-json-file"
             }
           ]
@@ -532,7 +532,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lodash.assign"
             }
           ]
@@ -556,7 +556,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lodash.keys"
             }
           ]
@@ -580,7 +580,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lodash.rest"
             }
           ]
@@ -604,7 +604,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/normalize-package-data"
             }
           ]
@@ -628,7 +628,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/number-is-nan"
             }
           ]
@@ -652,7 +652,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/object-assign"
             }
           ]
@@ -676,7 +676,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/os-locale"
             }
           ]
@@ -700,7 +700,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/parse-json"
             }
           ]
@@ -724,7 +724,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/path-exists"
             }
           ]
@@ -748,7 +748,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/path-type"
             }
           ]
@@ -772,7 +772,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pify"
             }
           ]
@@ -796,7 +796,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pinkie-promise"
             }
           ]
@@ -820,7 +820,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pinkie"
             }
           ]
@@ -844,7 +844,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pkg-conf"
             }
           ]
@@ -868,7 +868,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/read-pkg-up"
             }
           ]
@@ -892,7 +892,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/read-pkg"
             }
           ]
@@ -916,7 +916,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/require-main-filename"
             }
           ]
@@ -940,7 +940,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/semver"
             }
           ]
@@ -964,7 +964,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-correct"
             }
           ]
@@ -988,7 +988,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-exceptions"
             }
           ]
@@ -1010,7 +1010,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-expression-parse"
             }
           ]
@@ -1034,7 +1034,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-license-ids"
             }
           ]
@@ -1058,7 +1058,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/string-width"
             }
           ]
@@ -1082,7 +1082,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/strip-ansi"
             }
           ]
@@ -1106,7 +1106,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/strip-bom"
             }
           ]
@@ -1130,7 +1130,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/symbol"
             }
           ]
@@ -1154,7 +1154,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/validate-npm-package-license"
             }
           ]
@@ -1178,7 +1178,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/window-size"
             }
           ]
@@ -1202,7 +1202,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/wrap-ansi"
             }
           ]
@@ -1226,7 +1226,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/y18n"
             }
           ]
@@ -1250,7 +1250,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/yargs-parser"
             }
           ]
@@ -1274,7 +1274,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/yargs"
             }
           ]

--- a/tests/_data/sbom_demo-results/bundled-dependencies_npm9_node18_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bundled-dependencies_npm9_node18_macos-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-bundled-deps@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -70,6 +74,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bundle-dependencies"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -88,6 +98,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/ansi-regex"
             }
           ]
         },
@@ -108,6 +122,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/builtin-modules"
             }
           ]
         },
@@ -128,6 +146,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/camelcase"
             }
           ]
         },
@@ -148,6 +170,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/cliui"
             }
           ]
         },
@@ -168,6 +194,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/code-point-at"
             }
           ]
         },
@@ -188,6 +218,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/decamelize"
             }
           ]
         },
@@ -208,6 +242,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/error-ex"
             }
           ]
         },
@@ -228,6 +266,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/escape-string-regexp"
             }
           ]
         },
@@ -248,6 +290,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/find-up"
             }
           ]
         },
@@ -268,6 +314,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/graceful-fs"
             }
           ]
         },
@@ -288,6 +338,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/hosted-git-info"
             }
           ]
         },
@@ -308,6 +362,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/invert-kv"
             }
           ]
         },
@@ -328,6 +386,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-arrayish"
             }
           ]
         },
@@ -348,6 +410,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-builtin-module"
             }
           ]
         },
@@ -368,6 +434,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-fullwidth-code-point"
             }
           ]
         },
@@ -388,6 +458,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-utf8"
             }
           ]
         },
@@ -408,6 +482,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lcid"
             }
           ]
         },
@@ -428,6 +506,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/load-json-file"
             }
           ]
         },
@@ -448,6 +530,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lodash.assign"
             }
           ]
         },
@@ -468,6 +554,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lodash.keys"
             }
           ]
         },
@@ -488,6 +578,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lodash.rest"
             }
           ]
         },
@@ -508,6 +602,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/normalize-package-data"
             }
           ]
         },
@@ -528,6 +626,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/number-is-nan"
             }
           ]
         },
@@ -548,6 +650,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/object-assign"
             }
           ]
         },
@@ -568,6 +674,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/os-locale"
             }
           ]
         },
@@ -588,6 +698,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/parse-json"
             }
           ]
         },
@@ -608,6 +722,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/path-exists"
             }
           ]
         },
@@ -628,6 +746,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/path-type"
             }
           ]
         },
@@ -648,6 +770,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pify"
             }
           ]
         },
@@ -668,6 +794,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pinkie-promise"
             }
           ]
         },
@@ -688,6 +818,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pinkie"
             }
           ]
         },
@@ -708,6 +842,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pkg-conf"
             }
           ]
         },
@@ -728,6 +866,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/read-pkg-up"
             }
           ]
         },
@@ -748,6 +890,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/read-pkg"
             }
           ]
         },
@@ -768,6 +914,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/require-main-filename"
             }
           ]
         },
@@ -788,6 +938,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/semver"
             }
           ]
         },
@@ -808,6 +962,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-correct"
             }
           ]
         },
@@ -828,6 +986,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-exceptions"
             }
           ]
         },
@@ -846,6 +1008,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-expression-parse"
             }
           ]
         },
@@ -866,6 +1032,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-license-ids"
             }
           ]
         },
@@ -886,6 +1056,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/string-width"
             }
           ]
         },
@@ -906,6 +1080,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/strip-ansi"
             }
           ]
         },
@@ -926,6 +1104,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/strip-bom"
             }
           ]
         },
@@ -946,6 +1128,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/symbol"
             }
           ]
         },
@@ -966,6 +1152,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/validate-npm-package-license"
             }
           ]
         },
@@ -986,6 +1176,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/window-size"
             }
           ]
         },
@@ -1006,6 +1200,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/wrap-ansi"
             }
           ]
         },
@@ -1026,6 +1224,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/y18n"
             }
           ]
         },
@@ -1046,6 +1248,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/yargs-parser"
             }
           ]
         },
@@ -1066,6 +1272,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/yargs"
             }
           ]
         }

--- a/tests/_data/sbom_demo-results/bundled-dependencies_npm9_node18_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bundled-dependencies_npm9_node18_ubuntu-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-bundled-deps@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -76,7 +76,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bundle-dependencies"
         }
       ],
@@ -100,7 +100,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/ansi-regex"
             }
           ]
@@ -124,7 +124,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/builtin-modules"
             }
           ]
@@ -148,7 +148,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/camelcase"
             }
           ]
@@ -172,7 +172,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/cliui"
             }
           ]
@@ -196,7 +196,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/code-point-at"
             }
           ]
@@ -220,7 +220,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/decamelize"
             }
           ]
@@ -244,7 +244,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/error-ex"
             }
           ]
@@ -268,7 +268,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/escape-string-regexp"
             }
           ]
@@ -292,7 +292,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/find-up"
             }
           ]
@@ -316,7 +316,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/graceful-fs"
             }
           ]
@@ -340,7 +340,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/hosted-git-info"
             }
           ]
@@ -364,7 +364,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/invert-kv"
             }
           ]
@@ -388,7 +388,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-arrayish"
             }
           ]
@@ -412,7 +412,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-builtin-module"
             }
           ]
@@ -436,7 +436,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -460,7 +460,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/is-utf8"
             }
           ]
@@ -484,7 +484,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lcid"
             }
           ]
@@ -508,7 +508,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/load-json-file"
             }
           ]
@@ -532,7 +532,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lodash.assign"
             }
           ]
@@ -556,7 +556,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lodash.keys"
             }
           ]
@@ -580,7 +580,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/lodash.rest"
             }
           ]
@@ -604,7 +604,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/normalize-package-data"
             }
           ]
@@ -628,7 +628,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/number-is-nan"
             }
           ]
@@ -652,7 +652,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/object-assign"
             }
           ]
@@ -676,7 +676,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/os-locale"
             }
           ]
@@ -700,7 +700,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/parse-json"
             }
           ]
@@ -724,7 +724,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/path-exists"
             }
           ]
@@ -748,7 +748,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/path-type"
             }
           ]
@@ -772,7 +772,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pify"
             }
           ]
@@ -796,7 +796,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pinkie-promise"
             }
           ]
@@ -820,7 +820,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pinkie"
             }
           ]
@@ -844,7 +844,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/pkg-conf"
             }
           ]
@@ -868,7 +868,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/read-pkg-up"
             }
           ]
@@ -892,7 +892,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/read-pkg"
             }
           ]
@@ -916,7 +916,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/require-main-filename"
             }
           ]
@@ -940,7 +940,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/semver"
             }
           ]
@@ -964,7 +964,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-correct"
             }
           ]
@@ -988,7 +988,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-exceptions"
             }
           ]
@@ -1010,7 +1010,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-expression-parse"
             }
           ]
@@ -1034,7 +1034,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/spdx-license-ids"
             }
           ]
@@ -1058,7 +1058,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/string-width"
             }
           ]
@@ -1082,7 +1082,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/strip-ansi"
             }
           ]
@@ -1106,7 +1106,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/strip-bom"
             }
           ]
@@ -1130,7 +1130,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/symbol"
             }
           ]
@@ -1154,7 +1154,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/validate-npm-package-license"
             }
           ]
@@ -1178,7 +1178,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/window-size"
             }
           ]
@@ -1202,7 +1202,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/wrap-ansi"
             }
           ]
@@ -1226,7 +1226,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/y18n"
             }
           ]
@@ -1250,7 +1250,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/yargs-parser"
             }
           ]
@@ -1274,7 +1274,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies/node_modules/yargs"
             }
           ]

--- a/tests/_data/sbom_demo-results/bundled-dependencies_npm9_node18_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bundled-dependencies_npm9_node18_ubuntu-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-bundled-deps@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -70,6 +74,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bundle-dependencies"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -88,6 +98,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/ansi-regex"
             }
           ]
         },
@@ -108,6 +122,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/builtin-modules"
             }
           ]
         },
@@ -128,6 +146,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/camelcase"
             }
           ]
         },
@@ -148,6 +170,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/cliui"
             }
           ]
         },
@@ -168,6 +194,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/code-point-at"
             }
           ]
         },
@@ -188,6 +218,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/decamelize"
             }
           ]
         },
@@ -208,6 +242,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/error-ex"
             }
           ]
         },
@@ -228,6 +266,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/escape-string-regexp"
             }
           ]
         },
@@ -248,6 +290,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/find-up"
             }
           ]
         },
@@ -268,6 +314,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/graceful-fs"
             }
           ]
         },
@@ -288,6 +338,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/hosted-git-info"
             }
           ]
         },
@@ -308,6 +362,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/invert-kv"
             }
           ]
         },
@@ -328,6 +386,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-arrayish"
             }
           ]
         },
@@ -348,6 +410,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-builtin-module"
             }
           ]
         },
@@ -368,6 +434,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-fullwidth-code-point"
             }
           ]
         },
@@ -388,6 +458,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/is-utf8"
             }
           ]
         },
@@ -408,6 +482,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lcid"
             }
           ]
         },
@@ -428,6 +506,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/load-json-file"
             }
           ]
         },
@@ -448,6 +530,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lodash.assign"
             }
           ]
         },
@@ -468,6 +554,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lodash.keys"
             }
           ]
         },
@@ -488,6 +578,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/lodash.rest"
             }
           ]
         },
@@ -508,6 +602,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/normalize-package-data"
             }
           ]
         },
@@ -528,6 +626,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/number-is-nan"
             }
           ]
         },
@@ -548,6 +650,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/object-assign"
             }
           ]
         },
@@ -568,6 +674,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/os-locale"
             }
           ]
         },
@@ -588,6 +698,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/parse-json"
             }
           ]
         },
@@ -608,6 +722,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/path-exists"
             }
           ]
         },
@@ -628,6 +746,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/path-type"
             }
           ]
         },
@@ -648,6 +770,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pify"
             }
           ]
         },
@@ -668,6 +794,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pinkie-promise"
             }
           ]
         },
@@ -688,6 +818,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pinkie"
             }
           ]
         },
@@ -708,6 +842,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/pkg-conf"
             }
           ]
         },
@@ -728,6 +866,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/read-pkg-up"
             }
           ]
         },
@@ -748,6 +890,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/read-pkg"
             }
           ]
         },
@@ -768,6 +914,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/require-main-filename"
             }
           ]
         },
@@ -788,6 +938,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/semver"
             }
           ]
         },
@@ -808,6 +962,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-correct"
             }
           ]
         },
@@ -828,6 +986,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-exceptions"
             }
           ]
         },
@@ -846,6 +1008,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-expression-parse"
             }
           ]
         },
@@ -866,6 +1032,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/spdx-license-ids"
             }
           ]
         },
@@ -886,6 +1056,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/string-width"
             }
           ]
         },
@@ -906,6 +1080,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/strip-ansi"
             }
           ]
         },
@@ -926,6 +1104,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/strip-bom"
             }
           ]
         },
@@ -946,6 +1128,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/symbol"
             }
           ]
         },
@@ -966,6 +1152,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/validate-npm-package-license"
             }
           ]
         },
@@ -986,6 +1176,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/window-size"
             }
           ]
         },
@@ -1006,6 +1200,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/wrap-ansi"
             }
           ]
         },
@@ -1026,6 +1224,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/y18n"
             }
           ]
         },
@@ -1046,6 +1248,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/yargs-parser"
             }
           ]
         },
@@ -1066,6 +1272,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies/node_modules/yargs"
             }
           ]
         }

--- a/tests/_data/sbom_demo-results/bundled-dependencies_npm9_node18_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bundled-dependencies_npm9_node18_windows-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-bundled-deps@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -70,6 +74,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bundle-dependencies"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -88,6 +98,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\ansi-regex"
             }
           ]
         },
@@ -108,6 +122,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\builtin-modules"
             }
           ]
         },
@@ -128,6 +146,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\camelcase"
             }
           ]
         },
@@ -148,6 +170,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\cliui"
             }
           ]
         },
@@ -168,6 +194,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\code-point-at"
             }
           ]
         },
@@ -188,6 +218,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\decamelize"
             }
           ]
         },
@@ -208,6 +242,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\error-ex"
             }
           ]
         },
@@ -228,6 +266,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\escape-string-regexp"
             }
           ]
         },
@@ -248,6 +290,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\find-up"
             }
           ]
         },
@@ -268,6 +314,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\graceful-fs"
             }
           ]
         },
@@ -288,6 +338,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\hosted-git-info"
             }
           ]
         },
@@ -308,6 +362,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\invert-kv"
             }
           ]
         },
@@ -328,6 +386,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\is-arrayish"
             }
           ]
         },
@@ -348,6 +410,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\is-builtin-module"
             }
           ]
         },
@@ -368,6 +434,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\is-fullwidth-code-point"
             }
           ]
         },
@@ -388,6 +458,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\is-utf8"
             }
           ]
         },
@@ -408,6 +482,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\lcid"
             }
           ]
         },
@@ -428,6 +506,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\load-json-file"
             }
           ]
         },
@@ -448,6 +530,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\lodash.assign"
             }
           ]
         },
@@ -468,6 +554,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\lodash.keys"
             }
           ]
         },
@@ -488,6 +578,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\lodash.rest"
             }
           ]
         },
@@ -508,6 +602,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\normalize-package-data"
             }
           ]
         },
@@ -528,6 +626,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\number-is-nan"
             }
           ]
         },
@@ -548,6 +650,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\object-assign"
             }
           ]
         },
@@ -568,6 +674,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\os-locale"
             }
           ]
         },
@@ -588,6 +698,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\parse-json"
             }
           ]
         },
@@ -608,6 +722,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\path-exists"
             }
           ]
         },
@@ -628,6 +746,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\path-type"
             }
           ]
         },
@@ -648,6 +770,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\pify"
             }
           ]
         },
@@ -668,6 +794,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\pinkie-promise"
             }
           ]
         },
@@ -688,6 +818,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\pinkie"
             }
           ]
         },
@@ -708,6 +842,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\pkg-conf"
             }
           ]
         },
@@ -728,6 +866,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\read-pkg-up"
             }
           ]
         },
@@ -748,6 +890,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\read-pkg"
             }
           ]
         },
@@ -768,6 +914,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\require-main-filename"
             }
           ]
         },
@@ -788,6 +938,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\semver"
             }
           ]
         },
@@ -808,6 +962,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\spdx-correct"
             }
           ]
         },
@@ -828,6 +986,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\spdx-exceptions"
             }
           ]
         },
@@ -846,6 +1008,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\spdx-expression-parse"
             }
           ]
         },
@@ -866,6 +1032,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\spdx-license-ids"
             }
           ]
         },
@@ -886,6 +1056,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\string-width"
             }
           ]
         },
@@ -906,6 +1080,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\strip-ansi"
             }
           ]
         },
@@ -926,6 +1104,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\strip-bom"
             }
           ]
         },
@@ -946,6 +1128,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\symbol"
             }
           ]
         },
@@ -966,6 +1152,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\validate-npm-package-license"
             }
           ]
         },
@@ -986,6 +1176,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\window-size"
             }
           ]
         },
@@ -1006,6 +1200,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\wrap-ansi"
             }
           ]
         },
@@ -1026,6 +1224,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\y18n"
             }
           ]
         },
@@ -1046,6 +1248,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\yargs-parser"
             }
           ]
         },
@@ -1066,6 +1272,10 @@
             {
               "name": "cdx:npm:package:bundled",
               "value": "true"
+            },
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bundle-dependencies\\node_modules\\yargs"
             }
           ]
         }

--- a/tests/_data/sbom_demo-results/bundled-dependencies_npm9_node18_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bundled-dependencies_npm9_node18_windows-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-bundled-deps@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -76,7 +76,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bundle-dependencies"
         }
       ],
@@ -100,7 +100,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\ansi-regex"
             }
           ]
@@ -124,7 +124,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\builtin-modules"
             }
           ]
@@ -148,7 +148,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\camelcase"
             }
           ]
@@ -172,7 +172,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\cliui"
             }
           ]
@@ -196,7 +196,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\code-point-at"
             }
           ]
@@ -220,7 +220,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\decamelize"
             }
           ]
@@ -244,7 +244,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\error-ex"
             }
           ]
@@ -268,7 +268,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\escape-string-regexp"
             }
           ]
@@ -292,7 +292,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\find-up"
             }
           ]
@@ -316,7 +316,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\graceful-fs"
             }
           ]
@@ -340,7 +340,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\hosted-git-info"
             }
           ]
@@ -364,7 +364,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\invert-kv"
             }
           ]
@@ -388,7 +388,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\is-arrayish"
             }
           ]
@@ -412,7 +412,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\is-builtin-module"
             }
           ]
@@ -436,7 +436,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\is-fullwidth-code-point"
             }
           ]
@@ -460,7 +460,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\is-utf8"
             }
           ]
@@ -484,7 +484,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\lcid"
             }
           ]
@@ -508,7 +508,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\load-json-file"
             }
           ]
@@ -532,7 +532,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\lodash.assign"
             }
           ]
@@ -556,7 +556,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\lodash.keys"
             }
           ]
@@ -580,7 +580,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\lodash.rest"
             }
           ]
@@ -604,7 +604,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\normalize-package-data"
             }
           ]
@@ -628,7 +628,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\number-is-nan"
             }
           ]
@@ -652,7 +652,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\object-assign"
             }
           ]
@@ -676,7 +676,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\os-locale"
             }
           ]
@@ -700,7 +700,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\parse-json"
             }
           ]
@@ -724,7 +724,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\path-exists"
             }
           ]
@@ -748,7 +748,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\path-type"
             }
           ]
@@ -772,7 +772,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\pify"
             }
           ]
@@ -796,7 +796,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\pinkie-promise"
             }
           ]
@@ -820,7 +820,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\pinkie"
             }
           ]
@@ -844,7 +844,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\pkg-conf"
             }
           ]
@@ -868,7 +868,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\read-pkg-up"
             }
           ]
@@ -892,7 +892,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\read-pkg"
             }
           ]
@@ -916,7 +916,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\require-main-filename"
             }
           ]
@@ -940,7 +940,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\semver"
             }
           ]
@@ -964,7 +964,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\spdx-correct"
             }
           ]
@@ -988,7 +988,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\spdx-exceptions"
             }
           ]
@@ -1010,7 +1010,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\spdx-expression-parse"
             }
           ]
@@ -1034,7 +1034,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\spdx-license-ids"
             }
           ]
@@ -1058,7 +1058,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\string-width"
             }
           ]
@@ -1082,7 +1082,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\strip-ansi"
             }
           ]
@@ -1106,7 +1106,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\strip-bom"
             }
           ]
@@ -1130,7 +1130,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\symbol"
             }
           ]
@@ -1154,7 +1154,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\validate-npm-package-license"
             }
           ]
@@ -1178,7 +1178,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\window-size"
             }
           ]
@@ -1202,7 +1202,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\wrap-ansi"
             }
           ]
@@ -1226,7 +1226,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\y18n"
             }
           ]
@@ -1250,7 +1250,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\yargs-parser"
             }
           ]
@@ -1274,7 +1274,7 @@
               "value": "true"
             },
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bundle-dependencies\\node_modules\\yargs"
             }
           ]

--- a/tests/_data/sbom_demo-results/dev-dependencies_npm6_node14_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/dev-dependencies_npm6_node14_macos-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-dev-dependencies@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -98,6 +102,10 @@
         {
           "name": "cdx:npm:package:development",
           "value": "true"
+        },
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/node"
         }
       ]
     }

--- a/tests/_data/sbom_demo-results/dev-dependencies_npm6_node14_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/dev-dependencies_npm6_node14_macos-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-dev-dependencies@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -104,7 +104,7 @@
           "value": "true"
         },
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/node"
         }
       ]

--- a/tests/_data/sbom_demo-results/dev-dependencies_npm6_node14_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/dev-dependencies_npm6_node14_ubuntu-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-dev-dependencies@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -98,6 +102,10 @@
         {
           "name": "cdx:npm:package:development",
           "value": "true"
+        },
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/node"
         }
       ]
     }

--- a/tests/_data/sbom_demo-results/dev-dependencies_npm6_node14_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/dev-dependencies_npm6_node14_ubuntu-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-dev-dependencies@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -104,7 +104,7 @@
           "value": "true"
         },
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/node"
         }
       ]

--- a/tests/_data/sbom_demo-results/dev-dependencies_npm6_node14_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/dev-dependencies_npm6_node14_windows-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-dev-dependencies@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -98,6 +102,10 @@
         {
           "name": "cdx:npm:package:development",
           "value": "true"
+        },
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types\\node"
         }
       ]
     }

--- a/tests/_data/sbom_demo-results/dev-dependencies_npm6_node14_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/dev-dependencies_npm6_node14_windows-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-dev-dependencies@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -104,7 +104,7 @@
           "value": "true"
         },
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types\\node"
         }
       ]

--- a/tests/_data/sbom_demo-results/dev-dependencies_npm6_node16_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/dev-dependencies_npm6_node16_macos-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-dev-dependencies@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -98,6 +102,10 @@
         {
           "name": "cdx:npm:package:development",
           "value": "true"
+        },
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/node"
         }
       ]
     }

--- a/tests/_data/sbom_demo-results/dev-dependencies_npm6_node16_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/dev-dependencies_npm6_node16_macos-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-dev-dependencies@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -104,7 +104,7 @@
           "value": "true"
         },
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/node"
         }
       ]

--- a/tests/_data/sbom_demo-results/dev-dependencies_npm6_node16_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/dev-dependencies_npm6_node16_ubuntu-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-dev-dependencies@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -98,6 +102,10 @@
         {
           "name": "cdx:npm:package:development",
           "value": "true"
+        },
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/node"
         }
       ]
     }

--- a/tests/_data/sbom_demo-results/dev-dependencies_npm6_node16_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/dev-dependencies_npm6_node16_ubuntu-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-dev-dependencies@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -104,7 +104,7 @@
           "value": "true"
         },
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/node"
         }
       ]

--- a/tests/_data/sbom_demo-results/dev-dependencies_npm6_node16_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/dev-dependencies_npm6_node16_windows-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-dev-dependencies@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -98,6 +102,10 @@
         {
           "name": "cdx:npm:package:development",
           "value": "true"
+        },
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types\\node"
         }
       ]
     }

--- a/tests/_data/sbom_demo-results/dev-dependencies_npm6_node16_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/dev-dependencies_npm6_node16_windows-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-dev-dependencies@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -104,7 +104,7 @@
           "value": "true"
         },
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types\\node"
         }
       ]

--- a/tests/_data/sbom_demo-results/dev-dependencies_npm6_node18_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/dev-dependencies_npm6_node18_macos-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-dev-dependencies@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -98,6 +102,10 @@
         {
           "name": "cdx:npm:package:development",
           "value": "true"
+        },
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/node"
         }
       ]
     }

--- a/tests/_data/sbom_demo-results/dev-dependencies_npm6_node18_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/dev-dependencies_npm6_node18_macos-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-dev-dependencies@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -104,7 +104,7 @@
           "value": "true"
         },
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/node"
         }
       ]

--- a/tests/_data/sbom_demo-results/dev-dependencies_npm6_node18_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/dev-dependencies_npm6_node18_ubuntu-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-dev-dependencies@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -98,6 +102,10 @@
         {
           "name": "cdx:npm:package:development",
           "value": "true"
+        },
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/node"
         }
       ]
     }

--- a/tests/_data/sbom_demo-results/dev-dependencies_npm6_node18_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/dev-dependencies_npm6_node18_ubuntu-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-dev-dependencies@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -104,7 +104,7 @@
           "value": "true"
         },
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/node"
         }
       ]

--- a/tests/_data/sbom_demo-results/dev-dependencies_npm6_node18_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/dev-dependencies_npm6_node18_windows-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-dev-dependencies@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -98,6 +102,10 @@
         {
           "name": "cdx:npm:package:development",
           "value": "true"
+        },
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types\\node"
         }
       ]
     }

--- a/tests/_data/sbom_demo-results/dev-dependencies_npm6_node18_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/dev-dependencies_npm6_node18_windows-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-dev-dependencies@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -104,7 +104,7 @@
           "value": "true"
         },
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types\\node"
         }
       ]

--- a/tests/_data/sbom_demo-results/dev-dependencies_npm7_node14_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/dev-dependencies_npm7_node14_macos-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-dev-dependencies@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -75,6 +79,10 @@
         {
           "name": "cdx:npm:package:development",
           "value": "true"
+        },
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/node"
         }
       ]
     }

--- a/tests/_data/sbom_demo-results/dev-dependencies_npm7_node14_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/dev-dependencies_npm7_node14_macos-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-dev-dependencies@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -81,7 +81,7 @@
           "value": "true"
         },
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/node"
         }
       ]

--- a/tests/_data/sbom_demo-results/dev-dependencies_npm7_node14_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/dev-dependencies_npm7_node14_ubuntu-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-dev-dependencies@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -75,6 +79,10 @@
         {
           "name": "cdx:npm:package:development",
           "value": "true"
+        },
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/node"
         }
       ]
     }

--- a/tests/_data/sbom_demo-results/dev-dependencies_npm7_node14_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/dev-dependencies_npm7_node14_ubuntu-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-dev-dependencies@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -81,7 +81,7 @@
           "value": "true"
         },
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/node"
         }
       ]

--- a/tests/_data/sbom_demo-results/dev-dependencies_npm7_node14_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/dev-dependencies_npm7_node14_windows-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-dev-dependencies@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -75,6 +79,10 @@
         {
           "name": "cdx:npm:package:development",
           "value": "true"
+        },
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types\\node"
         }
       ]
     }

--- a/tests/_data/sbom_demo-results/dev-dependencies_npm7_node14_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/dev-dependencies_npm7_node14_windows-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-dev-dependencies@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -81,7 +81,7 @@
           "value": "true"
         },
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types\\node"
         }
       ]

--- a/tests/_data/sbom_demo-results/dev-dependencies_npm7_node16_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/dev-dependencies_npm7_node16_macos-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-dev-dependencies@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -75,6 +79,10 @@
         {
           "name": "cdx:npm:package:development",
           "value": "true"
+        },
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/node"
         }
       ]
     }

--- a/tests/_data/sbom_demo-results/dev-dependencies_npm7_node16_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/dev-dependencies_npm7_node16_macos-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-dev-dependencies@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -81,7 +81,7 @@
           "value": "true"
         },
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/node"
         }
       ]

--- a/tests/_data/sbom_demo-results/dev-dependencies_npm7_node16_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/dev-dependencies_npm7_node16_ubuntu-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-dev-dependencies@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -75,6 +79,10 @@
         {
           "name": "cdx:npm:package:development",
           "value": "true"
+        },
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/node"
         }
       ]
     }

--- a/tests/_data/sbom_demo-results/dev-dependencies_npm7_node16_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/dev-dependencies_npm7_node16_ubuntu-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-dev-dependencies@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -81,7 +81,7 @@
           "value": "true"
         },
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/node"
         }
       ]

--- a/tests/_data/sbom_demo-results/dev-dependencies_npm7_node16_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/dev-dependencies_npm7_node16_windows-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-dev-dependencies@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -75,6 +79,10 @@
         {
           "name": "cdx:npm:package:development",
           "value": "true"
+        },
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types\\node"
         }
       ]
     }

--- a/tests/_data/sbom_demo-results/dev-dependencies_npm7_node16_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/dev-dependencies_npm7_node16_windows-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-dev-dependencies@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -81,7 +81,7 @@
           "value": "true"
         },
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types\\node"
         }
       ]

--- a/tests/_data/sbom_demo-results/dev-dependencies_npm7_node18_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/dev-dependencies_npm7_node18_macos-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-dev-dependencies@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -75,6 +79,10 @@
         {
           "name": "cdx:npm:package:development",
           "value": "true"
+        },
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/node"
         }
       ]
     }

--- a/tests/_data/sbom_demo-results/dev-dependencies_npm7_node18_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/dev-dependencies_npm7_node18_macos-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-dev-dependencies@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -81,7 +81,7 @@
           "value": "true"
         },
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/node"
         }
       ]

--- a/tests/_data/sbom_demo-results/dev-dependencies_npm7_node18_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/dev-dependencies_npm7_node18_ubuntu-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-dev-dependencies@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -75,6 +79,10 @@
         {
           "name": "cdx:npm:package:development",
           "value": "true"
+        },
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/node"
         }
       ]
     }

--- a/tests/_data/sbom_demo-results/dev-dependencies_npm7_node18_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/dev-dependencies_npm7_node18_ubuntu-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-dev-dependencies@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -81,7 +81,7 @@
           "value": "true"
         },
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/node"
         }
       ]

--- a/tests/_data/sbom_demo-results/dev-dependencies_npm7_node18_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/dev-dependencies_npm7_node18_windows-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-dev-dependencies@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -75,6 +79,10 @@
         {
           "name": "cdx:npm:package:development",
           "value": "true"
+        },
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types\\node"
         }
       ]
     }

--- a/tests/_data/sbom_demo-results/dev-dependencies_npm7_node18_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/dev-dependencies_npm7_node18_windows-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-dev-dependencies@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -81,7 +81,7 @@
           "value": "true"
         },
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types\\node"
         }
       ]

--- a/tests/_data/sbom_demo-results/dev-dependencies_npm8_node14_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/dev-dependencies_npm8_node14_macos-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-dev-dependencies@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -75,6 +79,10 @@
         {
           "name": "cdx:npm:package:development",
           "value": "true"
+        },
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/node"
         }
       ]
     }

--- a/tests/_data/sbom_demo-results/dev-dependencies_npm8_node14_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/dev-dependencies_npm8_node14_macos-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-dev-dependencies@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -81,7 +81,7 @@
           "value": "true"
         },
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/node"
         }
       ]

--- a/tests/_data/sbom_demo-results/dev-dependencies_npm8_node14_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/dev-dependencies_npm8_node14_ubuntu-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-dev-dependencies@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -75,6 +79,10 @@
         {
           "name": "cdx:npm:package:development",
           "value": "true"
+        },
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/node"
         }
       ]
     }

--- a/tests/_data/sbom_demo-results/dev-dependencies_npm8_node14_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/dev-dependencies_npm8_node14_ubuntu-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-dev-dependencies@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -81,7 +81,7 @@
           "value": "true"
         },
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/node"
         }
       ]

--- a/tests/_data/sbom_demo-results/dev-dependencies_npm8_node14_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/dev-dependencies_npm8_node14_windows-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-dev-dependencies@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -75,6 +79,10 @@
         {
           "name": "cdx:npm:package:development",
           "value": "true"
+        },
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types\\node"
         }
       ]
     }

--- a/tests/_data/sbom_demo-results/dev-dependencies_npm8_node14_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/dev-dependencies_npm8_node14_windows-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-dev-dependencies@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -81,7 +81,7 @@
           "value": "true"
         },
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types\\node"
         }
       ]

--- a/tests/_data/sbom_demo-results/dev-dependencies_npm8_node16_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/dev-dependencies_npm8_node16_macos-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-dev-dependencies@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -75,6 +79,10 @@
         {
           "name": "cdx:npm:package:development",
           "value": "true"
+        },
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/node"
         }
       ]
     }

--- a/tests/_data/sbom_demo-results/dev-dependencies_npm8_node16_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/dev-dependencies_npm8_node16_macos-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-dev-dependencies@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -81,7 +81,7 @@
           "value": "true"
         },
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/node"
         }
       ]

--- a/tests/_data/sbom_demo-results/dev-dependencies_npm8_node16_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/dev-dependencies_npm8_node16_ubuntu-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-dev-dependencies@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -75,6 +79,10 @@
         {
           "name": "cdx:npm:package:development",
           "value": "true"
+        },
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/node"
         }
       ]
     }

--- a/tests/_data/sbom_demo-results/dev-dependencies_npm8_node16_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/dev-dependencies_npm8_node16_ubuntu-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-dev-dependencies@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -81,7 +81,7 @@
           "value": "true"
         },
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/node"
         }
       ]

--- a/tests/_data/sbom_demo-results/dev-dependencies_npm8_node16_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/dev-dependencies_npm8_node16_windows-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-dev-dependencies@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -75,6 +79,10 @@
         {
           "name": "cdx:npm:package:development",
           "value": "true"
+        },
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types\\node"
         }
       ]
     }

--- a/tests/_data/sbom_demo-results/dev-dependencies_npm8_node16_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/dev-dependencies_npm8_node16_windows-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-dev-dependencies@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -81,7 +81,7 @@
           "value": "true"
         },
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types\\node"
         }
       ]

--- a/tests/_data/sbom_demo-results/dev-dependencies_npm8_node18_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/dev-dependencies_npm8_node18_macos-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-dev-dependencies@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -75,6 +79,10 @@
         {
           "name": "cdx:npm:package:development",
           "value": "true"
+        },
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/node"
         }
       ]
     }

--- a/tests/_data/sbom_demo-results/dev-dependencies_npm8_node18_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/dev-dependencies_npm8_node18_macos-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-dev-dependencies@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -81,7 +81,7 @@
           "value": "true"
         },
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/node"
         }
       ]

--- a/tests/_data/sbom_demo-results/dev-dependencies_npm8_node18_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/dev-dependencies_npm8_node18_ubuntu-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-dev-dependencies@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -75,6 +79,10 @@
         {
           "name": "cdx:npm:package:development",
           "value": "true"
+        },
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/node"
         }
       ]
     }

--- a/tests/_data/sbom_demo-results/dev-dependencies_npm8_node18_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/dev-dependencies_npm8_node18_ubuntu-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-dev-dependencies@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -81,7 +81,7 @@
           "value": "true"
         },
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/node"
         }
       ]

--- a/tests/_data/sbom_demo-results/dev-dependencies_npm8_node18_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/dev-dependencies_npm8_node18_windows-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-dev-dependencies@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -75,6 +79,10 @@
         {
           "name": "cdx:npm:package:development",
           "value": "true"
+        },
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types\\node"
         }
       ]
     }

--- a/tests/_data/sbom_demo-results/dev-dependencies_npm8_node18_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/dev-dependencies_npm8_node18_windows-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-dev-dependencies@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -81,7 +81,7 @@
           "value": "true"
         },
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types\\node"
         }
       ]

--- a/tests/_data/sbom_demo-results/dev-dependencies_npm9_node16_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/dev-dependencies_npm9_node16_macos-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-dev-dependencies@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -75,6 +79,10 @@
         {
           "name": "cdx:npm:package:development",
           "value": "true"
+        },
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/node"
         }
       ]
     }

--- a/tests/_data/sbom_demo-results/dev-dependencies_npm9_node16_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/dev-dependencies_npm9_node16_macos-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-dev-dependencies@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -81,7 +81,7 @@
           "value": "true"
         },
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/node"
         }
       ]

--- a/tests/_data/sbom_demo-results/dev-dependencies_npm9_node16_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/dev-dependencies_npm9_node16_ubuntu-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-dev-dependencies@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -75,6 +79,10 @@
         {
           "name": "cdx:npm:package:development",
           "value": "true"
+        },
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/node"
         }
       ]
     }

--- a/tests/_data/sbom_demo-results/dev-dependencies_npm9_node16_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/dev-dependencies_npm9_node16_ubuntu-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-dev-dependencies@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -81,7 +81,7 @@
           "value": "true"
         },
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/node"
         }
       ]

--- a/tests/_data/sbom_demo-results/dev-dependencies_npm9_node16_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/dev-dependencies_npm9_node16_windows-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-dev-dependencies@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -75,6 +79,10 @@
         {
           "name": "cdx:npm:package:development",
           "value": "true"
+        },
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types\\node"
         }
       ]
     }

--- a/tests/_data/sbom_demo-results/dev-dependencies_npm9_node16_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/dev-dependencies_npm9_node16_windows-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-dev-dependencies@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -81,7 +81,7 @@
           "value": "true"
         },
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types\\node"
         }
       ]

--- a/tests/_data/sbom_demo-results/dev-dependencies_npm9_node18_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/dev-dependencies_npm9_node18_macos-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-dev-dependencies@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -75,6 +79,10 @@
         {
           "name": "cdx:npm:package:development",
           "value": "true"
+        },
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/node"
         }
       ]
     }

--- a/tests/_data/sbom_demo-results/dev-dependencies_npm9_node18_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/dev-dependencies_npm9_node18_macos-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-dev-dependencies@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -81,7 +81,7 @@
           "value": "true"
         },
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/node"
         }
       ]

--- a/tests/_data/sbom_demo-results/dev-dependencies_npm9_node18_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/dev-dependencies_npm9_node18_ubuntu-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-dev-dependencies@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -75,6 +79,10 @@
         {
           "name": "cdx:npm:package:development",
           "value": "true"
+        },
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/node"
         }
       ]
     }

--- a/tests/_data/sbom_demo-results/dev-dependencies_npm9_node18_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/dev-dependencies_npm9_node18_ubuntu-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-dev-dependencies@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -81,7 +81,7 @@
           "value": "true"
         },
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/node"
         }
       ]

--- a/tests/_data/sbom_demo-results/dev-dependencies_npm9_node18_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/dev-dependencies_npm9_node18_windows-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-dev-dependencies@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -75,6 +79,10 @@
         {
           "name": "cdx:npm:package:development",
           "value": "true"
+        },
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types\\node"
         }
       ]
     }

--- a/tests/_data/sbom_demo-results/dev-dependencies_npm9_node18_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/dev-dependencies_npm9_node18_windows-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-dev-dependencies@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -81,7 +81,7 @@
           "value": "true"
         },
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types\\node"
         }
       ]

--- a/tests/_data/sbom_demo-results/juice-shop_npm7_node16_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/juice-shop_npm7_node16_macos-latest.snap.json
@@ -62,7 +62,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -95,7 +95,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@babel/helper-string-parser"
         }
       ]
@@ -122,7 +122,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@babel/helper-validator-identifier"
         }
       ]
@@ -149,7 +149,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@babel/parser"
         }
       ]
@@ -176,7 +176,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@babel/types"
         }
       ]
@@ -203,7 +203,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@colors/colors"
         }
       ]
@@ -230,7 +230,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@dabh/diagnostics"
         }
       ]
@@ -257,7 +257,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@gar/promisify"
         }
       ]
@@ -284,7 +284,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@mapbox/node-pre-gyp"
         }
       ],
@@ -310,7 +310,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/ansi-regex"
             }
           ]
@@ -336,7 +336,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/are-we-there-yet"
             }
           ]
@@ -362,7 +362,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/detect-libc"
             }
           ]
@@ -388,7 +388,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/gauge"
             }
           ]
@@ -414,7 +414,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -440,7 +440,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/make-dir"
             }
           ],
@@ -466,7 +466,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/@mapbox/node-pre-gyp/node_modules/make-dir/node_modules/semver"
                 }
               ]
@@ -494,7 +494,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/nopt"
             }
           ]
@@ -520,7 +520,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/npmlog"
             }
           ]
@@ -546,7 +546,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/readable-stream"
             }
           ]
@@ -572,7 +572,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/string-width"
             }
           ]
@@ -598,7 +598,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/strip-ansi"
             }
           ]
@@ -627,7 +627,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/core-loader"
         }
       ]
@@ -654,7 +654,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/core"
         }
       ]
@@ -681,7 +681,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/evaluator"
         }
       ]
@@ -708,7 +708,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-all"
         }
       ]
@@ -735,7 +735,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ar"
         }
       ]
@@ -762,7 +762,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-bn"
         }
       ]
@@ -789,7 +789,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ca"
         }
       ]
@@ -816,7 +816,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-cs"
         }
       ]
@@ -843,7 +843,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-da"
         }
       ]
@@ -870,7 +870,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-de"
         }
       ]
@@ -897,7 +897,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-el"
         }
       ]
@@ -924,7 +924,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-en-min"
         }
       ]
@@ -951,7 +951,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-en"
         }
       ]
@@ -978,7 +978,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-es"
         }
       ]
@@ -1005,7 +1005,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-eu"
         }
       ]
@@ -1032,7 +1032,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-fa"
         }
       ]
@@ -1059,7 +1059,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-fi"
         }
       ]
@@ -1086,7 +1086,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-fr"
         }
       ]
@@ -1113,7 +1113,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ga"
         }
       ]
@@ -1140,7 +1140,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-gl"
         }
       ]
@@ -1167,7 +1167,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-hi"
         }
       ]
@@ -1194,7 +1194,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-hu"
         }
       ]
@@ -1221,7 +1221,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-hy"
         }
       ]
@@ -1248,7 +1248,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-id"
         }
       ]
@@ -1275,7 +1275,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-it"
         }
       ]
@@ -1302,7 +1302,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ja"
         }
       ]
@@ -1329,7 +1329,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ko"
         }
       ]
@@ -1356,7 +1356,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-lt"
         }
       ]
@@ -1383,7 +1383,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ms"
         }
       ]
@@ -1410,7 +1410,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ne"
         }
       ]
@@ -1437,7 +1437,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-nl"
         }
       ]
@@ -1464,7 +1464,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-no"
         }
       ]
@@ -1491,7 +1491,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-pl"
         }
       ]
@@ -1518,7 +1518,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-pt"
         }
       ]
@@ -1545,7 +1545,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ro"
         }
       ]
@@ -1572,7 +1572,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ru"
         }
       ]
@@ -1599,7 +1599,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-sl"
         }
       ]
@@ -1626,7 +1626,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-sr"
         }
       ]
@@ -1653,7 +1653,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-sv"
         }
       ]
@@ -1680,7 +1680,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ta"
         }
       ]
@@ -1707,7 +1707,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-th"
         }
       ]
@@ -1734,7 +1734,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-tl"
         }
       ]
@@ -1761,7 +1761,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-tr"
         }
       ]
@@ -1788,7 +1788,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-uk"
         }
       ]
@@ -1815,7 +1815,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-zh"
         }
       ]
@@ -1842,7 +1842,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/language-min"
         }
       ]
@@ -1869,7 +1869,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/language"
         }
       ]
@@ -1896,7 +1896,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/ner"
         }
       ]
@@ -1923,7 +1923,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/neural"
         }
       ]
@@ -1950,7 +1950,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/nlg"
         }
       ]
@@ -1977,7 +1977,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/nlp"
         }
       ]
@@ -2004,7 +2004,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/nlu"
         }
       ]
@@ -2031,7 +2031,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/request"
         }
       ]
@@ -2058,7 +2058,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/sentiment"
         }
       ]
@@ -2085,7 +2085,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/similarity"
         }
       ]
@@ -2112,7 +2112,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/slot"
         }
       ]
@@ -2139,7 +2139,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@npmcli/fs"
         }
       ]
@@ -2166,7 +2166,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@npmcli/move-file"
         }
       ]
@@ -2193,7 +2193,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib/core"
         }
       ]
@@ -2220,7 +2220,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib/plugin-crypto"
         }
       ]
@@ -2247,7 +2247,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib/plugin-thirty-two"
         }
       ]
@@ -2274,7 +2274,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib/preset-default"
         }
       ]
@@ -2301,7 +2301,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib/preset-v11"
         }
       ]
@@ -2328,7 +2328,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@sindresorhus/is"
         }
       ]
@@ -2355,7 +2355,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@swc/helpers"
         }
       ]
@@ -2382,7 +2382,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@tokenizer/token"
         }
       ]
@@ -2409,7 +2409,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@tootallnate/once"
         }
       ]
@@ -2436,7 +2436,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/component-emitter"
         }
       ]
@@ -2463,7 +2463,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/cookie"
         }
       ]
@@ -2490,7 +2490,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/cors"
         }
       ]
@@ -2517,7 +2517,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/debug"
         }
       ]
@@ -2544,7 +2544,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/ms"
         }
       ]
@@ -2571,7 +2571,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/node"
         }
       ]
@@ -2598,7 +2598,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/strip-bom"
         }
       ]
@@ -2625,7 +2625,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/strip-json-comments"
         }
       ]
@@ -2652,7 +2652,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/validator"
         }
       ]
@@ -2678,7 +2678,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/abbrev"
         }
       ]
@@ -2704,7 +2704,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/accepts"
         }
       ]
@@ -2730,7 +2730,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/acorn-walk"
         }
       ]
@@ -2756,7 +2756,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/acorn"
         }
       ]
@@ -2782,7 +2782,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/agent-base"
         }
       ],
@@ -2808,7 +2808,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agent-base/node_modules/debug"
             }
           ]
@@ -2834,7 +2834,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agent-base/node_modules/ms"
             }
           ]
@@ -2862,7 +2862,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/agentkeepalive"
         }
       ],
@@ -2888,7 +2888,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agentkeepalive/node_modules/debug"
             }
           ]
@@ -2914,7 +2914,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agentkeepalive/node_modules/depd"
             }
           ]
@@ -2940,7 +2940,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agentkeepalive/node_modules/ms"
             }
           ]
@@ -2968,7 +2968,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/aggregate-error"
         }
       ]
@@ -2994,7 +2994,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ajv"
         }
       ]
@@ -3020,7 +3020,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ansi-regex"
         }
       ]
@@ -3046,7 +3046,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ansi-styles"
         }
       ]
@@ -3072,7 +3072,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/anymatch"
         }
       ],
@@ -3098,7 +3098,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/anymatch/node_modules/normalize-path"
             }
           ]
@@ -3126,7 +3126,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/append-field"
         }
       ]
@@ -3152,7 +3152,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/aproba"
         }
       ]
@@ -3178,7 +3178,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/archive-type"
         }
       ],
@@ -3204,7 +3204,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/archive-type/node_modules/file-type"
             }
           ]
@@ -3232,7 +3232,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/archiver-utils"
         }
       ]
@@ -3258,7 +3258,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/archiver"
         }
       ]
@@ -3284,7 +3284,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/are-we-there-yet"
         }
       ]
@@ -3310,7 +3310,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/arg"
         }
       ]
@@ -3336,7 +3336,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/argparse"
         }
       ],
@@ -3362,7 +3362,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/argparse/node_modules/sprintf-js"
             }
           ]
@@ -3390,7 +3390,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/arr-diff"
         }
       ]
@@ -3416,7 +3416,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/arr-flatten"
         }
       ]
@@ -3442,7 +3442,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/arr-union"
         }
       ]
@@ -3468,7 +3468,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/array-each"
         }
       ]
@@ -3494,7 +3494,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/array-flatten"
         }
       ]
@@ -3520,7 +3520,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/array-slice"
         }
       ]
@@ -3546,7 +3546,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/array-unique"
         }
       ]
@@ -3572,7 +3572,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/asap"
         }
       ]
@@ -3598,7 +3598,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/asn1"
         }
       ]
@@ -3624,7 +3624,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/assert-never"
         }
       ]
@@ -3650,7 +3650,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/assert-plus"
         }
       ]
@@ -3676,7 +3676,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/assign-symbols"
         }
       ]
@@ -3702,7 +3702,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/async"
         }
       ]
@@ -3728,7 +3728,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/asynckit"
         }
       ]
@@ -3754,7 +3754,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/at-least-node"
         }
       ]
@@ -3780,7 +3780,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/atob"
         }
       ]
@@ -3806,7 +3806,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/available-typed-arrays"
         }
       ]
@@ -3832,7 +3832,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/aws-sign2"
         }
       ]
@@ -3858,7 +3858,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/aws4"
         }
       ]
@@ -3884,7 +3884,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/babel-walk"
         }
       ]
@@ -3910,7 +3910,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/balanced-match"
         }
       ]
@@ -3936,7 +3936,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base"
         }
       ],
@@ -3962,7 +3962,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/base/node_modules/define-property"
             }
           ]
@@ -3990,7 +3990,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base64-arraybuffer"
         }
       ]
@@ -4016,7 +4016,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base64-js"
         }
       ]
@@ -4042,7 +4042,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base64id"
         }
       ]
@@ -4068,7 +4068,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base64url"
         }
       ]
@@ -4094,7 +4094,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/basic-auth"
         }
       ]
@@ -4120,7 +4120,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/batch"
         }
       ]
@@ -4146,7 +4146,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bcrypt-pbkdf"
         }
       ]
@@ -4172,7 +4172,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/big-integer"
         }
       ]
@@ -4198,7 +4198,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/binary-extensions"
         }
       ]
@@ -4224,7 +4224,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/binary"
         }
       ]
@@ -4250,7 +4250,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bindings"
         }
       ]
@@ -4276,7 +4276,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bintrees"
         }
       ]
@@ -4302,7 +4302,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bl"
         }
       ]
@@ -4328,7 +4328,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bluebird"
         }
       ]
@@ -4354,7 +4354,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/body-parser"
         }
       ]
@@ -4380,7 +4380,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bower-config"
         }
       ],
@@ -4406,7 +4406,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bower-config/node_modules/minimist"
             }
           ]
@@ -4434,7 +4434,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/brace-expansion"
         }
       ]
@@ -4460,7 +4460,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/braces"
         }
       ],
@@ -4486,7 +4486,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/braces/node_modules/extend-shallow"
             }
           ]
@@ -4512,7 +4512,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/braces/node_modules/is-extendable"
             }
           ]
@@ -4540,7 +4540,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/brotli"
         }
       ]
@@ -4566,7 +4566,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-alloc-unsafe"
         }
       ]
@@ -4592,7 +4592,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-alloc"
         }
       ]
@@ -4618,7 +4618,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-crc32"
         }
       ]
@@ -4644,7 +4644,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-fill"
         }
       ]
@@ -4670,7 +4670,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-from"
         }
       ]
@@ -4696,7 +4696,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-indexof-polyfill"
         }
       ]
@@ -4722,7 +4722,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer"
         }
       ]
@@ -4748,7 +4748,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffers"
         }
       ]
@@ -4774,7 +4774,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/busboy"
         }
       ],
@@ -4800,7 +4800,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/busboy/node_modules/isarray"
             }
           ]
@@ -4826,7 +4826,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/busboy/node_modules/readable-stream"
             }
           ]
@@ -4852,7 +4852,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/busboy/node_modules/string_decoder"
             }
           ]
@@ -4880,7 +4880,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/byline"
         }
       ]
@@ -4906,7 +4906,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bytes"
         }
       ]
@@ -4932,7 +4932,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cacache"
         }
       ]
@@ -4958,7 +4958,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cache-base"
         }
       ]
@@ -4984,7 +4984,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cacheable-request"
         }
       ],
@@ -5010,7 +5010,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cacheable-request/node_modules/get-stream"
             }
           ]
@@ -5036,7 +5036,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cacheable-request/node_modules/lowercase-keys"
             }
           ]
@@ -5064,7 +5064,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/call-bind"
         }
       ]
@@ -5090,7 +5090,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/camelcase"
         }
       ]
@@ -5116,7 +5116,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/caseless"
         }
       ]
@@ -5142,7 +5142,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/chainsaw"
         }
       ]
@@ -5168,7 +5168,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/chalk"
         }
       ]
@@ -5194,7 +5194,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/character-parser"
         }
       ]
@@ -5220,7 +5220,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/check-dependencies"
         }
       ],
@@ -5246,7 +5246,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/check-dependencies/node_modules/semver"
             }
           ]
@@ -5274,7 +5274,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/check-types"
         }
       ]
@@ -5300,7 +5300,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/chokidar"
         }
       ],
@@ -5326,7 +5326,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar/node_modules/braces"
             }
           ]
@@ -5352,7 +5352,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar/node_modules/fill-range"
             }
           ]
@@ -5378,7 +5378,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar/node_modules/is-glob"
             }
           ]
@@ -5404,7 +5404,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar/node_modules/is-number"
             }
           ]
@@ -5430,7 +5430,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar/node_modules/normalize-path"
             }
           ]
@@ -5456,7 +5456,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar/node_modules/to-regex-range"
             }
           ]
@@ -5484,7 +5484,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/chownr"
         }
       ]
@@ -5510,7 +5510,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/clarinet"
         }
       ]
@@ -5536,7 +5536,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/class-utils"
         }
       ],
@@ -5562,7 +5562,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils/node_modules/define-property"
             }
           ]
@@ -5588,7 +5588,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils/node_modules/is-accessor-descriptor"
             }
           ],
@@ -5614,7 +5614,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/class-utils/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
@@ -5642,7 +5642,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils/node_modules/is-data-descriptor"
             }
           ],
@@ -5668,7 +5668,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/class-utils/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
@@ -5696,7 +5696,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils/node_modules/is-descriptor"
             }
           ]
@@ -5722,7 +5722,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils/node_modules/kind-of"
             }
           ]
@@ -5750,7 +5750,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/clean-stack"
         }
       ]
@@ -5776,7 +5776,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cliui"
         }
       ],
@@ -5802,7 +5802,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui/node_modules/ansi-regex"
             }
           ]
@@ -5828,7 +5828,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui/node_modules/emoji-regex"
             }
           ]
@@ -5854,7 +5854,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -5880,7 +5880,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui/node_modules/string-width"
             }
           ]
@@ -5906,7 +5906,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui/node_modules/strip-ansi"
             }
           ]
@@ -5934,7 +5934,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/clone-response"
         }
       ]
@@ -5960,7 +5960,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/clone"
         }
       ]
@@ -5986,7 +5986,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/code-point-at"
         }
       ]
@@ -6012,7 +6012,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/collection-visit"
         }
       ]
@@ -6038,7 +6038,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color-convert"
         }
       ]
@@ -6064,7 +6064,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color-name"
         }
       ]
@@ -6090,7 +6090,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color-string"
         }
       ]
@@ -6116,7 +6116,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color-support"
         }
       ]
@@ -6142,7 +6142,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color"
         }
       ]
@@ -6168,7 +6168,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/colors"
         }
       ]
@@ -6194,7 +6194,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/colorspace"
         }
       ]
@@ -6220,7 +6220,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/combined-stream"
         }
       ]
@@ -6246,7 +6246,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/commander"
         }
       ]
@@ -6272,7 +6272,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/component-emitter"
         }
       ]
@@ -6298,7 +6298,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/component-type"
         }
       ]
@@ -6324,7 +6324,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/compress-commons"
         }
       ]
@@ -6350,7 +6350,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/compressible"
         }
       ]
@@ -6376,7 +6376,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/compression"
         }
       ],
@@ -6402,7 +6402,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/compression/node_modules/bytes"
             }
           ]
@@ -6430,7 +6430,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/concat-map"
         }
       ]
@@ -6456,7 +6456,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/concat-stream"
         }
       ]
@@ -6482,7 +6482,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/concurrently"
         }
       ],
@@ -6508,7 +6508,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/concurrently/node_modules/supports-color"
             }
           ]
@@ -6536,7 +6536,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/config"
         }
       ]
@@ -6562,7 +6562,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/console-control-strings"
         }
       ]
@@ -6588,7 +6588,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/constantinople"
         }
       ]
@@ -6614,7 +6614,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/content-disposition"
         }
       ],
@@ -6640,7 +6640,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/content-disposition/node_modules/safe-buffer"
             }
           ]
@@ -6668,7 +6668,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/content-type"
         }
       ]
@@ -6694,7 +6694,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cookie-parser"
         }
       ]
@@ -6720,7 +6720,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cookie-signature"
         }
       ]
@@ -6746,7 +6746,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cookie"
         }
       ]
@@ -6772,7 +6772,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/copy-descriptor"
         }
       ]
@@ -6798,7 +6798,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/core-util-is"
         }
       ]
@@ -6824,7 +6824,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cors"
         }
       ]
@@ -6850,7 +6850,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/crc"
         }
       ]
@@ -6876,7 +6876,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/crc32-stream"
         }
       ]
@@ -6902,7 +6902,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/create-require"
         }
       ]
@@ -6928,7 +6928,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/crypto-js"
         }
       ]
@@ -6954,7 +6954,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dashdash"
         }
       ]
@@ -6980,7 +6980,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/date-fns"
         }
       ]
@@ -7006,7 +7006,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dateformat"
         }
       ]
@@ -7032,7 +7032,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/debug"
         }
       ]
@@ -7058,7 +7058,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decamelize"
         }
       ]
@@ -7084,7 +7084,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decode-uri-component"
         }
       ]
@@ -7110,7 +7110,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-response"
         }
       ]
@@ -7136,7 +7136,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-tar"
         }
       ],
@@ -7162,7 +7162,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-tar/node_modules/file-type"
             }
           ]
@@ -7190,7 +7190,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-tarbz2"
         }
       ],
@@ -7216,7 +7216,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-tarbz2/node_modules/file-type"
             }
           ]
@@ -7244,7 +7244,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-targz"
         }
       ],
@@ -7270,7 +7270,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-targz/node_modules/file-type"
             }
           ]
@@ -7298,7 +7298,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-unzip"
         }
       ],
@@ -7324,7 +7324,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-unzip/node_modules/file-type"
             }
           ]
@@ -7350,7 +7350,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-unzip/node_modules/get-stream"
             }
           ]
@@ -7376,7 +7376,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-unzip/node_modules/pify"
             }
           ]
@@ -7404,7 +7404,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress"
         }
       ],
@@ -7430,7 +7430,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress/node_modules/make-dir"
             }
           ],
@@ -7456,7 +7456,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/decompress/node_modules/make-dir/node_modules/pify"
                 }
               ]
@@ -7484,7 +7484,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress/node_modules/pify"
             }
           ]
@@ -7512,7 +7512,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/deep-equal"
         }
       ]
@@ -7538,7 +7538,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/deep-extend"
         }
       ]
@@ -7564,7 +7564,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/deep-is"
         }
       ]
@@ -7590,7 +7590,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/define-properties"
         }
       ]
@@ -7616,7 +7616,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/define-property"
         }
       ]
@@ -7642,7 +7642,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/delayed-stream"
         }
       ]
@@ -7668,7 +7668,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/delegates"
         }
       ]
@@ -7694,7 +7694,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/depd"
         }
       ]
@@ -7720,7 +7720,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/destroy"
         }
       ]
@@ -7746,7 +7746,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/detect-file"
         }
       ]
@@ -7772,7 +7772,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/detect-libc"
         }
       ]
@@ -7798,7 +7798,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dfa"
         }
       ]
@@ -7824,7 +7824,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dicer"
         }
       ],
@@ -7850,7 +7850,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/dicer/node_modules/isarray"
             }
           ]
@@ -7876,7 +7876,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/dicer/node_modules/readable-stream"
             }
           ]
@@ -7902,7 +7902,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/dicer/node_modules/string_decoder"
             }
           ]
@@ -7930,7 +7930,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/diff"
         }
       ]
@@ -7956,7 +7956,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/doctypes"
         }
       ]
@@ -7982,7 +7982,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/domelementtype"
         }
       ]
@@ -8008,7 +8008,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/domhandler"
         }
       ]
@@ -8034,7 +8034,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/domutils"
         }
       ]
@@ -8060,7 +8060,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dottie"
         }
       ]
@@ -8086,7 +8086,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/double-ended-queue"
         }
       ]
@@ -8112,7 +8112,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/doublearray"
         }
       ]
@@ -8138,7 +8138,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/download"
         }
       ],
@@ -8164,7 +8164,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/download/node_modules/file-type"
             }
           ]
@@ -8192,7 +8192,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/duplexer2"
         }
       ]
@@ -8218,7 +8218,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/duplexer3"
         }
       ]
@@ -8244,7 +8244,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dynamic-dedupe"
         }
       ]
@@ -8270,7 +8270,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ecc-jsbn"
         }
       ]
@@ -8296,7 +8296,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ee-first"
         }
       ]
@@ -8322,7 +8322,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/eivindfjeldstad-dot"
         }
       ]
@@ -8348,7 +8348,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/emoji-regex"
         }
       ]
@@ -8374,7 +8374,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/enabled"
         }
       ]
@@ -8400,7 +8400,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/encodeurl"
         }
       ]
@@ -8426,7 +8426,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/encoding"
         }
       ],
@@ -8452,7 +8452,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/encoding/node_modules/iconv-lite"
             }
           ]
@@ -8480,7 +8480,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/end-of-stream"
         }
       ]
@@ -8506,7 +8506,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/engine.io-parser"
         }
       ]
@@ -8532,7 +8532,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/engine.io"
         }
       ],
@@ -8558,7 +8558,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/engine.io/node_modules/debug"
             }
           ]
@@ -8584,7 +8584,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/engine.io/node_modules/ms"
             }
           ]
@@ -8612,7 +8612,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/env-paths"
         }
       ]
@@ -8638,7 +8638,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/err-code"
         }
       ]
@@ -8664,7 +8664,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/error-ex"
         }
       ]
@@ -8690,7 +8690,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/errorhandler"
         }
       ]
@@ -8716,7 +8716,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/es-abstract"
         }
       ]
@@ -8742,7 +8742,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/es-get-iterator"
         }
       ]
@@ -8768,7 +8768,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/es-to-primitive"
         }
       ]
@@ -8794,7 +8794,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/escape-html"
         }
       ]
@@ -8820,7 +8820,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/escape-string-regexp"
         }
       ]
@@ -8846,7 +8846,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/escodegen"
         }
       ]
@@ -8872,7 +8872,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/esprima"
         }
       ]
@@ -8898,7 +8898,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/estraverse"
         }
       ]
@@ -8924,7 +8924,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/esutils"
         }
       ]
@@ -8950,7 +8950,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/etag"
         }
       ]
@@ -8976,7 +8976,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/eventemitter2"
         }
       ]
@@ -9002,7 +9002,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/eventemitter3"
         }
       ]
@@ -9028,7 +9028,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/exif"
         }
       ]
@@ -9054,7 +9054,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/exit"
         }
       ]
@@ -9080,7 +9080,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/expand-brackets"
         }
       ],
@@ -9106,7 +9106,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/define-property"
             }
           ]
@@ -9132,7 +9132,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/extend-shallow"
             }
           ]
@@ -9158,7 +9158,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/is-accessor-descriptor"
             }
           ],
@@ -9184,7 +9184,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/expand-brackets/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
@@ -9212,7 +9212,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/is-data-descriptor"
             }
           ],
@@ -9238,7 +9238,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/expand-brackets/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
@@ -9266,7 +9266,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/is-descriptor"
             }
           ]
@@ -9292,7 +9292,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/is-extendable"
             }
           ]
@@ -9318,7 +9318,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/kind-of"
             }
           ]
@@ -9346,7 +9346,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/expand-template"
         }
       ]
@@ -9372,7 +9372,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/expand-tilde"
         }
       ]
@@ -9398,7 +9398,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-ipfilter"
         }
       ]
@@ -9424,7 +9424,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-jwt"
         }
       ],
@@ -9450,7 +9450,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/express-jwt/node_modules/jsonwebtoken"
             }
           ]
@@ -9476,7 +9476,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/express-jwt/node_modules/moment"
             }
           ]
@@ -9504,7 +9504,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-rate-limit"
         }
       ]
@@ -9530,7 +9530,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-robots-txt"
         }
       ]
@@ -9556,7 +9556,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-security.txt"
         }
       ]
@@ -9582,7 +9582,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express"
         }
       ],
@@ -9608,7 +9608,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/express/node_modules/cookie"
             }
           ]
@@ -9634,7 +9634,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/express/node_modules/safe-buffer"
             }
           ]
@@ -9662,7 +9662,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ext-list"
         }
       ]
@@ -9688,7 +9688,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ext-name"
         }
       ]
@@ -9714,7 +9714,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/extend-shallow"
         }
       ]
@@ -9740,7 +9740,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/extend"
         }
       ]
@@ -9766,7 +9766,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/extglob"
         }
       ],
@@ -9792,7 +9792,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/extglob/node_modules/define-property"
             }
           ]
@@ -9818,7 +9818,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/extglob/node_modules/extend-shallow"
             }
           ]
@@ -9844,7 +9844,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/extglob/node_modules/is-extendable"
             }
           ]
@@ -9872,7 +9872,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/extsprintf"
         }
       ]
@@ -9898,7 +9898,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fast-deep-equal"
         }
       ]
@@ -9924,7 +9924,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fast-json-stable-stringify"
         }
       ]
@@ -9950,7 +9950,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fast-levenshtein"
         }
       ]
@@ -9976,7 +9976,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fast.js"
         }
       ]
@@ -10002,7 +10002,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fd-slicer"
         }
       ]
@@ -10028,7 +10028,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/feature-policy"
         }
       ]
@@ -10054,7 +10054,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fecha"
         }
       ]
@@ -10080,7 +10080,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/file-js"
         }
       ],
@@ -10106,7 +10106,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/file-js/node_modules/brace-expansion"
             }
           ]
@@ -10132,7 +10132,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/file-js/node_modules/minimatch"
             }
           ]
@@ -10160,7 +10160,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/file-stream-rotator"
         }
       ]
@@ -10186,7 +10186,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/file-type"
         }
       ]
@@ -10212,7 +10212,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/file-uri-to-path"
         }
       ]
@@ -10238,7 +10238,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/filehound"
         }
       ]
@@ -10264,7 +10264,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/filename-reserved-regex"
         }
       ]
@@ -10290,7 +10290,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/filenamify"
         }
       ]
@@ -10316,7 +10316,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/filesniffer"
         }
       ]
@@ -10342,7 +10342,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fill-range"
         }
       ],
@@ -10368,7 +10368,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/fill-range/node_modules/extend-shallow"
             }
           ]
@@ -10394,7 +10394,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/fill-range/node_modules/is-extendable"
             }
           ]
@@ -10422,7 +10422,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/finale-rest"
         }
       ]
@@ -10448,7 +10448,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/finalhandler"
         }
       ]
@@ -10474,7 +10474,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/find-up"
         }
       ]
@@ -10500,7 +10500,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/findup-sync"
         }
       ]
@@ -10526,7 +10526,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fined"
         }
       ]
@@ -10552,7 +10552,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/flagged-respawn"
         }
       ]
@@ -10578,7 +10578,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fn.name"
         }
       ]
@@ -10604,7 +10604,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fontkit"
         }
       ]
@@ -10630,7 +10630,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/for-each"
         }
       ]
@@ -10656,7 +10656,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/for-in"
         }
       ]
@@ -10682,7 +10682,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/for-own"
         }
       ]
@@ -10708,7 +10708,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/foreachasync"
         }
       ]
@@ -10734,7 +10734,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/forever-agent"
         }
       ]
@@ -10760,7 +10760,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/form-data"
         }
       ]
@@ -10786,7 +10786,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/formatio"
         }
       ]
@@ -10812,7 +10812,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/forwarded"
         }
       ]
@@ -10838,7 +10838,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fragment-cache"
         }
       ]
@@ -10864,7 +10864,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fresh"
         }
       ]
@@ -10890,7 +10890,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/from2"
         }
       ]
@@ -10916,7 +10916,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fs-constants"
         }
       ]
@@ -10942,7 +10942,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fs-extra"
         }
       ]
@@ -10968,7 +10968,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fs-minipass"
         }
       ]
@@ -10994,7 +10994,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fs.realpath"
         }
       ]
@@ -11020,7 +11020,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fsevents"
         }
       ]
@@ -11046,7 +11046,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fstream"
         }
       ],
@@ -11072,7 +11072,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/fstream/node_modules/mkdirp"
             }
           ]
@@ -11098,7 +11098,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/fstream/node_modules/rimraf"
             }
           ]
@@ -11126,7 +11126,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/function-bind"
         }
       ]
@@ -11152,7 +11152,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/function.prototype.name"
         }
       ]
@@ -11178,7 +11178,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/functions-have-names"
         }
       ]
@@ -11204,7 +11204,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fuzzball"
         }
       ]
@@ -11230,7 +11230,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/gauge"
         }
       ]
@@ -11256,7 +11256,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/geojson-utils"
         }
       ]
@@ -11282,7 +11282,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-caller-file"
         }
       ]
@@ -11308,7 +11308,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-intrinsic"
         }
       ]
@@ -11334,7 +11334,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-stream"
         }
       ]
@@ -11360,7 +11360,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-symbol-description"
         }
       ]
@@ -11386,7 +11386,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-value"
         }
       ]
@@ -11412,7 +11412,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/getobject"
         }
       ]
@@ -11438,7 +11438,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/getpass"
         }
       ]
@@ -11464,7 +11464,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/github-from-package"
         }
       ]
@@ -11490,7 +11490,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/glob-parent"
         }
       ],
@@ -11516,7 +11516,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/glob-parent/node_modules/is-glob"
             }
           ]
@@ -11544,7 +11544,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/glob"
         }
       ],
@@ -11570,7 +11570,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/glob/node_modules/brace-expansion"
             }
           ]
@@ -11596,7 +11596,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/glob/node_modules/minimatch"
             }
           ]
@@ -11624,7 +11624,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/global-modules"
         }
       ]
@@ -11650,7 +11650,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/global-prefix"
         }
       ],
@@ -11676,7 +11676,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/global-prefix/node_modules/which"
             }
           ]
@@ -11704,7 +11704,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/got"
         }
       ],
@@ -11730,7 +11730,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/got/node_modules/get-stream"
             }
           ]
@@ -11756,7 +11756,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/got/node_modules/pify"
             }
           ]
@@ -11784,7 +11784,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/graceful-fs"
         }
       ]
@@ -11810,7 +11810,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-cli"
         }
       ],
@@ -11836,7 +11836,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-cli/node_modules/nopt"
             }
           ]
@@ -11864,7 +11864,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-contrib-compress"
         }
       ],
@@ -11890,7 +11890,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-contrib-compress/node_modules/ansi-styles"
             }
           ]
@@ -11916,7 +11916,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-contrib-compress/node_modules/chalk"
             }
           ]
@@ -11942,7 +11942,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-contrib-compress/node_modules/supports-color"
             }
           ]
@@ -11970,7 +11970,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-known-options"
         }
       ]
@@ -11996,7 +11996,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-legacy-log-utils"
         }
       ],
@@ -12022,7 +12022,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils/node_modules/ansi-styles"
             }
           ]
@@ -12048,7 +12048,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils/node_modules/chalk"
             }
           ]
@@ -12074,7 +12074,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils/node_modules/color-convert"
             }
           ]
@@ -12100,7 +12100,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils/node_modules/color-name"
             }
           ]
@@ -12126,7 +12126,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils/node_modules/has-flag"
             }
           ]
@@ -12152,7 +12152,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils/node_modules/supports-color"
             }
           ]
@@ -12180,7 +12180,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-legacy-log"
         }
       ],
@@ -12206,7 +12206,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log/node_modules/colors"
             }
           ]
@@ -12234,7 +12234,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-legacy-util"
         }
       ],
@@ -12260,7 +12260,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-util/node_modules/async"
             }
           ]
@@ -12288,7 +12288,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-replace-json"
         }
       ]
@@ -12314,7 +12314,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt"
         }
       ],
@@ -12340,7 +12340,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt/node_modules/brace-expansion"
             }
           ]
@@ -12366,7 +12366,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt/node_modules/findup-sync"
             }
           ],
@@ -12392,7 +12392,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/grunt/node_modules/findup-sync/node_modules/glob"
                 }
               ]
@@ -12420,7 +12420,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt/node_modules/glob"
             }
           ]
@@ -12446,7 +12446,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt/node_modules/minimatch"
             }
           ]
@@ -12474,7 +12474,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/handlebars"
         }
       ],
@@ -12500,7 +12500,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/handlebars/node_modules/wordwrap"
             }
           ]
@@ -12528,7 +12528,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/har-schema"
         }
       ]
@@ -12554,7 +12554,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/har-validator"
         }
       ]
@@ -12580,7 +12580,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-ansi"
         }
       ]
@@ -12606,7 +12606,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-bigints"
         }
       ]
@@ -12632,7 +12632,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-flag"
         }
       ]
@@ -12658,7 +12658,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-property-descriptors"
         }
       ]
@@ -12684,7 +12684,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-symbol-support-x"
         }
       ]
@@ -12710,7 +12710,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-symbols"
         }
       ]
@@ -12736,7 +12736,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-to-string-tag-x"
         }
       ]
@@ -12762,7 +12762,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-tostringtag"
         }
       ]
@@ -12788,7 +12788,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-unicode"
         }
       ]
@@ -12814,7 +12814,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-value"
         }
       ]
@@ -12840,7 +12840,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-values"
         }
       ],
@@ -12866,7 +12866,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/has-values/node_modules/kind-of"
             }
           ]
@@ -12894,7 +12894,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has"
         }
       ]
@@ -12920,7 +12920,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hashids"
         }
       ]
@@ -12946,7 +12946,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hbs"
         }
       ]
@@ -12972,7 +12972,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/he"
         }
       ]
@@ -12998,7 +12998,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/heap"
         }
       ]
@@ -13024,7 +13024,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/helmet"
         }
       ]
@@ -13050,7 +13050,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hoister"
         }
       ]
@@ -13076,7 +13076,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/homedir-polyfill"
         }
       ]
@@ -13102,7 +13102,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hooker"
         }
       ]
@@ -13128,7 +13128,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hosted-git-info"
         }
       ]
@@ -13154,7 +13154,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/html-entities"
         }
       ]
@@ -13180,7 +13180,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/htmlparser2"
         }
       ],
@@ -13206,7 +13206,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/htmlparser2/node_modules/isarray"
             }
           ]
@@ -13232,7 +13232,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/htmlparser2/node_modules/readable-stream"
             }
           ]
@@ -13258,7 +13258,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/htmlparser2/node_modules/string_decoder"
             }
           ]
@@ -13286,7 +13286,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/http-cache-semantics"
         }
       ]
@@ -13312,7 +13312,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/http-errors"
         }
       ]
@@ -13338,7 +13338,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/http-proxy-agent"
         }
       ],
@@ -13364,7 +13364,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/http-proxy-agent/node_modules/debug"
             }
           ]
@@ -13390,7 +13390,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/http-proxy-agent/node_modules/ms"
             }
           ]
@@ -13418,7 +13418,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/http-signature"
         }
       ]
@@ -13444,7 +13444,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/https-proxy-agent"
         }
       ],
@@ -13470,7 +13470,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/https-proxy-agent/node_modules/debug"
             }
           ]
@@ -13496,7 +13496,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/https-proxy-agent/node_modules/ms"
             }
           ]
@@ -13524,7 +13524,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/humanize-ms"
         }
       ]
@@ -13550,7 +13550,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/i18n"
         }
       ]
@@ -13576,7 +13576,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/iconv-lite"
         }
       ]
@@ -13602,7 +13602,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ieee754"
         }
       ]
@@ -13628,7 +13628,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ignore-walk"
         }
       ],
@@ -13654,7 +13654,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/ignore-walk/node_modules/brace-expansion"
             }
           ]
@@ -13680,7 +13680,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/ignore-walk/node_modules/minimatch"
             }
           ]
@@ -13708,7 +13708,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/iltorb"
         }
       ]
@@ -13734,7 +13734,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/imurmurhash"
         }
       ]
@@ -13760,7 +13760,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/indent-string"
         }
       ]
@@ -13786,7 +13786,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/infer-owner"
         }
       ]
@@ -13812,7 +13812,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/inflection"
         }
       ]
@@ -13838,7 +13838,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/inflight"
         }
       ]
@@ -13864,7 +13864,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/inherits"
         }
       ]
@@ -13890,7 +13890,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ini"
         }
       ]
@@ -13916,7 +13916,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/internal-slot"
         }
       ]
@@ -13942,7 +13942,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/interpret"
         }
       ]
@@ -13968,7 +13968,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/into-stream"
         }
       ]
@@ -13994,7 +13994,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/invariant"
         }
       ]
@@ -14020,7 +14020,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ip"
         }
       ]
@@ -14046,7 +14046,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ip6"
         }
       ]
@@ -14072,7 +14072,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ipaddr.js"
         }
       ]
@@ -14098,7 +14098,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-absolute"
         }
       ]
@@ -14124,7 +14124,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-accessor-descriptor"
         }
       ]
@@ -14150,7 +14150,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-arguments"
         }
       ]
@@ -14176,7 +14176,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-arrayish"
         }
       ]
@@ -14202,7 +14202,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-bigint"
         }
       ]
@@ -14228,7 +14228,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-binary-path"
         }
       ]
@@ -14254,7 +14254,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-boolean-object"
         }
       ]
@@ -14280,7 +14280,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-buffer"
         }
       ]
@@ -14306,7 +14306,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-callable"
         }
       ]
@@ -14332,7 +14332,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-core-module"
         }
       ]
@@ -14358,7 +14358,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-data-descriptor"
         }
       ]
@@ -14384,7 +14384,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-date-object"
         }
       ]
@@ -14410,7 +14410,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-descriptor"
         }
       ]
@@ -14436,7 +14436,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-docker"
         }
       ]
@@ -14462,7 +14462,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-expression"
         }
       ]
@@ -14488,7 +14488,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-extendable"
         }
       ]
@@ -14514,7 +14514,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-extglob"
         }
       ]
@@ -14540,7 +14540,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-fullwidth-code-point"
         }
       ]
@@ -14566,7 +14566,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-generator-function"
         }
       ]
@@ -14592,7 +14592,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-glob"
         }
       ]
@@ -14618,7 +14618,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-heroku"
         }
       ]
@@ -14644,7 +14644,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-lambda"
         }
       ]
@@ -14670,7 +14670,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-map"
         }
       ]
@@ -14696,7 +14696,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-natural-number"
         }
       ]
@@ -14722,7 +14722,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-negative-zero"
         }
       ]
@@ -14748,7 +14748,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-number-like"
         }
       ]
@@ -14774,7 +14774,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-number-object"
         }
       ]
@@ -14800,7 +14800,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-number"
         }
       ],
@@ -14826,7 +14826,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/is-number/node_modules/kind-of"
             }
           ]
@@ -14854,7 +14854,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-object"
         }
       ]
@@ -14880,7 +14880,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-plain-obj"
         }
       ]
@@ -14906,7 +14906,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-plain-object"
         }
       ]
@@ -14932,7 +14932,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-promise"
         }
       ]
@@ -14958,7 +14958,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-regex"
         }
       ]
@@ -14984,7 +14984,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-relative"
         }
       ]
@@ -15010,7 +15010,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-retry-allowed"
         }
       ]
@@ -15036,7 +15036,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-set"
         }
       ]
@@ -15062,7 +15062,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-shared-array-buffer"
         }
       ]
@@ -15088,7 +15088,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-stream"
         }
       ]
@@ -15114,7 +15114,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-string"
         }
       ]
@@ -15140,7 +15140,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-symbol"
         }
       ]
@@ -15166,7 +15166,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-typed-array"
         }
       ]
@@ -15192,7 +15192,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-typedarray"
         }
       ]
@@ -15218,7 +15218,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-unc-path"
         }
       ]
@@ -15244,7 +15244,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-weakmap"
         }
       ]
@@ -15270,7 +15270,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-weakref"
         }
       ]
@@ -15296,7 +15296,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-weakset"
         }
       ]
@@ -15322,7 +15322,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-windows"
         }
       ]
@@ -15348,7 +15348,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isarray"
         }
       ]
@@ -15374,7 +15374,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isexe"
         }
       ]
@@ -15400,7 +15400,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isobject"
         }
       ]
@@ -15426,7 +15426,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isstream"
         }
       ]
@@ -15452,7 +15452,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isurl"
         }
       ]
@@ -15478,7 +15478,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/js-stringify"
         }
       ]
@@ -15504,7 +15504,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/js-tokens"
         }
       ]
@@ -15530,7 +15530,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/js-yaml"
         }
       ]
@@ -15556,7 +15556,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jsbn"
         }
       ]
@@ -15582,7 +15582,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-buffer"
         }
       ]
@@ -15608,7 +15608,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-parse-better-errors"
         }
       ]
@@ -15634,7 +15634,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-schema-traverse"
         }
       ]
@@ -15660,7 +15660,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-schema"
         }
       ]
@@ -15686,7 +15686,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-stringify-safe"
         }
       ]
@@ -15712,7 +15712,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json5"
         }
       ]
@@ -15738,7 +15738,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jsonfile"
         }
       ]
@@ -15764,7 +15764,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jsonwebtoken"
         }
       ]
@@ -15790,7 +15790,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jsprim"
         }
       ]
@@ -15816,7 +15816,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jssha"
         }
       ]
@@ -15842,7 +15842,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jstransformer"
         }
       ]
@@ -15868,7 +15868,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/juicy-chat-bot"
         }
       ]
@@ -15894,7 +15894,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jwa"
         }
       ]
@@ -15920,7 +15920,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jws"
         }
       ]
@@ -15946,7 +15946,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/keyv"
         }
       ]
@@ -15972,7 +15972,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/kind-of"
         }
       ]
@@ -15998,7 +15998,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/kuler"
         }
       ]
@@ -16024,7 +16024,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/kuromoji"
         }
       ]
@@ -16050,7 +16050,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lazystream"
         }
       ]
@@ -16076,7 +16076,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/levn"
         }
       ]
@@ -16102,7 +16102,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/libxmljs2"
         }
       ],
@@ -16128,7 +16128,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/libxmljs2/node_modules/nan"
             }
           ]
@@ -16156,7 +16156,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/liftup"
         }
       ],
@@ -16182,7 +16182,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/braces"
             }
           ]
@@ -16208,7 +16208,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/fill-range"
             }
           ]
@@ -16234,7 +16234,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/findup-sync"
             }
           ]
@@ -16260,7 +16260,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/is-glob"
             }
           ]
@@ -16286,7 +16286,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/is-number"
             }
           ]
@@ -16312,7 +16312,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/micromatch"
             }
           ]
@@ -16338,7 +16338,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/to-regex-range"
             }
           ]
@@ -16366,7 +16366,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/linebreak"
         }
       ],
@@ -16392,7 +16392,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/linebreak/node_modules/base64-js"
             }
           ]
@@ -16420,7 +16420,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/listenercount"
         }
       ]
@@ -16446,7 +16446,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/locate-path"
         }
       ]
@@ -16472,7 +16472,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lodash.camelcase"
         }
       ]
@@ -16498,7 +16498,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lodash.isfinite"
         }
       ]
@@ -16524,7 +16524,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lodash.set"
         }
       ]
@@ -16550,7 +16550,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lodash"
         }
       ]
@@ -16576,7 +16576,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/logform"
         }
       ],
@@ -16602,7 +16602,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/logform/node_modules/ms"
             }
           ]
@@ -16630,7 +16630,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lolex"
         }
       ]
@@ -16656,7 +16656,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/loose-envify"
         }
       ]
@@ -16682,7 +16682,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lowercase-keys"
         }
       ]
@@ -16708,7 +16708,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lru-cache"
         }
       ]
@@ -16734,7 +16734,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-dir"
         }
       ],
@@ -16760,7 +16760,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-dir/node_modules/semver"
             }
           ]
@@ -16788,7 +16788,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-error"
         }
       ]
@@ -16814,7 +16814,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-fetch-happen"
         }
       ],
@@ -16841,7 +16841,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen/node_modules/@tootallnate/once"
             }
           ]
@@ -16867,7 +16867,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen/node_modules/debug"
             }
           ]
@@ -16893,7 +16893,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen/node_modules/http-cache-semantics"
             }
           ]
@@ -16919,7 +16919,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen/node_modules/http-proxy-agent"
             }
           ]
@@ -16945,7 +16945,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen/node_modules/ms"
             }
           ]
@@ -16973,7 +16973,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-iterator"
         }
       ]
@@ -16999,7 +16999,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-plural"
         }
       ]
@@ -17025,7 +17025,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/map-cache"
         }
       ]
@@ -17051,7 +17051,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/map-visit"
         }
       ]
@@ -17077,7 +17077,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/marsdb"
         }
       ]
@@ -17103,7 +17103,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/math-interval-parser"
         }
       ]
@@ -17129,7 +17129,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/media-typer"
         }
       ]
@@ -17155,7 +17155,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/merge-descriptors"
         }
       ]
@@ -17181,7 +17181,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/messageformat-formatters"
         }
       ]
@@ -17207,7 +17207,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/messageformat-parser"
         }
       ]
@@ -17233,7 +17233,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/messageformat"
         }
       ],
@@ -17259,7 +17259,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/messageformat/node_modules/make-plural"
             }
           ]
@@ -17287,7 +17287,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/methods"
         }
       ]
@@ -17313,7 +17313,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/micromatch"
         }
       ]
@@ -17339,7 +17339,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mime-db"
         }
       ]
@@ -17365,7 +17365,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mime-types"
         }
       ]
@@ -17391,7 +17391,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mime"
         }
       ]
@@ -17417,7 +17417,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mimic-response"
         }
       ]
@@ -17443,7 +17443,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minimatch"
         }
       ]
@@ -17469,7 +17469,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minimist"
         }
       ]
@@ -17495,7 +17495,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-collect"
         }
       ]
@@ -17521,7 +17521,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-fetch"
         }
       ]
@@ -17547,7 +17547,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-flush"
         }
       ]
@@ -17573,7 +17573,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-pipeline"
         }
       ]
@@ -17599,7 +17599,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-sized"
         }
       ]
@@ -17625,7 +17625,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass"
         }
       ]
@@ -17651,7 +17651,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minizlib"
         }
       ]
@@ -17677,7 +17677,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mixin-deep"
         }
       ]
@@ -17703,7 +17703,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mkdirp-classic"
         }
       ]
@@ -17729,7 +17729,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mkdirp"
         }
       ]
@@ -17755,7 +17755,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/moment-timezone"
         }
       ]
@@ -17781,7 +17781,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/moment"
         }
       ]
@@ -17807,7 +17807,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/morgan"
         }
       ],
@@ -17833,7 +17833,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/morgan/node_modules/on-finished"
             }
           ]
@@ -17861,7 +17861,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mout"
         }
       ]
@@ -17887,7 +17887,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ms"
         }
       ]
@@ -17913,7 +17913,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/multer"
         }
       ],
@@ -17939,7 +17939,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/multer/node_modules/mkdirp"
             }
           ]
@@ -17967,7 +17967,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mustache"
         }
       ]
@@ -17993,7 +17993,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/nan"
         }
       ]
@@ -18019,7 +18019,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/nanomatch"
         }
       ]
@@ -18045,7 +18045,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/napi-build-utils"
         }
       ]
@@ -18071,7 +18071,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/needle"
         }
       ],
@@ -18097,7 +18097,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/needle/node_modules/debug"
             }
           ]
@@ -18123,7 +18123,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/needle/node_modules/ms"
             }
           ]
@@ -18151,7 +18151,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/negotiator"
         }
       ]
@@ -18177,7 +18177,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/neo-async"
         }
       ]
@@ -18203,7 +18203,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-abi"
         }
       ],
@@ -18229,7 +18229,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-abi/node_modules/semver"
             }
           ]
@@ -18257,7 +18257,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-addon-api"
         }
       ]
@@ -18283,7 +18283,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-fetch"
         }
       ]
@@ -18309,7 +18309,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-gyp"
         }
       ],
@@ -18335,7 +18335,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/ansi-regex"
             }
           ]
@@ -18361,7 +18361,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/are-we-there-yet"
             }
           ]
@@ -18387,7 +18387,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/gauge"
             }
           ]
@@ -18413,7 +18413,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -18439,7 +18439,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/nopt"
             }
           ]
@@ -18465,7 +18465,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/npmlog"
             }
           ]
@@ -18491,7 +18491,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/readable-stream"
             }
           ]
@@ -18517,7 +18517,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/string-width"
             }
           ]
@@ -18543,7 +18543,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/strip-ansi"
             }
           ]
@@ -18571,7 +18571,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-pre-gyp"
         }
       ],
@@ -18597,7 +18597,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/chownr"
             }
           ]
@@ -18623,7 +18623,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/fs-minipass"
             }
           ]
@@ -18649,7 +18649,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/minipass"
             }
           ]
@@ -18675,7 +18675,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/minizlib"
             }
           ]
@@ -18701,7 +18701,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/mkdirp"
             }
           ]
@@ -18727,7 +18727,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/nopt"
             }
           ]
@@ -18753,7 +18753,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/rimraf"
             }
           ]
@@ -18779,7 +18779,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/safe-buffer"
             }
           ]
@@ -18805,7 +18805,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/semver"
             }
           ]
@@ -18831,7 +18831,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/tar"
             }
           ]
@@ -18857,7 +18857,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/yallist"
             }
           ]
@@ -18885,7 +18885,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/noop-logger"
         }
       ]
@@ -18911,7 +18911,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/nopt"
         }
       ]
@@ -18937,7 +18937,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/normalize-package-data"
         }
       ],
@@ -18963,7 +18963,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/normalize-package-data/node_modules/semver"
             }
           ]
@@ -18991,7 +18991,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/normalize-path"
         }
       ]
@@ -19017,7 +19017,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/normalize-url"
         }
       ]
@@ -19043,7 +19043,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/notevil"
         }
       ],
@@ -19069,7 +19069,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/notevil/node_modules/esprima"
             }
           ]
@@ -19097,7 +19097,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/npm-bundled"
         }
       ]
@@ -19123,7 +19123,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/npm-normalize-package-bin"
         }
       ]
@@ -19149,7 +19149,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/npm-packlist"
         }
       ]
@@ -19175,7 +19175,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/npmlog"
         }
       ]
@@ -19201,7 +19201,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/number-is-nan"
         }
       ]
@@ -19227,7 +19227,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/oauth-sign"
         }
       ]
@@ -19253,7 +19253,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-assign"
         }
       ]
@@ -19279,7 +19279,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-copy"
         }
       ],
@@ -19305,7 +19305,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy/node_modules/define-property"
             }
           ]
@@ -19331,7 +19331,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy/node_modules/is-accessor-descriptor"
             }
           ]
@@ -19357,7 +19357,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy/node_modules/is-data-descriptor"
             }
           ]
@@ -19383,7 +19383,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy/node_modules/is-descriptor"
             }
           ],
@@ -19409,7 +19409,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/object-copy/node_modules/is-descriptor/node_modules/kind-of"
                 }
               ]
@@ -19437,7 +19437,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy/node_modules/kind-of"
             }
           ]
@@ -19465,7 +19465,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-inspect"
         }
       ]
@@ -19491,7 +19491,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-is"
         }
       ]
@@ -19517,7 +19517,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-keys"
         }
       ]
@@ -19543,7 +19543,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-visit"
         }
       ]
@@ -19569,7 +19569,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object.assign"
         }
       ]
@@ -19595,7 +19595,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object.defaults"
         }
       ]
@@ -19621,7 +19621,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object.map"
         }
       ]
@@ -19647,7 +19647,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object.pick"
         }
       ]
@@ -19673,7 +19673,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/on-finished"
         }
       ]
@@ -19699,7 +19699,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/on-headers"
         }
       ]
@@ -19725,7 +19725,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/once"
         }
       ]
@@ -19751,7 +19751,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/one-time"
         }
       ]
@@ -19777,7 +19777,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/opentype.js"
         }
       ]
@@ -19803,7 +19803,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/optionator"
         }
       ]
@@ -19829,7 +19829,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/os-homedir"
         }
       ]
@@ -19855,7 +19855,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/os-tmpdir"
         }
       ]
@@ -19881,7 +19881,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/osenv"
         }
       ]
@@ -19907,7 +19907,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/otplib"
         }
       ]
@@ -19933,7 +19933,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-cancelable"
         }
       ]
@@ -19959,7 +19959,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-event"
         }
       ]
@@ -19985,7 +19985,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-finally"
         }
       ]
@@ -20011,7 +20011,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-is-promise"
         }
       ]
@@ -20037,7 +20037,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-limit"
         }
       ]
@@ -20063,7 +20063,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-locate"
         }
       ]
@@ -20089,7 +20089,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-map"
         }
       ]
@@ -20115,7 +20115,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-timeout"
         }
       ]
@@ -20141,7 +20141,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-try"
         }
       ]
@@ -20167,7 +20167,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pako"
         }
       ]
@@ -20193,7 +20193,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/parse-filepath"
         }
       ]
@@ -20219,7 +20219,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/parse-json"
         }
       ]
@@ -20245,7 +20245,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/parse-passwd"
         }
       ]
@@ -20271,7 +20271,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/parseurl"
         }
       ]
@@ -20297,7 +20297,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pascalcase"
         }
       ]
@@ -20323,7 +20323,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-exists"
         }
       ]
@@ -20349,7 +20349,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-is-absolute"
         }
       ]
@@ -20375,7 +20375,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-parse"
         }
       ]
@@ -20401,7 +20401,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-root-regex"
         }
       ]
@@ -20427,7 +20427,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-root"
         }
       ]
@@ -20453,7 +20453,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-to-regexp"
         }
       ]
@@ -20479,7 +20479,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pdfkit"
         }
       ]
@@ -20505,7 +20505,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/peek-readable"
         }
       ]
@@ -20531,7 +20531,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pend"
         }
       ]
@@ -20557,7 +20557,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/performance-now"
         }
       ]
@@ -20583,7 +20583,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pg-connection-string"
         }
       ]
@@ -20609,7 +20609,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/picomatch"
         }
       ]
@@ -20635,7 +20635,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pify"
         }
       ]
@@ -20661,7 +20661,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pinkie-promise"
         }
       ]
@@ -20687,7 +20687,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pinkie"
         }
       ]
@@ -20713,7 +20713,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/png-js"
         }
       ]
@@ -20739,7 +20739,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/portscanner"
         }
       ]
@@ -20765,7 +20765,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/posix-character-classes"
         }
       ]
@@ -20791,7 +20791,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/prebuild-install"
         }
       ]
@@ -20817,7 +20817,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/prelude-ls"
         }
       ]
@@ -20843,7 +20843,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/prepend-http"
         }
       ]
@@ -20869,7 +20869,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pretty-bytes"
         }
       ]
@@ -20895,7 +20895,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/process-nextick-args"
         }
       ]
@@ -20921,7 +20921,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/prom-client"
         }
       ]
@@ -20947,7 +20947,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/promise-inflight"
         }
       ]
@@ -20973,7 +20973,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/promise-retry"
         }
       ],
@@ -20999,7 +20999,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/promise-retry/node_modules/err-code"
             }
           ]
@@ -21025,7 +21025,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/promise-retry/node_modules/retry"
             }
           ]
@@ -21053,7 +21053,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/promise"
         }
       ]
@@ -21079,7 +21079,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/proper-lockfile"
         }
       ]
@@ -21105,7 +21105,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/proxy-addr"
         }
       ]
@@ -21131,7 +21131,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/psl"
         }
       ]
@@ -21157,7 +21157,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-attrs"
         }
       ]
@@ -21183,7 +21183,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-code-gen"
         }
       ]
@@ -21209,7 +21209,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-error"
         }
       ]
@@ -21235,7 +21235,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-filters"
         }
       ]
@@ -21261,7 +21261,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-lexer"
         }
       ]
@@ -21287,7 +21287,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-linker"
         }
       ]
@@ -21313,7 +21313,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-load"
         }
       ]
@@ -21339,7 +21339,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-parser"
         }
       ]
@@ -21365,7 +21365,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-runtime"
         }
       ]
@@ -21391,7 +21391,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-strip-comments"
         }
       ]
@@ -21417,7 +21417,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-walk"
         }
       ]
@@ -21443,7 +21443,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug"
         }
       ]
@@ -21469,7 +21469,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pump"
         }
       ]
@@ -21495,7 +21495,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/punycode"
         }
       ]
@@ -21521,7 +21521,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/qs"
         }
       ]
@@ -21547,7 +21547,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/query-string"
         }
       ]
@@ -21573,7 +21573,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/range_check"
         }
       ]
@@ -21599,7 +21599,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/range-parser"
         }
       ]
@@ -21625,7 +21625,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/raw-body"
         }
       ]
@@ -21651,7 +21651,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/rc"
         }
       ]
@@ -21677,7 +21677,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/read-pkg"
         }
       ],
@@ -21703,7 +21703,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/read-pkg/node_modules/pify"
             }
           ]
@@ -21731,7 +21731,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/readable-stream"
         }
       ],
@@ -21757,7 +21757,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/readable-stream/node_modules/isarray"
             }
           ]
@@ -21785,7 +21785,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/readable-web-to-node-stream"
         }
       ],
@@ -21811,7 +21811,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/readable-web-to-node-stream/node_modules/readable-stream"
             }
           ]
@@ -21839,7 +21839,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/readdirp"
         }
       ]
@@ -21865,7 +21865,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/rechoir"
         }
       ]
@@ -21891,7 +21891,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/regex-not"
         }
       ]
@@ -21917,7 +21917,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/regexp.prototype.flags"
         }
       ]
@@ -21943,7 +21943,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/remove-trailing-separator"
         }
       ]
@@ -21969,7 +21969,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/repeat-element"
         }
       ]
@@ -21995,7 +21995,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/repeat-string"
         }
       ]
@@ -22021,7 +22021,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/replace"
         }
       ],
@@ -22047,7 +22047,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/ansi-regex"
             }
           ]
@@ -22073,7 +22073,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/ansi-styles"
             }
           ]
@@ -22099,7 +22099,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/brace-expansion"
             }
           ]
@@ -22125,7 +22125,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/cliui"
             }
           ]
@@ -22151,7 +22151,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/color-convert"
             }
           ]
@@ -22177,7 +22177,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/color-name"
             }
           ]
@@ -22203,7 +22203,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/find-up"
             }
           ]
@@ -22229,7 +22229,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -22255,7 +22255,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/locate-path"
             }
           ]
@@ -22281,7 +22281,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/minimatch"
             }
           ]
@@ -22307,7 +22307,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/p-locate"
             }
           ]
@@ -22333,7 +22333,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/path-exists"
             }
           ]
@@ -22359,7 +22359,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/string-width"
             }
           ]
@@ -22385,7 +22385,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/strip-ansi"
             }
           ]
@@ -22411,7 +22411,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/wrap-ansi"
             }
           ]
@@ -22437,7 +22437,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/yargs-parser"
             }
           ]
@@ -22463,7 +22463,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/yargs"
             }
           ]
@@ -22491,7 +22491,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/request"
         }
       ],
@@ -22517,7 +22517,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/request/node_modules/qs"
             }
           ]
@@ -22545,7 +22545,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/require-directory"
         }
       ]
@@ -22571,7 +22571,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/require-main-filename"
         }
       ]
@@ -22597,7 +22597,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/resolve-dir"
         }
       ]
@@ -22623,7 +22623,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/resolve-url"
         }
       ]
@@ -22649,7 +22649,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/resolve"
         }
       ]
@@ -22675,7 +22675,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/responselike"
         }
       ]
@@ -22701,7 +22701,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/restructure"
         }
       ]
@@ -22727,7 +22727,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ret"
         }
       ]
@@ -22753,7 +22753,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/retry-as-promised"
         }
       ]
@@ -22779,7 +22779,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/retry"
         }
       ]
@@ -22805,7 +22805,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/rimraf"
         }
       ]
@@ -22831,7 +22831,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/rxjs"
         }
       ],
@@ -22857,7 +22857,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/rxjs/node_modules/tslib"
             }
           ]
@@ -22885,7 +22885,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safe-buffer"
         }
       ]
@@ -22911,7 +22911,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safe-regex-test"
         }
       ]
@@ -22937,7 +22937,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safe-regex"
         }
       ]
@@ -22963,7 +22963,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safe-stable-stringify"
         }
       ]
@@ -22989,7 +22989,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safer-buffer"
         }
       ]
@@ -23015,7 +23015,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/samsam"
         }
       ]
@@ -23041,7 +23041,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sanitize-filename"
         }
       ]
@@ -23067,7 +23067,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sanitize-html"
         }
       ],
@@ -23093,7 +23093,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sanitize-html/node_modules/lodash"
             }
           ]
@@ -23121,7 +23121,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sax"
         }
       ]
@@ -23147,7 +23147,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/seek-bzip"
         }
       ]
@@ -23173,7 +23173,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/semver"
         }
       ]
@@ -23199,7 +23199,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/send"
         }
       ],
@@ -23225,7 +23225,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/send/node_modules/ms"
             }
           ]
@@ -23253,7 +23253,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sequelize-pool"
         }
       ]
@@ -23279,7 +23279,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sequelize"
         }
       ],
@@ -23305,7 +23305,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sequelize/node_modules/debug"
             }
           ]
@@ -23331,7 +23331,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sequelize/node_modules/ms"
             }
           ]
@@ -23357,7 +23357,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sequelize/node_modules/uuid"
             }
           ]
@@ -23385,7 +23385,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/serve-index"
         }
       ],
@@ -23411,7 +23411,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index/node_modules/depd"
             }
           ]
@@ -23437,7 +23437,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index/node_modules/http-errors"
             }
           ]
@@ -23463,7 +23463,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index/node_modules/inherits"
             }
           ]
@@ -23489,7 +23489,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index/node_modules/setprototypeof"
             }
           ]
@@ -23515,7 +23515,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index/node_modules/statuses"
             }
           ]
@@ -23543,7 +23543,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/serve-static"
         }
       ]
@@ -23569,7 +23569,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/set-blocking"
         }
       ]
@@ -23595,7 +23595,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/set-value"
         }
       ],
@@ -23621,7 +23621,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/set-value/node_modules/extend-shallow"
             }
           ]
@@ -23647,7 +23647,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/set-value/node_modules/is-extendable"
             }
           ]
@@ -23675,7 +23675,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/setimmediate"
         }
       ]
@@ -23701,7 +23701,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/setprototypeof"
         }
       ]
@@ -23727,7 +23727,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/side-channel"
         }
       ]
@@ -23753,7 +23753,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/signal-exit"
         }
       ]
@@ -23779,7 +23779,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/simple-concat"
         }
       ]
@@ -23805,7 +23805,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/simple-get"
         }
       ],
@@ -23831,7 +23831,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/simple-get/node_modules/decompress-response"
             }
           ]
@@ -23857,7 +23857,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/simple-get/node_modules/mimic-response"
             }
           ]
@@ -23885,7 +23885,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/simple-swizzle"
         }
       ],
@@ -23911,7 +23911,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/simple-swizzle/node_modules/is-arrayish"
             }
           ]
@@ -23939,7 +23939,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sinon"
         }
       ]
@@ -23965,7 +23965,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/smart-buffer"
         }
       ]
@@ -23991,7 +23991,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/snapdragon-node"
         }
       ],
@@ -24017,7 +24017,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon-node/node_modules/define-property"
             }
           ]
@@ -24045,7 +24045,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/snapdragon-util"
         }
       ],
@@ -24071,7 +24071,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon-util/node_modules/kind-of"
             }
           ]
@@ -24099,7 +24099,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/snapdragon"
         }
       ],
@@ -24125,7 +24125,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/define-property"
             }
           ]
@@ -24151,7 +24151,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/extend-shallow"
             }
           ]
@@ -24177,7 +24177,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/is-accessor-descriptor"
             }
           ],
@@ -24203,7 +24203,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/snapdragon/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
@@ -24231,7 +24231,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/is-data-descriptor"
             }
           ],
@@ -24257,7 +24257,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/snapdragon/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
@@ -24285,7 +24285,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/is-descriptor"
             }
           ]
@@ -24311,7 +24311,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/is-extendable"
             }
           ]
@@ -24337,7 +24337,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/kind-of"
             }
           ]
@@ -24363,7 +24363,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/source-map"
             }
           ]
@@ -24391,7 +24391,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socket.io-adapter"
         }
       ]
@@ -24417,7 +24417,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socket.io-parser"
         }
       ],
@@ -24443,7 +24443,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socket.io-parser/node_modules/debug"
             }
           ]
@@ -24469,7 +24469,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socket.io-parser/node_modules/ms"
             }
           ]
@@ -24497,7 +24497,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socket.io"
         }
       ],
@@ -24523,7 +24523,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socket.io/node_modules/debug"
             }
           ]
@@ -24549,7 +24549,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socket.io/node_modules/ms"
             }
           ]
@@ -24577,7 +24577,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socks-proxy-agent"
         }
       ],
@@ -24603,7 +24603,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socks-proxy-agent/node_modules/debug"
             }
           ]
@@ -24629,7 +24629,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socks-proxy-agent/node_modules/ms"
             }
           ]
@@ -24657,7 +24657,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socks"
         }
       ],
@@ -24683,7 +24683,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socks/node_modules/ip"
             }
           ]
@@ -24711,7 +24711,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sort-keys-length"
         }
       ],
@@ -24737,7 +24737,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sort-keys-length/node_modules/sort-keys"
             }
           ]
@@ -24765,7 +24765,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sort-keys"
         }
       ]
@@ -24791,7 +24791,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/source-map-resolve"
         }
       ]
@@ -24817,7 +24817,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/source-map-support"
         }
       ]
@@ -24843,7 +24843,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/source-map-url"
         }
       ]
@@ -24869,7 +24869,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/source-map"
         }
       ]
@@ -24895,7 +24895,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spawn-command"
         }
       ]
@@ -24921,7 +24921,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spdx-correct"
         }
       ]
@@ -24947,7 +24947,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spdx-exceptions"
         }
       ]
@@ -24973,7 +24973,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spdx-expression-parse"
         }
       ]
@@ -24999,7 +24999,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spdx-license-ids"
         }
       ]
@@ -25025,7 +25025,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/split-string"
         }
       ]
@@ -25051,7 +25051,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sprintf-js"
         }
       ]
@@ -25077,7 +25077,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sqlite3"
         }
       ]
@@ -25103,7 +25103,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sshpk"
         }
       ]
@@ -25129,7 +25129,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ssri"
         }
       ]
@@ -25155,7 +25155,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/stack-trace"
         }
       ]
@@ -25181,7 +25181,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/static-extend"
         }
       ],
@@ -25207,7 +25207,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend/node_modules/define-property"
             }
           ]
@@ -25233,7 +25233,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend/node_modules/is-accessor-descriptor"
             }
           ],
@@ -25259,7 +25259,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/static-extend/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
@@ -25287,7 +25287,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend/node_modules/is-data-descriptor"
             }
           ],
@@ -25313,7 +25313,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/static-extend/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
@@ -25341,7 +25341,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend/node_modules/is-descriptor"
             }
           ]
@@ -25367,7 +25367,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend/node_modules/kind-of"
             }
           ]
@@ -25395,7 +25395,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/statuses"
         }
       ]
@@ -25421,7 +25421,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/stream-buffers"
         }
       ]
@@ -25447,7 +25447,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/streamsearch"
         }
       ]
@@ -25473,7 +25473,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strict-uri-encode"
         }
       ]
@@ -25499,7 +25499,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string_decoder"
         }
       ]
@@ -25525,7 +25525,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string-width"
         }
       ]
@@ -25551,7 +25551,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string.fromcodepoint"
         }
       ]
@@ -25577,7 +25577,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string.prototype.codepointat"
         }
       ]
@@ -25603,7 +25603,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string.prototype.trimend"
         }
       ]
@@ -25629,7 +25629,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string.prototype.trimstart"
         }
       ]
@@ -25655,7 +25655,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-ansi"
         }
       ]
@@ -25681,7 +25681,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-bom"
         }
       ]
@@ -25707,7 +25707,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-dirs"
         }
       ]
@@ -25733,7 +25733,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-json-comments"
         }
       ]
@@ -25759,7 +25759,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-outer"
         }
       ]
@@ -25785,7 +25785,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strtok3"
         }
       ]
@@ -25811,7 +25811,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/supports-color"
         }
       ]
@@ -25837,7 +25837,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/supports-preserve-symlinks-flag"
         }
       ]
@@ -25863,7 +25863,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/svg-captcha"
         }
       ]
@@ -25889,7 +25889,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/swagger-ui-dist"
         }
       ]
@@ -25915,7 +25915,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/swagger-ui-express"
         }
       ]
@@ -25941,7 +25941,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tar-fs"
         }
       ],
@@ -25967,7 +25967,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/tar-fs/node_modules/bl"
             }
           ]
@@ -25993,7 +25993,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/tar-fs/node_modules/chownr"
             }
           ]
@@ -26019,7 +26019,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/tar-fs/node_modules/readable-stream"
             }
           ]
@@ -26045,7 +26045,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/tar-fs/node_modules/tar-stream"
             }
           ]
@@ -26073,7 +26073,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tar-stream"
         }
       ]
@@ -26099,7 +26099,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tar"
         }
       ]
@@ -26125,7 +26125,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tdigest"
         }
       ]
@@ -26151,7 +26151,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/text-hex"
         }
       ]
@@ -26177,7 +26177,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/thirty-two"
         }
       ]
@@ -26203,7 +26203,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/through"
         }
       ]
@@ -26229,7 +26229,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/timed-out"
         }
       ]
@@ -26255,7 +26255,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tiny-inflate"
         }
       ]
@@ -26281,7 +26281,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-buffer"
         }
       ]
@@ -26307,7 +26307,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-fast-properties"
         }
       ]
@@ -26333,7 +26333,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-object-path"
         }
       ],
@@ -26359,7 +26359,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/to-object-path/node_modules/kind-of"
             }
           ]
@@ -26387,7 +26387,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-regex-range"
         }
       ]
@@ -26413,7 +26413,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-regex"
         }
       ]
@@ -26439,7 +26439,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/toidentifier"
         }
       ]
@@ -26465,7 +26465,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/token-stream"
         }
       ]
@@ -26491,7 +26491,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/token-types"
         }
       ]
@@ -26517,7 +26517,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/toposort-class"
         }
       ]
@@ -26543,7 +26543,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tough-cookie"
         }
       ]
@@ -26569,7 +26569,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tr46"
         }
       ]
@@ -26595,7 +26595,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/traverse"
         }
       ]
@@ -26621,7 +26621,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tree-kill"
         }
       ]
@@ -26647,7 +26647,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/trim-repeated"
         }
       ]
@@ -26673,7 +26673,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/triple-beam"
         }
       ]
@@ -26699,7 +26699,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/truncate-utf8-bytes"
         }
       ]
@@ -26725,7 +26725,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ts-node-dev"
         }
       ],
@@ -26751,7 +26751,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/ts-node-dev/node_modules/rimraf"
             }
           ]
@@ -26779,7 +26779,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ts-node"
         }
       ]
@@ -26805,7 +26805,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tsconfig"
         }
       ]
@@ -26831,7 +26831,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tslib"
         }
       ]
@@ -26857,7 +26857,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tunnel-agent"
         }
       ]
@@ -26883,7 +26883,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tweetnacl"
         }
       ]
@@ -26909,7 +26909,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/type-check"
         }
       ]
@@ -26935,7 +26935,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/type-is"
         }
       ]
@@ -26961,7 +26961,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/typecast"
         }
       ]
@@ -26987,7 +26987,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/typedarray"
         }
       ]
@@ -27013,7 +27013,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/typescript"
         }
       ]
@@ -27039,7 +27039,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/uglify-js"
         }
       ]
@@ -27065,7 +27065,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unbox-primitive"
         }
       ]
@@ -27091,7 +27091,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unbzip2-stream"
         }
       ]
@@ -27117,7 +27117,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unc-path-regex"
         }
       ]
@@ -27143,7 +27143,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/underscore.string"
         }
       ]
@@ -27169,7 +27169,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unicode-properties"
         }
       ]
@@ -27195,7 +27195,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unicode-trie"
         }
       ]
@@ -27221,7 +27221,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/union-value"
         }
       ],
@@ -27247,7 +27247,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/union-value/node_modules/is-extendable"
             }
           ]
@@ -27275,7 +27275,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unique-filename"
         }
       ]
@@ -27301,7 +27301,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unique-slug"
         }
       ]
@@ -27327,7 +27327,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unit-compare"
         }
       ]
@@ -27353,7 +27353,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/universalify"
         }
       ]
@@ -27379,7 +27379,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unpipe"
         }
       ]
@@ -27405,7 +27405,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unset-value"
         }
       ],
@@ -27431,7 +27431,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/unset-value/node_modules/has-value"
             }
           ],
@@ -27457,7 +27457,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/unset-value/node_modules/has-value/node_modules/isobject"
                 }
               ]
@@ -27485,7 +27485,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/unset-value/node_modules/has-values"
             }
           ]
@@ -27511,7 +27511,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/unset-value/node_modules/isarray"
             }
           ]
@@ -27539,7 +27539,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/untildify"
         }
       ]
@@ -27565,7 +27565,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unzipper"
         }
       ],
@@ -27591,7 +27591,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/unzipper/node_modules/bluebird"
             }
           ]
@@ -27619,7 +27619,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/uri-js"
         }
       ]
@@ -27645,7 +27645,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/urix"
         }
       ]
@@ -27671,7 +27671,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/url-parse-lax"
         }
       ]
@@ -27697,7 +27697,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/url-to-options"
         }
       ]
@@ -27723,7 +27723,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/use"
         }
       ]
@@ -27749,7 +27749,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/utf8-byte-length"
         }
       ]
@@ -27775,7 +27775,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/util-deprecate"
         }
       ]
@@ -27801,7 +27801,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/util"
         }
       ]
@@ -27827,7 +27827,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/utils-merge"
         }
       ]
@@ -27853,7 +27853,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/uuid"
         }
       ]
@@ -27879,7 +27879,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/v8flags"
         }
       ]
@@ -27905,7 +27905,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/validate-npm-package-license"
         }
       ]
@@ -27931,7 +27931,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/validate"
         }
       ]
@@ -27957,7 +27957,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/validator"
         }
       ]
@@ -27983,7 +27983,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/vary"
         }
       ]
@@ -28009,7 +28009,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/verror"
         }
       ],
@@ -28035,7 +28035,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/verror/node_modules/core-util-is"
             }
           ]
@@ -28063,7 +28063,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/vm2"
         }
       ],
@@ -28089,7 +28089,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/vm2/node_modules/acorn"
             }
           ]
@@ -28117,7 +28117,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/void-elements"
         }
       ]
@@ -28143,7 +28143,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/walk"
         }
       ]
@@ -28169,7 +28169,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/walkdir"
         }
       ]
@@ -28195,7 +28195,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/webidl-conversions"
         }
       ]
@@ -28221,7 +28221,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/whatwg-url"
         }
       ]
@@ -28247,7 +28247,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-boxed-primitive"
         }
       ]
@@ -28273,7 +28273,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-collection"
         }
       ]
@@ -28299,7 +28299,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-module"
         }
       ]
@@ -28325,7 +28325,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-pm-runs"
         }
       ]
@@ -28351,7 +28351,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-typed-array"
         }
       ]
@@ -28377,7 +28377,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which"
         }
       ]
@@ -28403,7 +28403,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wide-align"
         }
       ]
@@ -28429,7 +28429,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/winston-transport"
         }
       ],
@@ -28455,7 +28455,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/winston-transport/node_modules/readable-stream"
             }
           ]
@@ -28483,7 +28483,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/winston"
         }
       ],
@@ -28509,7 +28509,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/winston/node_modules/async"
             }
           ]
@@ -28535,7 +28535,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/winston/node_modules/is-stream"
             }
           ]
@@ -28561,7 +28561,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/winston/node_modules/readable-stream"
             }
           ]
@@ -28589,7 +28589,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/with"
         }
       ]
@@ -28615,7 +28615,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wkx"
         }
       ]
@@ -28641,7 +28641,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/word-wrap"
         }
       ]
@@ -28667,7 +28667,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wordwrap"
         }
       ]
@@ -28693,7 +28693,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wrap-ansi"
         }
       ],
@@ -28719,7 +28719,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi/node_modules/ansi-regex"
             }
           ]
@@ -28745,7 +28745,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi/node_modules/emoji-regex"
             }
           ]
@@ -28771,7 +28771,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -28797,7 +28797,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi/node_modules/string-width"
             }
           ]
@@ -28823,7 +28823,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi/node_modules/strip-ansi"
             }
           ]
@@ -28851,7 +28851,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wrappy"
         }
       ]
@@ -28877,7 +28877,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ws"
         }
       ]
@@ -28903,7 +28903,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/xtend"
         }
       ]
@@ -28929,7 +28929,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/y18n"
         }
       ]
@@ -28955,7 +28955,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yallist"
         }
       ]
@@ -28981,7 +28981,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yaml-schema-validator"
         }
       ]
@@ -29007,7 +29007,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yargs-parser"
         }
       ]
@@ -29033,7 +29033,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yargs"
         }
       ],
@@ -29059,7 +29059,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs/node_modules/ansi-regex"
             }
           ]
@@ -29085,7 +29085,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs/node_modules/emoji-regex"
             }
           ]
@@ -29111,7 +29111,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -29137,7 +29137,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs/node_modules/string-width"
             }
           ]
@@ -29163,7 +29163,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs/node_modules/strip-ansi"
             }
           ]
@@ -29191,7 +29191,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yauzl"
         }
       ]
@@ -29217,7 +29217,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yn"
         }
       ]
@@ -29243,7 +29243,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/z85"
         }
       ]
@@ -29269,7 +29269,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/zip-stream"
         }
       ]
@@ -29295,7 +29295,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/zlibjs"
         }
       ]

--- a/tests/_data/sbom_demo-results/juice-shop_npm7_node16_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/juice-shop_npm7_node16_macos-latest.snap.json
@@ -62,6 +62,10 @@
       ],
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -88,6 +92,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@babel/helper-string-parser"
+        }
       ]
     },
     {
@@ -108,6 +118,12 @@
           "url": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@babel/helper-validator-identifier"
         }
       ]
     },
@@ -130,6 +146,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@babel/parser"
+        }
       ]
     },
     {
@@ -150,6 +172,12 @@
           "url": "https://registry.npmjs.org/@babel/types/-/types-7.20.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@babel/types"
         }
       ]
     },
@@ -172,6 +200,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@colors/colors"
+        }
       ]
     },
     {
@@ -193,6 +227,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@dabh/diagnostics"
+        }
       ]
     },
     {
@@ -213,6 +253,12 @@
           "url": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@gar/promisify"
         }
       ]
     },
@@ -236,6 +282,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@mapbox/node-pre-gyp"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -254,6 +306,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/ansi-regex"
             }
           ]
         },
@@ -275,6 +333,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/are-we-there-yet"
+            }
           ]
         },
         {
@@ -294,6 +358,12 @@
               "url": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/detect-libc"
             }
           ]
         },
@@ -315,6 +385,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/gauge"
+            }
           ]
         },
         {
@@ -334,6 +410,12 @@
               "url": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/is-fullwidth-code-point"
             }
           ]
         },
@@ -356,6 +438,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/make-dir"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -374,6 +462,12 @@
                   "url": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/@mapbox/node-pre-gyp/node_modules/make-dir/node_modules/semver"
                 }
               ]
             }
@@ -397,6 +491,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/nopt"
+            }
           ]
         },
         {
@@ -416,6 +516,12 @@
               "url": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/npmlog"
             }
           ]
         },
@@ -437,6 +543,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/readable-stream"
+            }
           ]
         },
         {
@@ -457,6 +569,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/string-width"
+            }
           ]
         },
         {
@@ -476,6 +594,12 @@
               "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/strip-ansi"
             }
           ]
         }
@@ -500,6 +624,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/core-loader"
+        }
       ]
     },
     {
@@ -520,6 +650,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/core/-/core-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/core"
         }
       ]
     },
@@ -542,6 +678,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/evaluator"
+        }
       ]
     },
     {
@@ -562,6 +704,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-all/-/lang-all-4.24.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-all"
         }
       ]
     },
@@ -584,6 +732,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ar"
+        }
       ]
     },
     {
@@ -604,6 +758,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-bn/-/lang-bn-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-bn"
         }
       ]
     },
@@ -626,6 +786,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ca"
+        }
       ]
     },
     {
@@ -646,6 +812,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-cs/-/lang-cs-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-cs"
         }
       ]
     },
@@ -668,6 +840,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-da"
+        }
       ]
     },
     {
@@ -688,6 +866,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-de/-/lang-de-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-de"
         }
       ]
     },
@@ -710,6 +894,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-el"
+        }
       ]
     },
     {
@@ -730,6 +920,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-en-min/-/lang-en-min-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-en-min"
         }
       ]
     },
@@ -752,6 +948,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-en"
+        }
       ]
     },
     {
@@ -772,6 +974,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-es/-/lang-es-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-es"
         }
       ]
     },
@@ -794,6 +1002,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-eu"
+        }
       ]
     },
     {
@@ -814,6 +1028,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-fa/-/lang-fa-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-fa"
         }
       ]
     },
@@ -836,6 +1056,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-fi"
+        }
       ]
     },
     {
@@ -856,6 +1082,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-fr/-/lang-fr-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-fr"
         }
       ]
     },
@@ -878,6 +1110,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ga"
+        }
       ]
     },
     {
@@ -898,6 +1136,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-gl/-/lang-gl-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-gl"
         }
       ]
     },
@@ -920,6 +1164,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-hi"
+        }
       ]
     },
     {
@@ -940,6 +1190,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-hu/-/lang-hu-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-hu"
         }
       ]
     },
@@ -962,6 +1218,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-hy"
+        }
       ]
     },
     {
@@ -982,6 +1244,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-id/-/lang-id-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-id"
         }
       ]
     },
@@ -1004,6 +1272,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-it"
+        }
       ]
     },
     {
@@ -1024,6 +1298,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-ja/-/lang-ja-4.24.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ja"
         }
       ]
     },
@@ -1046,6 +1326,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ko"
+        }
       ]
     },
     {
@@ -1066,6 +1352,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-lt/-/lang-lt-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-lt"
         }
       ]
     },
@@ -1088,6 +1380,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ms"
+        }
       ]
     },
     {
@@ -1108,6 +1406,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-ne/-/lang-ne-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ne"
         }
       ]
     },
@@ -1130,6 +1434,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-nl"
+        }
       ]
     },
     {
@@ -1150,6 +1460,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-no/-/lang-no-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-no"
         }
       ]
     },
@@ -1172,6 +1488,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-pl"
+        }
       ]
     },
     {
@@ -1192,6 +1514,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-pt/-/lang-pt-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-pt"
         }
       ]
     },
@@ -1214,6 +1542,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ro"
+        }
       ]
     },
     {
@@ -1234,6 +1568,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-ru/-/lang-ru-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ru"
         }
       ]
     },
@@ -1256,6 +1596,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-sl"
+        }
       ]
     },
     {
@@ -1276,6 +1622,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-sr/-/lang-sr-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-sr"
         }
       ]
     },
@@ -1298,6 +1650,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-sv"
+        }
       ]
     },
     {
@@ -1318,6 +1676,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-ta/-/lang-ta-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ta"
         }
       ]
     },
@@ -1340,6 +1704,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-th"
+        }
       ]
     },
     {
@@ -1360,6 +1730,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-tl/-/lang-tl-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-tl"
         }
       ]
     },
@@ -1382,6 +1758,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-tr"
+        }
       ]
     },
     {
@@ -1402,6 +1784,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-uk/-/lang-uk-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-uk"
         }
       ]
     },
@@ -1424,6 +1812,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-zh"
+        }
       ]
     },
     {
@@ -1444,6 +1838,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/language-min/-/language-min-4.22.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/language-min"
         }
       ]
     },
@@ -1466,6 +1866,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/language"
+        }
       ]
     },
     {
@@ -1486,6 +1892,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/ner/-/ner-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/ner"
         }
       ]
     },
@@ -1508,6 +1920,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/neural"
+        }
       ]
     },
     {
@@ -1528,6 +1946,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/nlg/-/nlg-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/nlg"
         }
       ]
     },
@@ -1550,6 +1974,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/nlp"
+        }
       ]
     },
     {
@@ -1570,6 +2000,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/nlu/-/nlu-4.23.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/nlu"
         }
       ]
     },
@@ -1592,6 +2028,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/request"
+        }
       ]
     },
     {
@@ -1612,6 +2054,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/sentiment/-/sentiment-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/sentiment"
         }
       ]
     },
@@ -1634,6 +2082,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/similarity"
+        }
       ]
     },
     {
@@ -1654,6 +2108,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/slot/-/slot-4.22.17.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/slot"
         }
       ]
     },
@@ -1676,6 +2136,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@npmcli/fs"
+        }
       ]
     },
     {
@@ -1696,6 +2162,12 @@
           "url": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@npmcli/move-file"
         }
       ]
     },
@@ -1718,6 +2190,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib/core"
+        }
       ]
     },
     {
@@ -1738,6 +2216,12 @@
           "url": "https://registry.npmjs.org/@otplib/plugin-crypto/-/plugin-crypto-12.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib/plugin-crypto"
         }
       ]
     },
@@ -1760,6 +2244,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib/plugin-thirty-two"
+        }
       ]
     },
     {
@@ -1780,6 +2270,12 @@
           "url": "https://registry.npmjs.org/@otplib/preset-default/-/preset-default-12.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib/preset-default"
         }
       ]
     },
@@ -1802,6 +2298,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib/preset-v11"
+        }
       ]
     },
     {
@@ -1822,6 +2324,12 @@
           "url": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@sindresorhus/is"
         }
       ]
     },
@@ -1844,6 +2352,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@swc/helpers"
+        }
       ]
     },
     {
@@ -1864,6 +2378,12 @@
           "url": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@tokenizer/token"
         }
       ]
     },
@@ -1886,6 +2406,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@tootallnate/once"
+        }
       ]
     },
     {
@@ -1906,6 +2432,12 @@
           "url": "https://registry.npmjs.org/@types/component-emitter/-/component-emitter-1.2.11.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/component-emitter"
         }
       ]
     },
@@ -1928,6 +2460,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/cookie"
+        }
       ]
     },
     {
@@ -1948,6 +2486,12 @@
           "url": "https://registry.npmjs.org/@types/cors/-/cors-2.8.12.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/cors"
         }
       ]
     },
@@ -1970,6 +2514,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/debug"
+        }
       ]
     },
     {
@@ -1990,6 +2540,12 @@
           "url": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/ms"
         }
       ]
     },
@@ -2012,6 +2568,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/node"
+        }
       ]
     },
     {
@@ -2032,6 +2594,12 @@
           "url": "https://registry.npmjs.org/@types/strip-bom/-/strip-bom-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/strip-bom"
         }
       ]
     },
@@ -2054,6 +2622,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/strip-json-comments"
+        }
       ]
     },
     {
@@ -2075,6 +2649,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/validator"
+        }
       ]
     },
     {
@@ -2094,6 +2674,12 @@
           "url": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/abbrev"
         }
       ]
     },
@@ -2115,6 +2701,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/accepts"
+        }
       ]
     },
     {
@@ -2135,6 +2727,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/acorn-walk"
+        }
       ]
     },
     {
@@ -2154,6 +2752,12 @@
           "url": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/acorn"
         }
       ]
     },
@@ -2176,6 +2780,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/agent-base"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -2194,6 +2804,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agent-base/node_modules/debug"
             }
           ]
         },
@@ -2214,6 +2830,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agent-base/node_modules/ms"
             }
           ]
         }
@@ -2238,6 +2860,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/agentkeepalive"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -2256,6 +2884,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agentkeepalive/node_modules/debug"
             }
           ]
         },
@@ -2277,6 +2911,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agentkeepalive/node_modules/depd"
+            }
           ]
         },
         {
@@ -2296,6 +2936,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agentkeepalive/node_modules/ms"
             }
           ]
         }
@@ -2319,6 +2965,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/aggregate-error"
+        }
       ]
     },
     {
@@ -2338,6 +2990,12 @@
           "url": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ajv"
         }
       ]
     },
@@ -2359,6 +3017,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ansi-regex"
+        }
       ]
     },
     {
@@ -2378,6 +3042,12 @@
           "url": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ansi-styles"
         }
       ]
     },
@@ -2400,6 +3070,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/anymatch"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -2418,6 +3094,12 @@
               "url": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/anymatch/node_modules/normalize-path"
             }
           ]
         }
@@ -2441,6 +3123,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/append-field"
+        }
       ]
     },
     {
@@ -2460,6 +3148,12 @@
           "url": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/aproba"
         }
       ]
     },
@@ -2482,6 +3176,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/archive-type"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -2500,6 +3200,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-4.4.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/archive-type/node_modules/file-type"
             }
           ]
         }
@@ -2523,6 +3229,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/archiver-utils"
+        }
       ]
     },
     {
@@ -2542,6 +3254,12 @@
           "url": "https://registry.npmjs.org/archiver/-/archiver-1.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/archiver"
         }
       ]
     },
@@ -2563,6 +3281,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/are-we-there-yet"
+        }
       ]
     },
     {
@@ -2582,6 +3306,12 @@
           "url": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/arg"
         }
       ]
     },
@@ -2604,6 +3334,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/argparse"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -2622,6 +3358,12 @@
               "url": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/argparse/node_modules/sprintf-js"
             }
           ]
         }
@@ -2645,6 +3387,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/arr-diff"
+        }
       ]
     },
     {
@@ -2664,6 +3412,12 @@
           "url": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/arr-flatten"
         }
       ]
     },
@@ -2685,6 +3439,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/arr-union"
+        }
       ]
     },
     {
@@ -2704,6 +3464,12 @@
           "url": "https://registry.npmjs.org/array-each/-/array-each-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/array-each"
         }
       ]
     },
@@ -2725,6 +3491,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/array-flatten"
+        }
       ]
     },
     {
@@ -2744,6 +3516,12 @@
           "url": "https://registry.npmjs.org/array-slice/-/array-slice-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/array-slice"
         }
       ]
     },
@@ -2765,6 +3543,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/array-unique"
+        }
       ]
     },
     {
@@ -2784,6 +3568,12 @@
           "url": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/asap"
         }
       ]
     },
@@ -2805,6 +3595,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/asn1"
+        }
       ]
     },
     {
@@ -2824,6 +3620,12 @@
           "url": "https://registry.npmjs.org/assert-never/-/assert-never-1.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/assert-never"
         }
       ]
     },
@@ -2845,6 +3647,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/assert-plus"
+        }
       ]
     },
     {
@@ -2864,6 +3672,12 @@
           "url": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/assign-symbols"
         }
       ]
     },
@@ -2885,6 +3699,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/async"
+        }
       ]
     },
     {
@@ -2904,6 +3724,12 @@
           "url": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/asynckit"
         }
       ]
     },
@@ -2925,6 +3751,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/at-least-node"
+        }
       ]
     },
     {
@@ -2944,6 +3776,12 @@
           "url": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/atob"
         }
       ]
     },
@@ -2965,6 +3803,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/available-typed-arrays"
+        }
       ]
     },
     {
@@ -2984,6 +3828,12 @@
           "url": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/aws-sign2"
         }
       ]
     },
@@ -3005,6 +3855,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/aws4"
+        }
       ]
     },
     {
@@ -3025,6 +3881,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/babel-walk"
+        }
       ]
     },
     {
@@ -3044,6 +3906,12 @@
           "url": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/balanced-match"
         }
       ]
     },
@@ -3066,6 +3934,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -3084,6 +3958,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/base/node_modules/define-property"
             }
           ]
         }
@@ -3107,6 +3987,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base64-arraybuffer"
+        }
       ]
     },
     {
@@ -3126,6 +4012,12 @@
           "url": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base64-js"
         }
       ]
     },
@@ -3147,6 +4039,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base64id"
+        }
       ]
     },
     {
@@ -3166,6 +4064,12 @@
           "url": "https://registry.npmjs.org/base64url/-/base64url-0.0.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base64url"
         }
       ]
     },
@@ -3187,6 +4091,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/basic-auth"
+        }
       ]
     },
     {
@@ -3206,6 +4116,12 @@
           "url": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/batch"
         }
       ]
     },
@@ -3227,6 +4143,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bcrypt-pbkdf"
+        }
       ]
     },
     {
@@ -3246,6 +4168,12 @@
           "url": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/big-integer"
         }
       ]
     },
@@ -3267,6 +4195,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/binary-extensions"
+        }
       ]
     },
     {
@@ -3286,6 +4220,12 @@
           "url": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/binary"
         }
       ]
     },
@@ -3307,6 +4247,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bindings"
+        }
       ]
     },
     {
@@ -3326,6 +4272,12 @@
           "url": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bintrees"
         }
       ]
     },
@@ -3347,6 +4299,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bl"
+        }
       ]
     },
     {
@@ -3367,6 +4325,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bluebird"
+        }
       ]
     },
     {
@@ -3386,6 +4350,12 @@
           "url": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/body-parser"
         }
       ]
     },
@@ -3408,6 +4378,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bower-config"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -3426,6 +4402,12 @@
               "url": "https://registry.npmjs.org/minimist/-/minimist-0.2.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bower-config/node_modules/minimist"
             }
           ]
         }
@@ -3449,6 +4431,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/brace-expansion"
+        }
       ]
     },
     {
@@ -3470,6 +4458,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/braces"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -3488,6 +4482,12 @@
               "url": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/braces/node_modules/extend-shallow"
             }
           ]
         },
@@ -3508,6 +4508,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/braces/node_modules/is-extendable"
             }
           ]
         }
@@ -3531,6 +4537,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/brotli"
+        }
       ]
     },
     {
@@ -3550,6 +4562,12 @@
           "url": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-alloc-unsafe"
         }
       ]
     },
@@ -3571,6 +4589,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-alloc"
+        }
       ]
     },
     {
@@ -3590,6 +4614,12 @@
           "url": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-crc32"
         }
       ]
     },
@@ -3611,6 +4641,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-fill"
+        }
       ]
     },
     {
@@ -3630,6 +4666,12 @@
           "url": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-from"
         }
       ]
     },
@@ -3651,6 +4693,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-indexof-polyfill"
+        }
       ]
     },
     {
@@ -3671,6 +4719,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer"
+        }
       ]
     },
     {
@@ -3690,6 +4744,12 @@
           "url": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffers"
         }
       ]
     },
@@ -3712,6 +4772,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/busboy"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -3730,6 +4796,12 @@
               "url": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/busboy/node_modules/isarray"
             }
           ]
         },
@@ -3751,6 +4823,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/busboy/node_modules/readable-stream"
+            }
           ]
         },
         {
@@ -3770,6 +4848,12 @@
               "url": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/busboy/node_modules/string_decoder"
             }
           ]
         }
@@ -3793,6 +4877,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/byline"
+        }
       ]
     },
     {
@@ -3812,6 +4902,12 @@
           "url": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bytes"
         }
       ]
     },
@@ -3833,6 +4929,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cacache"
+        }
       ]
     },
     {
@@ -3852,6 +4954,12 @@
           "url": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cache-base"
         }
       ]
     },
@@ -3874,6 +4982,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cacheable-request"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -3892,6 +5006,12 @@
               "url": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cacheable-request/node_modules/get-stream"
             }
           ]
         },
@@ -3912,6 +5032,12 @@
               "url": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cacheable-request/node_modules/lowercase-keys"
             }
           ]
         }
@@ -3935,6 +5061,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/call-bind"
+        }
       ]
     },
     {
@@ -3954,6 +5086,12 @@
           "url": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/camelcase"
         }
       ]
     },
@@ -3975,6 +5113,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/caseless"
+        }
       ]
     },
     {
@@ -3994,6 +5138,12 @@
           "url": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/chainsaw"
         }
       ]
     },
@@ -4015,6 +5165,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/chalk"
+        }
       ]
     },
     {
@@ -4034,6 +5190,12 @@
           "url": "https://registry.npmjs.org/character-parser/-/character-parser-2.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/character-parser"
         }
       ]
     },
@@ -4056,6 +5218,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/check-dependencies"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4074,6 +5242,12 @@
               "url": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/check-dependencies/node_modules/semver"
             }
           ]
         }
@@ -4097,6 +5271,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/check-types"
+        }
       ]
     },
     {
@@ -4118,6 +5298,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/chokidar"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4136,6 +5322,12 @@
               "url": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar/node_modules/braces"
             }
           ]
         },
@@ -4157,6 +5349,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar/node_modules/fill-range"
+            }
           ]
         },
         {
@@ -4176,6 +5374,12 @@
               "url": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar/node_modules/is-glob"
             }
           ]
         },
@@ -4197,6 +5401,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar/node_modules/is-number"
+            }
           ]
         },
         {
@@ -4217,6 +5427,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar/node_modules/normalize-path"
+            }
           ]
         },
         {
@@ -4236,6 +5452,12 @@
               "url": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar/node_modules/to-regex-range"
             }
           ]
         }
@@ -4259,6 +5481,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/chownr"
+        }
       ]
     },
     {
@@ -4278,6 +5506,12 @@
           "url": "https://registry.npmjs.org/clarinet/-/clarinet-0.12.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/clarinet"
         }
       ]
     },
@@ -4300,6 +5534,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/class-utils"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4318,6 +5558,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils/node_modules/define-property"
             }
           ]
         },
@@ -4340,6 +5586,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils/node_modules/is-accessor-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -4358,6 +5610,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/class-utils/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -4382,6 +5640,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils/node_modules/is-data-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -4400,6 +5664,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/class-utils/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -4423,6 +5693,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils/node_modules/is-descriptor"
+            }
           ]
         },
         {
@@ -4442,6 +5718,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils/node_modules/kind-of"
             }
           ]
         }
@@ -4465,6 +5747,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/clean-stack"
+        }
       ]
     },
     {
@@ -4486,6 +5774,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cliui"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4504,6 +5798,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui/node_modules/ansi-regex"
             }
           ]
         },
@@ -4525,6 +5825,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui/node_modules/emoji-regex"
+            }
           ]
         },
         {
@@ -4544,6 +5850,12 @@
               "url": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui/node_modules/is-fullwidth-code-point"
             }
           ]
         },
@@ -4565,6 +5877,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui/node_modules/string-width"
+            }
           ]
         },
         {
@@ -4584,6 +5902,12 @@
               "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui/node_modules/strip-ansi"
             }
           ]
         }
@@ -4607,6 +5931,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/clone-response"
+        }
       ]
     },
     {
@@ -4626,6 +5956,12 @@
           "url": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/clone"
         }
       ]
     },
@@ -4647,6 +5983,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/code-point-at"
+        }
       ]
     },
     {
@@ -4666,6 +6008,12 @@
           "url": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/collection-visit"
         }
       ]
     },
@@ -4687,6 +6035,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color-convert"
+        }
       ]
     },
     {
@@ -4706,6 +6060,12 @@
           "url": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color-name"
         }
       ]
     },
@@ -4727,6 +6087,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color-string"
+        }
       ]
     },
     {
@@ -4746,6 +6112,12 @@
           "url": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color-support"
         }
       ]
     },
@@ -4767,6 +6139,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color"
+        }
       ]
     },
     {
@@ -4786,6 +6164,12 @@
           "url": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/colors"
         }
       ]
     },
@@ -4807,6 +6191,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/colorspace"
+        }
       ]
     },
     {
@@ -4826,6 +6216,12 @@
           "url": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/combined-stream"
         }
       ]
     },
@@ -4847,6 +6243,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/commander"
+        }
       ]
     },
     {
@@ -4866,6 +6268,12 @@
           "url": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/component-emitter"
         }
       ]
     },
@@ -4887,6 +6295,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/component-type"
+        }
       ]
     },
     {
@@ -4907,6 +6321,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/compress-commons"
+        }
       ]
     },
     {
@@ -4926,6 +6346,12 @@
           "url": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/compressible"
         }
       ]
     },
@@ -4948,6 +6374,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/compression"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4966,6 +6398,12 @@
               "url": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/compression/node_modules/bytes"
             }
           ]
         }
@@ -4989,6 +6427,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/concat-map"
+        }
       ]
     },
     {
@@ -5008,6 +6452,12 @@
           "url": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/concat-stream"
         }
       ]
     },
@@ -5030,6 +6480,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/concurrently"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5048,6 +6504,12 @@
               "url": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/concurrently/node_modules/supports-color"
             }
           ]
         }
@@ -5071,6 +6533,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/config"
+        }
       ]
     },
     {
@@ -5091,6 +6559,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/console-control-strings"
+        }
       ]
     },
     {
@@ -5110,6 +6584,12 @@
           "url": "https://registry.npmjs.org/constantinople/-/constantinople-4.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/constantinople"
         }
       ]
     },
@@ -5132,6 +6612,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/content-disposition"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5150,6 +6636,12 @@
               "url": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/content-disposition/node_modules/safe-buffer"
             }
           ]
         }
@@ -5173,6 +6665,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/content-type"
+        }
       ]
     },
     {
@@ -5192,6 +6690,12 @@
           "url": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cookie-parser"
         }
       ]
     },
@@ -5213,6 +6717,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cookie-signature"
+        }
       ]
     },
     {
@@ -5232,6 +6742,12 @@
           "url": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cookie"
         }
       ]
     },
@@ -5253,6 +6769,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/copy-descriptor"
+        }
       ]
     },
     {
@@ -5272,6 +6794,12 @@
           "url": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/core-util-is"
         }
       ]
     },
@@ -5293,6 +6821,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cors"
+        }
       ]
     },
     {
@@ -5312,6 +6846,12 @@
           "url": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/crc"
         }
       ]
     },
@@ -5333,6 +6873,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/crc32-stream"
+        }
       ]
     },
     {
@@ -5352,6 +6898,12 @@
           "url": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/create-require"
         }
       ]
     },
@@ -5373,6 +6925,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/crypto-js"
+        }
       ]
     },
     {
@@ -5392,6 +6950,12 @@
           "url": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dashdash"
         }
       ]
     },
@@ -5413,6 +6977,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/date-fns"
+        }
       ]
     },
     {
@@ -5432,6 +7002,12 @@
           "url": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dateformat"
         }
       ]
     },
@@ -5453,6 +7029,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/debug"
+        }
       ]
     },
     {
@@ -5472,6 +7054,12 @@
           "url": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decamelize"
         }
       ]
     },
@@ -5493,6 +7081,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decode-uri-component"
+        }
       ]
     },
     {
@@ -5512,6 +7106,12 @@
           "url": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-response"
         }
       ]
     },
@@ -5534,6 +7134,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-tar"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5552,6 +7158,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-tar/node_modules/file-type"
             }
           ]
         }
@@ -5576,6 +7188,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-tarbz2"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5594,6 +7212,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-6.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-tarbz2/node_modules/file-type"
             }
           ]
         }
@@ -5618,6 +7242,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-targz"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5636,6 +7266,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-targz/node_modules/file-type"
             }
           ]
         }
@@ -5660,6 +7296,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-unzip"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5678,6 +7320,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-unzip/node_modules/file-type"
             }
           ]
         },
@@ -5699,6 +7347,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-unzip/node_modules/get-stream"
+            }
           ]
         },
         {
@@ -5718,6 +7372,12 @@
               "url": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-unzip/node_modules/pify"
             }
           ]
         }
@@ -5742,6 +7402,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5762,6 +7428,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress/node_modules/make-dir"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -5780,6 +7452,12 @@
                   "url": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/decompress/node_modules/make-dir/node_modules/pify"
                 }
               ]
             }
@@ -5803,6 +7481,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress/node_modules/pify"
+            }
           ]
         }
       ]
@@ -5825,6 +7509,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/deep-equal"
+        }
       ]
     },
     {
@@ -5844,6 +7534,12 @@
           "url": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/deep-extend"
         }
       ]
     },
@@ -5865,6 +7561,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/deep-is"
+        }
       ]
     },
     {
@@ -5884,6 +7586,12 @@
           "url": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/define-properties"
         }
       ]
     },
@@ -5905,6 +7613,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/define-property"
+        }
       ]
     },
     {
@@ -5924,6 +7638,12 @@
           "url": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/delayed-stream"
         }
       ]
     },
@@ -5945,6 +7665,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/delegates"
+        }
       ]
     },
     {
@@ -5964,6 +7690,12 @@
           "url": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/depd"
         }
       ]
     },
@@ -5985,6 +7717,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/destroy"
+        }
       ]
     },
     {
@@ -6004,6 +7742,12 @@
           "url": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/detect-file"
         }
       ]
     },
@@ -6025,6 +7769,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/detect-libc"
+        }
       ]
     },
     {
@@ -6044,6 +7794,12 @@
           "url": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dfa"
         }
       ]
     },
@@ -6066,6 +7822,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dicer"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -6084,6 +7846,12 @@
               "url": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/dicer/node_modules/isarray"
             }
           ]
         },
@@ -6105,6 +7873,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/dicer/node_modules/readable-stream"
+            }
           ]
         },
         {
@@ -6124,6 +7898,12 @@
               "url": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/dicer/node_modules/string_decoder"
             }
           ]
         }
@@ -6147,6 +7927,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/diff"
+        }
       ]
     },
     {
@@ -6166,6 +7952,12 @@
           "url": "https://registry.npmjs.org/doctypes/-/doctypes-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/doctypes"
         }
       ]
     },
@@ -6187,6 +7979,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/domelementtype"
+        }
       ]
     },
     {
@@ -6206,6 +8004,12 @@
           "url": "https://registry.npmjs.org/domhandler/-/domhandler-2.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/domhandler"
         }
       ]
     },
@@ -6227,6 +8031,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/domutils"
+        }
       ]
     },
     {
@@ -6246,6 +8056,12 @@
           "url": "https://registry.npmjs.org/dottie/-/dottie-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dottie"
         }
       ]
     },
@@ -6267,6 +8083,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/double-ended-queue"
+        }
       ]
     },
     {
@@ -6286,6 +8108,12 @@
           "url": "https://registry.npmjs.org/doublearray/-/doublearray-0.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/doublearray"
         }
       ]
     },
@@ -6308,6 +8136,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/download"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -6326,6 +8160,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-11.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/download/node_modules/file-type"
             }
           ]
         }
@@ -6349,6 +8189,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/duplexer2"
+        }
       ]
     },
     {
@@ -6368,6 +8214,12 @@
           "url": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/duplexer3"
         }
       ]
     },
@@ -6389,6 +8241,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dynamic-dedupe"
+        }
       ]
     },
     {
@@ -6408,6 +8266,12 @@
           "url": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ecc-jsbn"
         }
       ]
     },
@@ -6429,6 +8293,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ee-first"
+        }
       ]
     },
     {
@@ -6448,6 +8318,12 @@
           "url": "https://registry.npmjs.org/eivindfjeldstad-dot/-/eivindfjeldstad-dot-0.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/eivindfjeldstad-dot"
         }
       ]
     },
@@ -6469,6 +8345,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/emoji-regex"
+        }
       ]
     },
     {
@@ -6489,6 +8371,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/enabled"
+        }
       ]
     },
     {
@@ -6508,6 +8396,12 @@
           "url": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/encodeurl"
         }
       ]
     },
@@ -6530,6 +8424,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/encoding"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -6548,6 +8448,12 @@
               "url": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/encoding/node_modules/iconv-lite"
             }
           ]
         }
@@ -6571,6 +8477,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/end-of-stream"
+        }
       ]
     },
     {
@@ -6590,6 +8502,12 @@
           "url": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-4.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/engine.io-parser"
         }
       ]
     },
@@ -6612,6 +8530,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/engine.io"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -6630,6 +8554,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/engine.io/node_modules/debug"
             }
           ]
         },
@@ -6650,6 +8580,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/engine.io/node_modules/ms"
             }
           ]
         }
@@ -6673,6 +8609,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/env-paths"
+        }
       ]
     },
     {
@@ -6692,6 +8634,12 @@
           "url": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/err-code"
         }
       ]
     },
@@ -6713,6 +8661,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/error-ex"
+        }
       ]
     },
     {
@@ -6732,6 +8686,12 @@
           "url": "https://registry.npmjs.org/errorhandler/-/errorhandler-1.5.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/errorhandler"
         }
       ]
     },
@@ -6753,6 +8713,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/es-abstract"
+        }
       ]
     },
     {
@@ -6772,6 +8738,12 @@
           "url": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/es-get-iterator"
         }
       ]
     },
@@ -6793,6 +8765,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/es-to-primitive"
+        }
       ]
     },
     {
@@ -6812,6 +8790,12 @@
           "url": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/escape-html"
         }
       ]
     },
@@ -6833,6 +8817,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/escape-string-regexp"
+        }
       ]
     },
     {
@@ -6852,6 +8842,12 @@
           "url": "https://registry.npmjs.org/escodegen/-/escodegen-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/escodegen"
         }
       ]
     },
@@ -6873,6 +8869,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/esprima"
+        }
       ]
     },
     {
@@ -6892,6 +8894,12 @@
           "url": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/estraverse"
         }
       ]
     },
@@ -6913,6 +8921,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/esutils"
+        }
       ]
     },
     {
@@ -6932,6 +8946,12 @@
           "url": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/etag"
         }
       ]
     },
@@ -6953,6 +8973,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/eventemitter2"
+        }
       ]
     },
     {
@@ -6972,6 +8998,12 @@
           "url": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/eventemitter3"
         }
       ]
     },
@@ -6993,6 +9025,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/exif"
+        }
       ]
     },
     {
@@ -7012,6 +9050,12 @@
           "url": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/exit"
         }
       ]
     },
@@ -7034,6 +9078,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/expand-brackets"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7052,6 +9102,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/define-property"
             }
           ]
         },
@@ -7072,6 +9128,12 @@
               "url": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/extend-shallow"
             }
           ]
         },
@@ -7094,6 +9156,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/is-accessor-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -7112,6 +9180,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/expand-brackets/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -7136,6 +9210,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/is-data-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -7154,6 +9234,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/expand-brackets/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -7177,6 +9263,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/is-descriptor"
+            }
           ]
         },
         {
@@ -7197,6 +9289,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/is-extendable"
+            }
           ]
         },
         {
@@ -7216,6 +9314,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/kind-of"
             }
           ]
         }
@@ -7239,6 +9343,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/expand-template"
+        }
       ]
     },
     {
@@ -7259,6 +9369,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/expand-tilde"
+        }
       ]
     },
     {
@@ -7278,6 +9394,12 @@
           "url": "https://registry.npmjs.org/express-ipfilter/-/express-ipfilter-1.3.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-ipfilter"
         }
       ]
     },
@@ -7300,6 +9422,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-jwt"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7318,6 +9446,12 @@
               "url": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-0.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/express-jwt/node_modules/jsonwebtoken"
             }
           ]
         },
@@ -7338,6 +9472,12 @@
               "url": "https://registry.npmjs.org/moment/-/moment-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/express-jwt/node_modules/moment"
             }
           ]
         }
@@ -7361,6 +9501,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-rate-limit"
+        }
       ]
     },
     {
@@ -7381,6 +9527,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-robots-txt"
+        }
       ]
     },
     {
@@ -7400,6 +9552,12 @@
           "url": "https://registry.npmjs.org/express-security.txt/-/express-security.txt-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-security.txt"
         }
       ]
     },
@@ -7422,6 +9580,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7440,6 +9604,12 @@
               "url": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/express/node_modules/cookie"
             }
           ]
         },
@@ -7460,6 +9630,12 @@
               "url": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/express/node_modules/safe-buffer"
             }
           ]
         }
@@ -7483,6 +9659,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ext-list"
+        }
       ]
     },
     {
@@ -7502,6 +9684,12 @@
           "url": "https://registry.npmjs.org/ext-name/-/ext-name-5.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ext-name"
         }
       ]
     },
@@ -7523,6 +9711,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/extend-shallow"
+        }
       ]
     },
     {
@@ -7542,6 +9736,12 @@
           "url": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/extend"
         }
       ]
     },
@@ -7564,6 +9764,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/extglob"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7582,6 +9788,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/extglob/node_modules/define-property"
             }
           ]
         },
@@ -7603,6 +9815,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/extglob/node_modules/extend-shallow"
+            }
           ]
         },
         {
@@ -7622,6 +9840,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/extglob/node_modules/is-extendable"
             }
           ]
         }
@@ -7645,6 +9869,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/extsprintf"
+        }
       ]
     },
     {
@@ -7664,6 +9894,12 @@
           "url": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fast-deep-equal"
         }
       ]
     },
@@ -7685,6 +9921,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fast-json-stable-stringify"
+        }
       ]
     },
     {
@@ -7704,6 +9946,12 @@
           "url": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fast-levenshtein"
         }
       ]
     },
@@ -7725,6 +9973,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fast.js"
+        }
       ]
     },
     {
@@ -7744,6 +9998,12 @@
           "url": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fd-slicer"
         }
       ]
     },
@@ -7765,6 +10025,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/feature-policy"
+        }
       ]
     },
     {
@@ -7784,6 +10050,12 @@
           "url": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fecha"
         }
       ]
     },
@@ -7806,6 +10078,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/file-js"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7824,6 +10102,12 @@
               "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/file-js/node_modules/brace-expansion"
             }
           ]
         },
@@ -7844,6 +10128,12 @@
               "url": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/file-js/node_modules/minimatch"
             }
           ]
         }
@@ -7867,6 +10157,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/file-stream-rotator"
+        }
       ]
     },
     {
@@ -7886,6 +10182,12 @@
           "url": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/file-type"
         }
       ]
     },
@@ -7907,6 +10209,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/file-uri-to-path"
+        }
       ]
     },
     {
@@ -7926,6 +10234,12 @@
           "url": "https://registry.npmjs.org/filehound/-/filehound-1.17.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/filehound"
         }
       ]
     },
@@ -7947,6 +10261,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/filename-reserved-regex"
+        }
       ]
     },
     {
@@ -7967,6 +10287,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/filenamify"
+        }
       ]
     },
     {
@@ -7986,6 +10312,12 @@
           "url": "https://registry.npmjs.org/filesniffer/-/filesniffer-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/filesniffer"
         }
       ]
     },
@@ -8008,6 +10340,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fill-range"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -8026,6 +10364,12 @@
               "url": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/fill-range/node_modules/extend-shallow"
             }
           ]
         },
@@ -8046,6 +10390,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/fill-range/node_modules/is-extendable"
             }
           ]
         }
@@ -8069,6 +10419,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/finale-rest"
+        }
       ]
     },
     {
@@ -8088,6 +10444,12 @@
           "url": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/finalhandler"
         }
       ]
     },
@@ -8109,6 +10471,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/find-up"
+        }
       ]
     },
     {
@@ -8128,6 +10496,12 @@
           "url": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/findup-sync"
         }
       ]
     },
@@ -8149,6 +10523,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fined"
+        }
       ]
     },
     {
@@ -8168,6 +10548,12 @@
           "url": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/flagged-respawn"
         }
       ]
     },
@@ -8189,6 +10575,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fn.name"
+        }
       ]
     },
     {
@@ -8208,6 +10600,12 @@
           "url": "https://registry.npmjs.org/fontkit/-/fontkit-1.9.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fontkit"
         }
       ]
     },
@@ -8229,6 +10627,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/for-each"
+        }
       ]
     },
     {
@@ -8248,6 +10652,12 @@
           "url": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/for-in"
         }
       ]
     },
@@ -8269,6 +10679,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/for-own"
+        }
       ]
     },
     {
@@ -8288,6 +10704,12 @@
           "url": "https://registry.npmjs.org/foreachasync/-/foreachasync-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/foreachasync"
         }
       ]
     },
@@ -8309,6 +10731,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/forever-agent"
+        }
       ]
     },
     {
@@ -8328,6 +10756,12 @@
           "url": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/form-data"
         }
       ]
     },
@@ -8349,6 +10783,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/formatio"
+        }
       ]
     },
     {
@@ -8368,6 +10808,12 @@
           "url": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/forwarded"
         }
       ]
     },
@@ -8389,6 +10835,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fragment-cache"
+        }
       ]
     },
     {
@@ -8408,6 +10860,12 @@
           "url": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fresh"
         }
       ]
     },
@@ -8429,6 +10887,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/from2"
+        }
       ]
     },
     {
@@ -8448,6 +10912,12 @@
           "url": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fs-constants"
         }
       ]
     },
@@ -8469,6 +10939,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fs-extra"
+        }
       ]
     },
     {
@@ -8488,6 +10964,12 @@
           "url": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fs-minipass"
         }
       ]
     },
@@ -8509,6 +10991,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fs.realpath"
+        }
       ]
     },
     {
@@ -8528,6 +11016,12 @@
           "url": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fsevents"
         }
       ]
     },
@@ -8550,6 +11044,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fstream"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -8568,6 +11068,12 @@
               "url": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/fstream/node_modules/mkdirp"
             }
           ]
         },
@@ -8588,6 +11094,12 @@
               "url": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/fstream/node_modules/rimraf"
             }
           ]
         }
@@ -8611,6 +11123,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/function-bind"
+        }
       ]
     },
     {
@@ -8630,6 +11148,12 @@
           "url": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/function.prototype.name"
         }
       ]
     },
@@ -8651,6 +11175,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/functions-have-names"
+        }
       ]
     },
     {
@@ -8670,6 +11200,12 @@
           "url": "https://registry.npmjs.org/fuzzball/-/fuzzball-1.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fuzzball"
         }
       ]
     },
@@ -8691,6 +11227,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/gauge"
+        }
       ]
     },
     {
@@ -8710,6 +11252,12 @@
           "url": "https://registry.npmjs.org/geojson-utils/-/geojson-utils-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/geojson-utils"
         }
       ]
     },
@@ -8731,6 +11279,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-caller-file"
+        }
       ]
     },
     {
@@ -8750,6 +11304,12 @@
           "url": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-intrinsic"
         }
       ]
     },
@@ -8771,6 +11331,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-stream"
+        }
       ]
     },
     {
@@ -8790,6 +11356,12 @@
           "url": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-symbol-description"
         }
       ]
     },
@@ -8811,6 +11383,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-value"
+        }
       ]
     },
     {
@@ -8830,6 +11408,12 @@
           "url": "https://registry.npmjs.org/getobject/-/getobject-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/getobject"
         }
       ]
     },
@@ -8851,6 +11435,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/getpass"
+        }
       ]
     },
     {
@@ -8870,6 +11460,12 @@
           "url": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/github-from-package"
         }
       ]
     },
@@ -8892,6 +11488,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/glob-parent"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -8910,6 +11512,12 @@
               "url": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/glob-parent/node_modules/is-glob"
             }
           ]
         }
@@ -8934,6 +11542,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/glob"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -8952,6 +11566,12 @@
               "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/glob/node_modules/brace-expansion"
             }
           ]
         },
@@ -8972,6 +11592,12 @@
               "url": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/glob/node_modules/minimatch"
             }
           ]
         }
@@ -8995,6 +11621,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/global-modules"
+        }
       ]
     },
     {
@@ -9016,6 +11648,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/global-prefix"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9034,6 +11672,12 @@
               "url": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/global-prefix/node_modules/which"
             }
           ]
         }
@@ -9058,6 +11702,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/got"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9076,6 +11726,12 @@
               "url": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/got/node_modules/get-stream"
             }
           ]
         },
@@ -9096,6 +11752,12 @@
               "url": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/got/node_modules/pify"
             }
           ]
         }
@@ -9119,6 +11781,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/graceful-fs"
+        }
       ]
     },
     {
@@ -9140,6 +11808,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-cli"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9158,6 +11832,12 @@
               "url": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-cli/node_modules/nopt"
             }
           ]
         }
@@ -9182,6 +11862,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-contrib-compress"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9200,6 +11886,12 @@
               "url": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-contrib-compress/node_modules/ansi-styles"
             }
           ]
         },
@@ -9221,6 +11913,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-contrib-compress/node_modules/chalk"
+            }
           ]
         },
         {
@@ -9240,6 +11938,12 @@
               "url": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-contrib-compress/node_modules/supports-color"
             }
           ]
         }
@@ -9263,6 +11967,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-known-options"
+        }
       ]
     },
     {
@@ -9284,6 +11994,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-legacy-log-utils"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9302,6 +12018,12 @@
               "url": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils/node_modules/ansi-styles"
             }
           ]
         },
@@ -9323,6 +12045,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils/node_modules/chalk"
+            }
           ]
         },
         {
@@ -9342,6 +12070,12 @@
               "url": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils/node_modules/color-convert"
             }
           ]
         },
@@ -9363,6 +12097,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils/node_modules/color-name"
+            }
           ]
         },
         {
@@ -9383,6 +12123,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils/node_modules/has-flag"
+            }
           ]
         },
         {
@@ -9402,6 +12148,12 @@
               "url": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils/node_modules/supports-color"
             }
           ]
         }
@@ -9426,6 +12178,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-legacy-log"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9444,6 +12202,12 @@
               "url": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log/node_modules/colors"
             }
           ]
         }
@@ -9468,6 +12232,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-legacy-util"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9486,6 +12256,12 @@
               "url": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-util/node_modules/async"
             }
           ]
         }
@@ -9509,6 +12285,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-replace-json"
+        }
       ]
     },
     {
@@ -9530,6 +12312,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9548,6 +12336,12 @@
               "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt/node_modules/brace-expansion"
             }
           ]
         },
@@ -9570,6 +12364,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt/node_modules/findup-sync"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -9588,6 +12388,12 @@
                   "url": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/grunt/node_modules/findup-sync/node_modules/glob"
                 }
               ]
             }
@@ -9611,6 +12417,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt/node_modules/glob"
+            }
           ]
         },
         {
@@ -9630,6 +12442,12 @@
               "url": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.8.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt/node_modules/minimatch"
             }
           ]
         }
@@ -9654,6 +12472,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/handlebars"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9672,6 +12496,12 @@
               "url": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/handlebars/node_modules/wordwrap"
             }
           ]
         }
@@ -9695,6 +12525,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/har-schema"
+        }
       ]
     },
     {
@@ -9714,6 +12550,12 @@
           "url": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/har-validator"
         }
       ]
     },
@@ -9735,6 +12577,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-ansi"
+        }
       ]
     },
     {
@@ -9754,6 +12602,12 @@
           "url": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-bigints"
         }
       ]
     },
@@ -9775,6 +12629,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-flag"
+        }
       ]
     },
     {
@@ -9794,6 +12654,12 @@
           "url": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-property-descriptors"
         }
       ]
     },
@@ -9815,6 +12681,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-symbol-support-x"
+        }
       ]
     },
     {
@@ -9834,6 +12706,12 @@
           "url": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-symbols"
         }
       ]
     },
@@ -9855,6 +12733,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-to-string-tag-x"
+        }
       ]
     },
     {
@@ -9874,6 +12758,12 @@
           "url": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-tostringtag"
         }
       ]
     },
@@ -9895,6 +12785,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-unicode"
+        }
       ]
     },
     {
@@ -9914,6 +12810,12 @@
           "url": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-value"
         }
       ]
     },
@@ -9936,6 +12838,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-values"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9954,6 +12862,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/has-values/node_modules/kind-of"
             }
           ]
         }
@@ -9977,6 +12891,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has"
+        }
       ]
     },
     {
@@ -9996,6 +12916,12 @@
           "url": "https://registry.npmjs.org/hashids/-/hashids-2.2.10.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hashids"
         }
       ]
     },
@@ -10017,6 +12943,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hbs"
+        }
       ]
     },
     {
@@ -10036,6 +12968,12 @@
           "url": "https://registry.npmjs.org/he/-/he-0.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/he"
         }
       ]
     },
@@ -10057,6 +12995,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/heap"
+        }
       ]
     },
     {
@@ -10076,6 +13020,12 @@
           "url": "https://registry.npmjs.org/helmet/-/helmet-4.6.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/helmet"
         }
       ]
     },
@@ -10097,6 +13047,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hoister"
+        }
       ]
     },
     {
@@ -10116,6 +13072,12 @@
           "url": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/homedir-polyfill"
         }
       ]
     },
@@ -10137,6 +13099,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hooker"
+        }
       ]
     },
     {
@@ -10157,6 +13125,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hosted-git-info"
+        }
       ]
     },
     {
@@ -10176,6 +13150,12 @@
           "url": "https://registry.npmjs.org/html-entities/-/html-entities-1.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/html-entities"
         }
       ]
     },
@@ -10198,6 +13178,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/htmlparser2"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -10216,6 +13202,12 @@
               "url": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/htmlparser2/node_modules/isarray"
             }
           ]
         },
@@ -10237,6 +13229,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/htmlparser2/node_modules/readable-stream"
+            }
           ]
         },
         {
@@ -10256,6 +13254,12 @@
               "url": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/htmlparser2/node_modules/string_decoder"
             }
           ]
         }
@@ -10279,6 +13283,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/http-cache-semantics"
+        }
       ]
     },
     {
@@ -10298,6 +13308,12 @@
           "url": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/http-errors"
         }
       ]
     },
@@ -10320,6 +13336,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/http-proxy-agent"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -10338,6 +13360,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/http-proxy-agent/node_modules/debug"
             }
           ]
         },
@@ -10358,6 +13386,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/http-proxy-agent/node_modules/ms"
             }
           ]
         }
@@ -10381,6 +13415,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/http-signature"
+        }
       ]
     },
     {
@@ -10402,6 +13442,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/https-proxy-agent"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -10420,6 +13466,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/https-proxy-agent/node_modules/debug"
             }
           ]
         },
@@ -10440,6 +13492,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/https-proxy-agent/node_modules/ms"
             }
           ]
         }
@@ -10463,6 +13521,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/humanize-ms"
+        }
       ]
     },
     {
@@ -10482,6 +13546,12 @@
           "url": "https://registry.npmjs.org/i18n/-/i18n-0.11.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/i18n"
         }
       ]
     },
@@ -10503,6 +13573,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/iconv-lite"
+        }
       ]
     },
     {
@@ -10522,6 +13598,12 @@
           "url": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ieee754"
         }
       ]
     },
@@ -10544,6 +13626,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ignore-walk"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -10562,6 +13650,12 @@
               "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/ignore-walk/node_modules/brace-expansion"
             }
           ]
         },
@@ -10582,6 +13676,12 @@
               "url": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/ignore-walk/node_modules/minimatch"
             }
           ]
         }
@@ -10605,6 +13705,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/iltorb"
+        }
       ]
     },
     {
@@ -10624,6 +13730,12 @@
           "url": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/imurmurhash"
         }
       ]
     },
@@ -10645,6 +13757,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/indent-string"
+        }
       ]
     },
     {
@@ -10664,6 +13782,12 @@
           "url": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/infer-owner"
         }
       ]
     },
@@ -10685,6 +13809,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/inflection"
+        }
       ]
     },
     {
@@ -10704,6 +13834,12 @@
           "url": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/inflight"
         }
       ]
     },
@@ -10725,6 +13861,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/inherits"
+        }
       ]
     },
     {
@@ -10744,6 +13886,12 @@
           "url": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ini"
         }
       ]
     },
@@ -10765,6 +13913,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/internal-slot"
+        }
       ]
     },
     {
@@ -10784,6 +13938,12 @@
           "url": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/interpret"
         }
       ]
     },
@@ -10805,6 +13965,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/into-stream"
+        }
       ]
     },
     {
@@ -10824,6 +13990,12 @@
           "url": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/invariant"
         }
       ]
     },
@@ -10845,6 +14017,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ip"
+        }
       ]
     },
     {
@@ -10864,6 +14042,12 @@
           "url": "https://registry.npmjs.org/ip6/-/ip6-0.2.10.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ip6"
         }
       ]
     },
@@ -10885,6 +14069,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ipaddr.js"
+        }
       ]
     },
     {
@@ -10904,6 +14094,12 @@
           "url": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-absolute"
         }
       ]
     },
@@ -10925,6 +14121,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-accessor-descriptor"
+        }
       ]
     },
     {
@@ -10944,6 +14146,12 @@
           "url": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-arguments"
         }
       ]
     },
@@ -10965,6 +14173,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-arrayish"
+        }
       ]
     },
     {
@@ -10984,6 +14198,12 @@
           "url": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-bigint"
         }
       ]
     },
@@ -11005,6 +14225,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-binary-path"
+        }
       ]
     },
     {
@@ -11024,6 +14250,12 @@
           "url": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-boolean-object"
         }
       ]
     },
@@ -11045,6 +14277,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-buffer"
+        }
       ]
     },
     {
@@ -11064,6 +14302,12 @@
           "url": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-callable"
         }
       ]
     },
@@ -11085,6 +14329,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-core-module"
+        }
       ]
     },
     {
@@ -11104,6 +14354,12 @@
           "url": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-data-descriptor"
         }
       ]
     },
@@ -11125,6 +14381,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-date-object"
+        }
       ]
     },
     {
@@ -11144,6 +14406,12 @@
           "url": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-descriptor"
         }
       ]
     },
@@ -11165,6 +14433,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-docker"
+        }
       ]
     },
     {
@@ -11184,6 +14458,12 @@
           "url": "https://registry.npmjs.org/is-expression/-/is-expression-4.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-expression"
         }
       ]
     },
@@ -11205,6 +14485,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-extendable"
+        }
       ]
     },
     {
@@ -11224,6 +14510,12 @@
           "url": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-extglob"
         }
       ]
     },
@@ -11245,6 +14537,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-fullwidth-code-point"
+        }
       ]
     },
     {
@@ -11264,6 +14562,12 @@
           "url": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-generator-function"
         }
       ]
     },
@@ -11285,6 +14589,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-glob"
+        }
       ]
     },
     {
@@ -11304,6 +14614,12 @@
           "url": "https://registry.npmjs.org/is-heroku/-/is-heroku-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-heroku"
         }
       ]
     },
@@ -11325,6 +14641,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-lambda"
+        }
       ]
     },
     {
@@ -11344,6 +14666,12 @@
           "url": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-map"
         }
       ]
     },
@@ -11365,6 +14693,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-natural-number"
+        }
       ]
     },
     {
@@ -11384,6 +14718,12 @@
           "url": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-negative-zero"
         }
       ]
     },
@@ -11405,6 +14745,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-number-like"
+        }
       ]
     },
     {
@@ -11424,6 +14770,12 @@
           "url": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-number-object"
         }
       ]
     },
@@ -11446,6 +14798,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-number"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -11464,6 +14822,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/is-number/node_modules/kind-of"
             }
           ]
         }
@@ -11487,6 +14851,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-object"
+        }
       ]
     },
     {
@@ -11506,6 +14876,12 @@
           "url": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-plain-obj"
         }
       ]
     },
@@ -11527,6 +14903,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-plain-object"
+        }
       ]
     },
     {
@@ -11546,6 +14928,12 @@
           "url": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-promise"
         }
       ]
     },
@@ -11567,6 +14955,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-regex"
+        }
       ]
     },
     {
@@ -11586,6 +14980,12 @@
           "url": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-relative"
         }
       ]
     },
@@ -11607,6 +15007,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-retry-allowed"
+        }
       ]
     },
     {
@@ -11626,6 +15032,12 @@
           "url": "https://registry.npmjs.org/is-set/-/is-set-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-set"
         }
       ]
     },
@@ -11647,6 +15059,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-shared-array-buffer"
+        }
       ]
     },
     {
@@ -11666,6 +15084,12 @@
           "url": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-stream"
         }
       ]
     },
@@ -11687,6 +15111,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-string"
+        }
       ]
     },
     {
@@ -11706,6 +15136,12 @@
           "url": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-symbol"
         }
       ]
     },
@@ -11727,6 +15163,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-typed-array"
+        }
       ]
     },
     {
@@ -11746,6 +15188,12 @@
           "url": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-typedarray"
         }
       ]
     },
@@ -11767,6 +15215,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-unc-path"
+        }
       ]
     },
     {
@@ -11786,6 +15240,12 @@
           "url": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-weakmap"
         }
       ]
     },
@@ -11807,6 +15267,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-weakref"
+        }
       ]
     },
     {
@@ -11826,6 +15292,12 @@
           "url": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-weakset"
         }
       ]
     },
@@ -11847,6 +15319,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-windows"
+        }
       ]
     },
     {
@@ -11866,6 +15344,12 @@
           "url": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isarray"
         }
       ]
     },
@@ -11887,6 +15371,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isexe"
+        }
       ]
     },
     {
@@ -11906,6 +15396,12 @@
           "url": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isobject"
         }
       ]
     },
@@ -11927,6 +15423,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isstream"
+        }
       ]
     },
     {
@@ -11946,6 +15448,12 @@
           "url": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isurl"
         }
       ]
     },
@@ -11967,6 +15475,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/js-stringify"
+        }
       ]
     },
     {
@@ -11986,6 +15500,12 @@
           "url": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/js-tokens"
         }
       ]
     },
@@ -12007,6 +15527,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/js-yaml"
+        }
       ]
     },
     {
@@ -12026,6 +15552,12 @@
           "url": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jsbn"
         }
       ]
     },
@@ -12047,6 +15579,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-buffer"
+        }
       ]
     },
     {
@@ -12066,6 +15604,12 @@
           "url": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-parse-better-errors"
         }
       ]
     },
@@ -12087,6 +15631,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-schema-traverse"
+        }
       ]
     },
     {
@@ -12106,6 +15656,12 @@
           "url": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-schema"
         }
       ]
     },
@@ -12127,6 +15683,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-stringify-safe"
+        }
       ]
     },
     {
@@ -12146,6 +15708,12 @@
           "url": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json5"
         }
       ]
     },
@@ -12167,6 +15735,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jsonfile"
+        }
       ]
     },
     {
@@ -12186,6 +15760,12 @@
           "url": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-0.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jsonwebtoken"
         }
       ]
     },
@@ -12207,6 +15787,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jsprim"
+        }
       ]
     },
     {
@@ -12226,6 +15812,12 @@
           "url": "https://registry.npmjs.org/jssha/-/jssha-3.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jssha"
         }
       ]
     },
@@ -12247,6 +15839,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jstransformer"
+        }
       ]
     },
     {
@@ -12266,6 +15864,12 @@
           "url": "https://registry.npmjs.org/juicy-chat-bot/-/juicy-chat-bot-0.6.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/juicy-chat-bot"
         }
       ]
     },
@@ -12287,6 +15891,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jwa"
+        }
       ]
     },
     {
@@ -12306,6 +15916,12 @@
           "url": "https://registry.npmjs.org/jws/-/jws-0.2.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jws"
         }
       ]
     },
@@ -12327,6 +15943,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/keyv"
+        }
       ]
     },
     {
@@ -12346,6 +15968,12 @@
           "url": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/kind-of"
         }
       ]
     },
@@ -12367,6 +15995,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/kuler"
+        }
       ]
     },
     {
@@ -12386,6 +16020,12 @@
           "url": "https://registry.npmjs.org/kuromoji/-/kuromoji-0.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/kuromoji"
         }
       ]
     },
@@ -12407,6 +16047,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lazystream"
+        }
       ]
     },
     {
@@ -12426,6 +16072,12 @@
           "url": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/levn"
         }
       ]
     },
@@ -12448,6 +16100,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/libxmljs2"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12466,6 +16124,12 @@
               "url": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/libxmljs2/node_modules/nan"
             }
           ]
         }
@@ -12490,6 +16154,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/liftup"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12508,6 +16178,12 @@
               "url": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/braces"
             }
           ]
         },
@@ -12529,6 +16205,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/fill-range"
+            }
           ]
         },
         {
@@ -12548,6 +16230,12 @@
               "url": "https://registry.npmjs.org/findup-sync/-/findup-sync-4.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/findup-sync"
             }
           ]
         },
@@ -12569,6 +16257,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/is-glob"
+            }
           ]
         },
         {
@@ -12588,6 +16282,12 @@
               "url": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/is-number"
             }
           ]
         },
@@ -12609,6 +16309,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/micromatch"
+            }
           ]
         },
         {
@@ -12628,6 +16334,12 @@
               "url": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/to-regex-range"
             }
           ]
         }
@@ -12652,6 +16364,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/linebreak"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12670,6 +16388,12 @@
               "url": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/linebreak/node_modules/base64-js"
             }
           ]
         }
@@ -12693,6 +16417,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/listenercount"
+        }
       ]
     },
     {
@@ -12712,6 +16442,12 @@
           "url": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/locate-path"
         }
       ]
     },
@@ -12733,6 +16469,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lodash.camelcase"
+        }
       ]
     },
     {
@@ -12752,6 +16494,12 @@
           "url": "https://registry.npmjs.org/lodash.isfinite/-/lodash.isfinite-3.3.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lodash.isfinite"
         }
       ]
     },
@@ -12773,6 +16521,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lodash.set"
+        }
       ]
     },
     {
@@ -12792,6 +16546,12 @@
           "url": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lodash"
         }
       ]
     },
@@ -12814,6 +16574,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/logform"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12832,6 +16598,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/logform/node_modules/ms"
             }
           ]
         }
@@ -12855,6 +16627,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lolex"
+        }
       ]
     },
     {
@@ -12874,6 +16652,12 @@
           "url": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/loose-envify"
         }
       ]
     },
@@ -12895,6 +16679,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lowercase-keys"
+        }
       ]
     },
     {
@@ -12914,6 +16704,12 @@
           "url": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lru-cache"
         }
       ]
     },
@@ -12936,6 +16732,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-dir"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12954,6 +16756,12 @@
               "url": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-dir/node_modules/semver"
             }
           ]
         }
@@ -12977,6 +16785,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-error"
+        }
       ]
     },
     {
@@ -12996,6 +16810,12 @@
           "url": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-9.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-fetch-happen"
         }
       ],
       "components": [
@@ -13018,6 +16838,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen/node_modules/@tootallnate/once"
+            }
           ]
         },
         {
@@ -13037,6 +16863,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen/node_modules/debug"
             }
           ]
         },
@@ -13058,6 +16890,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen/node_modules/http-cache-semantics"
+            }
           ]
         },
         {
@@ -13078,6 +16916,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen/node_modules/http-proxy-agent"
+            }
           ]
         },
         {
@@ -13097,6 +16941,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen/node_modules/ms"
             }
           ]
         }
@@ -13120,6 +16970,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-iterator"
+        }
       ]
     },
     {
@@ -13139,6 +16995,12 @@
           "url": "https://registry.npmjs.org/make-plural/-/make-plural-6.2.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-plural"
         }
       ]
     },
@@ -13160,6 +17022,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/map-cache"
+        }
       ]
     },
     {
@@ -13179,6 +17047,12 @@
           "url": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/map-visit"
         }
       ]
     },
@@ -13200,6 +17074,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/marsdb"
+        }
       ]
     },
     {
@@ -13219,6 +17099,12 @@
           "url": "https://registry.npmjs.org/math-interval-parser/-/math-interval-parser-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/math-interval-parser"
         }
       ]
     },
@@ -13240,6 +17126,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/media-typer"
+        }
       ]
     },
     {
@@ -13259,6 +17151,12 @@
           "url": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/merge-descriptors"
         }
       ]
     },
@@ -13280,6 +17178,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/messageformat-formatters"
+        }
       ]
     },
     {
@@ -13299,6 +17203,12 @@
           "url": "https://registry.npmjs.org/messageformat-parser/-/messageformat-parser-4.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/messageformat-parser"
         }
       ]
     },
@@ -13321,6 +17231,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/messageformat"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -13339,6 +17255,12 @@
               "url": "https://registry.npmjs.org/make-plural/-/make-plural-4.3.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/messageformat/node_modules/make-plural"
             }
           ]
         }
@@ -13362,6 +17284,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/methods"
+        }
       ]
     },
     {
@@ -13381,6 +17309,12 @@
           "url": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/micromatch"
         }
       ]
     },
@@ -13402,6 +17336,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mime-db"
+        }
       ]
     },
     {
@@ -13421,6 +17361,12 @@
           "url": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mime-types"
         }
       ]
     },
@@ -13442,6 +17388,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mime"
+        }
       ]
     },
     {
@@ -13461,6 +17413,12 @@
           "url": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mimic-response"
         }
       ]
     },
@@ -13482,6 +17440,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minimatch"
+        }
       ]
     },
     {
@@ -13501,6 +17465,12 @@
           "url": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minimist"
         }
       ]
     },
@@ -13522,6 +17492,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-collect"
+        }
       ]
     },
     {
@@ -13541,6 +17517,12 @@
           "url": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-1.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-fetch"
         }
       ]
     },
@@ -13562,6 +17544,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-flush"
+        }
       ]
     },
     {
@@ -13581,6 +17569,12 @@
           "url": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-pipeline"
         }
       ]
     },
@@ -13602,6 +17596,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-sized"
+        }
       ]
     },
     {
@@ -13621,6 +17621,12 @@
           "url": "https://registry.npmjs.org/minipass/-/minipass-3.3.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass"
         }
       ]
     },
@@ -13642,6 +17648,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minizlib"
+        }
       ]
     },
     {
@@ -13661,6 +17673,12 @@
           "url": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mixin-deep"
         }
       ]
     },
@@ -13682,6 +17700,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mkdirp-classic"
+        }
       ]
     },
     {
@@ -13701,6 +17725,12 @@
           "url": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mkdirp"
         }
       ]
     },
@@ -13722,6 +17752,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/moment-timezone"
+        }
       ]
     },
     {
@@ -13741,6 +17777,12 @@
           "url": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/moment"
         }
       ]
     },
@@ -13763,6 +17805,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/morgan"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -13781,6 +17829,12 @@
               "url": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/morgan/node_modules/on-finished"
             }
           ]
         }
@@ -13804,6 +17858,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mout"
+        }
       ]
     },
     {
@@ -13823,6 +17883,12 @@
           "url": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ms"
         }
       ]
     },
@@ -13845,6 +17911,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/multer"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -13863,6 +17935,12 @@
               "url": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/multer/node_modules/mkdirp"
             }
           ]
         }
@@ -13886,6 +17964,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mustache"
+        }
       ]
     },
     {
@@ -13905,6 +17989,12 @@
           "url": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/nan"
         }
       ]
     },
@@ -13926,6 +18016,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/nanomatch"
+        }
       ]
     },
     {
@@ -13945,6 +18041,12 @@
           "url": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/napi-build-utils"
         }
       ]
     },
@@ -13967,6 +18069,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/needle"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -13985,6 +18093,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/needle/node_modules/debug"
             }
           ]
         },
@@ -14005,6 +18119,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/needle/node_modules/ms"
             }
           ]
         }
@@ -14028,6 +18148,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/negotiator"
+        }
       ]
     },
     {
@@ -14047,6 +18173,12 @@
           "url": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/neo-async"
         }
       ]
     },
@@ -14069,6 +18201,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-abi"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14087,6 +18225,12 @@
               "url": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-abi/node_modules/semver"
             }
           ]
         }
@@ -14110,6 +18254,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-addon-api"
+        }
       ]
     },
     {
@@ -14129,6 +18279,12 @@
           "url": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-fetch"
         }
       ]
     },
@@ -14151,6 +18307,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-gyp"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14169,6 +18331,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/ansi-regex"
             }
           ]
         },
@@ -14190,6 +18358,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/are-we-there-yet"
+            }
           ]
         },
         {
@@ -14209,6 +18383,12 @@
               "url": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/gauge"
             }
           ]
         },
@@ -14230,6 +18410,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/is-fullwidth-code-point"
+            }
           ]
         },
         {
@@ -14249,6 +18435,12 @@
               "url": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/nopt"
             }
           ]
         },
@@ -14270,6 +18462,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/npmlog"
+            }
           ]
         },
         {
@@ -14289,6 +18487,12 @@
               "url": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/readable-stream"
             }
           ]
         },
@@ -14310,6 +18514,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/string-width"
+            }
           ]
         },
         {
@@ -14329,6 +18539,12 @@
               "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/strip-ansi"
             }
           ]
         }
@@ -14353,6 +18569,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-pre-gyp"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14371,6 +18593,12 @@
               "url": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/chownr"
             }
           ]
         },
@@ -14392,6 +18620,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/fs-minipass"
+            }
           ]
         },
         {
@@ -14411,6 +18645,12 @@
               "url": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/minipass"
             }
           ]
         },
@@ -14432,6 +18672,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/minizlib"
+            }
           ]
         },
         {
@@ -14451,6 +18697,12 @@
               "url": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/mkdirp"
             }
           ]
         },
@@ -14472,6 +18724,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/nopt"
+            }
           ]
         },
         {
@@ -14491,6 +18749,12 @@
               "url": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/rimraf"
             }
           ]
         },
@@ -14512,6 +18776,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/safe-buffer"
+            }
           ]
         },
         {
@@ -14531,6 +18801,12 @@
               "url": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/semver"
             }
           ]
         },
@@ -14552,6 +18828,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/tar"
+            }
           ]
         },
         {
@@ -14571,6 +18853,12 @@
               "url": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/yallist"
             }
           ]
         }
@@ -14594,6 +18882,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/noop-logger"
+        }
       ]
     },
     {
@@ -14613,6 +18907,12 @@
           "url": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/nopt"
         }
       ]
     },
@@ -14635,6 +18935,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/normalize-package-data"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14653,6 +18959,12 @@
               "url": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/normalize-package-data/node_modules/semver"
             }
           ]
         }
@@ -14676,6 +18988,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/normalize-path"
+        }
       ]
     },
     {
@@ -14695,6 +19013,12 @@
           "url": "https://registry.npmjs.org/normalize-url/-/normalize-url-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/normalize-url"
         }
       ]
     },
@@ -14717,6 +19041,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/notevil"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14735,6 +19065,12 @@
               "url": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/notevil/node_modules/esprima"
             }
           ]
         }
@@ -14758,6 +19094,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/npm-bundled"
+        }
       ]
     },
     {
@@ -14777,6 +19119,12 @@
           "url": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/npm-normalize-package-bin"
         }
       ]
     },
@@ -14798,6 +19146,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/npm-packlist"
+        }
       ]
     },
     {
@@ -14817,6 +19171,12 @@
           "url": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/npmlog"
         }
       ]
     },
@@ -14838,6 +19198,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/number-is-nan"
+        }
       ]
     },
     {
@@ -14858,6 +19224,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/oauth-sign"
+        }
       ]
     },
     {
@@ -14877,6 +19249,12 @@
           "url": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-assign"
         }
       ]
     },
@@ -14899,6 +19277,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-copy"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14917,6 +19301,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy/node_modules/define-property"
             }
           ]
         },
@@ -14938,6 +19328,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy/node_modules/is-accessor-descriptor"
+            }
           ]
         },
         {
@@ -14957,6 +19353,12 @@
               "url": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy/node_modules/is-data-descriptor"
             }
           ]
         },
@@ -14979,6 +19381,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy/node_modules/is-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -14997,6 +19405,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/object-copy/node_modules/is-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -15020,6 +19434,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy/node_modules/kind-of"
+            }
           ]
         }
       ]
@@ -15042,6 +19462,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-inspect"
+        }
       ]
     },
     {
@@ -15061,6 +19487,12 @@
           "url": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-is"
         }
       ]
     },
@@ -15082,6 +19514,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-keys"
+        }
       ]
     },
     {
@@ -15101,6 +19539,12 @@
           "url": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-visit"
         }
       ]
     },
@@ -15122,6 +19566,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object.assign"
+        }
       ]
     },
     {
@@ -15141,6 +19591,12 @@
           "url": "https://registry.npmjs.org/object.defaults/-/object.defaults-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object.defaults"
         }
       ]
     },
@@ -15162,6 +19618,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object.map"
+        }
       ]
     },
     {
@@ -15181,6 +19643,12 @@
           "url": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object.pick"
         }
       ]
     },
@@ -15202,6 +19670,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/on-finished"
+        }
       ]
     },
     {
@@ -15221,6 +19695,12 @@
           "url": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/on-headers"
         }
       ]
     },
@@ -15242,6 +19722,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/once"
+        }
       ]
     },
     {
@@ -15261,6 +19747,12 @@
           "url": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/one-time"
         }
       ]
     },
@@ -15282,6 +19774,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/opentype.js"
+        }
       ]
     },
     {
@@ -15301,6 +19799,12 @@
           "url": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/optionator"
         }
       ]
     },
@@ -15322,6 +19826,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/os-homedir"
+        }
       ]
     },
     {
@@ -15341,6 +19851,12 @@
           "url": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/os-tmpdir"
         }
       ]
     },
@@ -15362,6 +19878,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/osenv"
+        }
       ]
     },
     {
@@ -15381,6 +19903,12 @@
           "url": "https://registry.npmjs.org/otplib/-/otplib-12.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/otplib"
         }
       ]
     },
@@ -15402,6 +19930,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-cancelable"
+        }
       ]
     },
     {
@@ -15421,6 +19955,12 @@
           "url": "https://registry.npmjs.org/p-event/-/p-event-2.3.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-event"
         }
       ]
     },
@@ -15442,6 +19982,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-finally"
+        }
       ]
     },
     {
@@ -15461,6 +20007,12 @@
           "url": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-is-promise"
         }
       ]
     },
@@ -15482,6 +20034,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-limit"
+        }
       ]
     },
     {
@@ -15501,6 +20059,12 @@
           "url": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-locate"
         }
       ]
     },
@@ -15522,6 +20086,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-map"
+        }
       ]
     },
     {
@@ -15541,6 +20111,12 @@
           "url": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-timeout"
         }
       ]
     },
@@ -15562,6 +20138,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-try"
+        }
       ]
     },
     {
@@ -15581,6 +20163,12 @@
           "url": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pako"
         }
       ]
     },
@@ -15602,6 +20190,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/parse-filepath"
+        }
       ]
     },
     {
@@ -15621,6 +20215,12 @@
           "url": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/parse-json"
         }
       ]
     },
@@ -15642,6 +20242,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/parse-passwd"
+        }
       ]
     },
     {
@@ -15661,6 +20267,12 @@
           "url": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/parseurl"
         }
       ]
     },
@@ -15682,6 +20294,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pascalcase"
+        }
       ]
     },
     {
@@ -15701,6 +20319,12 @@
           "url": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-exists"
         }
       ]
     },
@@ -15722,6 +20346,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-is-absolute"
+        }
       ]
     },
     {
@@ -15741,6 +20371,12 @@
           "url": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-parse"
         }
       ]
     },
@@ -15762,6 +20398,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-root-regex"
+        }
       ]
     },
     {
@@ -15781,6 +20423,12 @@
           "url": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-root"
         }
       ]
     },
@@ -15802,6 +20450,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-to-regexp"
+        }
       ]
     },
     {
@@ -15821,6 +20475,12 @@
           "url": "https://registry.npmjs.org/pdfkit/-/pdfkit-0.11.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pdfkit"
         }
       ]
     },
@@ -15842,6 +20502,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/peek-readable"
+        }
       ]
     },
     {
@@ -15861,6 +20527,12 @@
           "url": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pend"
         }
       ]
     },
@@ -15882,6 +20554,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/performance-now"
+        }
       ]
     },
     {
@@ -15901,6 +20579,12 @@
           "url": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.5.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pg-connection-string"
         }
       ]
     },
@@ -15922,6 +20606,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/picomatch"
+        }
       ]
     },
     {
@@ -15941,6 +20631,12 @@
           "url": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pify"
         }
       ]
     },
@@ -15962,6 +20658,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pinkie-promise"
+        }
       ]
     },
     {
@@ -15981,6 +20683,12 @@
           "url": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pinkie"
         }
       ]
     },
@@ -16002,6 +20710,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/png-js"
+        }
       ]
     },
     {
@@ -16021,6 +20735,12 @@
           "url": "https://registry.npmjs.org/portscanner/-/portscanner-2.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/portscanner"
         }
       ]
     },
@@ -16042,6 +20762,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/posix-character-classes"
+        }
       ]
     },
     {
@@ -16061,6 +20787,12 @@
           "url": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.3.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/prebuild-install"
         }
       ]
     },
@@ -16082,6 +20814,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/prelude-ls"
+        }
       ]
     },
     {
@@ -16101,6 +20839,12 @@
           "url": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/prepend-http"
         }
       ]
     },
@@ -16122,6 +20866,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pretty-bytes"
+        }
       ]
     },
     {
@@ -16141,6 +20891,12 @@
           "url": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/process-nextick-args"
         }
       ]
     },
@@ -16162,6 +20918,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/prom-client"
+        }
       ]
     },
     {
@@ -16181,6 +20943,12 @@
           "url": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/promise-inflight"
         }
       ]
     },
@@ -16203,6 +20971,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/promise-retry"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -16221,6 +20995,12 @@
               "url": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/promise-retry/node_modules/err-code"
             }
           ]
         },
@@ -16241,6 +21021,12 @@
               "url": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/promise-retry/node_modules/retry"
             }
           ]
         }
@@ -16264,6 +21050,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/promise"
+        }
       ]
     },
     {
@@ -16283,6 +21075,12 @@
           "url": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/proper-lockfile"
         }
       ]
     },
@@ -16304,6 +21102,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/proxy-addr"
+        }
       ]
     },
     {
@@ -16323,6 +21127,12 @@
           "url": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/psl"
         }
       ]
     },
@@ -16344,6 +21154,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-attrs"
+        }
       ]
     },
     {
@@ -16363,6 +21179,12 @@
           "url": "https://registry.npmjs.org/pug-code-gen/-/pug-code-gen-3.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-code-gen"
         }
       ]
     },
@@ -16384,6 +21206,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-error"
+        }
       ]
     },
     {
@@ -16403,6 +21231,12 @@
           "url": "https://registry.npmjs.org/pug-filters/-/pug-filters-4.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-filters"
         }
       ]
     },
@@ -16424,6 +21258,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-lexer"
+        }
       ]
     },
     {
@@ -16443,6 +21283,12 @@
           "url": "https://registry.npmjs.org/pug-linker/-/pug-linker-4.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-linker"
         }
       ]
     },
@@ -16464,6 +21310,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-load"
+        }
       ]
     },
     {
@@ -16483,6 +21335,12 @@
           "url": "https://registry.npmjs.org/pug-parser/-/pug-parser-6.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-parser"
         }
       ]
     },
@@ -16504,6 +21362,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-runtime"
+        }
       ]
     },
     {
@@ -16523,6 +21387,12 @@
           "url": "https://registry.npmjs.org/pug-strip-comments/-/pug-strip-comments-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-strip-comments"
         }
       ]
     },
@@ -16544,6 +21414,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-walk"
+        }
       ]
     },
     {
@@ -16563,6 +21439,12 @@
           "url": "https://registry.npmjs.org/pug/-/pug-3.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug"
         }
       ]
     },
@@ -16584,6 +21466,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pump"
+        }
       ]
     },
     {
@@ -16603,6 +21491,12 @@
           "url": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/punycode"
         }
       ]
     },
@@ -16624,6 +21518,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/qs"
+        }
       ]
     },
     {
@@ -16643,6 +21543,12 @@
           "url": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/query-string"
         }
       ]
     },
@@ -16664,6 +21570,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/range_check"
+        }
       ]
     },
     {
@@ -16683,6 +21595,12 @@
           "url": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/range-parser"
         }
       ]
     },
@@ -16704,6 +21622,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/raw-body"
+        }
       ]
     },
     {
@@ -16723,6 +21647,12 @@
           "url": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/rc"
         }
       ]
     },
@@ -16745,6 +21675,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/read-pkg"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -16763,6 +21699,12 @@
               "url": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/read-pkg/node_modules/pify"
             }
           ]
         }
@@ -16787,6 +21729,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/readable-stream"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -16805,6 +21753,12 @@
               "url": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/readable-stream/node_modules/isarray"
             }
           ]
         }
@@ -16829,6 +21783,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/readable-web-to-node-stream"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -16847,6 +21807,12 @@
               "url": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/readable-web-to-node-stream/node_modules/readable-stream"
             }
           ]
         }
@@ -16870,6 +21836,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/readdirp"
+        }
       ]
     },
     {
@@ -16889,6 +21861,12 @@
           "url": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/rechoir"
         }
       ]
     },
@@ -16910,6 +21888,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/regex-not"
+        }
       ]
     },
     {
@@ -16929,6 +21913,12 @@
           "url": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/regexp.prototype.flags"
         }
       ]
     },
@@ -16950,6 +21940,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/remove-trailing-separator"
+        }
       ]
     },
     {
@@ -16970,6 +21966,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/repeat-element"
+        }
       ]
     },
     {
@@ -16989,6 +21991,12 @@
           "url": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/repeat-string"
         }
       ]
     },
@@ -17011,6 +22019,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/replace"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17029,6 +22043,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/ansi-regex"
             }
           ]
         },
@@ -17050,6 +22070,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/ansi-styles"
+            }
           ]
         },
         {
@@ -17069,6 +22095,12 @@
               "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/brace-expansion"
             }
           ]
         },
@@ -17090,6 +22122,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/cliui"
+            }
           ]
         },
         {
@@ -17109,6 +22147,12 @@
               "url": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/color-convert"
             }
           ]
         },
@@ -17130,6 +22174,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/color-name"
+            }
           ]
         },
         {
@@ -17149,6 +22199,12 @@
               "url": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/find-up"
             }
           ]
         },
@@ -17170,6 +22226,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/is-fullwidth-code-point"
+            }
           ]
         },
         {
@@ -17189,6 +22251,12 @@
               "url": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/locate-path"
             }
           ]
         },
@@ -17210,6 +22278,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/minimatch"
+            }
           ]
         },
         {
@@ -17229,6 +22303,12 @@
               "url": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/p-locate"
             }
           ]
         },
@@ -17250,6 +22330,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/path-exists"
+            }
           ]
         },
         {
@@ -17269,6 +22355,12 @@
               "url": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/string-width"
             }
           ]
         },
@@ -17290,6 +22382,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/strip-ansi"
+            }
           ]
         },
         {
@@ -17309,6 +22407,12 @@
               "url": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/wrap-ansi"
             }
           ]
         },
@@ -17330,6 +22434,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/yargs-parser"
+            }
           ]
         },
         {
@@ -17349,6 +22459,12 @@
               "url": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/yargs"
             }
           ]
         }
@@ -17373,6 +22489,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/request"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17391,6 +22513,12 @@
               "url": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/request/node_modules/qs"
             }
           ]
         }
@@ -17414,6 +22542,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/require-directory"
+        }
       ]
     },
     {
@@ -17433,6 +22567,12 @@
           "url": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/require-main-filename"
         }
       ]
     },
@@ -17454,6 +22594,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/resolve-dir"
+        }
       ]
     },
     {
@@ -17473,6 +22619,12 @@
           "url": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/resolve-url"
         }
       ]
     },
@@ -17494,6 +22646,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/resolve"
+        }
       ]
     },
     {
@@ -17513,6 +22671,12 @@
           "url": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/responselike"
         }
       ]
     },
@@ -17534,6 +22698,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/restructure"
+        }
       ]
     },
     {
@@ -17553,6 +22723,12 @@
           "url": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ret"
         }
       ]
     },
@@ -17574,6 +22750,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/retry-as-promised"
+        }
       ]
     },
     {
@@ -17594,6 +22776,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/retry"
+        }
       ]
     },
     {
@@ -17613,6 +22801,12 @@
           "url": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/rimraf"
         }
       ]
     },
@@ -17635,6 +22829,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/rxjs"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17653,6 +22853,12 @@
               "url": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/rxjs/node_modules/tslib"
             }
           ]
         }
@@ -17676,6 +22882,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safe-buffer"
+        }
       ]
     },
     {
@@ -17695,6 +22907,12 @@
           "url": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safe-regex-test"
         }
       ]
     },
@@ -17716,6 +22934,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safe-regex"
+        }
       ]
     },
     {
@@ -17735,6 +22959,12 @@
           "url": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safe-stable-stringify"
         }
       ]
     },
@@ -17756,6 +22986,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safer-buffer"
+        }
       ]
     },
     {
@@ -17776,6 +23012,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/samsam"
+        }
       ]
     },
     {
@@ -17795,6 +23037,12 @@
           "url": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sanitize-filename"
         }
       ]
     },
@@ -17817,6 +23065,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sanitize-html"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17835,6 +23089,12 @@
               "url": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sanitize-html/node_modules/lodash"
             }
           ]
         }
@@ -17858,6 +23118,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sax"
+        }
       ]
     },
     {
@@ -17878,6 +23144,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/seek-bzip"
+        }
       ]
     },
     {
@@ -17897,6 +23169,12 @@
           "url": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/semver"
         }
       ]
     },
@@ -17919,6 +23197,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/send"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17937,6 +23221,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/send/node_modules/ms"
             }
           ]
         }
@@ -17960,6 +23250,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sequelize-pool"
+        }
       ]
     },
     {
@@ -17981,6 +23277,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sequelize"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17999,6 +23301,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sequelize/node_modules/debug"
             }
           ]
         },
@@ -18020,6 +23328,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sequelize/node_modules/ms"
+            }
           ]
         },
         {
@@ -18039,6 +23353,12 @@
               "url": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sequelize/node_modules/uuid"
             }
           ]
         }
@@ -18063,6 +23383,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/serve-index"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18081,6 +23407,12 @@
               "url": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index/node_modules/depd"
             }
           ]
         },
@@ -18102,6 +23434,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index/node_modules/http-errors"
+            }
           ]
         },
         {
@@ -18121,6 +23459,12 @@
               "url": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index/node_modules/inherits"
             }
           ]
         },
@@ -18142,6 +23486,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index/node_modules/setprototypeof"
+            }
           ]
         },
         {
@@ -18161,6 +23511,12 @@
               "url": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index/node_modules/statuses"
             }
           ]
         }
@@ -18184,6 +23540,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/serve-static"
+        }
       ]
     },
     {
@@ -18203,6 +23565,12 @@
           "url": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/set-blocking"
         }
       ]
     },
@@ -18225,6 +23593,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/set-value"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18243,6 +23617,12 @@
               "url": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/set-value/node_modules/extend-shallow"
             }
           ]
         },
@@ -18263,6 +23643,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/set-value/node_modules/is-extendable"
             }
           ]
         }
@@ -18286,6 +23672,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/setimmediate"
+        }
       ]
     },
     {
@@ -18305,6 +23697,12 @@
           "url": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/setprototypeof"
         }
       ]
     },
@@ -18326,6 +23724,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/side-channel"
+        }
       ]
     },
     {
@@ -18346,6 +23750,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/signal-exit"
+        }
       ]
     },
     {
@@ -18365,6 +23775,12 @@
           "url": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/simple-concat"
         }
       ]
     },
@@ -18387,6 +23803,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/simple-get"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18405,6 +23827,12 @@
               "url": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/simple-get/node_modules/decompress-response"
             }
           ]
         },
@@ -18425,6 +23853,12 @@
               "url": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/simple-get/node_modules/mimic-response"
             }
           ]
         }
@@ -18449,6 +23883,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/simple-swizzle"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18467,6 +23907,12 @@
               "url": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/simple-swizzle/node_modules/is-arrayish"
             }
           ]
         }
@@ -18490,6 +23936,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sinon"
+        }
       ]
     },
     {
@@ -18509,6 +23961,12 @@
           "url": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/smart-buffer"
         }
       ]
     },
@@ -18531,6 +23989,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/snapdragon-node"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18549,6 +24013,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon-node/node_modules/define-property"
             }
           ]
         }
@@ -18573,6 +24043,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/snapdragon-util"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18591,6 +24067,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon-util/node_modules/kind-of"
             }
           ]
         }
@@ -18615,6 +24097,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/snapdragon"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18633,6 +24121,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/define-property"
             }
           ]
         },
@@ -18653,6 +24147,12 @@
               "url": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/extend-shallow"
             }
           ]
         },
@@ -18675,6 +24175,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/is-accessor-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -18693,6 +24199,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/snapdragon/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -18717,6 +24229,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/is-data-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -18735,6 +24253,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/snapdragon/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -18758,6 +24282,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/is-descriptor"
+            }
           ]
         },
         {
@@ -18777,6 +24307,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/is-extendable"
             }
           ]
         },
@@ -18798,6 +24334,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/kind-of"
+            }
           ]
         },
         {
@@ -18817,6 +24359,12 @@
               "url": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/source-map"
             }
           ]
         }
@@ -18840,6 +24388,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socket.io-adapter"
+        }
       ]
     },
     {
@@ -18861,6 +24415,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socket.io-parser"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18879,6 +24439,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socket.io-parser/node_modules/debug"
             }
           ]
         },
@@ -18899,6 +24465,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socket.io-parser/node_modules/ms"
             }
           ]
         }
@@ -18923,6 +24495,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socket.io"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18941,6 +24519,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socket.io/node_modules/debug"
             }
           ]
         },
@@ -18961,6 +24545,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socket.io/node_modules/ms"
             }
           ]
         }
@@ -18985,6 +24575,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socks-proxy-agent"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -19003,6 +24599,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socks-proxy-agent/node_modules/debug"
             }
           ]
         },
@@ -19023,6 +24625,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socks-proxy-agent/node_modules/ms"
             }
           ]
         }
@@ -19047,6 +24655,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socks"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -19065,6 +24679,12 @@
               "url": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socks/node_modules/ip"
             }
           ]
         }
@@ -19089,6 +24709,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sort-keys-length"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -19107,6 +24733,12 @@
               "url": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sort-keys-length/node_modules/sort-keys"
             }
           ]
         }
@@ -19130,6 +24762,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sort-keys"
+        }
       ]
     },
     {
@@ -19149,6 +24787,12 @@
           "url": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/source-map-resolve"
         }
       ]
     },
@@ -19170,6 +24814,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/source-map-support"
+        }
       ]
     },
     {
@@ -19189,6 +24839,12 @@
           "url": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/source-map-url"
         }
       ]
     },
@@ -19210,6 +24866,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/source-map"
+        }
       ]
     },
     {
@@ -19229,6 +24891,12 @@
           "url": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2-1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spawn-command"
         }
       ]
     },
@@ -19250,6 +24918,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spdx-correct"
+        }
       ]
     },
     {
@@ -19269,6 +24943,12 @@
           "url": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spdx-exceptions"
         }
       ]
     },
@@ -19290,6 +24970,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spdx-expression-parse"
+        }
       ]
     },
     {
@@ -19309,6 +24995,12 @@
           "url": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.12.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spdx-license-ids"
         }
       ]
     },
@@ -19330,6 +25022,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/split-string"
+        }
       ]
     },
     {
@@ -19349,6 +25047,12 @@
           "url": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sprintf-js"
         }
       ]
     },
@@ -19370,6 +25074,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sqlite3"
+        }
       ]
     },
     {
@@ -19389,6 +25099,12 @@
           "url": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sshpk"
         }
       ]
     },
@@ -19410,6 +25126,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ssri"
+        }
       ]
     },
     {
@@ -19429,6 +25151,12 @@
           "url": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/stack-trace"
         }
       ]
     },
@@ -19451,6 +25179,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/static-extend"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -19469,6 +25203,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend/node_modules/define-property"
             }
           ]
         },
@@ -19491,6 +25231,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend/node_modules/is-accessor-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -19509,6 +25255,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/static-extend/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -19533,6 +25285,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend/node_modules/is-data-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -19551,6 +25309,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/static-extend/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -19574,6 +25338,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend/node_modules/is-descriptor"
+            }
           ]
         },
         {
@@ -19593,6 +25363,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend/node_modules/kind-of"
             }
           ]
         }
@@ -19616,6 +25392,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/statuses"
+        }
       ]
     },
     {
@@ -19635,6 +25417,12 @@
           "url": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-2.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/stream-buffers"
         }
       ]
     },
@@ -19656,6 +25444,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/streamsearch"
+        }
       ]
     },
     {
@@ -19675,6 +25469,12 @@
           "url": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strict-uri-encode"
         }
       ]
     },
@@ -19696,6 +25496,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string_decoder"
+        }
       ]
     },
     {
@@ -19715,6 +25521,12 @@
           "url": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string-width"
         }
       ]
     },
@@ -19736,6 +25548,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string.fromcodepoint"
+        }
       ]
     },
     {
@@ -19755,6 +25573,12 @@
           "url": "https://registry.npmjs.org/string.prototype.codepointat/-/string.prototype.codepointat-0.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string.prototype.codepointat"
         }
       ]
     },
@@ -19776,6 +25600,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string.prototype.trimend"
+        }
       ]
     },
     {
@@ -19795,6 +25625,12 @@
           "url": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string.prototype.trimstart"
         }
       ]
     },
@@ -19816,6 +25652,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-ansi"
+        }
       ]
     },
     {
@@ -19835,6 +25677,12 @@
           "url": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-bom"
         }
       ]
     },
@@ -19856,6 +25704,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-dirs"
+        }
       ]
     },
     {
@@ -19875,6 +25729,12 @@
           "url": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-json-comments"
         }
       ]
     },
@@ -19896,6 +25756,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-outer"
+        }
       ]
     },
     {
@@ -19915,6 +25781,12 @@
           "url": "https://registry.npmjs.org/strtok3/-/strtok3-6.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strtok3"
         }
       ]
     },
@@ -19936,6 +25808,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/supports-color"
+        }
       ]
     },
     {
@@ -19955,6 +25833,12 @@
           "url": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/supports-preserve-symlinks-flag"
         }
       ]
     },
@@ -19976,6 +25860,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/svg-captcha"
+        }
       ]
     },
     {
@@ -19996,6 +25886,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/swagger-ui-dist"
+        }
       ]
     },
     {
@@ -20015,6 +25911,12 @@
           "url": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-4.5.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/swagger-ui-express"
         }
       ]
     },
@@ -20037,6 +25939,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tar-fs"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -20055,6 +25963,12 @@
               "url": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/tar-fs/node_modules/bl"
             }
           ]
         },
@@ -20076,6 +25990,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/tar-fs/node_modules/chownr"
+            }
           ]
         },
         {
@@ -20096,6 +26016,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/tar-fs/node_modules/readable-stream"
+            }
           ]
         },
         {
@@ -20115,6 +26041,12 @@
               "url": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/tar-fs/node_modules/tar-stream"
             }
           ]
         }
@@ -20138,6 +26070,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tar-stream"
+        }
       ]
     },
     {
@@ -20157,6 +26095,12 @@
           "url": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tar"
         }
       ]
     },
@@ -20178,6 +26122,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tdigest"
+        }
       ]
     },
     {
@@ -20197,6 +26147,12 @@
           "url": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/text-hex"
         }
       ]
     },
@@ -20218,6 +26174,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/thirty-two"
+        }
       ]
     },
     {
@@ -20237,6 +26199,12 @@
           "url": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/through"
         }
       ]
     },
@@ -20258,6 +26226,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/timed-out"
+        }
       ]
     },
     {
@@ -20277,6 +26251,12 @@
           "url": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tiny-inflate"
         }
       ]
     },
@@ -20298,6 +26278,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-buffer"
+        }
       ]
     },
     {
@@ -20317,6 +26303,12 @@
           "url": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-fast-properties"
         }
       ]
     },
@@ -20339,6 +26331,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-object-path"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -20357,6 +26355,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/to-object-path/node_modules/kind-of"
             }
           ]
         }
@@ -20380,6 +26384,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-regex-range"
+        }
       ]
     },
     {
@@ -20399,6 +26409,12 @@
           "url": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-regex"
         }
       ]
     },
@@ -20420,6 +26436,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/toidentifier"
+        }
       ]
     },
     {
@@ -20439,6 +26461,12 @@
           "url": "https://registry.npmjs.org/token-stream/-/token-stream-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/token-stream"
         }
       ]
     },
@@ -20460,6 +26488,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/token-types"
+        }
       ]
     },
     {
@@ -20479,6 +26513,12 @@
           "url": "https://registry.npmjs.org/toposort-class/-/toposort-class-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/toposort-class"
         }
       ]
     },
@@ -20500,6 +26540,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tough-cookie"
+        }
       ]
     },
     {
@@ -20519,6 +26565,12 @@
           "url": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tr46"
         }
       ]
     },
@@ -20540,6 +26592,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/traverse"
+        }
       ]
     },
     {
@@ -20559,6 +26617,12 @@
           "url": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tree-kill"
         }
       ]
     },
@@ -20580,6 +26644,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/trim-repeated"
+        }
       ]
     },
     {
@@ -20600,6 +26670,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/triple-beam"
+        }
       ]
     },
     {
@@ -20619,6 +26695,12 @@
           "url": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/truncate-utf8-bytes"
         }
       ]
     },
@@ -20641,6 +26723,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ts-node-dev"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -20659,6 +26747,12 @@
               "url": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/ts-node-dev/node_modules/rimraf"
             }
           ]
         }
@@ -20682,6 +26776,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ts-node"
+        }
       ]
     },
     {
@@ -20701,6 +26801,12 @@
           "url": "https://registry.npmjs.org/tsconfig/-/tsconfig-7.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tsconfig"
         }
       ]
     },
@@ -20722,6 +26828,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tslib"
+        }
       ]
     },
     {
@@ -20741,6 +26853,12 @@
           "url": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tunnel-agent"
         }
       ]
     },
@@ -20762,6 +26880,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tweetnacl"
+        }
       ]
     },
     {
@@ -20781,6 +26905,12 @@
           "url": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/type-check"
         }
       ]
     },
@@ -20802,6 +26932,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/type-is"
+        }
       ]
     },
     {
@@ -20821,6 +26957,12 @@
           "url": "https://registry.npmjs.org/typecast/-/typecast-0.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/typecast"
         }
       ]
     },
@@ -20842,6 +26984,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/typedarray"
+        }
       ]
     },
     {
@@ -20861,6 +27009,12 @@
           "url": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/typescript"
         }
       ]
     },
@@ -20882,6 +27036,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/uglify-js"
+        }
       ]
     },
     {
@@ -20901,6 +27061,12 @@
           "url": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unbox-primitive"
         }
       ]
     },
@@ -20922,6 +27088,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unbzip2-stream"
+        }
       ]
     },
     {
@@ -20941,6 +27113,12 @@
           "url": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unc-path-regex"
         }
       ]
     },
@@ -20962,6 +27140,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/underscore.string"
+        }
       ]
     },
     {
@@ -20982,6 +27166,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unicode-properties"
+        }
       ]
     },
     {
@@ -21001,6 +27191,12 @@
           "url": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unicode-trie"
         }
       ]
     },
@@ -21023,6 +27219,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/union-value"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21041,6 +27243,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/union-value/node_modules/is-extendable"
             }
           ]
         }
@@ -21064,6 +27272,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unique-filename"
+        }
       ]
     },
     {
@@ -21083,6 +27297,12 @@
           "url": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unique-slug"
         }
       ]
     },
@@ -21104,6 +27324,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unit-compare"
+        }
       ]
     },
     {
@@ -21124,6 +27350,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/universalify"
+        }
       ]
     },
     {
@@ -21143,6 +27375,12 @@
           "url": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unpipe"
         }
       ]
     },
@@ -21165,6 +27403,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unset-value"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21185,6 +27429,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/unset-value/node_modules/has-value"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -21203,6 +27453,12 @@
                   "url": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/unset-value/node_modules/has-value/node_modules/isobject"
                 }
               ]
             }
@@ -21226,6 +27482,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/unset-value/node_modules/has-values"
+            }
           ]
         },
         {
@@ -21245,6 +27507,12 @@
               "url": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/unset-value/node_modules/isarray"
             }
           ]
         }
@@ -21268,6 +27536,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/untildify"
+        }
       ]
     },
     {
@@ -21289,6 +27563,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unzipper"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21307,6 +27587,12 @@
               "url": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/unzipper/node_modules/bluebird"
             }
           ]
         }
@@ -21330,6 +27616,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/uri-js"
+        }
       ]
     },
     {
@@ -21349,6 +27641,12 @@
           "url": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/urix"
         }
       ]
     },
@@ -21370,6 +27668,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/url-parse-lax"
+        }
       ]
     },
     {
@@ -21389,6 +27693,12 @@
           "url": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/url-to-options"
         }
       ]
     },
@@ -21410,6 +27720,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/use"
+        }
       ]
     },
     {
@@ -21429,6 +27745,12 @@
           "url": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/utf8-byte-length"
         }
       ]
     },
@@ -21450,6 +27772,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/util-deprecate"
+        }
       ]
     },
     {
@@ -21469,6 +27797,12 @@
           "url": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/util"
         }
       ]
     },
@@ -21490,6 +27824,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/utils-merge"
+        }
       ]
     },
     {
@@ -21509,6 +27849,12 @@
           "url": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/uuid"
         }
       ]
     },
@@ -21530,6 +27876,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/v8flags"
+        }
       ]
     },
     {
@@ -21549,6 +27901,12 @@
           "url": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/validate-npm-package-license"
         }
       ]
     },
@@ -21570,6 +27928,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/validate"
+        }
       ]
     },
     {
@@ -21590,6 +27954,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/validator"
+        }
       ]
     },
     {
@@ -21609,6 +27979,12 @@
           "url": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/vary"
         }
       ]
     },
@@ -21631,6 +28007,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/verror"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21649,6 +28031,12 @@
               "url": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/verror/node_modules/core-util-is"
             }
           ]
         }
@@ -21673,6 +28061,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/vm2"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21691,6 +28085,12 @@
               "url": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/vm2/node_modules/acorn"
             }
           ]
         }
@@ -21714,6 +28114,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/void-elements"
+        }
       ]
     },
     {
@@ -21733,6 +28139,12 @@
           "url": "https://registry.npmjs.org/walk/-/walk-2.3.15.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/walk"
         }
       ]
     },
@@ -21754,6 +28166,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/walkdir"
+        }
       ]
     },
     {
@@ -21773,6 +28191,12 @@
           "url": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/webidl-conversions"
         }
       ]
     },
@@ -21794,6 +28218,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/whatwg-url"
+        }
       ]
     },
     {
@@ -21813,6 +28243,12 @@
           "url": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-boxed-primitive"
         }
       ]
     },
@@ -21834,6 +28270,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-collection"
+        }
       ]
     },
     {
@@ -21853,6 +28295,12 @@
           "url": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-module"
         }
       ]
     },
@@ -21874,6 +28322,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-pm-runs"
+        }
       ]
     },
     {
@@ -21893,6 +28347,12 @@
           "url": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-typed-array"
         }
       ]
     },
@@ -21914,6 +28374,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which"
+        }
       ]
     },
     {
@@ -21933,6 +28399,12 @@
           "url": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wide-align"
         }
       ]
     },
@@ -21955,6 +28427,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/winston-transport"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21973,6 +28451,12 @@
               "url": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/winston-transport/node_modules/readable-stream"
             }
           ]
         }
@@ -21997,6 +28481,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/winston"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -22015,6 +28505,12 @@
               "url": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/winston/node_modules/async"
             }
           ]
         },
@@ -22036,6 +28532,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/winston/node_modules/is-stream"
+            }
           ]
         },
         {
@@ -22055,6 +28557,12 @@
               "url": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/winston/node_modules/readable-stream"
             }
           ]
         }
@@ -22078,6 +28586,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/with"
+        }
       ]
     },
     {
@@ -22097,6 +28611,12 @@
           "url": "https://registry.npmjs.org/wkx/-/wkx-0.5.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wkx"
         }
       ]
     },
@@ -22118,6 +28638,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/word-wrap"
+        }
       ]
     },
     {
@@ -22137,6 +28663,12 @@
           "url": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wordwrap"
         }
       ]
     },
@@ -22159,6 +28691,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wrap-ansi"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -22177,6 +28715,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi/node_modules/ansi-regex"
             }
           ]
         },
@@ -22198,6 +28742,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi/node_modules/emoji-regex"
+            }
           ]
         },
         {
@@ -22217,6 +28767,12 @@
               "url": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi/node_modules/is-fullwidth-code-point"
             }
           ]
         },
@@ -22238,6 +28794,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi/node_modules/string-width"
+            }
           ]
         },
         {
@@ -22257,6 +28819,12 @@
               "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi/node_modules/strip-ansi"
             }
           ]
         }
@@ -22280,6 +28848,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wrappy"
+        }
       ]
     },
     {
@@ -22299,6 +28873,12 @@
           "url": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ws"
         }
       ]
     },
@@ -22320,6 +28900,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/xtend"
+        }
       ]
     },
     {
@@ -22339,6 +28925,12 @@
           "url": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/y18n"
         }
       ]
     },
@@ -22360,6 +28952,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yallist"
+        }
       ]
     },
     {
@@ -22380,6 +28978,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yaml-schema-validator"
+        }
       ]
     },
     {
@@ -22399,6 +29003,12 @@
           "url": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yargs-parser"
         }
       ]
     },
@@ -22421,6 +29031,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yargs"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -22439,6 +29055,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs/node_modules/ansi-regex"
             }
           ]
         },
@@ -22460,6 +29082,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs/node_modules/emoji-regex"
+            }
           ]
         },
         {
@@ -22479,6 +29107,12 @@
               "url": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs/node_modules/is-fullwidth-code-point"
             }
           ]
         },
@@ -22500,6 +29134,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs/node_modules/string-width"
+            }
           ]
         },
         {
@@ -22519,6 +29159,12 @@
               "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs/node_modules/strip-ansi"
             }
           ]
         }
@@ -22542,6 +29188,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yauzl"
+        }
       ]
     },
     {
@@ -22561,6 +29213,12 @@
           "url": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yn"
         }
       ]
     },
@@ -22582,6 +29240,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/z85"
+        }
       ]
     },
     {
@@ -22602,6 +29266,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/zip-stream"
+        }
       ]
     },
     {
@@ -22621,6 +29291,12 @@
           "url": "https://registry.npmjs.org/zlibjs/-/zlibjs-0.3.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/zlibjs"
         }
       ]
     }

--- a/tests/_data/sbom_demo-results/juice-shop_npm7_node16_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/juice-shop_npm7_node16_ubuntu-latest.snap.json
@@ -62,6 +62,10 @@
       ],
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -88,6 +92,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@babel/helper-string-parser"
+        }
       ]
     },
     {
@@ -108,6 +118,12 @@
           "url": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@babel/helper-validator-identifier"
         }
       ]
     },
@@ -130,6 +146,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@babel/parser"
+        }
       ]
     },
     {
@@ -150,6 +172,12 @@
           "url": "https://registry.npmjs.org/@babel/types/-/types-7.20.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@babel/types"
         }
       ]
     },
@@ -172,6 +200,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@colors/colors"
+        }
       ]
     },
     {
@@ -193,6 +227,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@dabh/diagnostics"
+        }
       ]
     },
     {
@@ -213,6 +253,12 @@
           "url": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@gar/promisify"
         }
       ]
     },
@@ -236,6 +282,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@mapbox/node-pre-gyp"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -254,6 +306,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/ansi-regex"
             }
           ]
         },
@@ -275,6 +333,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/are-we-there-yet"
+            }
           ]
         },
         {
@@ -294,6 +358,12 @@
               "url": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/detect-libc"
             }
           ]
         },
@@ -315,6 +385,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/gauge"
+            }
           ]
         },
         {
@@ -334,6 +410,12 @@
               "url": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/is-fullwidth-code-point"
             }
           ]
         },
@@ -356,6 +438,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/make-dir"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -374,6 +462,12 @@
                   "url": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/@mapbox/node-pre-gyp/node_modules/make-dir/node_modules/semver"
                 }
               ]
             }
@@ -397,6 +491,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/nopt"
+            }
           ]
         },
         {
@@ -416,6 +516,12 @@
               "url": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/npmlog"
             }
           ]
         },
@@ -437,6 +543,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/readable-stream"
+            }
           ]
         },
         {
@@ -457,6 +569,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/string-width"
+            }
           ]
         },
         {
@@ -476,6 +594,12 @@
               "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/strip-ansi"
             }
           ]
         }
@@ -500,6 +624,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/core-loader"
+        }
       ]
     },
     {
@@ -520,6 +650,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/core/-/core-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/core"
         }
       ]
     },
@@ -542,6 +678,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/evaluator"
+        }
       ]
     },
     {
@@ -562,6 +704,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-all/-/lang-all-4.24.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-all"
         }
       ]
     },
@@ -584,6 +732,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ar"
+        }
       ]
     },
     {
@@ -604,6 +758,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-bn/-/lang-bn-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-bn"
         }
       ]
     },
@@ -626,6 +786,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ca"
+        }
       ]
     },
     {
@@ -646,6 +812,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-cs/-/lang-cs-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-cs"
         }
       ]
     },
@@ -668,6 +840,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-da"
+        }
       ]
     },
     {
@@ -688,6 +866,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-de/-/lang-de-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-de"
         }
       ]
     },
@@ -710,6 +894,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-el"
+        }
       ]
     },
     {
@@ -730,6 +920,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-en-min/-/lang-en-min-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-en-min"
         }
       ]
     },
@@ -752,6 +948,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-en"
+        }
       ]
     },
     {
@@ -772,6 +974,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-es/-/lang-es-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-es"
         }
       ]
     },
@@ -794,6 +1002,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-eu"
+        }
       ]
     },
     {
@@ -814,6 +1028,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-fa/-/lang-fa-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-fa"
         }
       ]
     },
@@ -836,6 +1056,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-fi"
+        }
       ]
     },
     {
@@ -856,6 +1082,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-fr/-/lang-fr-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-fr"
         }
       ]
     },
@@ -878,6 +1110,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ga"
+        }
       ]
     },
     {
@@ -898,6 +1136,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-gl/-/lang-gl-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-gl"
         }
       ]
     },
@@ -920,6 +1164,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-hi"
+        }
       ]
     },
     {
@@ -940,6 +1190,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-hu/-/lang-hu-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-hu"
         }
       ]
     },
@@ -962,6 +1218,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-hy"
+        }
       ]
     },
     {
@@ -982,6 +1244,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-id/-/lang-id-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-id"
         }
       ]
     },
@@ -1004,6 +1272,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-it"
+        }
       ]
     },
     {
@@ -1024,6 +1298,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-ja/-/lang-ja-4.24.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ja"
         }
       ]
     },
@@ -1046,6 +1326,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ko"
+        }
       ]
     },
     {
@@ -1066,6 +1352,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-lt/-/lang-lt-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-lt"
         }
       ]
     },
@@ -1088,6 +1380,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ms"
+        }
       ]
     },
     {
@@ -1108,6 +1406,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-ne/-/lang-ne-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ne"
         }
       ]
     },
@@ -1130,6 +1434,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-nl"
+        }
       ]
     },
     {
@@ -1150,6 +1460,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-no/-/lang-no-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-no"
         }
       ]
     },
@@ -1172,6 +1488,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-pl"
+        }
       ]
     },
     {
@@ -1192,6 +1514,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-pt/-/lang-pt-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-pt"
         }
       ]
     },
@@ -1214,6 +1542,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ro"
+        }
       ]
     },
     {
@@ -1234,6 +1568,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-ru/-/lang-ru-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ru"
         }
       ]
     },
@@ -1256,6 +1596,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-sl"
+        }
       ]
     },
     {
@@ -1276,6 +1622,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-sr/-/lang-sr-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-sr"
         }
       ]
     },
@@ -1298,6 +1650,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-sv"
+        }
       ]
     },
     {
@@ -1318,6 +1676,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-ta/-/lang-ta-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ta"
         }
       ]
     },
@@ -1340,6 +1704,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-th"
+        }
       ]
     },
     {
@@ -1360,6 +1730,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-tl/-/lang-tl-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-tl"
         }
       ]
     },
@@ -1382,6 +1758,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-tr"
+        }
       ]
     },
     {
@@ -1402,6 +1784,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-uk/-/lang-uk-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-uk"
         }
       ]
     },
@@ -1424,6 +1812,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-zh"
+        }
       ]
     },
     {
@@ -1444,6 +1838,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/language-min/-/language-min-4.22.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/language-min"
         }
       ]
     },
@@ -1466,6 +1866,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/language"
+        }
       ]
     },
     {
@@ -1486,6 +1892,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/ner/-/ner-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/ner"
         }
       ]
     },
@@ -1508,6 +1920,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/neural"
+        }
       ]
     },
     {
@@ -1528,6 +1946,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/nlg/-/nlg-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/nlg"
         }
       ]
     },
@@ -1550,6 +1974,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/nlp"
+        }
       ]
     },
     {
@@ -1570,6 +2000,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/nlu/-/nlu-4.23.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/nlu"
         }
       ]
     },
@@ -1592,6 +2028,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/request"
+        }
       ]
     },
     {
@@ -1612,6 +2054,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/sentiment/-/sentiment-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/sentiment"
         }
       ]
     },
@@ -1634,6 +2082,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/similarity"
+        }
       ]
     },
     {
@@ -1654,6 +2108,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/slot/-/slot-4.22.17.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/slot"
         }
       ]
     },
@@ -1676,6 +2136,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@npmcli/fs"
+        }
       ]
     },
     {
@@ -1696,6 +2162,12 @@
           "url": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@npmcli/move-file"
         }
       ]
     },
@@ -1718,6 +2190,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib/core"
+        }
       ]
     },
     {
@@ -1738,6 +2216,12 @@
           "url": "https://registry.npmjs.org/@otplib/plugin-crypto/-/plugin-crypto-12.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib/plugin-crypto"
         }
       ]
     },
@@ -1760,6 +2244,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib/plugin-thirty-two"
+        }
       ]
     },
     {
@@ -1780,6 +2270,12 @@
           "url": "https://registry.npmjs.org/@otplib/preset-default/-/preset-default-12.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib/preset-default"
         }
       ]
     },
@@ -1802,6 +2298,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib/preset-v11"
+        }
       ]
     },
     {
@@ -1822,6 +2324,12 @@
           "url": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@sindresorhus/is"
         }
       ]
     },
@@ -1844,6 +2352,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@swc/helpers"
+        }
       ]
     },
     {
@@ -1864,6 +2378,12 @@
           "url": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@tokenizer/token"
         }
       ]
     },
@@ -1886,6 +2406,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@tootallnate/once"
+        }
       ]
     },
     {
@@ -1906,6 +2432,12 @@
           "url": "https://registry.npmjs.org/@types/component-emitter/-/component-emitter-1.2.11.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/component-emitter"
         }
       ]
     },
@@ -1928,6 +2460,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/cookie"
+        }
       ]
     },
     {
@@ -1948,6 +2486,12 @@
           "url": "https://registry.npmjs.org/@types/cors/-/cors-2.8.12.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/cors"
         }
       ]
     },
@@ -1970,6 +2514,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/debug"
+        }
       ]
     },
     {
@@ -1990,6 +2540,12 @@
           "url": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/ms"
         }
       ]
     },
@@ -2012,6 +2568,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/node"
+        }
       ]
     },
     {
@@ -2032,6 +2594,12 @@
           "url": "https://registry.npmjs.org/@types/strip-bom/-/strip-bom-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/strip-bom"
         }
       ]
     },
@@ -2054,6 +2622,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/strip-json-comments"
+        }
       ]
     },
     {
@@ -2075,6 +2649,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/validator"
+        }
       ]
     },
     {
@@ -2094,6 +2674,12 @@
           "url": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/abbrev"
         }
       ]
     },
@@ -2115,6 +2701,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/accepts"
+        }
       ]
     },
     {
@@ -2135,6 +2727,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/acorn-walk"
+        }
       ]
     },
     {
@@ -2154,6 +2752,12 @@
           "url": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/acorn"
         }
       ]
     },
@@ -2176,6 +2780,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/agent-base"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -2194,6 +2804,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agent-base/node_modules/debug"
             }
           ]
         },
@@ -2214,6 +2830,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agent-base/node_modules/ms"
             }
           ]
         }
@@ -2238,6 +2860,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/agentkeepalive"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -2256,6 +2884,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agentkeepalive/node_modules/debug"
             }
           ]
         },
@@ -2277,6 +2911,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agentkeepalive/node_modules/depd"
+            }
           ]
         },
         {
@@ -2296,6 +2936,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agentkeepalive/node_modules/ms"
             }
           ]
         }
@@ -2319,6 +2965,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/aggregate-error"
+        }
       ]
     },
     {
@@ -2338,6 +2990,12 @@
           "url": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ajv"
         }
       ]
     },
@@ -2359,6 +3017,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ansi-regex"
+        }
       ]
     },
     {
@@ -2378,6 +3042,12 @@
           "url": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ansi-styles"
         }
       ]
     },
@@ -2400,6 +3070,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/anymatch"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -2418,6 +3094,12 @@
               "url": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/anymatch/node_modules/normalize-path"
             }
           ]
         }
@@ -2441,6 +3123,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/append-field"
+        }
       ]
     },
     {
@@ -2460,6 +3148,12 @@
           "url": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/aproba"
         }
       ]
     },
@@ -2482,6 +3176,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/archive-type"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -2500,6 +3200,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-4.4.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/archive-type/node_modules/file-type"
             }
           ]
         }
@@ -2523,6 +3229,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/archiver-utils"
+        }
       ]
     },
     {
@@ -2542,6 +3254,12 @@
           "url": "https://registry.npmjs.org/archiver/-/archiver-1.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/archiver"
         }
       ]
     },
@@ -2563,6 +3281,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/are-we-there-yet"
+        }
       ]
     },
     {
@@ -2582,6 +3306,12 @@
           "url": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/arg"
         }
       ]
     },
@@ -2604,6 +3334,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/argparse"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -2622,6 +3358,12 @@
               "url": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/argparse/node_modules/sprintf-js"
             }
           ]
         }
@@ -2645,6 +3387,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/arr-diff"
+        }
       ]
     },
     {
@@ -2664,6 +3412,12 @@
           "url": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/arr-flatten"
         }
       ]
     },
@@ -2685,6 +3439,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/arr-union"
+        }
       ]
     },
     {
@@ -2704,6 +3464,12 @@
           "url": "https://registry.npmjs.org/array-each/-/array-each-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/array-each"
         }
       ]
     },
@@ -2725,6 +3491,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/array-flatten"
+        }
       ]
     },
     {
@@ -2744,6 +3516,12 @@
           "url": "https://registry.npmjs.org/array-slice/-/array-slice-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/array-slice"
         }
       ]
     },
@@ -2765,6 +3543,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/array-unique"
+        }
       ]
     },
     {
@@ -2784,6 +3568,12 @@
           "url": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/asap"
         }
       ]
     },
@@ -2805,6 +3595,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/asn1"
+        }
       ]
     },
     {
@@ -2824,6 +3620,12 @@
           "url": "https://registry.npmjs.org/assert-never/-/assert-never-1.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/assert-never"
         }
       ]
     },
@@ -2845,6 +3647,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/assert-plus"
+        }
       ]
     },
     {
@@ -2864,6 +3672,12 @@
           "url": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/assign-symbols"
         }
       ]
     },
@@ -2885,6 +3699,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/async"
+        }
       ]
     },
     {
@@ -2904,6 +3724,12 @@
           "url": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/asynckit"
         }
       ]
     },
@@ -2925,6 +3751,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/at-least-node"
+        }
       ]
     },
     {
@@ -2944,6 +3776,12 @@
           "url": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/atob"
         }
       ]
     },
@@ -2965,6 +3803,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/available-typed-arrays"
+        }
       ]
     },
     {
@@ -2984,6 +3828,12 @@
           "url": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/aws-sign2"
         }
       ]
     },
@@ -3005,6 +3855,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/aws4"
+        }
       ]
     },
     {
@@ -3025,6 +3881,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/babel-walk"
+        }
       ]
     },
     {
@@ -3044,6 +3906,12 @@
           "url": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/balanced-match"
         }
       ]
     },
@@ -3066,6 +3934,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -3084,6 +3958,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/base/node_modules/define-property"
             }
           ]
         }
@@ -3107,6 +3987,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base64-arraybuffer"
+        }
       ]
     },
     {
@@ -3126,6 +4012,12 @@
           "url": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base64-js"
         }
       ]
     },
@@ -3147,6 +4039,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base64id"
+        }
       ]
     },
     {
@@ -3166,6 +4064,12 @@
           "url": "https://registry.npmjs.org/base64url/-/base64url-0.0.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base64url"
         }
       ]
     },
@@ -3187,6 +4091,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/basic-auth"
+        }
       ]
     },
     {
@@ -3206,6 +4116,12 @@
           "url": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/batch"
         }
       ]
     },
@@ -3227,6 +4143,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bcrypt-pbkdf"
+        }
       ]
     },
     {
@@ -3246,6 +4168,12 @@
           "url": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/big-integer"
         }
       ]
     },
@@ -3267,6 +4195,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/binary-extensions"
+        }
       ]
     },
     {
@@ -3286,6 +4220,12 @@
           "url": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/binary"
         }
       ]
     },
@@ -3307,6 +4247,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bindings"
+        }
       ]
     },
     {
@@ -3326,6 +4272,12 @@
           "url": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bintrees"
         }
       ]
     },
@@ -3347,6 +4299,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bl"
+        }
       ]
     },
     {
@@ -3367,6 +4325,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bluebird"
+        }
       ]
     },
     {
@@ -3386,6 +4350,12 @@
           "url": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/body-parser"
         }
       ]
     },
@@ -3408,6 +4378,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bower-config"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -3426,6 +4402,12 @@
               "url": "https://registry.npmjs.org/minimist/-/minimist-0.2.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bower-config/node_modules/minimist"
             }
           ]
         }
@@ -3449,6 +4431,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/brace-expansion"
+        }
       ]
     },
     {
@@ -3470,6 +4458,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/braces"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -3488,6 +4482,12 @@
               "url": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/braces/node_modules/extend-shallow"
             }
           ]
         },
@@ -3508,6 +4508,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/braces/node_modules/is-extendable"
             }
           ]
         }
@@ -3531,6 +4537,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/brotli"
+        }
       ]
     },
     {
@@ -3550,6 +4562,12 @@
           "url": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-alloc-unsafe"
         }
       ]
     },
@@ -3571,6 +4589,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-alloc"
+        }
       ]
     },
     {
@@ -3590,6 +4614,12 @@
           "url": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-crc32"
         }
       ]
     },
@@ -3611,6 +4641,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-fill"
+        }
       ]
     },
     {
@@ -3630,6 +4666,12 @@
           "url": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-from"
         }
       ]
     },
@@ -3651,6 +4693,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-indexof-polyfill"
+        }
       ]
     },
     {
@@ -3671,6 +4719,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer"
+        }
       ]
     },
     {
@@ -3690,6 +4744,12 @@
           "url": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffers"
         }
       ]
     },
@@ -3712,6 +4772,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/busboy"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -3730,6 +4796,12 @@
               "url": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/busboy/node_modules/isarray"
             }
           ]
         },
@@ -3751,6 +4823,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/busboy/node_modules/readable-stream"
+            }
           ]
         },
         {
@@ -3770,6 +4848,12 @@
               "url": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/busboy/node_modules/string_decoder"
             }
           ]
         }
@@ -3793,6 +4877,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/byline"
+        }
       ]
     },
     {
@@ -3812,6 +4902,12 @@
           "url": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bytes"
         }
       ]
     },
@@ -3833,6 +4929,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cacache"
+        }
       ]
     },
     {
@@ -3852,6 +4954,12 @@
           "url": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cache-base"
         }
       ]
     },
@@ -3874,6 +4982,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cacheable-request"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -3892,6 +5006,12 @@
               "url": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cacheable-request/node_modules/get-stream"
             }
           ]
         },
@@ -3912,6 +5032,12 @@
               "url": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cacheable-request/node_modules/lowercase-keys"
             }
           ]
         }
@@ -3935,6 +5061,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/call-bind"
+        }
       ]
     },
     {
@@ -3954,6 +5086,12 @@
           "url": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/camelcase"
         }
       ]
     },
@@ -3975,6 +5113,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/caseless"
+        }
       ]
     },
     {
@@ -3994,6 +5138,12 @@
           "url": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/chainsaw"
         }
       ]
     },
@@ -4015,6 +5165,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/chalk"
+        }
       ]
     },
     {
@@ -4034,6 +5190,12 @@
           "url": "https://registry.npmjs.org/character-parser/-/character-parser-2.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/character-parser"
         }
       ]
     },
@@ -4056,6 +5218,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/check-dependencies"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4074,6 +5242,12 @@
               "url": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/check-dependencies/node_modules/semver"
             }
           ]
         }
@@ -4097,6 +5271,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/check-types"
+        }
       ]
     },
     {
@@ -4118,6 +5298,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/chokidar"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4136,6 +5322,12 @@
               "url": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar/node_modules/braces"
             }
           ]
         },
@@ -4157,6 +5349,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar/node_modules/fill-range"
+            }
           ]
         },
         {
@@ -4176,6 +5374,12 @@
               "url": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar/node_modules/is-glob"
             }
           ]
         },
@@ -4197,6 +5401,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar/node_modules/is-number"
+            }
           ]
         },
         {
@@ -4217,6 +5427,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar/node_modules/normalize-path"
+            }
           ]
         },
         {
@@ -4236,6 +5452,12 @@
               "url": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar/node_modules/to-regex-range"
             }
           ]
         }
@@ -4259,6 +5481,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/chownr"
+        }
       ]
     },
     {
@@ -4278,6 +5506,12 @@
           "url": "https://registry.npmjs.org/clarinet/-/clarinet-0.12.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/clarinet"
         }
       ]
     },
@@ -4300,6 +5534,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/class-utils"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4318,6 +5558,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils/node_modules/define-property"
             }
           ]
         },
@@ -4340,6 +5586,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils/node_modules/is-accessor-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -4358,6 +5610,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/class-utils/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -4382,6 +5640,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils/node_modules/is-data-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -4400,6 +5664,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/class-utils/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -4423,6 +5693,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils/node_modules/is-descriptor"
+            }
           ]
         },
         {
@@ -4442,6 +5718,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils/node_modules/kind-of"
             }
           ]
         }
@@ -4465,6 +5747,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/clean-stack"
+        }
       ]
     },
     {
@@ -4486,6 +5774,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cliui"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4504,6 +5798,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui/node_modules/ansi-regex"
             }
           ]
         },
@@ -4525,6 +5825,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui/node_modules/emoji-regex"
+            }
           ]
         },
         {
@@ -4544,6 +5850,12 @@
               "url": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui/node_modules/is-fullwidth-code-point"
             }
           ]
         },
@@ -4565,6 +5877,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui/node_modules/string-width"
+            }
           ]
         },
         {
@@ -4584,6 +5902,12 @@
               "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui/node_modules/strip-ansi"
             }
           ]
         }
@@ -4607,6 +5931,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/clone-response"
+        }
       ]
     },
     {
@@ -4626,6 +5956,12 @@
           "url": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/clone"
         }
       ]
     },
@@ -4647,6 +5983,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/code-point-at"
+        }
       ]
     },
     {
@@ -4666,6 +6008,12 @@
           "url": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/collection-visit"
         }
       ]
     },
@@ -4687,6 +6035,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color-convert"
+        }
       ]
     },
     {
@@ -4706,6 +6060,12 @@
           "url": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color-name"
         }
       ]
     },
@@ -4727,6 +6087,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color-string"
+        }
       ]
     },
     {
@@ -4746,6 +6112,12 @@
           "url": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color-support"
         }
       ]
     },
@@ -4767,6 +6139,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color"
+        }
       ]
     },
     {
@@ -4786,6 +6164,12 @@
           "url": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/colors"
         }
       ]
     },
@@ -4807,6 +6191,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/colorspace"
+        }
       ]
     },
     {
@@ -4826,6 +6216,12 @@
           "url": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/combined-stream"
         }
       ]
     },
@@ -4847,6 +6243,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/commander"
+        }
       ]
     },
     {
@@ -4866,6 +6268,12 @@
           "url": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/component-emitter"
         }
       ]
     },
@@ -4887,6 +6295,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/component-type"
+        }
       ]
     },
     {
@@ -4907,6 +6321,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/compress-commons"
+        }
       ]
     },
     {
@@ -4926,6 +6346,12 @@
           "url": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/compressible"
         }
       ]
     },
@@ -4948,6 +6374,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/compression"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4966,6 +6398,12 @@
               "url": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/compression/node_modules/bytes"
             }
           ]
         }
@@ -4989,6 +6427,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/concat-map"
+        }
       ]
     },
     {
@@ -5008,6 +6452,12 @@
           "url": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/concat-stream"
         }
       ]
     },
@@ -5030,6 +6480,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/concurrently"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5048,6 +6504,12 @@
               "url": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/concurrently/node_modules/supports-color"
             }
           ]
         }
@@ -5071,6 +6533,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/config"
+        }
       ]
     },
     {
@@ -5091,6 +6559,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/console-control-strings"
+        }
       ]
     },
     {
@@ -5110,6 +6584,12 @@
           "url": "https://registry.npmjs.org/constantinople/-/constantinople-4.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/constantinople"
         }
       ]
     },
@@ -5132,6 +6612,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/content-disposition"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5150,6 +6636,12 @@
               "url": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/content-disposition/node_modules/safe-buffer"
             }
           ]
         }
@@ -5173,6 +6665,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/content-type"
+        }
       ]
     },
     {
@@ -5192,6 +6690,12 @@
           "url": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cookie-parser"
         }
       ]
     },
@@ -5213,6 +6717,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cookie-signature"
+        }
       ]
     },
     {
@@ -5232,6 +6742,12 @@
           "url": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cookie"
         }
       ]
     },
@@ -5253,6 +6769,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/copy-descriptor"
+        }
       ]
     },
     {
@@ -5272,6 +6794,12 @@
           "url": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/core-util-is"
         }
       ]
     },
@@ -5293,6 +6821,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cors"
+        }
       ]
     },
     {
@@ -5312,6 +6846,12 @@
           "url": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/crc"
         }
       ]
     },
@@ -5333,6 +6873,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/crc32-stream"
+        }
       ]
     },
     {
@@ -5352,6 +6898,12 @@
           "url": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/create-require"
         }
       ]
     },
@@ -5373,6 +6925,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/crypto-js"
+        }
       ]
     },
     {
@@ -5392,6 +6950,12 @@
           "url": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dashdash"
         }
       ]
     },
@@ -5413,6 +6977,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/date-fns"
+        }
       ]
     },
     {
@@ -5432,6 +7002,12 @@
           "url": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dateformat"
         }
       ]
     },
@@ -5453,6 +7029,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/debug"
+        }
       ]
     },
     {
@@ -5472,6 +7054,12 @@
           "url": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decamelize"
         }
       ]
     },
@@ -5493,6 +7081,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decode-uri-component"
+        }
       ]
     },
     {
@@ -5512,6 +7106,12 @@
           "url": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-response"
         }
       ]
     },
@@ -5534,6 +7134,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-tar"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5552,6 +7158,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-tar/node_modules/file-type"
             }
           ]
         }
@@ -5576,6 +7188,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-tarbz2"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5594,6 +7212,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-6.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-tarbz2/node_modules/file-type"
             }
           ]
         }
@@ -5618,6 +7242,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-targz"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5636,6 +7266,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-targz/node_modules/file-type"
             }
           ]
         }
@@ -5660,6 +7296,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-unzip"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5678,6 +7320,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-unzip/node_modules/file-type"
             }
           ]
         },
@@ -5699,6 +7347,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-unzip/node_modules/get-stream"
+            }
           ]
         },
         {
@@ -5718,6 +7372,12 @@
               "url": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-unzip/node_modules/pify"
             }
           ]
         }
@@ -5742,6 +7402,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5762,6 +7428,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress/node_modules/make-dir"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -5780,6 +7452,12 @@
                   "url": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/decompress/node_modules/make-dir/node_modules/pify"
                 }
               ]
             }
@@ -5803,6 +7481,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress/node_modules/pify"
+            }
           ]
         }
       ]
@@ -5825,6 +7509,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/deep-equal"
+        }
       ]
     },
     {
@@ -5844,6 +7534,12 @@
           "url": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/deep-extend"
         }
       ]
     },
@@ -5865,6 +7561,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/deep-is"
+        }
       ]
     },
     {
@@ -5884,6 +7586,12 @@
           "url": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/define-properties"
         }
       ]
     },
@@ -5905,6 +7613,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/define-property"
+        }
       ]
     },
     {
@@ -5924,6 +7638,12 @@
           "url": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/delayed-stream"
         }
       ]
     },
@@ -5945,6 +7665,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/delegates"
+        }
       ]
     },
     {
@@ -5964,6 +7690,12 @@
           "url": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/depd"
         }
       ]
     },
@@ -5985,6 +7717,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/destroy"
+        }
       ]
     },
     {
@@ -6004,6 +7742,12 @@
           "url": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/detect-file"
         }
       ]
     },
@@ -6025,6 +7769,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/detect-libc"
+        }
       ]
     },
     {
@@ -6044,6 +7794,12 @@
           "url": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dfa"
         }
       ]
     },
@@ -6066,6 +7822,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dicer"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -6084,6 +7846,12 @@
               "url": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/dicer/node_modules/isarray"
             }
           ]
         },
@@ -6105,6 +7873,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/dicer/node_modules/readable-stream"
+            }
           ]
         },
         {
@@ -6124,6 +7898,12 @@
               "url": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/dicer/node_modules/string_decoder"
             }
           ]
         }
@@ -6147,6 +7927,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/diff"
+        }
       ]
     },
     {
@@ -6166,6 +7952,12 @@
           "url": "https://registry.npmjs.org/doctypes/-/doctypes-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/doctypes"
         }
       ]
     },
@@ -6187,6 +7979,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/domelementtype"
+        }
       ]
     },
     {
@@ -6206,6 +8004,12 @@
           "url": "https://registry.npmjs.org/domhandler/-/domhandler-2.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/domhandler"
         }
       ]
     },
@@ -6227,6 +8031,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/domutils"
+        }
       ]
     },
     {
@@ -6246,6 +8056,12 @@
           "url": "https://registry.npmjs.org/dottie/-/dottie-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dottie"
         }
       ]
     },
@@ -6267,6 +8083,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/double-ended-queue"
+        }
       ]
     },
     {
@@ -6286,6 +8108,12 @@
           "url": "https://registry.npmjs.org/doublearray/-/doublearray-0.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/doublearray"
         }
       ]
     },
@@ -6308,6 +8136,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/download"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -6326,6 +8160,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-11.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/download/node_modules/file-type"
             }
           ]
         }
@@ -6349,6 +8189,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/duplexer2"
+        }
       ]
     },
     {
@@ -6368,6 +8214,12 @@
           "url": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/duplexer3"
         }
       ]
     },
@@ -6389,6 +8241,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dynamic-dedupe"
+        }
       ]
     },
     {
@@ -6408,6 +8266,12 @@
           "url": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ecc-jsbn"
         }
       ]
     },
@@ -6429,6 +8293,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ee-first"
+        }
       ]
     },
     {
@@ -6448,6 +8318,12 @@
           "url": "https://registry.npmjs.org/eivindfjeldstad-dot/-/eivindfjeldstad-dot-0.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/eivindfjeldstad-dot"
         }
       ]
     },
@@ -6469,6 +8345,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/emoji-regex"
+        }
       ]
     },
     {
@@ -6489,6 +8371,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/enabled"
+        }
       ]
     },
     {
@@ -6508,6 +8396,12 @@
           "url": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/encodeurl"
         }
       ]
     },
@@ -6530,6 +8424,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/encoding"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -6548,6 +8448,12 @@
               "url": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/encoding/node_modules/iconv-lite"
             }
           ]
         }
@@ -6571,6 +8477,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/end-of-stream"
+        }
       ]
     },
     {
@@ -6590,6 +8502,12 @@
           "url": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-4.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/engine.io-parser"
         }
       ]
     },
@@ -6612,6 +8530,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/engine.io"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -6630,6 +8554,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/engine.io/node_modules/debug"
             }
           ]
         },
@@ -6650,6 +8580,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/engine.io/node_modules/ms"
             }
           ]
         }
@@ -6673,6 +8609,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/env-paths"
+        }
       ]
     },
     {
@@ -6692,6 +8634,12 @@
           "url": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/err-code"
         }
       ]
     },
@@ -6713,6 +8661,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/error-ex"
+        }
       ]
     },
     {
@@ -6732,6 +8686,12 @@
           "url": "https://registry.npmjs.org/errorhandler/-/errorhandler-1.5.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/errorhandler"
         }
       ]
     },
@@ -6753,6 +8713,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/es-abstract"
+        }
       ]
     },
     {
@@ -6772,6 +8738,12 @@
           "url": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/es-get-iterator"
         }
       ]
     },
@@ -6793,6 +8765,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/es-to-primitive"
+        }
       ]
     },
     {
@@ -6812,6 +8790,12 @@
           "url": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/escape-html"
         }
       ]
     },
@@ -6833,6 +8817,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/escape-string-regexp"
+        }
       ]
     },
     {
@@ -6852,6 +8842,12 @@
           "url": "https://registry.npmjs.org/escodegen/-/escodegen-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/escodegen"
         }
       ]
     },
@@ -6873,6 +8869,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/esprima"
+        }
       ]
     },
     {
@@ -6892,6 +8894,12 @@
           "url": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/estraverse"
         }
       ]
     },
@@ -6913,6 +8921,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/esutils"
+        }
       ]
     },
     {
@@ -6932,6 +8946,12 @@
           "url": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/etag"
         }
       ]
     },
@@ -6953,6 +8973,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/eventemitter2"
+        }
       ]
     },
     {
@@ -6972,6 +8998,12 @@
           "url": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/eventemitter3"
         }
       ]
     },
@@ -6993,6 +9025,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/exif"
+        }
       ]
     },
     {
@@ -7012,6 +9050,12 @@
           "url": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/exit"
         }
       ]
     },
@@ -7034,6 +9078,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/expand-brackets"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7052,6 +9102,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/define-property"
             }
           ]
         },
@@ -7072,6 +9128,12 @@
               "url": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/extend-shallow"
             }
           ]
         },
@@ -7094,6 +9156,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/is-accessor-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -7112,6 +9180,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/expand-brackets/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -7136,6 +9210,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/is-data-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -7154,6 +9234,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/expand-brackets/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -7177,6 +9263,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/is-descriptor"
+            }
           ]
         },
         {
@@ -7197,6 +9289,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/is-extendable"
+            }
           ]
         },
         {
@@ -7216,6 +9314,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/kind-of"
             }
           ]
         }
@@ -7239,6 +9343,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/expand-template"
+        }
       ]
     },
     {
@@ -7259,6 +9369,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/expand-tilde"
+        }
       ]
     },
     {
@@ -7278,6 +9394,12 @@
           "url": "https://registry.npmjs.org/express-ipfilter/-/express-ipfilter-1.3.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-ipfilter"
         }
       ]
     },
@@ -7300,6 +9422,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-jwt"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7318,6 +9446,12 @@
               "url": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-0.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/express-jwt/node_modules/jsonwebtoken"
             }
           ]
         },
@@ -7338,6 +9472,12 @@
               "url": "https://registry.npmjs.org/moment/-/moment-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/express-jwt/node_modules/moment"
             }
           ]
         }
@@ -7361,6 +9501,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-rate-limit"
+        }
       ]
     },
     {
@@ -7381,6 +9527,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-robots-txt"
+        }
       ]
     },
     {
@@ -7400,6 +9552,12 @@
           "url": "https://registry.npmjs.org/express-security.txt/-/express-security.txt-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-security.txt"
         }
       ]
     },
@@ -7422,6 +9580,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7440,6 +9604,12 @@
               "url": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/express/node_modules/cookie"
             }
           ]
         },
@@ -7460,6 +9630,12 @@
               "url": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/express/node_modules/safe-buffer"
             }
           ]
         }
@@ -7483,6 +9659,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ext-list"
+        }
       ]
     },
     {
@@ -7502,6 +9684,12 @@
           "url": "https://registry.npmjs.org/ext-name/-/ext-name-5.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ext-name"
         }
       ]
     },
@@ -7523,6 +9711,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/extend-shallow"
+        }
       ]
     },
     {
@@ -7542,6 +9736,12 @@
           "url": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/extend"
         }
       ]
     },
@@ -7564,6 +9764,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/extglob"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7582,6 +9788,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/extglob/node_modules/define-property"
             }
           ]
         },
@@ -7603,6 +9815,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/extglob/node_modules/extend-shallow"
+            }
           ]
         },
         {
@@ -7622,6 +9840,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/extglob/node_modules/is-extendable"
             }
           ]
         }
@@ -7645,6 +9869,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/extsprintf"
+        }
       ]
     },
     {
@@ -7664,6 +9894,12 @@
           "url": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fast-deep-equal"
         }
       ]
     },
@@ -7685,6 +9921,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fast-json-stable-stringify"
+        }
       ]
     },
     {
@@ -7704,6 +9946,12 @@
           "url": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fast-levenshtein"
         }
       ]
     },
@@ -7725,6 +9973,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fast.js"
+        }
       ]
     },
     {
@@ -7744,6 +9998,12 @@
           "url": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fd-slicer"
         }
       ]
     },
@@ -7765,6 +10025,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/feature-policy"
+        }
       ]
     },
     {
@@ -7784,6 +10050,12 @@
           "url": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fecha"
         }
       ]
     },
@@ -7806,6 +10078,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/file-js"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7824,6 +10102,12 @@
               "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/file-js/node_modules/brace-expansion"
             }
           ]
         },
@@ -7844,6 +10128,12 @@
               "url": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/file-js/node_modules/minimatch"
             }
           ]
         }
@@ -7867,6 +10157,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/file-stream-rotator"
+        }
       ]
     },
     {
@@ -7886,6 +10182,12 @@
           "url": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/file-type"
         }
       ]
     },
@@ -7907,6 +10209,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/file-uri-to-path"
+        }
       ]
     },
     {
@@ -7926,6 +10234,12 @@
           "url": "https://registry.npmjs.org/filehound/-/filehound-1.17.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/filehound"
         }
       ]
     },
@@ -7947,6 +10261,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/filename-reserved-regex"
+        }
       ]
     },
     {
@@ -7967,6 +10287,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/filenamify"
+        }
       ]
     },
     {
@@ -7986,6 +10312,12 @@
           "url": "https://registry.npmjs.org/filesniffer/-/filesniffer-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/filesniffer"
         }
       ]
     },
@@ -8008,6 +10340,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fill-range"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -8026,6 +10364,12 @@
               "url": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/fill-range/node_modules/extend-shallow"
             }
           ]
         },
@@ -8046,6 +10390,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/fill-range/node_modules/is-extendable"
             }
           ]
         }
@@ -8069,6 +10419,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/finale-rest"
+        }
       ]
     },
     {
@@ -8088,6 +10444,12 @@
           "url": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/finalhandler"
         }
       ]
     },
@@ -8109,6 +10471,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/find-up"
+        }
       ]
     },
     {
@@ -8128,6 +10496,12 @@
           "url": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/findup-sync"
         }
       ]
     },
@@ -8149,6 +10523,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fined"
+        }
       ]
     },
     {
@@ -8168,6 +10548,12 @@
           "url": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/flagged-respawn"
         }
       ]
     },
@@ -8189,6 +10575,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fn.name"
+        }
       ]
     },
     {
@@ -8208,6 +10600,12 @@
           "url": "https://registry.npmjs.org/fontkit/-/fontkit-1.9.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fontkit"
         }
       ]
     },
@@ -8229,6 +10627,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/for-each"
+        }
       ]
     },
     {
@@ -8248,6 +10652,12 @@
           "url": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/for-in"
         }
       ]
     },
@@ -8269,6 +10679,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/for-own"
+        }
       ]
     },
     {
@@ -8288,6 +10704,12 @@
           "url": "https://registry.npmjs.org/foreachasync/-/foreachasync-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/foreachasync"
         }
       ]
     },
@@ -8309,6 +10731,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/forever-agent"
+        }
       ]
     },
     {
@@ -8328,6 +10756,12 @@
           "url": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/form-data"
         }
       ]
     },
@@ -8349,6 +10783,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/formatio"
+        }
       ]
     },
     {
@@ -8368,6 +10808,12 @@
           "url": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/forwarded"
         }
       ]
     },
@@ -8389,6 +10835,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fragment-cache"
+        }
       ]
     },
     {
@@ -8408,6 +10860,12 @@
           "url": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fresh"
         }
       ]
     },
@@ -8429,6 +10887,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/from2"
+        }
       ]
     },
     {
@@ -8448,6 +10912,12 @@
           "url": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fs-constants"
         }
       ]
     },
@@ -8469,6 +10939,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fs-extra"
+        }
       ]
     },
     {
@@ -8489,6 +10965,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fs-minipass"
+        }
       ]
     },
     {
@@ -8508,6 +10990,12 @@
           "url": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fs.realpath"
         }
       ]
     },
@@ -8530,6 +11018,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fstream"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -8548,6 +11042,12 @@
               "url": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/fstream/node_modules/mkdirp"
             }
           ]
         },
@@ -8568,6 +11068,12 @@
               "url": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/fstream/node_modules/rimraf"
             }
           ]
         }
@@ -8591,6 +11097,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/function-bind"
+        }
       ]
     },
     {
@@ -8610,6 +11122,12 @@
           "url": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/function.prototype.name"
         }
       ]
     },
@@ -8631,6 +11149,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/functions-have-names"
+        }
       ]
     },
     {
@@ -8650,6 +11174,12 @@
           "url": "https://registry.npmjs.org/fuzzball/-/fuzzball-1.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fuzzball"
         }
       ]
     },
@@ -8671,6 +11201,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/gauge"
+        }
       ]
     },
     {
@@ -8690,6 +11226,12 @@
           "url": "https://registry.npmjs.org/geojson-utils/-/geojson-utils-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/geojson-utils"
         }
       ]
     },
@@ -8711,6 +11253,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-caller-file"
+        }
       ]
     },
     {
@@ -8730,6 +11278,12 @@
           "url": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-intrinsic"
         }
       ]
     },
@@ -8751,6 +11305,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-stream"
+        }
       ]
     },
     {
@@ -8770,6 +11330,12 @@
           "url": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-symbol-description"
         }
       ]
     },
@@ -8791,6 +11357,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-value"
+        }
       ]
     },
     {
@@ -8810,6 +11382,12 @@
           "url": "https://registry.npmjs.org/getobject/-/getobject-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/getobject"
         }
       ]
     },
@@ -8831,6 +11409,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/getpass"
+        }
       ]
     },
     {
@@ -8850,6 +11434,12 @@
           "url": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/github-from-package"
         }
       ]
     },
@@ -8872,6 +11462,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/glob-parent"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -8890,6 +11486,12 @@
               "url": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/glob-parent/node_modules/is-glob"
             }
           ]
         }
@@ -8914,6 +11516,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/glob"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -8932,6 +11540,12 @@
               "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/glob/node_modules/brace-expansion"
             }
           ]
         },
@@ -8952,6 +11566,12 @@
               "url": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/glob/node_modules/minimatch"
             }
           ]
         }
@@ -8975,6 +11595,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/global-modules"
+        }
       ]
     },
     {
@@ -8996,6 +11622,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/global-prefix"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9014,6 +11646,12 @@
               "url": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/global-prefix/node_modules/which"
             }
           ]
         }
@@ -9038,6 +11676,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/got"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9056,6 +11700,12 @@
               "url": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/got/node_modules/get-stream"
             }
           ]
         },
@@ -9076,6 +11726,12 @@
               "url": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/got/node_modules/pify"
             }
           ]
         }
@@ -9099,6 +11755,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/graceful-fs"
+        }
       ]
     },
     {
@@ -9120,6 +11782,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-cli"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9138,6 +11806,12 @@
               "url": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-cli/node_modules/nopt"
             }
           ]
         }
@@ -9162,6 +11836,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-contrib-compress"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9180,6 +11860,12 @@
               "url": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-contrib-compress/node_modules/ansi-styles"
             }
           ]
         },
@@ -9201,6 +11887,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-contrib-compress/node_modules/chalk"
+            }
           ]
         },
         {
@@ -9220,6 +11912,12 @@
               "url": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-contrib-compress/node_modules/supports-color"
             }
           ]
         }
@@ -9243,6 +11941,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-known-options"
+        }
       ]
     },
     {
@@ -9264,6 +11968,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-legacy-log-utils"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9282,6 +11992,12 @@
               "url": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils/node_modules/ansi-styles"
             }
           ]
         },
@@ -9303,6 +12019,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils/node_modules/chalk"
+            }
           ]
         },
         {
@@ -9322,6 +12044,12 @@
               "url": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils/node_modules/color-convert"
             }
           ]
         },
@@ -9343,6 +12071,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils/node_modules/color-name"
+            }
           ]
         },
         {
@@ -9363,6 +12097,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils/node_modules/has-flag"
+            }
           ]
         },
         {
@@ -9382,6 +12122,12 @@
               "url": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils/node_modules/supports-color"
             }
           ]
         }
@@ -9406,6 +12152,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-legacy-log"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9424,6 +12176,12 @@
               "url": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log/node_modules/colors"
             }
           ]
         }
@@ -9448,6 +12206,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-legacy-util"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9466,6 +12230,12 @@
               "url": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-util/node_modules/async"
             }
           ]
         }
@@ -9489,6 +12259,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-replace-json"
+        }
       ]
     },
     {
@@ -9510,6 +12286,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9528,6 +12310,12 @@
               "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt/node_modules/brace-expansion"
             }
           ]
         },
@@ -9550,6 +12338,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt/node_modules/findup-sync"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -9568,6 +12362,12 @@
                   "url": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/grunt/node_modules/findup-sync/node_modules/glob"
                 }
               ]
             }
@@ -9591,6 +12391,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt/node_modules/glob"
+            }
           ]
         },
         {
@@ -9610,6 +12416,12 @@
               "url": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.8.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt/node_modules/minimatch"
             }
           ]
         }
@@ -9634,6 +12446,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/handlebars"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9652,6 +12470,12 @@
               "url": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/handlebars/node_modules/wordwrap"
             }
           ]
         }
@@ -9675,6 +12499,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/har-schema"
+        }
       ]
     },
     {
@@ -9694,6 +12524,12 @@
           "url": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/har-validator"
         }
       ]
     },
@@ -9715,6 +12551,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-ansi"
+        }
       ]
     },
     {
@@ -9734,6 +12576,12 @@
           "url": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-bigints"
         }
       ]
     },
@@ -9755,6 +12603,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-flag"
+        }
       ]
     },
     {
@@ -9774,6 +12628,12 @@
           "url": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-property-descriptors"
         }
       ]
     },
@@ -9795,6 +12655,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-symbol-support-x"
+        }
       ]
     },
     {
@@ -9814,6 +12680,12 @@
           "url": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-symbols"
         }
       ]
     },
@@ -9835,6 +12707,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-to-string-tag-x"
+        }
       ]
     },
     {
@@ -9854,6 +12732,12 @@
           "url": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-tostringtag"
         }
       ]
     },
@@ -9875,6 +12759,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-unicode"
+        }
       ]
     },
     {
@@ -9894,6 +12784,12 @@
           "url": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-value"
         }
       ]
     },
@@ -9916,6 +12812,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-values"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9934,6 +12836,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/has-values/node_modules/kind-of"
             }
           ]
         }
@@ -9957,6 +12865,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has"
+        }
       ]
     },
     {
@@ -9976,6 +12890,12 @@
           "url": "https://registry.npmjs.org/hashids/-/hashids-2.2.10.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hashids"
         }
       ]
     },
@@ -9997,6 +12917,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hbs"
+        }
       ]
     },
     {
@@ -10016,6 +12942,12 @@
           "url": "https://registry.npmjs.org/he/-/he-0.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/he"
         }
       ]
     },
@@ -10037,6 +12969,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/heap"
+        }
       ]
     },
     {
@@ -10056,6 +12994,12 @@
           "url": "https://registry.npmjs.org/helmet/-/helmet-4.6.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/helmet"
         }
       ]
     },
@@ -10077,6 +13021,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hoister"
+        }
       ]
     },
     {
@@ -10096,6 +13046,12 @@
           "url": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/homedir-polyfill"
         }
       ]
     },
@@ -10117,6 +13073,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hooker"
+        }
       ]
     },
     {
@@ -10137,6 +13099,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hosted-git-info"
+        }
       ]
     },
     {
@@ -10156,6 +13124,12 @@
           "url": "https://registry.npmjs.org/html-entities/-/html-entities-1.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/html-entities"
         }
       ]
     },
@@ -10178,6 +13152,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/htmlparser2"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -10196,6 +13176,12 @@
               "url": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/htmlparser2/node_modules/isarray"
             }
           ]
         },
@@ -10217,6 +13203,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/htmlparser2/node_modules/readable-stream"
+            }
           ]
         },
         {
@@ -10236,6 +13228,12 @@
               "url": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/htmlparser2/node_modules/string_decoder"
             }
           ]
         }
@@ -10259,6 +13257,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/http-cache-semantics"
+        }
       ]
     },
     {
@@ -10278,6 +13282,12 @@
           "url": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/http-errors"
         }
       ]
     },
@@ -10300,6 +13310,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/http-proxy-agent"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -10318,6 +13334,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/http-proxy-agent/node_modules/debug"
             }
           ]
         },
@@ -10338,6 +13360,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/http-proxy-agent/node_modules/ms"
             }
           ]
         }
@@ -10361,6 +13389,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/http-signature"
+        }
       ]
     },
     {
@@ -10382,6 +13416,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/https-proxy-agent"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -10400,6 +13440,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/https-proxy-agent/node_modules/debug"
             }
           ]
         },
@@ -10420,6 +13466,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/https-proxy-agent/node_modules/ms"
             }
           ]
         }
@@ -10443,6 +13495,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/humanize-ms"
+        }
       ]
     },
     {
@@ -10462,6 +13520,12 @@
           "url": "https://registry.npmjs.org/i18n/-/i18n-0.11.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/i18n"
         }
       ]
     },
@@ -10483,6 +13547,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/iconv-lite"
+        }
       ]
     },
     {
@@ -10502,6 +13572,12 @@
           "url": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ieee754"
         }
       ]
     },
@@ -10524,6 +13600,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ignore-walk"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -10542,6 +13624,12 @@
               "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/ignore-walk/node_modules/brace-expansion"
             }
           ]
         },
@@ -10562,6 +13650,12 @@
               "url": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/ignore-walk/node_modules/minimatch"
             }
           ]
         }
@@ -10585,6 +13679,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/iltorb"
+        }
       ]
     },
     {
@@ -10604,6 +13704,12 @@
           "url": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/imurmurhash"
         }
       ]
     },
@@ -10625,6 +13731,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/indent-string"
+        }
       ]
     },
     {
@@ -10644,6 +13756,12 @@
           "url": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/infer-owner"
         }
       ]
     },
@@ -10665,6 +13783,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/inflection"
+        }
       ]
     },
     {
@@ -10684,6 +13808,12 @@
           "url": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/inflight"
         }
       ]
     },
@@ -10705,6 +13835,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/inherits"
+        }
       ]
     },
     {
@@ -10724,6 +13860,12 @@
           "url": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ini"
         }
       ]
     },
@@ -10745,6 +13887,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/internal-slot"
+        }
       ]
     },
     {
@@ -10764,6 +13912,12 @@
           "url": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/interpret"
         }
       ]
     },
@@ -10785,6 +13939,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/into-stream"
+        }
       ]
     },
     {
@@ -10804,6 +13964,12 @@
           "url": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/invariant"
         }
       ]
     },
@@ -10825,6 +13991,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ip"
+        }
       ]
     },
     {
@@ -10844,6 +14016,12 @@
           "url": "https://registry.npmjs.org/ip6/-/ip6-0.2.10.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ip6"
         }
       ]
     },
@@ -10865,6 +14043,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ipaddr.js"
+        }
       ]
     },
     {
@@ -10884,6 +14068,12 @@
           "url": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-absolute"
         }
       ]
     },
@@ -10905,6 +14095,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-accessor-descriptor"
+        }
       ]
     },
     {
@@ -10924,6 +14120,12 @@
           "url": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-arguments"
         }
       ]
     },
@@ -10945,6 +14147,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-arrayish"
+        }
       ]
     },
     {
@@ -10964,6 +14172,12 @@
           "url": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-bigint"
         }
       ]
     },
@@ -10985,6 +14199,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-binary-path"
+        }
       ]
     },
     {
@@ -11004,6 +14224,12 @@
           "url": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-boolean-object"
         }
       ]
     },
@@ -11025,6 +14251,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-buffer"
+        }
       ]
     },
     {
@@ -11044,6 +14276,12 @@
           "url": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-callable"
         }
       ]
     },
@@ -11065,6 +14303,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-core-module"
+        }
       ]
     },
     {
@@ -11084,6 +14328,12 @@
           "url": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-data-descriptor"
         }
       ]
     },
@@ -11105,6 +14355,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-date-object"
+        }
       ]
     },
     {
@@ -11124,6 +14380,12 @@
           "url": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-descriptor"
         }
       ]
     },
@@ -11145,6 +14407,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-docker"
+        }
       ]
     },
     {
@@ -11164,6 +14432,12 @@
           "url": "https://registry.npmjs.org/is-expression/-/is-expression-4.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-expression"
         }
       ]
     },
@@ -11185,6 +14459,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-extendable"
+        }
       ]
     },
     {
@@ -11204,6 +14484,12 @@
           "url": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-extglob"
         }
       ]
     },
@@ -11225,6 +14511,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-fullwidth-code-point"
+        }
       ]
     },
     {
@@ -11244,6 +14536,12 @@
           "url": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-generator-function"
         }
       ]
     },
@@ -11265,6 +14563,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-glob"
+        }
       ]
     },
     {
@@ -11284,6 +14588,12 @@
           "url": "https://registry.npmjs.org/is-heroku/-/is-heroku-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-heroku"
         }
       ]
     },
@@ -11305,6 +14615,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-lambda"
+        }
       ]
     },
     {
@@ -11324,6 +14640,12 @@
           "url": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-map"
         }
       ]
     },
@@ -11345,6 +14667,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-natural-number"
+        }
       ]
     },
     {
@@ -11364,6 +14692,12 @@
           "url": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-negative-zero"
         }
       ]
     },
@@ -11385,6 +14719,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-number-like"
+        }
       ]
     },
     {
@@ -11404,6 +14744,12 @@
           "url": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-number-object"
         }
       ]
     },
@@ -11426,6 +14772,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-number"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -11444,6 +14796,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/is-number/node_modules/kind-of"
             }
           ]
         }
@@ -11467,6 +14825,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-object"
+        }
       ]
     },
     {
@@ -11486,6 +14850,12 @@
           "url": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-plain-obj"
         }
       ]
     },
@@ -11507,6 +14877,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-plain-object"
+        }
       ]
     },
     {
@@ -11526,6 +14902,12 @@
           "url": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-promise"
         }
       ]
     },
@@ -11547,6 +14929,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-regex"
+        }
       ]
     },
     {
@@ -11566,6 +14954,12 @@
           "url": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-relative"
         }
       ]
     },
@@ -11587,6 +14981,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-retry-allowed"
+        }
       ]
     },
     {
@@ -11606,6 +15006,12 @@
           "url": "https://registry.npmjs.org/is-set/-/is-set-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-set"
         }
       ]
     },
@@ -11627,6 +15033,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-shared-array-buffer"
+        }
       ]
     },
     {
@@ -11646,6 +15058,12 @@
           "url": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-stream"
         }
       ]
     },
@@ -11667,6 +15085,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-string"
+        }
       ]
     },
     {
@@ -11686,6 +15110,12 @@
           "url": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-symbol"
         }
       ]
     },
@@ -11707,6 +15137,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-typed-array"
+        }
       ]
     },
     {
@@ -11726,6 +15162,12 @@
           "url": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-typedarray"
         }
       ]
     },
@@ -11747,6 +15189,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-unc-path"
+        }
       ]
     },
     {
@@ -11766,6 +15214,12 @@
           "url": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-weakmap"
         }
       ]
     },
@@ -11787,6 +15241,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-weakref"
+        }
       ]
     },
     {
@@ -11806,6 +15266,12 @@
           "url": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-weakset"
         }
       ]
     },
@@ -11827,6 +15293,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-windows"
+        }
       ]
     },
     {
@@ -11846,6 +15318,12 @@
           "url": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isarray"
         }
       ]
     },
@@ -11867,6 +15345,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isexe"
+        }
       ]
     },
     {
@@ -11886,6 +15370,12 @@
           "url": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isobject"
         }
       ]
     },
@@ -11907,6 +15397,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isstream"
+        }
       ]
     },
     {
@@ -11926,6 +15422,12 @@
           "url": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isurl"
         }
       ]
     },
@@ -11947,6 +15449,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/js-stringify"
+        }
       ]
     },
     {
@@ -11966,6 +15474,12 @@
           "url": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/js-tokens"
         }
       ]
     },
@@ -11987,6 +15501,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/js-yaml"
+        }
       ]
     },
     {
@@ -12006,6 +15526,12 @@
           "url": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jsbn"
         }
       ]
     },
@@ -12027,6 +15553,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-buffer"
+        }
       ]
     },
     {
@@ -12046,6 +15578,12 @@
           "url": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-parse-better-errors"
         }
       ]
     },
@@ -12067,6 +15605,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-schema-traverse"
+        }
       ]
     },
     {
@@ -12086,6 +15630,12 @@
           "url": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-schema"
         }
       ]
     },
@@ -12107,6 +15657,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-stringify-safe"
+        }
       ]
     },
     {
@@ -12126,6 +15682,12 @@
           "url": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json5"
         }
       ]
     },
@@ -12147,6 +15709,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jsonfile"
+        }
       ]
     },
     {
@@ -12166,6 +15734,12 @@
           "url": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-0.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jsonwebtoken"
         }
       ]
     },
@@ -12187,6 +15761,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jsprim"
+        }
       ]
     },
     {
@@ -12206,6 +15786,12 @@
           "url": "https://registry.npmjs.org/jssha/-/jssha-3.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jssha"
         }
       ]
     },
@@ -12227,6 +15813,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jstransformer"
+        }
       ]
     },
     {
@@ -12246,6 +15838,12 @@
           "url": "https://registry.npmjs.org/juicy-chat-bot/-/juicy-chat-bot-0.6.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/juicy-chat-bot"
         }
       ]
     },
@@ -12267,6 +15865,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jwa"
+        }
       ]
     },
     {
@@ -12286,6 +15890,12 @@
           "url": "https://registry.npmjs.org/jws/-/jws-0.2.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jws"
         }
       ]
     },
@@ -12307,6 +15917,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/keyv"
+        }
       ]
     },
     {
@@ -12326,6 +15942,12 @@
           "url": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/kind-of"
         }
       ]
     },
@@ -12347,6 +15969,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/kuler"
+        }
       ]
     },
     {
@@ -12366,6 +15994,12 @@
           "url": "https://registry.npmjs.org/kuromoji/-/kuromoji-0.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/kuromoji"
         }
       ]
     },
@@ -12387,6 +16021,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lazystream"
+        }
       ]
     },
     {
@@ -12406,6 +16046,12 @@
           "url": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/levn"
         }
       ]
     },
@@ -12428,6 +16074,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/libxmljs2"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12446,6 +16098,12 @@
               "url": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/libxmljs2/node_modules/nan"
             }
           ]
         }
@@ -12470,6 +16128,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/liftup"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12488,6 +16152,12 @@
               "url": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/braces"
             }
           ]
         },
@@ -12509,6 +16179,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/fill-range"
+            }
           ]
         },
         {
@@ -12528,6 +16204,12 @@
               "url": "https://registry.npmjs.org/findup-sync/-/findup-sync-4.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/findup-sync"
             }
           ]
         },
@@ -12549,6 +16231,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/is-glob"
+            }
           ]
         },
         {
@@ -12568,6 +16256,12 @@
               "url": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/is-number"
             }
           ]
         },
@@ -12589,6 +16283,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/micromatch"
+            }
           ]
         },
         {
@@ -12608,6 +16308,12 @@
               "url": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/to-regex-range"
             }
           ]
         }
@@ -12632,6 +16338,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/linebreak"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12650,6 +16362,12 @@
               "url": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/linebreak/node_modules/base64-js"
             }
           ]
         }
@@ -12673,6 +16391,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/listenercount"
+        }
       ]
     },
     {
@@ -12692,6 +16416,12 @@
           "url": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/locate-path"
         }
       ]
     },
@@ -12713,6 +16443,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lodash.camelcase"
+        }
       ]
     },
     {
@@ -12732,6 +16468,12 @@
           "url": "https://registry.npmjs.org/lodash.isfinite/-/lodash.isfinite-3.3.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lodash.isfinite"
         }
       ]
     },
@@ -12753,6 +16495,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lodash.set"
+        }
       ]
     },
     {
@@ -12772,6 +16520,12 @@
           "url": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lodash"
         }
       ]
     },
@@ -12794,6 +16548,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/logform"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12812,6 +16572,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/logform/node_modules/ms"
             }
           ]
         }
@@ -12835,6 +16601,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lolex"
+        }
       ]
     },
     {
@@ -12854,6 +16626,12 @@
           "url": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/loose-envify"
         }
       ]
     },
@@ -12875,6 +16653,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lowercase-keys"
+        }
       ]
     },
     {
@@ -12894,6 +16678,12 @@
           "url": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lru-cache"
         }
       ]
     },
@@ -12916,6 +16706,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-dir"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12934,6 +16730,12 @@
               "url": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-dir/node_modules/semver"
             }
           ]
         }
@@ -12957,6 +16759,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-error"
+        }
       ]
     },
     {
@@ -12976,6 +16784,12 @@
           "url": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-9.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-fetch-happen"
         }
       ],
       "components": [
@@ -12998,6 +16812,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen/node_modules/@tootallnate/once"
+            }
           ]
         },
         {
@@ -13017,6 +16837,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen/node_modules/debug"
             }
           ]
         },
@@ -13038,6 +16864,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen/node_modules/http-cache-semantics"
+            }
           ]
         },
         {
@@ -13058,6 +16890,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen/node_modules/http-proxy-agent"
+            }
           ]
         },
         {
@@ -13077,6 +16915,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen/node_modules/ms"
             }
           ]
         }
@@ -13100,6 +16944,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-iterator"
+        }
       ]
     },
     {
@@ -13119,6 +16969,12 @@
           "url": "https://registry.npmjs.org/make-plural/-/make-plural-6.2.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-plural"
         }
       ]
     },
@@ -13140,6 +16996,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/map-cache"
+        }
       ]
     },
     {
@@ -13159,6 +17021,12 @@
           "url": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/map-visit"
         }
       ]
     },
@@ -13180,6 +17048,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/marsdb"
+        }
       ]
     },
     {
@@ -13199,6 +17073,12 @@
           "url": "https://registry.npmjs.org/math-interval-parser/-/math-interval-parser-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/math-interval-parser"
         }
       ]
     },
@@ -13220,6 +17100,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/media-typer"
+        }
       ]
     },
     {
@@ -13239,6 +17125,12 @@
           "url": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/merge-descriptors"
         }
       ]
     },
@@ -13260,6 +17152,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/messageformat-formatters"
+        }
       ]
     },
     {
@@ -13279,6 +17177,12 @@
           "url": "https://registry.npmjs.org/messageformat-parser/-/messageformat-parser-4.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/messageformat-parser"
         }
       ]
     },
@@ -13301,6 +17205,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/messageformat"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -13319,6 +17229,12 @@
               "url": "https://registry.npmjs.org/make-plural/-/make-plural-4.3.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/messageformat/node_modules/make-plural"
             }
           ]
         }
@@ -13342,6 +17258,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/methods"
+        }
       ]
     },
     {
@@ -13361,6 +17283,12 @@
           "url": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/micromatch"
         }
       ]
     },
@@ -13382,6 +17310,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mime-db"
+        }
       ]
     },
     {
@@ -13401,6 +17335,12 @@
           "url": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mime-types"
         }
       ]
     },
@@ -13422,6 +17362,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mime"
+        }
       ]
     },
     {
@@ -13441,6 +17387,12 @@
           "url": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mimic-response"
         }
       ]
     },
@@ -13462,6 +17414,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minimatch"
+        }
       ]
     },
     {
@@ -13481,6 +17439,12 @@
           "url": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minimist"
         }
       ]
     },
@@ -13502,6 +17466,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-collect"
+        }
       ]
     },
     {
@@ -13521,6 +17491,12 @@
           "url": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-1.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-fetch"
         }
       ]
     },
@@ -13542,6 +17518,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-flush"
+        }
       ]
     },
     {
@@ -13561,6 +17543,12 @@
           "url": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-pipeline"
         }
       ]
     },
@@ -13582,6 +17570,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-sized"
+        }
       ]
     },
     {
@@ -13601,6 +17595,12 @@
           "url": "https://registry.npmjs.org/minipass/-/minipass-3.3.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass"
         }
       ]
     },
@@ -13622,6 +17622,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minizlib"
+        }
       ]
     },
     {
@@ -13641,6 +17647,12 @@
           "url": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mixin-deep"
         }
       ]
     },
@@ -13662,6 +17674,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mkdirp-classic"
+        }
       ]
     },
     {
@@ -13681,6 +17699,12 @@
           "url": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mkdirp"
         }
       ]
     },
@@ -13702,6 +17726,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/moment-timezone"
+        }
       ]
     },
     {
@@ -13721,6 +17751,12 @@
           "url": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/moment"
         }
       ]
     },
@@ -13743,6 +17779,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/morgan"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -13761,6 +17803,12 @@
               "url": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/morgan/node_modules/on-finished"
             }
           ]
         }
@@ -13784,6 +17832,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mout"
+        }
       ]
     },
     {
@@ -13803,6 +17857,12 @@
           "url": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ms"
         }
       ]
     },
@@ -13825,6 +17885,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/multer"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -13843,6 +17909,12 @@
               "url": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/multer/node_modules/mkdirp"
             }
           ]
         }
@@ -13866,6 +17938,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mustache"
+        }
       ]
     },
     {
@@ -13885,6 +17963,12 @@
           "url": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/nan"
         }
       ]
     },
@@ -13906,6 +17990,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/nanomatch"
+        }
       ]
     },
     {
@@ -13925,6 +18015,12 @@
           "url": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/napi-build-utils"
         }
       ]
     },
@@ -13947,6 +18043,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/needle"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -13965,6 +18067,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/needle/node_modules/debug"
             }
           ]
         },
@@ -13985,6 +18093,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/needle/node_modules/ms"
             }
           ]
         }
@@ -14008,6 +18122,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/negotiator"
+        }
       ]
     },
     {
@@ -14027,6 +18147,12 @@
           "url": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/neo-async"
         }
       ]
     },
@@ -14049,6 +18175,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-abi"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14067,6 +18199,12 @@
               "url": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-abi/node_modules/semver"
             }
           ]
         }
@@ -14090,6 +18228,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-addon-api"
+        }
       ]
     },
     {
@@ -14109,6 +18253,12 @@
           "url": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-fetch"
         }
       ]
     },
@@ -14131,6 +18281,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-gyp"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14149,6 +18305,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/ansi-regex"
             }
           ]
         },
@@ -14170,6 +18332,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/are-we-there-yet"
+            }
           ]
         },
         {
@@ -14189,6 +18357,12 @@
               "url": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/gauge"
             }
           ]
         },
@@ -14210,6 +18384,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/is-fullwidth-code-point"
+            }
           ]
         },
         {
@@ -14229,6 +18409,12 @@
               "url": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/nopt"
             }
           ]
         },
@@ -14250,6 +18436,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/npmlog"
+            }
           ]
         },
         {
@@ -14269,6 +18461,12 @@
               "url": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/readable-stream"
             }
           ]
         },
@@ -14290,6 +18488,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/string-width"
+            }
           ]
         },
         {
@@ -14309,6 +18513,12 @@
               "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/strip-ansi"
             }
           ]
         }
@@ -14333,6 +18543,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-pre-gyp"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14351,6 +18567,12 @@
               "url": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/chownr"
             }
           ]
         },
@@ -14372,6 +18594,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/fs-minipass"
+            }
           ]
         },
         {
@@ -14391,6 +18619,12 @@
               "url": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/minipass"
             }
           ]
         },
@@ -14412,6 +18646,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/minizlib"
+            }
           ]
         },
         {
@@ -14431,6 +18671,12 @@
               "url": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/mkdirp"
             }
           ]
         },
@@ -14452,6 +18698,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/nopt"
+            }
           ]
         },
         {
@@ -14471,6 +18723,12 @@
               "url": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/rimraf"
             }
           ]
         },
@@ -14492,6 +18750,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/safe-buffer"
+            }
           ]
         },
         {
@@ -14511,6 +18775,12 @@
               "url": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/semver"
             }
           ]
         },
@@ -14532,6 +18802,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/tar"
+            }
           ]
         },
         {
@@ -14551,6 +18827,12 @@
               "url": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/yallist"
             }
           ]
         }
@@ -14574,6 +18856,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/noop-logger"
+        }
       ]
     },
     {
@@ -14593,6 +18881,12 @@
           "url": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/nopt"
         }
       ]
     },
@@ -14615,6 +18909,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/normalize-package-data"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14633,6 +18933,12 @@
               "url": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/normalize-package-data/node_modules/semver"
             }
           ]
         }
@@ -14656,6 +18962,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/normalize-path"
+        }
       ]
     },
     {
@@ -14675,6 +18987,12 @@
           "url": "https://registry.npmjs.org/normalize-url/-/normalize-url-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/normalize-url"
         }
       ]
     },
@@ -14697,6 +19015,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/notevil"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14715,6 +19039,12 @@
               "url": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/notevil/node_modules/esprima"
             }
           ]
         }
@@ -14738,6 +19068,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/npm-bundled"
+        }
       ]
     },
     {
@@ -14757,6 +19093,12 @@
           "url": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/npm-normalize-package-bin"
         }
       ]
     },
@@ -14778,6 +19120,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/npm-packlist"
+        }
       ]
     },
     {
@@ -14797,6 +19145,12 @@
           "url": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/npmlog"
         }
       ]
     },
@@ -14818,6 +19172,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/number-is-nan"
+        }
       ]
     },
     {
@@ -14838,6 +19198,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/oauth-sign"
+        }
       ]
     },
     {
@@ -14857,6 +19223,12 @@
           "url": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-assign"
         }
       ]
     },
@@ -14879,6 +19251,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-copy"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14897,6 +19275,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy/node_modules/define-property"
             }
           ]
         },
@@ -14918,6 +19302,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy/node_modules/is-accessor-descriptor"
+            }
           ]
         },
         {
@@ -14937,6 +19327,12 @@
               "url": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy/node_modules/is-data-descriptor"
             }
           ]
         },
@@ -14959,6 +19355,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy/node_modules/is-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -14977,6 +19379,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/object-copy/node_modules/is-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -15000,6 +19408,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy/node_modules/kind-of"
+            }
           ]
         }
       ]
@@ -15022,6 +19436,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-inspect"
+        }
       ]
     },
     {
@@ -15041,6 +19461,12 @@
           "url": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-is"
         }
       ]
     },
@@ -15062,6 +19488,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-keys"
+        }
       ]
     },
     {
@@ -15081,6 +19513,12 @@
           "url": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-visit"
         }
       ]
     },
@@ -15102,6 +19540,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object.assign"
+        }
       ]
     },
     {
@@ -15121,6 +19565,12 @@
           "url": "https://registry.npmjs.org/object.defaults/-/object.defaults-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object.defaults"
         }
       ]
     },
@@ -15142,6 +19592,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object.map"
+        }
       ]
     },
     {
@@ -15161,6 +19617,12 @@
           "url": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object.pick"
         }
       ]
     },
@@ -15182,6 +19644,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/on-finished"
+        }
       ]
     },
     {
@@ -15201,6 +19669,12 @@
           "url": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/on-headers"
         }
       ]
     },
@@ -15222,6 +19696,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/once"
+        }
       ]
     },
     {
@@ -15241,6 +19721,12 @@
           "url": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/one-time"
         }
       ]
     },
@@ -15262,6 +19748,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/opentype.js"
+        }
       ]
     },
     {
@@ -15281,6 +19773,12 @@
           "url": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/optionator"
         }
       ]
     },
@@ -15302,6 +19800,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/os-homedir"
+        }
       ]
     },
     {
@@ -15321,6 +19825,12 @@
           "url": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/os-tmpdir"
         }
       ]
     },
@@ -15342,6 +19852,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/osenv"
+        }
       ]
     },
     {
@@ -15361,6 +19877,12 @@
           "url": "https://registry.npmjs.org/otplib/-/otplib-12.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/otplib"
         }
       ]
     },
@@ -15382,6 +19904,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-cancelable"
+        }
       ]
     },
     {
@@ -15401,6 +19929,12 @@
           "url": "https://registry.npmjs.org/p-event/-/p-event-2.3.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-event"
         }
       ]
     },
@@ -15422,6 +19956,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-finally"
+        }
       ]
     },
     {
@@ -15441,6 +19981,12 @@
           "url": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-is-promise"
         }
       ]
     },
@@ -15462,6 +20008,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-limit"
+        }
       ]
     },
     {
@@ -15481,6 +20033,12 @@
           "url": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-locate"
         }
       ]
     },
@@ -15502,6 +20060,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-map"
+        }
       ]
     },
     {
@@ -15521,6 +20085,12 @@
           "url": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-timeout"
         }
       ]
     },
@@ -15542,6 +20112,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-try"
+        }
       ]
     },
     {
@@ -15561,6 +20137,12 @@
           "url": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pako"
         }
       ]
     },
@@ -15582,6 +20164,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/parse-filepath"
+        }
       ]
     },
     {
@@ -15601,6 +20189,12 @@
           "url": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/parse-json"
         }
       ]
     },
@@ -15622,6 +20216,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/parse-passwd"
+        }
       ]
     },
     {
@@ -15641,6 +20241,12 @@
           "url": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/parseurl"
         }
       ]
     },
@@ -15662,6 +20268,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pascalcase"
+        }
       ]
     },
     {
@@ -15681,6 +20293,12 @@
           "url": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-exists"
         }
       ]
     },
@@ -15702,6 +20320,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-is-absolute"
+        }
       ]
     },
     {
@@ -15721,6 +20345,12 @@
           "url": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-parse"
         }
       ]
     },
@@ -15742,6 +20372,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-root-regex"
+        }
       ]
     },
     {
@@ -15761,6 +20397,12 @@
           "url": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-root"
         }
       ]
     },
@@ -15782,6 +20424,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-to-regexp"
+        }
       ]
     },
     {
@@ -15801,6 +20449,12 @@
           "url": "https://registry.npmjs.org/pdfkit/-/pdfkit-0.11.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pdfkit"
         }
       ]
     },
@@ -15822,6 +20476,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/peek-readable"
+        }
       ]
     },
     {
@@ -15841,6 +20501,12 @@
           "url": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pend"
         }
       ]
     },
@@ -15862,6 +20528,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/performance-now"
+        }
       ]
     },
     {
@@ -15881,6 +20553,12 @@
           "url": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.5.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pg-connection-string"
         }
       ]
     },
@@ -15902,6 +20580,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/picomatch"
+        }
       ]
     },
     {
@@ -15921,6 +20605,12 @@
           "url": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pify"
         }
       ]
     },
@@ -15942,6 +20632,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pinkie-promise"
+        }
       ]
     },
     {
@@ -15961,6 +20657,12 @@
           "url": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pinkie"
         }
       ]
     },
@@ -15982,6 +20684,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/png-js"
+        }
       ]
     },
     {
@@ -16001,6 +20709,12 @@
           "url": "https://registry.npmjs.org/portscanner/-/portscanner-2.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/portscanner"
         }
       ]
     },
@@ -16022,6 +20736,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/posix-character-classes"
+        }
       ]
     },
     {
@@ -16041,6 +20761,12 @@
           "url": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.3.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/prebuild-install"
         }
       ]
     },
@@ -16062,6 +20788,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/prelude-ls"
+        }
       ]
     },
     {
@@ -16081,6 +20813,12 @@
           "url": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/prepend-http"
         }
       ]
     },
@@ -16102,6 +20840,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pretty-bytes"
+        }
       ]
     },
     {
@@ -16121,6 +20865,12 @@
           "url": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/process-nextick-args"
         }
       ]
     },
@@ -16142,6 +20892,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/prom-client"
+        }
       ]
     },
     {
@@ -16161,6 +20917,12 @@
           "url": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/promise-inflight"
         }
       ]
     },
@@ -16183,6 +20945,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/promise-retry"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -16201,6 +20969,12 @@
               "url": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/promise-retry/node_modules/err-code"
             }
           ]
         },
@@ -16221,6 +20995,12 @@
               "url": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/promise-retry/node_modules/retry"
             }
           ]
         }
@@ -16244,6 +21024,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/promise"
+        }
       ]
     },
     {
@@ -16263,6 +21049,12 @@
           "url": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/proper-lockfile"
         }
       ]
     },
@@ -16284,6 +21076,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/proxy-addr"
+        }
       ]
     },
     {
@@ -16303,6 +21101,12 @@
           "url": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/psl"
         }
       ]
     },
@@ -16324,6 +21128,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-attrs"
+        }
       ]
     },
     {
@@ -16343,6 +21153,12 @@
           "url": "https://registry.npmjs.org/pug-code-gen/-/pug-code-gen-3.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-code-gen"
         }
       ]
     },
@@ -16364,6 +21180,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-error"
+        }
       ]
     },
     {
@@ -16383,6 +21205,12 @@
           "url": "https://registry.npmjs.org/pug-filters/-/pug-filters-4.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-filters"
         }
       ]
     },
@@ -16404,6 +21232,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-lexer"
+        }
       ]
     },
     {
@@ -16423,6 +21257,12 @@
           "url": "https://registry.npmjs.org/pug-linker/-/pug-linker-4.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-linker"
         }
       ]
     },
@@ -16444,6 +21284,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-load"
+        }
       ]
     },
     {
@@ -16463,6 +21309,12 @@
           "url": "https://registry.npmjs.org/pug-parser/-/pug-parser-6.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-parser"
         }
       ]
     },
@@ -16484,6 +21336,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-runtime"
+        }
       ]
     },
     {
@@ -16503,6 +21361,12 @@
           "url": "https://registry.npmjs.org/pug-strip-comments/-/pug-strip-comments-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-strip-comments"
         }
       ]
     },
@@ -16524,6 +21388,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-walk"
+        }
       ]
     },
     {
@@ -16543,6 +21413,12 @@
           "url": "https://registry.npmjs.org/pug/-/pug-3.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug"
         }
       ]
     },
@@ -16564,6 +21440,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pump"
+        }
       ]
     },
     {
@@ -16583,6 +21465,12 @@
           "url": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/punycode"
         }
       ]
     },
@@ -16604,6 +21492,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/qs"
+        }
       ]
     },
     {
@@ -16623,6 +21517,12 @@
           "url": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/query-string"
         }
       ]
     },
@@ -16644,6 +21544,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/range_check"
+        }
       ]
     },
     {
@@ -16663,6 +21569,12 @@
           "url": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/range-parser"
         }
       ]
     },
@@ -16684,6 +21596,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/raw-body"
+        }
       ]
     },
     {
@@ -16703,6 +21621,12 @@
           "url": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/rc"
         }
       ]
     },
@@ -16725,6 +21649,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/read-pkg"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -16743,6 +21673,12 @@
               "url": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/read-pkg/node_modules/pify"
             }
           ]
         }
@@ -16767,6 +21703,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/readable-stream"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -16785,6 +21727,12 @@
               "url": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/readable-stream/node_modules/isarray"
             }
           ]
         }
@@ -16809,6 +21757,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/readable-web-to-node-stream"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -16827,6 +21781,12 @@
               "url": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/readable-web-to-node-stream/node_modules/readable-stream"
             }
           ]
         }
@@ -16850,6 +21810,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/readdirp"
+        }
       ]
     },
     {
@@ -16869,6 +21835,12 @@
           "url": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/rechoir"
         }
       ]
     },
@@ -16890,6 +21862,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/regex-not"
+        }
       ]
     },
     {
@@ -16909,6 +21887,12 @@
           "url": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/regexp.prototype.flags"
         }
       ]
     },
@@ -16930,6 +21914,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/remove-trailing-separator"
+        }
       ]
     },
     {
@@ -16950,6 +21940,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/repeat-element"
+        }
       ]
     },
     {
@@ -16969,6 +21965,12 @@
           "url": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/repeat-string"
         }
       ]
     },
@@ -16991,6 +21993,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/replace"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17009,6 +22017,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/ansi-regex"
             }
           ]
         },
@@ -17030,6 +22044,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/ansi-styles"
+            }
           ]
         },
         {
@@ -17049,6 +22069,12 @@
               "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/brace-expansion"
             }
           ]
         },
@@ -17070,6 +22096,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/cliui"
+            }
           ]
         },
         {
@@ -17089,6 +22121,12 @@
               "url": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/color-convert"
             }
           ]
         },
@@ -17110,6 +22148,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/color-name"
+            }
           ]
         },
         {
@@ -17129,6 +22173,12 @@
               "url": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/find-up"
             }
           ]
         },
@@ -17150,6 +22200,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/is-fullwidth-code-point"
+            }
           ]
         },
         {
@@ -17169,6 +22225,12 @@
               "url": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/locate-path"
             }
           ]
         },
@@ -17190,6 +22252,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/minimatch"
+            }
           ]
         },
         {
@@ -17209,6 +22277,12 @@
               "url": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/p-locate"
             }
           ]
         },
@@ -17230,6 +22304,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/path-exists"
+            }
           ]
         },
         {
@@ -17249,6 +22329,12 @@
               "url": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/string-width"
             }
           ]
         },
@@ -17270,6 +22356,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/strip-ansi"
+            }
           ]
         },
         {
@@ -17289,6 +22381,12 @@
               "url": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/wrap-ansi"
             }
           ]
         },
@@ -17310,6 +22408,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/yargs-parser"
+            }
           ]
         },
         {
@@ -17329,6 +22433,12 @@
               "url": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/yargs"
             }
           ]
         }
@@ -17353,6 +22463,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/request"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17371,6 +22487,12 @@
               "url": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/request/node_modules/qs"
             }
           ]
         }
@@ -17394,6 +22516,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/require-directory"
+        }
       ]
     },
     {
@@ -17413,6 +22541,12 @@
           "url": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/require-main-filename"
         }
       ]
     },
@@ -17434,6 +22568,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/resolve-dir"
+        }
       ]
     },
     {
@@ -17453,6 +22593,12 @@
           "url": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/resolve-url"
         }
       ]
     },
@@ -17474,6 +22620,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/resolve"
+        }
       ]
     },
     {
@@ -17493,6 +22645,12 @@
           "url": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/responselike"
         }
       ]
     },
@@ -17514,6 +22672,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/restructure"
+        }
       ]
     },
     {
@@ -17533,6 +22697,12 @@
           "url": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ret"
         }
       ]
     },
@@ -17554,6 +22724,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/retry-as-promised"
+        }
       ]
     },
     {
@@ -17574,6 +22750,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/retry"
+        }
       ]
     },
     {
@@ -17593,6 +22775,12 @@
           "url": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/rimraf"
         }
       ]
     },
@@ -17615,6 +22803,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/rxjs"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17633,6 +22827,12 @@
               "url": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/rxjs/node_modules/tslib"
             }
           ]
         }
@@ -17656,6 +22856,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safe-buffer"
+        }
       ]
     },
     {
@@ -17675,6 +22881,12 @@
           "url": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safe-regex-test"
         }
       ]
     },
@@ -17696,6 +22908,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safe-regex"
+        }
       ]
     },
     {
@@ -17715,6 +22933,12 @@
           "url": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safe-stable-stringify"
         }
       ]
     },
@@ -17736,6 +22960,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safer-buffer"
+        }
       ]
     },
     {
@@ -17756,6 +22986,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/samsam"
+        }
       ]
     },
     {
@@ -17775,6 +23011,12 @@
           "url": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sanitize-filename"
         }
       ]
     },
@@ -17797,6 +23039,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sanitize-html"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17815,6 +23063,12 @@
               "url": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sanitize-html/node_modules/lodash"
             }
           ]
         }
@@ -17838,6 +23092,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sax"
+        }
       ]
     },
     {
@@ -17858,6 +23118,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/seek-bzip"
+        }
       ]
     },
     {
@@ -17877,6 +23143,12 @@
           "url": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/semver"
         }
       ]
     },
@@ -17899,6 +23171,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/send"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17917,6 +23195,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/send/node_modules/ms"
             }
           ]
         }
@@ -17940,6 +23224,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sequelize-pool"
+        }
       ]
     },
     {
@@ -17961,6 +23251,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sequelize"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17979,6 +23275,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sequelize/node_modules/debug"
             }
           ]
         },
@@ -18000,6 +23302,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sequelize/node_modules/ms"
+            }
           ]
         },
         {
@@ -18019,6 +23327,12 @@
               "url": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sequelize/node_modules/uuid"
             }
           ]
         }
@@ -18043,6 +23357,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/serve-index"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18061,6 +23381,12 @@
               "url": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index/node_modules/depd"
             }
           ]
         },
@@ -18082,6 +23408,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index/node_modules/http-errors"
+            }
           ]
         },
         {
@@ -18101,6 +23433,12 @@
               "url": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index/node_modules/inherits"
             }
           ]
         },
@@ -18122,6 +23460,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index/node_modules/setprototypeof"
+            }
           ]
         },
         {
@@ -18141,6 +23485,12 @@
               "url": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index/node_modules/statuses"
             }
           ]
         }
@@ -18164,6 +23514,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/serve-static"
+        }
       ]
     },
     {
@@ -18183,6 +23539,12 @@
           "url": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/set-blocking"
         }
       ]
     },
@@ -18205,6 +23567,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/set-value"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18223,6 +23591,12 @@
               "url": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/set-value/node_modules/extend-shallow"
             }
           ]
         },
@@ -18243,6 +23617,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/set-value/node_modules/is-extendable"
             }
           ]
         }
@@ -18266,6 +23646,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/setimmediate"
+        }
       ]
     },
     {
@@ -18285,6 +23671,12 @@
           "url": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/setprototypeof"
         }
       ]
     },
@@ -18306,6 +23698,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/side-channel"
+        }
       ]
     },
     {
@@ -18326,6 +23724,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/signal-exit"
+        }
       ]
     },
     {
@@ -18345,6 +23749,12 @@
           "url": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/simple-concat"
         }
       ]
     },
@@ -18367,6 +23777,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/simple-get"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18385,6 +23801,12 @@
               "url": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/simple-get/node_modules/decompress-response"
             }
           ]
         },
@@ -18405,6 +23827,12 @@
               "url": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/simple-get/node_modules/mimic-response"
             }
           ]
         }
@@ -18429,6 +23857,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/simple-swizzle"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18447,6 +23881,12 @@
               "url": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/simple-swizzle/node_modules/is-arrayish"
             }
           ]
         }
@@ -18470,6 +23910,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sinon"
+        }
       ]
     },
     {
@@ -18489,6 +23935,12 @@
           "url": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/smart-buffer"
         }
       ]
     },
@@ -18511,6 +23963,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/snapdragon-node"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18529,6 +23987,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon-node/node_modules/define-property"
             }
           ]
         }
@@ -18553,6 +24017,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/snapdragon-util"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18571,6 +24041,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon-util/node_modules/kind-of"
             }
           ]
         }
@@ -18595,6 +24071,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/snapdragon"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18613,6 +24095,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/define-property"
             }
           ]
         },
@@ -18633,6 +24121,12 @@
               "url": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/extend-shallow"
             }
           ]
         },
@@ -18655,6 +24149,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/is-accessor-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -18673,6 +24173,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/snapdragon/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -18697,6 +24203,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/is-data-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -18715,6 +24227,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/snapdragon/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -18738,6 +24256,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/is-descriptor"
+            }
           ]
         },
         {
@@ -18757,6 +24281,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/is-extendable"
             }
           ]
         },
@@ -18778,6 +24308,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/kind-of"
+            }
           ]
         },
         {
@@ -18797,6 +24333,12 @@
               "url": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/source-map"
             }
           ]
         }
@@ -18820,6 +24362,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socket.io-adapter"
+        }
       ]
     },
     {
@@ -18841,6 +24389,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socket.io-parser"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18859,6 +24413,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socket.io-parser/node_modules/debug"
             }
           ]
         },
@@ -18879,6 +24439,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socket.io-parser/node_modules/ms"
             }
           ]
         }
@@ -18903,6 +24469,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socket.io"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18921,6 +24493,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socket.io/node_modules/debug"
             }
           ]
         },
@@ -18941,6 +24519,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socket.io/node_modules/ms"
             }
           ]
         }
@@ -18965,6 +24549,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socks-proxy-agent"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18983,6 +24573,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socks-proxy-agent/node_modules/debug"
             }
           ]
         },
@@ -19003,6 +24599,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socks-proxy-agent/node_modules/ms"
             }
           ]
         }
@@ -19027,6 +24629,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socks"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -19045,6 +24653,12 @@
               "url": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socks/node_modules/ip"
             }
           ]
         }
@@ -19069,6 +24683,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sort-keys-length"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -19087,6 +24707,12 @@
               "url": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sort-keys-length/node_modules/sort-keys"
             }
           ]
         }
@@ -19110,6 +24736,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sort-keys"
+        }
       ]
     },
     {
@@ -19129,6 +24761,12 @@
           "url": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/source-map-resolve"
         }
       ]
     },
@@ -19150,6 +24788,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/source-map-support"
+        }
       ]
     },
     {
@@ -19169,6 +24813,12 @@
           "url": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/source-map-url"
         }
       ]
     },
@@ -19190,6 +24840,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/source-map"
+        }
       ]
     },
     {
@@ -19209,6 +24865,12 @@
           "url": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2-1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spawn-command"
         }
       ]
     },
@@ -19230,6 +24892,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spdx-correct"
+        }
       ]
     },
     {
@@ -19249,6 +24917,12 @@
           "url": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spdx-exceptions"
         }
       ]
     },
@@ -19270,6 +24944,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spdx-expression-parse"
+        }
       ]
     },
     {
@@ -19289,6 +24969,12 @@
           "url": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.12.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spdx-license-ids"
         }
       ]
     },
@@ -19310,6 +24996,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/split-string"
+        }
       ]
     },
     {
@@ -19329,6 +25021,12 @@
           "url": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sprintf-js"
         }
       ]
     },
@@ -19350,6 +25048,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sqlite3"
+        }
       ]
     },
     {
@@ -19369,6 +25073,12 @@
           "url": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sshpk"
         }
       ]
     },
@@ -19390,6 +25100,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ssri"
+        }
       ]
     },
     {
@@ -19409,6 +25125,12 @@
           "url": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/stack-trace"
         }
       ]
     },
@@ -19431,6 +25153,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/static-extend"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -19449,6 +25177,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend/node_modules/define-property"
             }
           ]
         },
@@ -19471,6 +25205,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend/node_modules/is-accessor-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -19489,6 +25229,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/static-extend/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -19513,6 +25259,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend/node_modules/is-data-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -19531,6 +25283,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/static-extend/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -19554,6 +25312,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend/node_modules/is-descriptor"
+            }
           ]
         },
         {
@@ -19573,6 +25337,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend/node_modules/kind-of"
             }
           ]
         }
@@ -19596,6 +25366,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/statuses"
+        }
       ]
     },
     {
@@ -19615,6 +25391,12 @@
           "url": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-2.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/stream-buffers"
         }
       ]
     },
@@ -19636,6 +25418,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/streamsearch"
+        }
       ]
     },
     {
@@ -19655,6 +25443,12 @@
           "url": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strict-uri-encode"
         }
       ]
     },
@@ -19676,6 +25470,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string_decoder"
+        }
       ]
     },
     {
@@ -19695,6 +25495,12 @@
           "url": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string-width"
         }
       ]
     },
@@ -19716,6 +25522,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string.fromcodepoint"
+        }
       ]
     },
     {
@@ -19735,6 +25547,12 @@
           "url": "https://registry.npmjs.org/string.prototype.codepointat/-/string.prototype.codepointat-0.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string.prototype.codepointat"
         }
       ]
     },
@@ -19756,6 +25574,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string.prototype.trimend"
+        }
       ]
     },
     {
@@ -19775,6 +25599,12 @@
           "url": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string.prototype.trimstart"
         }
       ]
     },
@@ -19796,6 +25626,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-ansi"
+        }
       ]
     },
     {
@@ -19815,6 +25651,12 @@
           "url": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-bom"
         }
       ]
     },
@@ -19836,6 +25678,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-dirs"
+        }
       ]
     },
     {
@@ -19855,6 +25703,12 @@
           "url": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-json-comments"
         }
       ]
     },
@@ -19876,6 +25730,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-outer"
+        }
       ]
     },
     {
@@ -19895,6 +25755,12 @@
           "url": "https://registry.npmjs.org/strtok3/-/strtok3-6.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strtok3"
         }
       ]
     },
@@ -19916,6 +25782,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/supports-color"
+        }
       ]
     },
     {
@@ -19935,6 +25807,12 @@
           "url": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/supports-preserve-symlinks-flag"
         }
       ]
     },
@@ -19956,6 +25834,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/svg-captcha"
+        }
       ]
     },
     {
@@ -19976,6 +25860,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/swagger-ui-dist"
+        }
       ]
     },
     {
@@ -19995,6 +25885,12 @@
           "url": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-4.5.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/swagger-ui-express"
         }
       ]
     },
@@ -20017,6 +25913,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tar-fs"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -20035,6 +25937,12 @@
               "url": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/tar-fs/node_modules/bl"
             }
           ]
         },
@@ -20056,6 +25964,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/tar-fs/node_modules/chownr"
+            }
           ]
         },
         {
@@ -20076,6 +25990,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/tar-fs/node_modules/readable-stream"
+            }
           ]
         },
         {
@@ -20095,6 +26015,12 @@
               "url": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/tar-fs/node_modules/tar-stream"
             }
           ]
         }
@@ -20118,6 +26044,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tar-stream"
+        }
       ]
     },
     {
@@ -20137,6 +26069,12 @@
           "url": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tar"
         }
       ]
     },
@@ -20158,6 +26096,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tdigest"
+        }
       ]
     },
     {
@@ -20177,6 +26121,12 @@
           "url": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/text-hex"
         }
       ]
     },
@@ -20198,6 +26148,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/thirty-two"
+        }
       ]
     },
     {
@@ -20217,6 +26173,12 @@
           "url": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/through"
         }
       ]
     },
@@ -20238,6 +26200,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/timed-out"
+        }
       ]
     },
     {
@@ -20257,6 +26225,12 @@
           "url": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tiny-inflate"
         }
       ]
     },
@@ -20278,6 +26252,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-buffer"
+        }
       ]
     },
     {
@@ -20297,6 +26277,12 @@
           "url": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-fast-properties"
         }
       ]
     },
@@ -20319,6 +26305,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-object-path"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -20337,6 +26329,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/to-object-path/node_modules/kind-of"
             }
           ]
         }
@@ -20360,6 +26358,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-regex-range"
+        }
       ]
     },
     {
@@ -20379,6 +26383,12 @@
           "url": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-regex"
         }
       ]
     },
@@ -20400,6 +26410,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/toidentifier"
+        }
       ]
     },
     {
@@ -20419,6 +26435,12 @@
           "url": "https://registry.npmjs.org/token-stream/-/token-stream-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/token-stream"
         }
       ]
     },
@@ -20440,6 +26462,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/token-types"
+        }
       ]
     },
     {
@@ -20459,6 +26487,12 @@
           "url": "https://registry.npmjs.org/toposort-class/-/toposort-class-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/toposort-class"
         }
       ]
     },
@@ -20480,6 +26514,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tough-cookie"
+        }
       ]
     },
     {
@@ -20499,6 +26539,12 @@
           "url": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tr46"
         }
       ]
     },
@@ -20520,6 +26566,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/traverse"
+        }
       ]
     },
     {
@@ -20539,6 +26591,12 @@
           "url": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tree-kill"
         }
       ]
     },
@@ -20560,6 +26618,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/trim-repeated"
+        }
       ]
     },
     {
@@ -20580,6 +26644,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/triple-beam"
+        }
       ]
     },
     {
@@ -20599,6 +26669,12 @@
           "url": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/truncate-utf8-bytes"
         }
       ]
     },
@@ -20621,6 +26697,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ts-node-dev"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -20639,6 +26721,12 @@
               "url": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/ts-node-dev/node_modules/rimraf"
             }
           ]
         }
@@ -20662,6 +26750,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ts-node"
+        }
       ]
     },
     {
@@ -20681,6 +26775,12 @@
           "url": "https://registry.npmjs.org/tsconfig/-/tsconfig-7.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tsconfig"
         }
       ]
     },
@@ -20702,6 +26802,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tslib"
+        }
       ]
     },
     {
@@ -20721,6 +26827,12 @@
           "url": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tunnel-agent"
         }
       ]
     },
@@ -20742,6 +26854,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tweetnacl"
+        }
       ]
     },
     {
@@ -20761,6 +26879,12 @@
           "url": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/type-check"
         }
       ]
     },
@@ -20782,6 +26906,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/type-is"
+        }
       ]
     },
     {
@@ -20801,6 +26931,12 @@
           "url": "https://registry.npmjs.org/typecast/-/typecast-0.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/typecast"
         }
       ]
     },
@@ -20822,6 +26958,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/typedarray"
+        }
       ]
     },
     {
@@ -20841,6 +26983,12 @@
           "url": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/typescript"
         }
       ]
     },
@@ -20862,6 +27010,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/uglify-js"
+        }
       ]
     },
     {
@@ -20881,6 +27035,12 @@
           "url": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unbox-primitive"
         }
       ]
     },
@@ -20902,6 +27062,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unbzip2-stream"
+        }
       ]
     },
     {
@@ -20921,6 +27087,12 @@
           "url": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unc-path-regex"
         }
       ]
     },
@@ -20942,6 +27114,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/underscore.string"
+        }
       ]
     },
     {
@@ -20962,6 +27140,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unicode-properties"
+        }
       ]
     },
     {
@@ -20981,6 +27165,12 @@
           "url": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unicode-trie"
         }
       ]
     },
@@ -21003,6 +27193,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/union-value"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21021,6 +27217,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/union-value/node_modules/is-extendable"
             }
           ]
         }
@@ -21044,6 +27246,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unique-filename"
+        }
       ]
     },
     {
@@ -21063,6 +27271,12 @@
           "url": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unique-slug"
         }
       ]
     },
@@ -21084,6 +27298,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unit-compare"
+        }
       ]
     },
     {
@@ -21104,6 +27324,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/universalify"
+        }
       ]
     },
     {
@@ -21123,6 +27349,12 @@
           "url": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unpipe"
         }
       ]
     },
@@ -21145,6 +27377,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unset-value"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21165,6 +27403,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/unset-value/node_modules/has-value"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -21183,6 +27427,12 @@
                   "url": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/unset-value/node_modules/has-value/node_modules/isobject"
                 }
               ]
             }
@@ -21206,6 +27456,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/unset-value/node_modules/has-values"
+            }
           ]
         },
         {
@@ -21225,6 +27481,12 @@
               "url": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/unset-value/node_modules/isarray"
             }
           ]
         }
@@ -21248,6 +27510,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/untildify"
+        }
       ]
     },
     {
@@ -21269,6 +27537,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unzipper"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21287,6 +27561,12 @@
               "url": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/unzipper/node_modules/bluebird"
             }
           ]
         }
@@ -21310,6 +27590,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/uri-js"
+        }
       ]
     },
     {
@@ -21329,6 +27615,12 @@
           "url": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/urix"
         }
       ]
     },
@@ -21350,6 +27642,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/url-parse-lax"
+        }
       ]
     },
     {
@@ -21369,6 +27667,12 @@
           "url": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/url-to-options"
         }
       ]
     },
@@ -21390,6 +27694,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/use"
+        }
       ]
     },
     {
@@ -21409,6 +27719,12 @@
           "url": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/utf8-byte-length"
         }
       ]
     },
@@ -21430,6 +27746,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/util-deprecate"
+        }
       ]
     },
     {
@@ -21449,6 +27771,12 @@
           "url": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/util"
         }
       ]
     },
@@ -21470,6 +27798,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/utils-merge"
+        }
       ]
     },
     {
@@ -21489,6 +27823,12 @@
           "url": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/uuid"
         }
       ]
     },
@@ -21510,6 +27850,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/v8flags"
+        }
       ]
     },
     {
@@ -21529,6 +27875,12 @@
           "url": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/validate-npm-package-license"
         }
       ]
     },
@@ -21550,6 +27902,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/validate"
+        }
       ]
     },
     {
@@ -21570,6 +27928,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/validator"
+        }
       ]
     },
     {
@@ -21589,6 +27953,12 @@
           "url": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/vary"
         }
       ]
     },
@@ -21611,6 +27981,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/verror"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21629,6 +28005,12 @@
               "url": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/verror/node_modules/core-util-is"
             }
           ]
         }
@@ -21653,6 +28035,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/vm2"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21671,6 +28059,12 @@
               "url": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/vm2/node_modules/acorn"
             }
           ]
         }
@@ -21694,6 +28088,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/void-elements"
+        }
       ]
     },
     {
@@ -21713,6 +28113,12 @@
           "url": "https://registry.npmjs.org/walk/-/walk-2.3.15.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/walk"
         }
       ]
     },
@@ -21734,6 +28140,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/walkdir"
+        }
       ]
     },
     {
@@ -21753,6 +28165,12 @@
           "url": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/webidl-conversions"
         }
       ]
     },
@@ -21774,6 +28192,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/whatwg-url"
+        }
       ]
     },
     {
@@ -21793,6 +28217,12 @@
           "url": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-boxed-primitive"
         }
       ]
     },
@@ -21814,6 +28244,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-collection"
+        }
       ]
     },
     {
@@ -21833,6 +28269,12 @@
           "url": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-module"
         }
       ]
     },
@@ -21854,6 +28296,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-pm-runs"
+        }
       ]
     },
     {
@@ -21873,6 +28321,12 @@
           "url": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-typed-array"
         }
       ]
     },
@@ -21894,6 +28348,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which"
+        }
       ]
     },
     {
@@ -21913,6 +28373,12 @@
           "url": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wide-align"
         }
       ]
     },
@@ -21935,6 +28401,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/winston-transport"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21953,6 +28425,12 @@
               "url": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/winston-transport/node_modules/readable-stream"
             }
           ]
         }
@@ -21977,6 +28455,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/winston"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21995,6 +28479,12 @@
               "url": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/winston/node_modules/async"
             }
           ]
         },
@@ -22016,6 +28506,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/winston/node_modules/is-stream"
+            }
           ]
         },
         {
@@ -22035,6 +28531,12 @@
               "url": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/winston/node_modules/readable-stream"
             }
           ]
         }
@@ -22058,6 +28560,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/with"
+        }
       ]
     },
     {
@@ -22077,6 +28585,12 @@
           "url": "https://registry.npmjs.org/wkx/-/wkx-0.5.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wkx"
         }
       ]
     },
@@ -22098,6 +28612,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/word-wrap"
+        }
       ]
     },
     {
@@ -22117,6 +28637,12 @@
           "url": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wordwrap"
         }
       ]
     },
@@ -22139,6 +28665,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wrap-ansi"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -22157,6 +28689,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi/node_modules/ansi-regex"
             }
           ]
         },
@@ -22178,6 +28716,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi/node_modules/emoji-regex"
+            }
           ]
         },
         {
@@ -22197,6 +28741,12 @@
               "url": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi/node_modules/is-fullwidth-code-point"
             }
           ]
         },
@@ -22218,6 +28768,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi/node_modules/string-width"
+            }
           ]
         },
         {
@@ -22237,6 +28793,12 @@
               "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi/node_modules/strip-ansi"
             }
           ]
         }
@@ -22260,6 +28822,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wrappy"
+        }
       ]
     },
     {
@@ -22279,6 +28847,12 @@
           "url": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ws"
         }
       ]
     },
@@ -22300,6 +28874,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/xtend"
+        }
       ]
     },
     {
@@ -22319,6 +28899,12 @@
           "url": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/y18n"
         }
       ]
     },
@@ -22340,6 +28926,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yallist"
+        }
       ]
     },
     {
@@ -22360,6 +28952,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yaml-schema-validator"
+        }
       ]
     },
     {
@@ -22379,6 +28977,12 @@
           "url": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yargs-parser"
         }
       ]
     },
@@ -22401,6 +29005,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yargs"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -22419,6 +29029,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs/node_modules/ansi-regex"
             }
           ]
         },
@@ -22440,6 +29056,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs/node_modules/emoji-regex"
+            }
           ]
         },
         {
@@ -22459,6 +29081,12 @@
               "url": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs/node_modules/is-fullwidth-code-point"
             }
           ]
         },
@@ -22480,6 +29108,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs/node_modules/string-width"
+            }
           ]
         },
         {
@@ -22499,6 +29133,12 @@
               "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs/node_modules/strip-ansi"
             }
           ]
         }
@@ -22522,6 +29162,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yauzl"
+        }
       ]
     },
     {
@@ -22541,6 +29187,12 @@
           "url": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yn"
         }
       ]
     },
@@ -22562,6 +29214,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/z85"
+        }
       ]
     },
     {
@@ -22582,6 +29240,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/zip-stream"
+        }
       ]
     },
     {
@@ -22601,6 +29265,12 @@
           "url": "https://registry.npmjs.org/zlibjs/-/zlibjs-0.3.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/zlibjs"
         }
       ]
     }

--- a/tests/_data/sbom_demo-results/juice-shop_npm7_node16_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/juice-shop_npm7_node16_ubuntu-latest.snap.json
@@ -62,7 +62,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -95,7 +95,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@babel/helper-string-parser"
         }
       ]
@@ -122,7 +122,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@babel/helper-validator-identifier"
         }
       ]
@@ -149,7 +149,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@babel/parser"
         }
       ]
@@ -176,7 +176,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@babel/types"
         }
       ]
@@ -203,7 +203,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@colors/colors"
         }
       ]
@@ -230,7 +230,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@dabh/diagnostics"
         }
       ]
@@ -257,7 +257,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@gar/promisify"
         }
       ]
@@ -284,7 +284,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@mapbox/node-pre-gyp"
         }
       ],
@@ -310,7 +310,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/ansi-regex"
             }
           ]
@@ -336,7 +336,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/are-we-there-yet"
             }
           ]
@@ -362,7 +362,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/detect-libc"
             }
           ]
@@ -388,7 +388,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/gauge"
             }
           ]
@@ -414,7 +414,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -440,7 +440,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/make-dir"
             }
           ],
@@ -466,7 +466,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/@mapbox/node-pre-gyp/node_modules/make-dir/node_modules/semver"
                 }
               ]
@@ -494,7 +494,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/nopt"
             }
           ]
@@ -520,7 +520,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/npmlog"
             }
           ]
@@ -546,7 +546,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/readable-stream"
             }
           ]
@@ -572,7 +572,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/string-width"
             }
           ]
@@ -598,7 +598,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/strip-ansi"
             }
           ]
@@ -627,7 +627,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/core-loader"
         }
       ]
@@ -654,7 +654,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/core"
         }
       ]
@@ -681,7 +681,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/evaluator"
         }
       ]
@@ -708,7 +708,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-all"
         }
       ]
@@ -735,7 +735,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ar"
         }
       ]
@@ -762,7 +762,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-bn"
         }
       ]
@@ -789,7 +789,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ca"
         }
       ]
@@ -816,7 +816,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-cs"
         }
       ]
@@ -843,7 +843,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-da"
         }
       ]
@@ -870,7 +870,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-de"
         }
       ]
@@ -897,7 +897,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-el"
         }
       ]
@@ -924,7 +924,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-en-min"
         }
       ]
@@ -951,7 +951,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-en"
         }
       ]
@@ -978,7 +978,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-es"
         }
       ]
@@ -1005,7 +1005,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-eu"
         }
       ]
@@ -1032,7 +1032,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-fa"
         }
       ]
@@ -1059,7 +1059,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-fi"
         }
       ]
@@ -1086,7 +1086,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-fr"
         }
       ]
@@ -1113,7 +1113,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ga"
         }
       ]
@@ -1140,7 +1140,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-gl"
         }
       ]
@@ -1167,7 +1167,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-hi"
         }
       ]
@@ -1194,7 +1194,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-hu"
         }
       ]
@@ -1221,7 +1221,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-hy"
         }
       ]
@@ -1248,7 +1248,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-id"
         }
       ]
@@ -1275,7 +1275,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-it"
         }
       ]
@@ -1302,7 +1302,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ja"
         }
       ]
@@ -1329,7 +1329,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ko"
         }
       ]
@@ -1356,7 +1356,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-lt"
         }
       ]
@@ -1383,7 +1383,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ms"
         }
       ]
@@ -1410,7 +1410,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ne"
         }
       ]
@@ -1437,7 +1437,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-nl"
         }
       ]
@@ -1464,7 +1464,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-no"
         }
       ]
@@ -1491,7 +1491,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-pl"
         }
       ]
@@ -1518,7 +1518,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-pt"
         }
       ]
@@ -1545,7 +1545,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ro"
         }
       ]
@@ -1572,7 +1572,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ru"
         }
       ]
@@ -1599,7 +1599,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-sl"
         }
       ]
@@ -1626,7 +1626,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-sr"
         }
       ]
@@ -1653,7 +1653,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-sv"
         }
       ]
@@ -1680,7 +1680,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ta"
         }
       ]
@@ -1707,7 +1707,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-th"
         }
       ]
@@ -1734,7 +1734,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-tl"
         }
       ]
@@ -1761,7 +1761,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-tr"
         }
       ]
@@ -1788,7 +1788,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-uk"
         }
       ]
@@ -1815,7 +1815,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-zh"
         }
       ]
@@ -1842,7 +1842,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/language-min"
         }
       ]
@@ -1869,7 +1869,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/language"
         }
       ]
@@ -1896,7 +1896,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/ner"
         }
       ]
@@ -1923,7 +1923,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/neural"
         }
       ]
@@ -1950,7 +1950,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/nlg"
         }
       ]
@@ -1977,7 +1977,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/nlp"
         }
       ]
@@ -2004,7 +2004,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/nlu"
         }
       ]
@@ -2031,7 +2031,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/request"
         }
       ]
@@ -2058,7 +2058,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/sentiment"
         }
       ]
@@ -2085,7 +2085,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/similarity"
         }
       ]
@@ -2112,7 +2112,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/slot"
         }
       ]
@@ -2139,7 +2139,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@npmcli/fs"
         }
       ]
@@ -2166,7 +2166,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@npmcli/move-file"
         }
       ]
@@ -2193,7 +2193,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib/core"
         }
       ]
@@ -2220,7 +2220,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib/plugin-crypto"
         }
       ]
@@ -2247,7 +2247,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib/plugin-thirty-two"
         }
       ]
@@ -2274,7 +2274,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib/preset-default"
         }
       ]
@@ -2301,7 +2301,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib/preset-v11"
         }
       ]
@@ -2328,7 +2328,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@sindresorhus/is"
         }
       ]
@@ -2355,7 +2355,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@swc/helpers"
         }
       ]
@@ -2382,7 +2382,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@tokenizer/token"
         }
       ]
@@ -2409,7 +2409,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@tootallnate/once"
         }
       ]
@@ -2436,7 +2436,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/component-emitter"
         }
       ]
@@ -2463,7 +2463,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/cookie"
         }
       ]
@@ -2490,7 +2490,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/cors"
         }
       ]
@@ -2517,7 +2517,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/debug"
         }
       ]
@@ -2544,7 +2544,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/ms"
         }
       ]
@@ -2571,7 +2571,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/node"
         }
       ]
@@ -2598,7 +2598,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/strip-bom"
         }
       ]
@@ -2625,7 +2625,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/strip-json-comments"
         }
       ]
@@ -2652,7 +2652,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/validator"
         }
       ]
@@ -2678,7 +2678,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/abbrev"
         }
       ]
@@ -2704,7 +2704,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/accepts"
         }
       ]
@@ -2730,7 +2730,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/acorn-walk"
         }
       ]
@@ -2756,7 +2756,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/acorn"
         }
       ]
@@ -2782,7 +2782,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/agent-base"
         }
       ],
@@ -2808,7 +2808,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agent-base/node_modules/debug"
             }
           ]
@@ -2834,7 +2834,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agent-base/node_modules/ms"
             }
           ]
@@ -2862,7 +2862,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/agentkeepalive"
         }
       ],
@@ -2888,7 +2888,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agentkeepalive/node_modules/debug"
             }
           ]
@@ -2914,7 +2914,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agentkeepalive/node_modules/depd"
             }
           ]
@@ -2940,7 +2940,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agentkeepalive/node_modules/ms"
             }
           ]
@@ -2968,7 +2968,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/aggregate-error"
         }
       ]
@@ -2994,7 +2994,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ajv"
         }
       ]
@@ -3020,7 +3020,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ansi-regex"
         }
       ]
@@ -3046,7 +3046,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ansi-styles"
         }
       ]
@@ -3072,7 +3072,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/anymatch"
         }
       ],
@@ -3098,7 +3098,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/anymatch/node_modules/normalize-path"
             }
           ]
@@ -3126,7 +3126,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/append-field"
         }
       ]
@@ -3152,7 +3152,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/aproba"
         }
       ]
@@ -3178,7 +3178,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/archive-type"
         }
       ],
@@ -3204,7 +3204,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/archive-type/node_modules/file-type"
             }
           ]
@@ -3232,7 +3232,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/archiver-utils"
         }
       ]
@@ -3258,7 +3258,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/archiver"
         }
       ]
@@ -3284,7 +3284,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/are-we-there-yet"
         }
       ]
@@ -3310,7 +3310,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/arg"
         }
       ]
@@ -3336,7 +3336,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/argparse"
         }
       ],
@@ -3362,7 +3362,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/argparse/node_modules/sprintf-js"
             }
           ]
@@ -3390,7 +3390,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/arr-diff"
         }
       ]
@@ -3416,7 +3416,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/arr-flatten"
         }
       ]
@@ -3442,7 +3442,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/arr-union"
         }
       ]
@@ -3468,7 +3468,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/array-each"
         }
       ]
@@ -3494,7 +3494,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/array-flatten"
         }
       ]
@@ -3520,7 +3520,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/array-slice"
         }
       ]
@@ -3546,7 +3546,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/array-unique"
         }
       ]
@@ -3572,7 +3572,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/asap"
         }
       ]
@@ -3598,7 +3598,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/asn1"
         }
       ]
@@ -3624,7 +3624,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/assert-never"
         }
       ]
@@ -3650,7 +3650,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/assert-plus"
         }
       ]
@@ -3676,7 +3676,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/assign-symbols"
         }
       ]
@@ -3702,7 +3702,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/async"
         }
       ]
@@ -3728,7 +3728,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/asynckit"
         }
       ]
@@ -3754,7 +3754,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/at-least-node"
         }
       ]
@@ -3780,7 +3780,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/atob"
         }
       ]
@@ -3806,7 +3806,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/available-typed-arrays"
         }
       ]
@@ -3832,7 +3832,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/aws-sign2"
         }
       ]
@@ -3858,7 +3858,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/aws4"
         }
       ]
@@ -3884,7 +3884,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/babel-walk"
         }
       ]
@@ -3910,7 +3910,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/balanced-match"
         }
       ]
@@ -3936,7 +3936,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base"
         }
       ],
@@ -3962,7 +3962,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/base/node_modules/define-property"
             }
           ]
@@ -3990,7 +3990,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base64-arraybuffer"
         }
       ]
@@ -4016,7 +4016,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base64-js"
         }
       ]
@@ -4042,7 +4042,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base64id"
         }
       ]
@@ -4068,7 +4068,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base64url"
         }
       ]
@@ -4094,7 +4094,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/basic-auth"
         }
       ]
@@ -4120,7 +4120,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/batch"
         }
       ]
@@ -4146,7 +4146,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bcrypt-pbkdf"
         }
       ]
@@ -4172,7 +4172,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/big-integer"
         }
       ]
@@ -4198,7 +4198,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/binary-extensions"
         }
       ]
@@ -4224,7 +4224,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/binary"
         }
       ]
@@ -4250,7 +4250,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bindings"
         }
       ]
@@ -4276,7 +4276,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bintrees"
         }
       ]
@@ -4302,7 +4302,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bl"
         }
       ]
@@ -4328,7 +4328,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bluebird"
         }
       ]
@@ -4354,7 +4354,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/body-parser"
         }
       ]
@@ -4380,7 +4380,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bower-config"
         }
       ],
@@ -4406,7 +4406,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bower-config/node_modules/minimist"
             }
           ]
@@ -4434,7 +4434,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/brace-expansion"
         }
       ]
@@ -4460,7 +4460,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/braces"
         }
       ],
@@ -4486,7 +4486,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/braces/node_modules/extend-shallow"
             }
           ]
@@ -4512,7 +4512,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/braces/node_modules/is-extendable"
             }
           ]
@@ -4540,7 +4540,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/brotli"
         }
       ]
@@ -4566,7 +4566,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-alloc-unsafe"
         }
       ]
@@ -4592,7 +4592,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-alloc"
         }
       ]
@@ -4618,7 +4618,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-crc32"
         }
       ]
@@ -4644,7 +4644,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-fill"
         }
       ]
@@ -4670,7 +4670,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-from"
         }
       ]
@@ -4696,7 +4696,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-indexof-polyfill"
         }
       ]
@@ -4722,7 +4722,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer"
         }
       ]
@@ -4748,7 +4748,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffers"
         }
       ]
@@ -4774,7 +4774,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/busboy"
         }
       ],
@@ -4800,7 +4800,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/busboy/node_modules/isarray"
             }
           ]
@@ -4826,7 +4826,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/busboy/node_modules/readable-stream"
             }
           ]
@@ -4852,7 +4852,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/busboy/node_modules/string_decoder"
             }
           ]
@@ -4880,7 +4880,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/byline"
         }
       ]
@@ -4906,7 +4906,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bytes"
         }
       ]
@@ -4932,7 +4932,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cacache"
         }
       ]
@@ -4958,7 +4958,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cache-base"
         }
       ]
@@ -4984,7 +4984,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cacheable-request"
         }
       ],
@@ -5010,7 +5010,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cacheable-request/node_modules/get-stream"
             }
           ]
@@ -5036,7 +5036,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cacheable-request/node_modules/lowercase-keys"
             }
           ]
@@ -5064,7 +5064,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/call-bind"
         }
       ]
@@ -5090,7 +5090,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/camelcase"
         }
       ]
@@ -5116,7 +5116,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/caseless"
         }
       ]
@@ -5142,7 +5142,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/chainsaw"
         }
       ]
@@ -5168,7 +5168,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/chalk"
         }
       ]
@@ -5194,7 +5194,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/character-parser"
         }
       ]
@@ -5220,7 +5220,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/check-dependencies"
         }
       ],
@@ -5246,7 +5246,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/check-dependencies/node_modules/semver"
             }
           ]
@@ -5274,7 +5274,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/check-types"
         }
       ]
@@ -5300,7 +5300,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/chokidar"
         }
       ],
@@ -5326,7 +5326,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar/node_modules/braces"
             }
           ]
@@ -5352,7 +5352,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar/node_modules/fill-range"
             }
           ]
@@ -5378,7 +5378,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar/node_modules/is-glob"
             }
           ]
@@ -5404,7 +5404,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar/node_modules/is-number"
             }
           ]
@@ -5430,7 +5430,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar/node_modules/normalize-path"
             }
           ]
@@ -5456,7 +5456,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar/node_modules/to-regex-range"
             }
           ]
@@ -5484,7 +5484,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/chownr"
         }
       ]
@@ -5510,7 +5510,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/clarinet"
         }
       ]
@@ -5536,7 +5536,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/class-utils"
         }
       ],
@@ -5562,7 +5562,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils/node_modules/define-property"
             }
           ]
@@ -5588,7 +5588,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils/node_modules/is-accessor-descriptor"
             }
           ],
@@ -5614,7 +5614,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/class-utils/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
@@ -5642,7 +5642,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils/node_modules/is-data-descriptor"
             }
           ],
@@ -5668,7 +5668,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/class-utils/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
@@ -5696,7 +5696,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils/node_modules/is-descriptor"
             }
           ]
@@ -5722,7 +5722,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils/node_modules/kind-of"
             }
           ]
@@ -5750,7 +5750,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/clean-stack"
         }
       ]
@@ -5776,7 +5776,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cliui"
         }
       ],
@@ -5802,7 +5802,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui/node_modules/ansi-regex"
             }
           ]
@@ -5828,7 +5828,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui/node_modules/emoji-regex"
             }
           ]
@@ -5854,7 +5854,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -5880,7 +5880,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui/node_modules/string-width"
             }
           ]
@@ -5906,7 +5906,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui/node_modules/strip-ansi"
             }
           ]
@@ -5934,7 +5934,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/clone-response"
         }
       ]
@@ -5960,7 +5960,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/clone"
         }
       ]
@@ -5986,7 +5986,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/code-point-at"
         }
       ]
@@ -6012,7 +6012,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/collection-visit"
         }
       ]
@@ -6038,7 +6038,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color-convert"
         }
       ]
@@ -6064,7 +6064,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color-name"
         }
       ]
@@ -6090,7 +6090,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color-string"
         }
       ]
@@ -6116,7 +6116,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color-support"
         }
       ]
@@ -6142,7 +6142,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color"
         }
       ]
@@ -6168,7 +6168,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/colors"
         }
       ]
@@ -6194,7 +6194,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/colorspace"
         }
       ]
@@ -6220,7 +6220,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/combined-stream"
         }
       ]
@@ -6246,7 +6246,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/commander"
         }
       ]
@@ -6272,7 +6272,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/component-emitter"
         }
       ]
@@ -6298,7 +6298,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/component-type"
         }
       ]
@@ -6324,7 +6324,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/compress-commons"
         }
       ]
@@ -6350,7 +6350,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/compressible"
         }
       ]
@@ -6376,7 +6376,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/compression"
         }
       ],
@@ -6402,7 +6402,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/compression/node_modules/bytes"
             }
           ]
@@ -6430,7 +6430,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/concat-map"
         }
       ]
@@ -6456,7 +6456,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/concat-stream"
         }
       ]
@@ -6482,7 +6482,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/concurrently"
         }
       ],
@@ -6508,7 +6508,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/concurrently/node_modules/supports-color"
             }
           ]
@@ -6536,7 +6536,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/config"
         }
       ]
@@ -6562,7 +6562,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/console-control-strings"
         }
       ]
@@ -6588,7 +6588,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/constantinople"
         }
       ]
@@ -6614,7 +6614,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/content-disposition"
         }
       ],
@@ -6640,7 +6640,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/content-disposition/node_modules/safe-buffer"
             }
           ]
@@ -6668,7 +6668,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/content-type"
         }
       ]
@@ -6694,7 +6694,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cookie-parser"
         }
       ]
@@ -6720,7 +6720,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cookie-signature"
         }
       ]
@@ -6746,7 +6746,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cookie"
         }
       ]
@@ -6772,7 +6772,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/copy-descriptor"
         }
       ]
@@ -6798,7 +6798,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/core-util-is"
         }
       ]
@@ -6824,7 +6824,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cors"
         }
       ]
@@ -6850,7 +6850,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/crc"
         }
       ]
@@ -6876,7 +6876,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/crc32-stream"
         }
       ]
@@ -6902,7 +6902,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/create-require"
         }
       ]
@@ -6928,7 +6928,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/crypto-js"
         }
       ]
@@ -6954,7 +6954,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dashdash"
         }
       ]
@@ -6980,7 +6980,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/date-fns"
         }
       ]
@@ -7006,7 +7006,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dateformat"
         }
       ]
@@ -7032,7 +7032,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/debug"
         }
       ]
@@ -7058,7 +7058,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decamelize"
         }
       ]
@@ -7084,7 +7084,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decode-uri-component"
         }
       ]
@@ -7110,7 +7110,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-response"
         }
       ]
@@ -7136,7 +7136,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-tar"
         }
       ],
@@ -7162,7 +7162,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-tar/node_modules/file-type"
             }
           ]
@@ -7190,7 +7190,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-tarbz2"
         }
       ],
@@ -7216,7 +7216,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-tarbz2/node_modules/file-type"
             }
           ]
@@ -7244,7 +7244,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-targz"
         }
       ],
@@ -7270,7 +7270,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-targz/node_modules/file-type"
             }
           ]
@@ -7298,7 +7298,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-unzip"
         }
       ],
@@ -7324,7 +7324,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-unzip/node_modules/file-type"
             }
           ]
@@ -7350,7 +7350,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-unzip/node_modules/get-stream"
             }
           ]
@@ -7376,7 +7376,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-unzip/node_modules/pify"
             }
           ]
@@ -7404,7 +7404,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress"
         }
       ],
@@ -7430,7 +7430,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress/node_modules/make-dir"
             }
           ],
@@ -7456,7 +7456,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/decompress/node_modules/make-dir/node_modules/pify"
                 }
               ]
@@ -7484,7 +7484,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress/node_modules/pify"
             }
           ]
@@ -7512,7 +7512,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/deep-equal"
         }
       ]
@@ -7538,7 +7538,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/deep-extend"
         }
       ]
@@ -7564,7 +7564,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/deep-is"
         }
       ]
@@ -7590,7 +7590,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/define-properties"
         }
       ]
@@ -7616,7 +7616,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/define-property"
         }
       ]
@@ -7642,7 +7642,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/delayed-stream"
         }
       ]
@@ -7668,7 +7668,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/delegates"
         }
       ]
@@ -7694,7 +7694,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/depd"
         }
       ]
@@ -7720,7 +7720,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/destroy"
         }
       ]
@@ -7746,7 +7746,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/detect-file"
         }
       ]
@@ -7772,7 +7772,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/detect-libc"
         }
       ]
@@ -7798,7 +7798,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dfa"
         }
       ]
@@ -7824,7 +7824,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dicer"
         }
       ],
@@ -7850,7 +7850,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/dicer/node_modules/isarray"
             }
           ]
@@ -7876,7 +7876,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/dicer/node_modules/readable-stream"
             }
           ]
@@ -7902,7 +7902,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/dicer/node_modules/string_decoder"
             }
           ]
@@ -7930,7 +7930,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/diff"
         }
       ]
@@ -7956,7 +7956,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/doctypes"
         }
       ]
@@ -7982,7 +7982,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/domelementtype"
         }
       ]
@@ -8008,7 +8008,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/domhandler"
         }
       ]
@@ -8034,7 +8034,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/domutils"
         }
       ]
@@ -8060,7 +8060,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dottie"
         }
       ]
@@ -8086,7 +8086,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/double-ended-queue"
         }
       ]
@@ -8112,7 +8112,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/doublearray"
         }
       ]
@@ -8138,7 +8138,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/download"
         }
       ],
@@ -8164,7 +8164,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/download/node_modules/file-type"
             }
           ]
@@ -8192,7 +8192,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/duplexer2"
         }
       ]
@@ -8218,7 +8218,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/duplexer3"
         }
       ]
@@ -8244,7 +8244,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dynamic-dedupe"
         }
       ]
@@ -8270,7 +8270,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ecc-jsbn"
         }
       ]
@@ -8296,7 +8296,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ee-first"
         }
       ]
@@ -8322,7 +8322,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/eivindfjeldstad-dot"
         }
       ]
@@ -8348,7 +8348,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/emoji-regex"
         }
       ]
@@ -8374,7 +8374,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/enabled"
         }
       ]
@@ -8400,7 +8400,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/encodeurl"
         }
       ]
@@ -8426,7 +8426,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/encoding"
         }
       ],
@@ -8452,7 +8452,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/encoding/node_modules/iconv-lite"
             }
           ]
@@ -8480,7 +8480,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/end-of-stream"
         }
       ]
@@ -8506,7 +8506,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/engine.io-parser"
         }
       ]
@@ -8532,7 +8532,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/engine.io"
         }
       ],
@@ -8558,7 +8558,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/engine.io/node_modules/debug"
             }
           ]
@@ -8584,7 +8584,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/engine.io/node_modules/ms"
             }
           ]
@@ -8612,7 +8612,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/env-paths"
         }
       ]
@@ -8638,7 +8638,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/err-code"
         }
       ]
@@ -8664,7 +8664,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/error-ex"
         }
       ]
@@ -8690,7 +8690,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/errorhandler"
         }
       ]
@@ -8716,7 +8716,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/es-abstract"
         }
       ]
@@ -8742,7 +8742,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/es-get-iterator"
         }
       ]
@@ -8768,7 +8768,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/es-to-primitive"
         }
       ]
@@ -8794,7 +8794,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/escape-html"
         }
       ]
@@ -8820,7 +8820,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/escape-string-regexp"
         }
       ]
@@ -8846,7 +8846,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/escodegen"
         }
       ]
@@ -8872,7 +8872,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/esprima"
         }
       ]
@@ -8898,7 +8898,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/estraverse"
         }
       ]
@@ -8924,7 +8924,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/esutils"
         }
       ]
@@ -8950,7 +8950,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/etag"
         }
       ]
@@ -8976,7 +8976,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/eventemitter2"
         }
       ]
@@ -9002,7 +9002,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/eventemitter3"
         }
       ]
@@ -9028,7 +9028,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/exif"
         }
       ]
@@ -9054,7 +9054,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/exit"
         }
       ]
@@ -9080,7 +9080,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/expand-brackets"
         }
       ],
@@ -9106,7 +9106,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/define-property"
             }
           ]
@@ -9132,7 +9132,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/extend-shallow"
             }
           ]
@@ -9158,7 +9158,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/is-accessor-descriptor"
             }
           ],
@@ -9184,7 +9184,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/expand-brackets/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
@@ -9212,7 +9212,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/is-data-descriptor"
             }
           ],
@@ -9238,7 +9238,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/expand-brackets/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
@@ -9266,7 +9266,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/is-descriptor"
             }
           ]
@@ -9292,7 +9292,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/is-extendable"
             }
           ]
@@ -9318,7 +9318,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/kind-of"
             }
           ]
@@ -9346,7 +9346,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/expand-template"
         }
       ]
@@ -9372,7 +9372,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/expand-tilde"
         }
       ]
@@ -9398,7 +9398,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-ipfilter"
         }
       ]
@@ -9424,7 +9424,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-jwt"
         }
       ],
@@ -9450,7 +9450,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/express-jwt/node_modules/jsonwebtoken"
             }
           ]
@@ -9476,7 +9476,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/express-jwt/node_modules/moment"
             }
           ]
@@ -9504,7 +9504,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-rate-limit"
         }
       ]
@@ -9530,7 +9530,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-robots-txt"
         }
       ]
@@ -9556,7 +9556,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-security.txt"
         }
       ]
@@ -9582,7 +9582,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express"
         }
       ],
@@ -9608,7 +9608,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/express/node_modules/cookie"
             }
           ]
@@ -9634,7 +9634,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/express/node_modules/safe-buffer"
             }
           ]
@@ -9662,7 +9662,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ext-list"
         }
       ]
@@ -9688,7 +9688,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ext-name"
         }
       ]
@@ -9714,7 +9714,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/extend-shallow"
         }
       ]
@@ -9740,7 +9740,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/extend"
         }
       ]
@@ -9766,7 +9766,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/extglob"
         }
       ],
@@ -9792,7 +9792,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/extglob/node_modules/define-property"
             }
           ]
@@ -9818,7 +9818,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/extglob/node_modules/extend-shallow"
             }
           ]
@@ -9844,7 +9844,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/extglob/node_modules/is-extendable"
             }
           ]
@@ -9872,7 +9872,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/extsprintf"
         }
       ]
@@ -9898,7 +9898,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fast-deep-equal"
         }
       ]
@@ -9924,7 +9924,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fast-json-stable-stringify"
         }
       ]
@@ -9950,7 +9950,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fast-levenshtein"
         }
       ]
@@ -9976,7 +9976,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fast.js"
         }
       ]
@@ -10002,7 +10002,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fd-slicer"
         }
       ]
@@ -10028,7 +10028,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/feature-policy"
         }
       ]
@@ -10054,7 +10054,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fecha"
         }
       ]
@@ -10080,7 +10080,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/file-js"
         }
       ],
@@ -10106,7 +10106,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/file-js/node_modules/brace-expansion"
             }
           ]
@@ -10132,7 +10132,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/file-js/node_modules/minimatch"
             }
           ]
@@ -10160,7 +10160,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/file-stream-rotator"
         }
       ]
@@ -10186,7 +10186,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/file-type"
         }
       ]
@@ -10212,7 +10212,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/file-uri-to-path"
         }
       ]
@@ -10238,7 +10238,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/filehound"
         }
       ]
@@ -10264,7 +10264,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/filename-reserved-regex"
         }
       ]
@@ -10290,7 +10290,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/filenamify"
         }
       ]
@@ -10316,7 +10316,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/filesniffer"
         }
       ]
@@ -10342,7 +10342,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fill-range"
         }
       ],
@@ -10368,7 +10368,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/fill-range/node_modules/extend-shallow"
             }
           ]
@@ -10394,7 +10394,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/fill-range/node_modules/is-extendable"
             }
           ]
@@ -10422,7 +10422,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/finale-rest"
         }
       ]
@@ -10448,7 +10448,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/finalhandler"
         }
       ]
@@ -10474,7 +10474,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/find-up"
         }
       ]
@@ -10500,7 +10500,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/findup-sync"
         }
       ]
@@ -10526,7 +10526,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fined"
         }
       ]
@@ -10552,7 +10552,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/flagged-respawn"
         }
       ]
@@ -10578,7 +10578,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fn.name"
         }
       ]
@@ -10604,7 +10604,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fontkit"
         }
       ]
@@ -10630,7 +10630,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/for-each"
         }
       ]
@@ -10656,7 +10656,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/for-in"
         }
       ]
@@ -10682,7 +10682,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/for-own"
         }
       ]
@@ -10708,7 +10708,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/foreachasync"
         }
       ]
@@ -10734,7 +10734,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/forever-agent"
         }
       ]
@@ -10760,7 +10760,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/form-data"
         }
       ]
@@ -10786,7 +10786,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/formatio"
         }
       ]
@@ -10812,7 +10812,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/forwarded"
         }
       ]
@@ -10838,7 +10838,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fragment-cache"
         }
       ]
@@ -10864,7 +10864,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fresh"
         }
       ]
@@ -10890,7 +10890,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/from2"
         }
       ]
@@ -10916,7 +10916,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fs-constants"
         }
       ]
@@ -10942,7 +10942,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fs-extra"
         }
       ]
@@ -10968,7 +10968,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fs-minipass"
         }
       ]
@@ -10994,7 +10994,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fs.realpath"
         }
       ]
@@ -11020,7 +11020,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fstream"
         }
       ],
@@ -11046,7 +11046,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/fstream/node_modules/mkdirp"
             }
           ]
@@ -11072,7 +11072,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/fstream/node_modules/rimraf"
             }
           ]
@@ -11100,7 +11100,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/function-bind"
         }
       ]
@@ -11126,7 +11126,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/function.prototype.name"
         }
       ]
@@ -11152,7 +11152,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/functions-have-names"
         }
       ]
@@ -11178,7 +11178,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fuzzball"
         }
       ]
@@ -11204,7 +11204,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/gauge"
         }
       ]
@@ -11230,7 +11230,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/geojson-utils"
         }
       ]
@@ -11256,7 +11256,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-caller-file"
         }
       ]
@@ -11282,7 +11282,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-intrinsic"
         }
       ]
@@ -11308,7 +11308,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-stream"
         }
       ]
@@ -11334,7 +11334,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-symbol-description"
         }
       ]
@@ -11360,7 +11360,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-value"
         }
       ]
@@ -11386,7 +11386,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/getobject"
         }
       ]
@@ -11412,7 +11412,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/getpass"
         }
       ]
@@ -11438,7 +11438,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/github-from-package"
         }
       ]
@@ -11464,7 +11464,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/glob-parent"
         }
       ],
@@ -11490,7 +11490,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/glob-parent/node_modules/is-glob"
             }
           ]
@@ -11518,7 +11518,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/glob"
         }
       ],
@@ -11544,7 +11544,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/glob/node_modules/brace-expansion"
             }
           ]
@@ -11570,7 +11570,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/glob/node_modules/minimatch"
             }
           ]
@@ -11598,7 +11598,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/global-modules"
         }
       ]
@@ -11624,7 +11624,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/global-prefix"
         }
       ],
@@ -11650,7 +11650,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/global-prefix/node_modules/which"
             }
           ]
@@ -11678,7 +11678,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/got"
         }
       ],
@@ -11704,7 +11704,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/got/node_modules/get-stream"
             }
           ]
@@ -11730,7 +11730,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/got/node_modules/pify"
             }
           ]
@@ -11758,7 +11758,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/graceful-fs"
         }
       ]
@@ -11784,7 +11784,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-cli"
         }
       ],
@@ -11810,7 +11810,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-cli/node_modules/nopt"
             }
           ]
@@ -11838,7 +11838,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-contrib-compress"
         }
       ],
@@ -11864,7 +11864,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-contrib-compress/node_modules/ansi-styles"
             }
           ]
@@ -11890,7 +11890,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-contrib-compress/node_modules/chalk"
             }
           ]
@@ -11916,7 +11916,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-contrib-compress/node_modules/supports-color"
             }
           ]
@@ -11944,7 +11944,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-known-options"
         }
       ]
@@ -11970,7 +11970,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-legacy-log-utils"
         }
       ],
@@ -11996,7 +11996,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils/node_modules/ansi-styles"
             }
           ]
@@ -12022,7 +12022,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils/node_modules/chalk"
             }
           ]
@@ -12048,7 +12048,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils/node_modules/color-convert"
             }
           ]
@@ -12074,7 +12074,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils/node_modules/color-name"
             }
           ]
@@ -12100,7 +12100,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils/node_modules/has-flag"
             }
           ]
@@ -12126,7 +12126,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils/node_modules/supports-color"
             }
           ]
@@ -12154,7 +12154,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-legacy-log"
         }
       ],
@@ -12180,7 +12180,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log/node_modules/colors"
             }
           ]
@@ -12208,7 +12208,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-legacy-util"
         }
       ],
@@ -12234,7 +12234,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-util/node_modules/async"
             }
           ]
@@ -12262,7 +12262,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-replace-json"
         }
       ]
@@ -12288,7 +12288,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt"
         }
       ],
@@ -12314,7 +12314,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt/node_modules/brace-expansion"
             }
           ]
@@ -12340,7 +12340,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt/node_modules/findup-sync"
             }
           ],
@@ -12366,7 +12366,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/grunt/node_modules/findup-sync/node_modules/glob"
                 }
               ]
@@ -12394,7 +12394,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt/node_modules/glob"
             }
           ]
@@ -12420,7 +12420,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt/node_modules/minimatch"
             }
           ]
@@ -12448,7 +12448,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/handlebars"
         }
       ],
@@ -12474,7 +12474,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/handlebars/node_modules/wordwrap"
             }
           ]
@@ -12502,7 +12502,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/har-schema"
         }
       ]
@@ -12528,7 +12528,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/har-validator"
         }
       ]
@@ -12554,7 +12554,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-ansi"
         }
       ]
@@ -12580,7 +12580,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-bigints"
         }
       ]
@@ -12606,7 +12606,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-flag"
         }
       ]
@@ -12632,7 +12632,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-property-descriptors"
         }
       ]
@@ -12658,7 +12658,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-symbol-support-x"
         }
       ]
@@ -12684,7 +12684,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-symbols"
         }
       ]
@@ -12710,7 +12710,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-to-string-tag-x"
         }
       ]
@@ -12736,7 +12736,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-tostringtag"
         }
       ]
@@ -12762,7 +12762,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-unicode"
         }
       ]
@@ -12788,7 +12788,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-value"
         }
       ]
@@ -12814,7 +12814,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-values"
         }
       ],
@@ -12840,7 +12840,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/has-values/node_modules/kind-of"
             }
           ]
@@ -12868,7 +12868,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has"
         }
       ]
@@ -12894,7 +12894,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hashids"
         }
       ]
@@ -12920,7 +12920,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hbs"
         }
       ]
@@ -12946,7 +12946,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/he"
         }
       ]
@@ -12972,7 +12972,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/heap"
         }
       ]
@@ -12998,7 +12998,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/helmet"
         }
       ]
@@ -13024,7 +13024,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hoister"
         }
       ]
@@ -13050,7 +13050,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/homedir-polyfill"
         }
       ]
@@ -13076,7 +13076,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hooker"
         }
       ]
@@ -13102,7 +13102,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hosted-git-info"
         }
       ]
@@ -13128,7 +13128,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/html-entities"
         }
       ]
@@ -13154,7 +13154,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/htmlparser2"
         }
       ],
@@ -13180,7 +13180,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/htmlparser2/node_modules/isarray"
             }
           ]
@@ -13206,7 +13206,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/htmlparser2/node_modules/readable-stream"
             }
           ]
@@ -13232,7 +13232,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/htmlparser2/node_modules/string_decoder"
             }
           ]
@@ -13260,7 +13260,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/http-cache-semantics"
         }
       ]
@@ -13286,7 +13286,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/http-errors"
         }
       ]
@@ -13312,7 +13312,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/http-proxy-agent"
         }
       ],
@@ -13338,7 +13338,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/http-proxy-agent/node_modules/debug"
             }
           ]
@@ -13364,7 +13364,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/http-proxy-agent/node_modules/ms"
             }
           ]
@@ -13392,7 +13392,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/http-signature"
         }
       ]
@@ -13418,7 +13418,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/https-proxy-agent"
         }
       ],
@@ -13444,7 +13444,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/https-proxy-agent/node_modules/debug"
             }
           ]
@@ -13470,7 +13470,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/https-proxy-agent/node_modules/ms"
             }
           ]
@@ -13498,7 +13498,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/humanize-ms"
         }
       ]
@@ -13524,7 +13524,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/i18n"
         }
       ]
@@ -13550,7 +13550,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/iconv-lite"
         }
       ]
@@ -13576,7 +13576,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ieee754"
         }
       ]
@@ -13602,7 +13602,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ignore-walk"
         }
       ],
@@ -13628,7 +13628,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/ignore-walk/node_modules/brace-expansion"
             }
           ]
@@ -13654,7 +13654,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/ignore-walk/node_modules/minimatch"
             }
           ]
@@ -13682,7 +13682,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/iltorb"
         }
       ]
@@ -13708,7 +13708,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/imurmurhash"
         }
       ]
@@ -13734,7 +13734,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/indent-string"
         }
       ]
@@ -13760,7 +13760,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/infer-owner"
         }
       ]
@@ -13786,7 +13786,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/inflection"
         }
       ]
@@ -13812,7 +13812,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/inflight"
         }
       ]
@@ -13838,7 +13838,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/inherits"
         }
       ]
@@ -13864,7 +13864,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ini"
         }
       ]
@@ -13890,7 +13890,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/internal-slot"
         }
       ]
@@ -13916,7 +13916,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/interpret"
         }
       ]
@@ -13942,7 +13942,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/into-stream"
         }
       ]
@@ -13968,7 +13968,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/invariant"
         }
       ]
@@ -13994,7 +13994,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ip"
         }
       ]
@@ -14020,7 +14020,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ip6"
         }
       ]
@@ -14046,7 +14046,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ipaddr.js"
         }
       ]
@@ -14072,7 +14072,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-absolute"
         }
       ]
@@ -14098,7 +14098,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-accessor-descriptor"
         }
       ]
@@ -14124,7 +14124,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-arguments"
         }
       ]
@@ -14150,7 +14150,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-arrayish"
         }
       ]
@@ -14176,7 +14176,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-bigint"
         }
       ]
@@ -14202,7 +14202,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-binary-path"
         }
       ]
@@ -14228,7 +14228,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-boolean-object"
         }
       ]
@@ -14254,7 +14254,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-buffer"
         }
       ]
@@ -14280,7 +14280,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-callable"
         }
       ]
@@ -14306,7 +14306,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-core-module"
         }
       ]
@@ -14332,7 +14332,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-data-descriptor"
         }
       ]
@@ -14358,7 +14358,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-date-object"
         }
       ]
@@ -14384,7 +14384,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-descriptor"
         }
       ]
@@ -14410,7 +14410,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-docker"
         }
       ]
@@ -14436,7 +14436,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-expression"
         }
       ]
@@ -14462,7 +14462,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-extendable"
         }
       ]
@@ -14488,7 +14488,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-extglob"
         }
       ]
@@ -14514,7 +14514,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-fullwidth-code-point"
         }
       ]
@@ -14540,7 +14540,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-generator-function"
         }
       ]
@@ -14566,7 +14566,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-glob"
         }
       ]
@@ -14592,7 +14592,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-heroku"
         }
       ]
@@ -14618,7 +14618,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-lambda"
         }
       ]
@@ -14644,7 +14644,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-map"
         }
       ]
@@ -14670,7 +14670,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-natural-number"
         }
       ]
@@ -14696,7 +14696,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-negative-zero"
         }
       ]
@@ -14722,7 +14722,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-number-like"
         }
       ]
@@ -14748,7 +14748,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-number-object"
         }
       ]
@@ -14774,7 +14774,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-number"
         }
       ],
@@ -14800,7 +14800,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/is-number/node_modules/kind-of"
             }
           ]
@@ -14828,7 +14828,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-object"
         }
       ]
@@ -14854,7 +14854,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-plain-obj"
         }
       ]
@@ -14880,7 +14880,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-plain-object"
         }
       ]
@@ -14906,7 +14906,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-promise"
         }
       ]
@@ -14932,7 +14932,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-regex"
         }
       ]
@@ -14958,7 +14958,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-relative"
         }
       ]
@@ -14984,7 +14984,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-retry-allowed"
         }
       ]
@@ -15010,7 +15010,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-set"
         }
       ]
@@ -15036,7 +15036,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-shared-array-buffer"
         }
       ]
@@ -15062,7 +15062,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-stream"
         }
       ]
@@ -15088,7 +15088,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-string"
         }
       ]
@@ -15114,7 +15114,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-symbol"
         }
       ]
@@ -15140,7 +15140,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-typed-array"
         }
       ]
@@ -15166,7 +15166,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-typedarray"
         }
       ]
@@ -15192,7 +15192,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-unc-path"
         }
       ]
@@ -15218,7 +15218,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-weakmap"
         }
       ]
@@ -15244,7 +15244,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-weakref"
         }
       ]
@@ -15270,7 +15270,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-weakset"
         }
       ]
@@ -15296,7 +15296,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-windows"
         }
       ]
@@ -15322,7 +15322,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isarray"
         }
       ]
@@ -15348,7 +15348,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isexe"
         }
       ]
@@ -15374,7 +15374,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isobject"
         }
       ]
@@ -15400,7 +15400,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isstream"
         }
       ]
@@ -15426,7 +15426,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isurl"
         }
       ]
@@ -15452,7 +15452,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/js-stringify"
         }
       ]
@@ -15478,7 +15478,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/js-tokens"
         }
       ]
@@ -15504,7 +15504,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/js-yaml"
         }
       ]
@@ -15530,7 +15530,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jsbn"
         }
       ]
@@ -15556,7 +15556,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-buffer"
         }
       ]
@@ -15582,7 +15582,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-parse-better-errors"
         }
       ]
@@ -15608,7 +15608,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-schema-traverse"
         }
       ]
@@ -15634,7 +15634,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-schema"
         }
       ]
@@ -15660,7 +15660,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-stringify-safe"
         }
       ]
@@ -15686,7 +15686,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json5"
         }
       ]
@@ -15712,7 +15712,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jsonfile"
         }
       ]
@@ -15738,7 +15738,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jsonwebtoken"
         }
       ]
@@ -15764,7 +15764,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jsprim"
         }
       ]
@@ -15790,7 +15790,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jssha"
         }
       ]
@@ -15816,7 +15816,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jstransformer"
         }
       ]
@@ -15842,7 +15842,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/juicy-chat-bot"
         }
       ]
@@ -15868,7 +15868,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jwa"
         }
       ]
@@ -15894,7 +15894,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jws"
         }
       ]
@@ -15920,7 +15920,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/keyv"
         }
       ]
@@ -15946,7 +15946,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/kind-of"
         }
       ]
@@ -15972,7 +15972,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/kuler"
         }
       ]
@@ -15998,7 +15998,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/kuromoji"
         }
       ]
@@ -16024,7 +16024,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lazystream"
         }
       ]
@@ -16050,7 +16050,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/levn"
         }
       ]
@@ -16076,7 +16076,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/libxmljs2"
         }
       ],
@@ -16102,7 +16102,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/libxmljs2/node_modules/nan"
             }
           ]
@@ -16130,7 +16130,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/liftup"
         }
       ],
@@ -16156,7 +16156,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/braces"
             }
           ]
@@ -16182,7 +16182,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/fill-range"
             }
           ]
@@ -16208,7 +16208,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/findup-sync"
             }
           ]
@@ -16234,7 +16234,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/is-glob"
             }
           ]
@@ -16260,7 +16260,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/is-number"
             }
           ]
@@ -16286,7 +16286,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/micromatch"
             }
           ]
@@ -16312,7 +16312,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/to-regex-range"
             }
           ]
@@ -16340,7 +16340,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/linebreak"
         }
       ],
@@ -16366,7 +16366,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/linebreak/node_modules/base64-js"
             }
           ]
@@ -16394,7 +16394,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/listenercount"
         }
       ]
@@ -16420,7 +16420,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/locate-path"
         }
       ]
@@ -16446,7 +16446,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lodash.camelcase"
         }
       ]
@@ -16472,7 +16472,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lodash.isfinite"
         }
       ]
@@ -16498,7 +16498,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lodash.set"
         }
       ]
@@ -16524,7 +16524,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lodash"
         }
       ]
@@ -16550,7 +16550,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/logform"
         }
       ],
@@ -16576,7 +16576,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/logform/node_modules/ms"
             }
           ]
@@ -16604,7 +16604,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lolex"
         }
       ]
@@ -16630,7 +16630,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/loose-envify"
         }
       ]
@@ -16656,7 +16656,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lowercase-keys"
         }
       ]
@@ -16682,7 +16682,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lru-cache"
         }
       ]
@@ -16708,7 +16708,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-dir"
         }
       ],
@@ -16734,7 +16734,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-dir/node_modules/semver"
             }
           ]
@@ -16762,7 +16762,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-error"
         }
       ]
@@ -16788,7 +16788,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-fetch-happen"
         }
       ],
@@ -16815,7 +16815,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen/node_modules/@tootallnate/once"
             }
           ]
@@ -16841,7 +16841,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen/node_modules/debug"
             }
           ]
@@ -16867,7 +16867,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen/node_modules/http-cache-semantics"
             }
           ]
@@ -16893,7 +16893,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen/node_modules/http-proxy-agent"
             }
           ]
@@ -16919,7 +16919,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen/node_modules/ms"
             }
           ]
@@ -16947,7 +16947,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-iterator"
         }
       ]
@@ -16973,7 +16973,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-plural"
         }
       ]
@@ -16999,7 +16999,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/map-cache"
         }
       ]
@@ -17025,7 +17025,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/map-visit"
         }
       ]
@@ -17051,7 +17051,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/marsdb"
         }
       ]
@@ -17077,7 +17077,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/math-interval-parser"
         }
       ]
@@ -17103,7 +17103,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/media-typer"
         }
       ]
@@ -17129,7 +17129,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/merge-descriptors"
         }
       ]
@@ -17155,7 +17155,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/messageformat-formatters"
         }
       ]
@@ -17181,7 +17181,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/messageformat-parser"
         }
       ]
@@ -17207,7 +17207,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/messageformat"
         }
       ],
@@ -17233,7 +17233,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/messageformat/node_modules/make-plural"
             }
           ]
@@ -17261,7 +17261,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/methods"
         }
       ]
@@ -17287,7 +17287,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/micromatch"
         }
       ]
@@ -17313,7 +17313,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mime-db"
         }
       ]
@@ -17339,7 +17339,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mime-types"
         }
       ]
@@ -17365,7 +17365,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mime"
         }
       ]
@@ -17391,7 +17391,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mimic-response"
         }
       ]
@@ -17417,7 +17417,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minimatch"
         }
       ]
@@ -17443,7 +17443,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minimist"
         }
       ]
@@ -17469,7 +17469,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-collect"
         }
       ]
@@ -17495,7 +17495,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-fetch"
         }
       ]
@@ -17521,7 +17521,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-flush"
         }
       ]
@@ -17547,7 +17547,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-pipeline"
         }
       ]
@@ -17573,7 +17573,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-sized"
         }
       ]
@@ -17599,7 +17599,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass"
         }
       ]
@@ -17625,7 +17625,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minizlib"
         }
       ]
@@ -17651,7 +17651,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mixin-deep"
         }
       ]
@@ -17677,7 +17677,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mkdirp-classic"
         }
       ]
@@ -17703,7 +17703,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mkdirp"
         }
       ]
@@ -17729,7 +17729,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/moment-timezone"
         }
       ]
@@ -17755,7 +17755,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/moment"
         }
       ]
@@ -17781,7 +17781,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/morgan"
         }
       ],
@@ -17807,7 +17807,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/morgan/node_modules/on-finished"
             }
           ]
@@ -17835,7 +17835,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mout"
         }
       ]
@@ -17861,7 +17861,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ms"
         }
       ]
@@ -17887,7 +17887,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/multer"
         }
       ],
@@ -17913,7 +17913,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/multer/node_modules/mkdirp"
             }
           ]
@@ -17941,7 +17941,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mustache"
         }
       ]
@@ -17967,7 +17967,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/nan"
         }
       ]
@@ -17993,7 +17993,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/nanomatch"
         }
       ]
@@ -18019,7 +18019,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/napi-build-utils"
         }
       ]
@@ -18045,7 +18045,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/needle"
         }
       ],
@@ -18071,7 +18071,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/needle/node_modules/debug"
             }
           ]
@@ -18097,7 +18097,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/needle/node_modules/ms"
             }
           ]
@@ -18125,7 +18125,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/negotiator"
         }
       ]
@@ -18151,7 +18151,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/neo-async"
         }
       ]
@@ -18177,7 +18177,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-abi"
         }
       ],
@@ -18203,7 +18203,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-abi/node_modules/semver"
             }
           ]
@@ -18231,7 +18231,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-addon-api"
         }
       ]
@@ -18257,7 +18257,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-fetch"
         }
       ]
@@ -18283,7 +18283,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-gyp"
         }
       ],
@@ -18309,7 +18309,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/ansi-regex"
             }
           ]
@@ -18335,7 +18335,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/are-we-there-yet"
             }
           ]
@@ -18361,7 +18361,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/gauge"
             }
           ]
@@ -18387,7 +18387,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -18413,7 +18413,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/nopt"
             }
           ]
@@ -18439,7 +18439,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/npmlog"
             }
           ]
@@ -18465,7 +18465,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/readable-stream"
             }
           ]
@@ -18491,7 +18491,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/string-width"
             }
           ]
@@ -18517,7 +18517,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/strip-ansi"
             }
           ]
@@ -18545,7 +18545,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-pre-gyp"
         }
       ],
@@ -18571,7 +18571,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/chownr"
             }
           ]
@@ -18597,7 +18597,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/fs-minipass"
             }
           ]
@@ -18623,7 +18623,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/minipass"
             }
           ]
@@ -18649,7 +18649,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/minizlib"
             }
           ]
@@ -18675,7 +18675,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/mkdirp"
             }
           ]
@@ -18701,7 +18701,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/nopt"
             }
           ]
@@ -18727,7 +18727,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/rimraf"
             }
           ]
@@ -18753,7 +18753,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/safe-buffer"
             }
           ]
@@ -18779,7 +18779,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/semver"
             }
           ]
@@ -18805,7 +18805,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/tar"
             }
           ]
@@ -18831,7 +18831,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/yallist"
             }
           ]
@@ -18859,7 +18859,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/noop-logger"
         }
       ]
@@ -18885,7 +18885,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/nopt"
         }
       ]
@@ -18911,7 +18911,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/normalize-package-data"
         }
       ],
@@ -18937,7 +18937,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/normalize-package-data/node_modules/semver"
             }
           ]
@@ -18965,7 +18965,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/normalize-path"
         }
       ]
@@ -18991,7 +18991,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/normalize-url"
         }
       ]
@@ -19017,7 +19017,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/notevil"
         }
       ],
@@ -19043,7 +19043,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/notevil/node_modules/esprima"
             }
           ]
@@ -19071,7 +19071,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/npm-bundled"
         }
       ]
@@ -19097,7 +19097,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/npm-normalize-package-bin"
         }
       ]
@@ -19123,7 +19123,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/npm-packlist"
         }
       ]
@@ -19149,7 +19149,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/npmlog"
         }
       ]
@@ -19175,7 +19175,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/number-is-nan"
         }
       ]
@@ -19201,7 +19201,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/oauth-sign"
         }
       ]
@@ -19227,7 +19227,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-assign"
         }
       ]
@@ -19253,7 +19253,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-copy"
         }
       ],
@@ -19279,7 +19279,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy/node_modules/define-property"
             }
           ]
@@ -19305,7 +19305,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy/node_modules/is-accessor-descriptor"
             }
           ]
@@ -19331,7 +19331,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy/node_modules/is-data-descriptor"
             }
           ]
@@ -19357,7 +19357,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy/node_modules/is-descriptor"
             }
           ],
@@ -19383,7 +19383,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/object-copy/node_modules/is-descriptor/node_modules/kind-of"
                 }
               ]
@@ -19411,7 +19411,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy/node_modules/kind-of"
             }
           ]
@@ -19439,7 +19439,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-inspect"
         }
       ]
@@ -19465,7 +19465,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-is"
         }
       ]
@@ -19491,7 +19491,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-keys"
         }
       ]
@@ -19517,7 +19517,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-visit"
         }
       ]
@@ -19543,7 +19543,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object.assign"
         }
       ]
@@ -19569,7 +19569,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object.defaults"
         }
       ]
@@ -19595,7 +19595,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object.map"
         }
       ]
@@ -19621,7 +19621,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object.pick"
         }
       ]
@@ -19647,7 +19647,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/on-finished"
         }
       ]
@@ -19673,7 +19673,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/on-headers"
         }
       ]
@@ -19699,7 +19699,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/once"
         }
       ]
@@ -19725,7 +19725,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/one-time"
         }
       ]
@@ -19751,7 +19751,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/opentype.js"
         }
       ]
@@ -19777,7 +19777,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/optionator"
         }
       ]
@@ -19803,7 +19803,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/os-homedir"
         }
       ]
@@ -19829,7 +19829,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/os-tmpdir"
         }
       ]
@@ -19855,7 +19855,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/osenv"
         }
       ]
@@ -19881,7 +19881,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/otplib"
         }
       ]
@@ -19907,7 +19907,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-cancelable"
         }
       ]
@@ -19933,7 +19933,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-event"
         }
       ]
@@ -19959,7 +19959,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-finally"
         }
       ]
@@ -19985,7 +19985,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-is-promise"
         }
       ]
@@ -20011,7 +20011,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-limit"
         }
       ]
@@ -20037,7 +20037,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-locate"
         }
       ]
@@ -20063,7 +20063,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-map"
         }
       ]
@@ -20089,7 +20089,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-timeout"
         }
       ]
@@ -20115,7 +20115,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-try"
         }
       ]
@@ -20141,7 +20141,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pako"
         }
       ]
@@ -20167,7 +20167,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/parse-filepath"
         }
       ]
@@ -20193,7 +20193,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/parse-json"
         }
       ]
@@ -20219,7 +20219,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/parse-passwd"
         }
       ]
@@ -20245,7 +20245,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/parseurl"
         }
       ]
@@ -20271,7 +20271,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pascalcase"
         }
       ]
@@ -20297,7 +20297,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-exists"
         }
       ]
@@ -20323,7 +20323,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-is-absolute"
         }
       ]
@@ -20349,7 +20349,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-parse"
         }
       ]
@@ -20375,7 +20375,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-root-regex"
         }
       ]
@@ -20401,7 +20401,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-root"
         }
       ]
@@ -20427,7 +20427,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-to-regexp"
         }
       ]
@@ -20453,7 +20453,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pdfkit"
         }
       ]
@@ -20479,7 +20479,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/peek-readable"
         }
       ]
@@ -20505,7 +20505,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pend"
         }
       ]
@@ -20531,7 +20531,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/performance-now"
         }
       ]
@@ -20557,7 +20557,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pg-connection-string"
         }
       ]
@@ -20583,7 +20583,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/picomatch"
         }
       ]
@@ -20609,7 +20609,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pify"
         }
       ]
@@ -20635,7 +20635,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pinkie-promise"
         }
       ]
@@ -20661,7 +20661,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pinkie"
         }
       ]
@@ -20687,7 +20687,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/png-js"
         }
       ]
@@ -20713,7 +20713,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/portscanner"
         }
       ]
@@ -20739,7 +20739,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/posix-character-classes"
         }
       ]
@@ -20765,7 +20765,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/prebuild-install"
         }
       ]
@@ -20791,7 +20791,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/prelude-ls"
         }
       ]
@@ -20817,7 +20817,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/prepend-http"
         }
       ]
@@ -20843,7 +20843,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pretty-bytes"
         }
       ]
@@ -20869,7 +20869,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/process-nextick-args"
         }
       ]
@@ -20895,7 +20895,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/prom-client"
         }
       ]
@@ -20921,7 +20921,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/promise-inflight"
         }
       ]
@@ -20947,7 +20947,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/promise-retry"
         }
       ],
@@ -20973,7 +20973,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/promise-retry/node_modules/err-code"
             }
           ]
@@ -20999,7 +20999,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/promise-retry/node_modules/retry"
             }
           ]
@@ -21027,7 +21027,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/promise"
         }
       ]
@@ -21053,7 +21053,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/proper-lockfile"
         }
       ]
@@ -21079,7 +21079,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/proxy-addr"
         }
       ]
@@ -21105,7 +21105,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/psl"
         }
       ]
@@ -21131,7 +21131,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-attrs"
         }
       ]
@@ -21157,7 +21157,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-code-gen"
         }
       ]
@@ -21183,7 +21183,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-error"
         }
       ]
@@ -21209,7 +21209,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-filters"
         }
       ]
@@ -21235,7 +21235,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-lexer"
         }
       ]
@@ -21261,7 +21261,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-linker"
         }
       ]
@@ -21287,7 +21287,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-load"
         }
       ]
@@ -21313,7 +21313,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-parser"
         }
       ]
@@ -21339,7 +21339,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-runtime"
         }
       ]
@@ -21365,7 +21365,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-strip-comments"
         }
       ]
@@ -21391,7 +21391,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-walk"
         }
       ]
@@ -21417,7 +21417,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug"
         }
       ]
@@ -21443,7 +21443,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pump"
         }
       ]
@@ -21469,7 +21469,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/punycode"
         }
       ]
@@ -21495,7 +21495,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/qs"
         }
       ]
@@ -21521,7 +21521,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/query-string"
         }
       ]
@@ -21547,7 +21547,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/range_check"
         }
       ]
@@ -21573,7 +21573,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/range-parser"
         }
       ]
@@ -21599,7 +21599,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/raw-body"
         }
       ]
@@ -21625,7 +21625,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/rc"
         }
       ]
@@ -21651,7 +21651,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/read-pkg"
         }
       ],
@@ -21677,7 +21677,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/read-pkg/node_modules/pify"
             }
           ]
@@ -21705,7 +21705,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/readable-stream"
         }
       ],
@@ -21731,7 +21731,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/readable-stream/node_modules/isarray"
             }
           ]
@@ -21759,7 +21759,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/readable-web-to-node-stream"
         }
       ],
@@ -21785,7 +21785,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/readable-web-to-node-stream/node_modules/readable-stream"
             }
           ]
@@ -21813,7 +21813,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/readdirp"
         }
       ]
@@ -21839,7 +21839,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/rechoir"
         }
       ]
@@ -21865,7 +21865,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/regex-not"
         }
       ]
@@ -21891,7 +21891,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/regexp.prototype.flags"
         }
       ]
@@ -21917,7 +21917,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/remove-trailing-separator"
         }
       ]
@@ -21943,7 +21943,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/repeat-element"
         }
       ]
@@ -21969,7 +21969,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/repeat-string"
         }
       ]
@@ -21995,7 +21995,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/replace"
         }
       ],
@@ -22021,7 +22021,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/ansi-regex"
             }
           ]
@@ -22047,7 +22047,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/ansi-styles"
             }
           ]
@@ -22073,7 +22073,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/brace-expansion"
             }
           ]
@@ -22099,7 +22099,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/cliui"
             }
           ]
@@ -22125,7 +22125,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/color-convert"
             }
           ]
@@ -22151,7 +22151,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/color-name"
             }
           ]
@@ -22177,7 +22177,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/find-up"
             }
           ]
@@ -22203,7 +22203,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -22229,7 +22229,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/locate-path"
             }
           ]
@@ -22255,7 +22255,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/minimatch"
             }
           ]
@@ -22281,7 +22281,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/p-locate"
             }
           ]
@@ -22307,7 +22307,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/path-exists"
             }
           ]
@@ -22333,7 +22333,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/string-width"
             }
           ]
@@ -22359,7 +22359,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/strip-ansi"
             }
           ]
@@ -22385,7 +22385,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/wrap-ansi"
             }
           ]
@@ -22411,7 +22411,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/yargs-parser"
             }
           ]
@@ -22437,7 +22437,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/yargs"
             }
           ]
@@ -22465,7 +22465,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/request"
         }
       ],
@@ -22491,7 +22491,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/request/node_modules/qs"
             }
           ]
@@ -22519,7 +22519,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/require-directory"
         }
       ]
@@ -22545,7 +22545,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/require-main-filename"
         }
       ]
@@ -22571,7 +22571,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/resolve-dir"
         }
       ]
@@ -22597,7 +22597,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/resolve-url"
         }
       ]
@@ -22623,7 +22623,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/resolve"
         }
       ]
@@ -22649,7 +22649,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/responselike"
         }
       ]
@@ -22675,7 +22675,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/restructure"
         }
       ]
@@ -22701,7 +22701,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ret"
         }
       ]
@@ -22727,7 +22727,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/retry-as-promised"
         }
       ]
@@ -22753,7 +22753,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/retry"
         }
       ]
@@ -22779,7 +22779,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/rimraf"
         }
       ]
@@ -22805,7 +22805,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/rxjs"
         }
       ],
@@ -22831,7 +22831,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/rxjs/node_modules/tslib"
             }
           ]
@@ -22859,7 +22859,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safe-buffer"
         }
       ]
@@ -22885,7 +22885,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safe-regex-test"
         }
       ]
@@ -22911,7 +22911,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safe-regex"
         }
       ]
@@ -22937,7 +22937,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safe-stable-stringify"
         }
       ]
@@ -22963,7 +22963,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safer-buffer"
         }
       ]
@@ -22989,7 +22989,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/samsam"
         }
       ]
@@ -23015,7 +23015,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sanitize-filename"
         }
       ]
@@ -23041,7 +23041,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sanitize-html"
         }
       ],
@@ -23067,7 +23067,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sanitize-html/node_modules/lodash"
             }
           ]
@@ -23095,7 +23095,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sax"
         }
       ]
@@ -23121,7 +23121,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/seek-bzip"
         }
       ]
@@ -23147,7 +23147,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/semver"
         }
       ]
@@ -23173,7 +23173,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/send"
         }
       ],
@@ -23199,7 +23199,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/send/node_modules/ms"
             }
           ]
@@ -23227,7 +23227,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sequelize-pool"
         }
       ]
@@ -23253,7 +23253,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sequelize"
         }
       ],
@@ -23279,7 +23279,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sequelize/node_modules/debug"
             }
           ]
@@ -23305,7 +23305,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sequelize/node_modules/ms"
             }
           ]
@@ -23331,7 +23331,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sequelize/node_modules/uuid"
             }
           ]
@@ -23359,7 +23359,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/serve-index"
         }
       ],
@@ -23385,7 +23385,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index/node_modules/depd"
             }
           ]
@@ -23411,7 +23411,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index/node_modules/http-errors"
             }
           ]
@@ -23437,7 +23437,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index/node_modules/inherits"
             }
           ]
@@ -23463,7 +23463,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index/node_modules/setprototypeof"
             }
           ]
@@ -23489,7 +23489,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index/node_modules/statuses"
             }
           ]
@@ -23517,7 +23517,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/serve-static"
         }
       ]
@@ -23543,7 +23543,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/set-blocking"
         }
       ]
@@ -23569,7 +23569,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/set-value"
         }
       ],
@@ -23595,7 +23595,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/set-value/node_modules/extend-shallow"
             }
           ]
@@ -23621,7 +23621,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/set-value/node_modules/is-extendable"
             }
           ]
@@ -23649,7 +23649,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/setimmediate"
         }
       ]
@@ -23675,7 +23675,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/setprototypeof"
         }
       ]
@@ -23701,7 +23701,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/side-channel"
         }
       ]
@@ -23727,7 +23727,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/signal-exit"
         }
       ]
@@ -23753,7 +23753,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/simple-concat"
         }
       ]
@@ -23779,7 +23779,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/simple-get"
         }
       ],
@@ -23805,7 +23805,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/simple-get/node_modules/decompress-response"
             }
           ]
@@ -23831,7 +23831,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/simple-get/node_modules/mimic-response"
             }
           ]
@@ -23859,7 +23859,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/simple-swizzle"
         }
       ],
@@ -23885,7 +23885,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/simple-swizzle/node_modules/is-arrayish"
             }
           ]
@@ -23913,7 +23913,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sinon"
         }
       ]
@@ -23939,7 +23939,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/smart-buffer"
         }
       ]
@@ -23965,7 +23965,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/snapdragon-node"
         }
       ],
@@ -23991,7 +23991,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon-node/node_modules/define-property"
             }
           ]
@@ -24019,7 +24019,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/snapdragon-util"
         }
       ],
@@ -24045,7 +24045,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon-util/node_modules/kind-of"
             }
           ]
@@ -24073,7 +24073,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/snapdragon"
         }
       ],
@@ -24099,7 +24099,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/define-property"
             }
           ]
@@ -24125,7 +24125,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/extend-shallow"
             }
           ]
@@ -24151,7 +24151,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/is-accessor-descriptor"
             }
           ],
@@ -24177,7 +24177,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/snapdragon/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
@@ -24205,7 +24205,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/is-data-descriptor"
             }
           ],
@@ -24231,7 +24231,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/snapdragon/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
@@ -24259,7 +24259,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/is-descriptor"
             }
           ]
@@ -24285,7 +24285,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/is-extendable"
             }
           ]
@@ -24311,7 +24311,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/kind-of"
             }
           ]
@@ -24337,7 +24337,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/source-map"
             }
           ]
@@ -24365,7 +24365,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socket.io-adapter"
         }
       ]
@@ -24391,7 +24391,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socket.io-parser"
         }
       ],
@@ -24417,7 +24417,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socket.io-parser/node_modules/debug"
             }
           ]
@@ -24443,7 +24443,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socket.io-parser/node_modules/ms"
             }
           ]
@@ -24471,7 +24471,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socket.io"
         }
       ],
@@ -24497,7 +24497,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socket.io/node_modules/debug"
             }
           ]
@@ -24523,7 +24523,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socket.io/node_modules/ms"
             }
           ]
@@ -24551,7 +24551,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socks-proxy-agent"
         }
       ],
@@ -24577,7 +24577,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socks-proxy-agent/node_modules/debug"
             }
           ]
@@ -24603,7 +24603,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socks-proxy-agent/node_modules/ms"
             }
           ]
@@ -24631,7 +24631,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socks"
         }
       ],
@@ -24657,7 +24657,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socks/node_modules/ip"
             }
           ]
@@ -24685,7 +24685,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sort-keys-length"
         }
       ],
@@ -24711,7 +24711,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sort-keys-length/node_modules/sort-keys"
             }
           ]
@@ -24739,7 +24739,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sort-keys"
         }
       ]
@@ -24765,7 +24765,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/source-map-resolve"
         }
       ]
@@ -24791,7 +24791,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/source-map-support"
         }
       ]
@@ -24817,7 +24817,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/source-map-url"
         }
       ]
@@ -24843,7 +24843,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/source-map"
         }
       ]
@@ -24869,7 +24869,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spawn-command"
         }
       ]
@@ -24895,7 +24895,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spdx-correct"
         }
       ]
@@ -24921,7 +24921,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spdx-exceptions"
         }
       ]
@@ -24947,7 +24947,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spdx-expression-parse"
         }
       ]
@@ -24973,7 +24973,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spdx-license-ids"
         }
       ]
@@ -24999,7 +24999,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/split-string"
         }
       ]
@@ -25025,7 +25025,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sprintf-js"
         }
       ]
@@ -25051,7 +25051,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sqlite3"
         }
       ]
@@ -25077,7 +25077,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sshpk"
         }
       ]
@@ -25103,7 +25103,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ssri"
         }
       ]
@@ -25129,7 +25129,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/stack-trace"
         }
       ]
@@ -25155,7 +25155,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/static-extend"
         }
       ],
@@ -25181,7 +25181,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend/node_modules/define-property"
             }
           ]
@@ -25207,7 +25207,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend/node_modules/is-accessor-descriptor"
             }
           ],
@@ -25233,7 +25233,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/static-extend/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
@@ -25261,7 +25261,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend/node_modules/is-data-descriptor"
             }
           ],
@@ -25287,7 +25287,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/static-extend/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
@@ -25315,7 +25315,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend/node_modules/is-descriptor"
             }
           ]
@@ -25341,7 +25341,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend/node_modules/kind-of"
             }
           ]
@@ -25369,7 +25369,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/statuses"
         }
       ]
@@ -25395,7 +25395,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/stream-buffers"
         }
       ]
@@ -25421,7 +25421,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/streamsearch"
         }
       ]
@@ -25447,7 +25447,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strict-uri-encode"
         }
       ]
@@ -25473,7 +25473,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string_decoder"
         }
       ]
@@ -25499,7 +25499,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string-width"
         }
       ]
@@ -25525,7 +25525,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string.fromcodepoint"
         }
       ]
@@ -25551,7 +25551,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string.prototype.codepointat"
         }
       ]
@@ -25577,7 +25577,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string.prototype.trimend"
         }
       ]
@@ -25603,7 +25603,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string.prototype.trimstart"
         }
       ]
@@ -25629,7 +25629,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-ansi"
         }
       ]
@@ -25655,7 +25655,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-bom"
         }
       ]
@@ -25681,7 +25681,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-dirs"
         }
       ]
@@ -25707,7 +25707,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-json-comments"
         }
       ]
@@ -25733,7 +25733,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-outer"
         }
       ]
@@ -25759,7 +25759,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strtok3"
         }
       ]
@@ -25785,7 +25785,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/supports-color"
         }
       ]
@@ -25811,7 +25811,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/supports-preserve-symlinks-flag"
         }
       ]
@@ -25837,7 +25837,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/svg-captcha"
         }
       ]
@@ -25863,7 +25863,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/swagger-ui-dist"
         }
       ]
@@ -25889,7 +25889,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/swagger-ui-express"
         }
       ]
@@ -25915,7 +25915,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tar-fs"
         }
       ],
@@ -25941,7 +25941,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/tar-fs/node_modules/bl"
             }
           ]
@@ -25967,7 +25967,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/tar-fs/node_modules/chownr"
             }
           ]
@@ -25993,7 +25993,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/tar-fs/node_modules/readable-stream"
             }
           ]
@@ -26019,7 +26019,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/tar-fs/node_modules/tar-stream"
             }
           ]
@@ -26047,7 +26047,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tar-stream"
         }
       ]
@@ -26073,7 +26073,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tar"
         }
       ]
@@ -26099,7 +26099,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tdigest"
         }
       ]
@@ -26125,7 +26125,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/text-hex"
         }
       ]
@@ -26151,7 +26151,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/thirty-two"
         }
       ]
@@ -26177,7 +26177,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/through"
         }
       ]
@@ -26203,7 +26203,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/timed-out"
         }
       ]
@@ -26229,7 +26229,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tiny-inflate"
         }
       ]
@@ -26255,7 +26255,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-buffer"
         }
       ]
@@ -26281,7 +26281,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-fast-properties"
         }
       ]
@@ -26307,7 +26307,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-object-path"
         }
       ],
@@ -26333,7 +26333,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/to-object-path/node_modules/kind-of"
             }
           ]
@@ -26361,7 +26361,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-regex-range"
         }
       ]
@@ -26387,7 +26387,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-regex"
         }
       ]
@@ -26413,7 +26413,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/toidentifier"
         }
       ]
@@ -26439,7 +26439,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/token-stream"
         }
       ]
@@ -26465,7 +26465,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/token-types"
         }
       ]
@@ -26491,7 +26491,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/toposort-class"
         }
       ]
@@ -26517,7 +26517,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tough-cookie"
         }
       ]
@@ -26543,7 +26543,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tr46"
         }
       ]
@@ -26569,7 +26569,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/traverse"
         }
       ]
@@ -26595,7 +26595,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tree-kill"
         }
       ]
@@ -26621,7 +26621,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/trim-repeated"
         }
       ]
@@ -26647,7 +26647,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/triple-beam"
         }
       ]
@@ -26673,7 +26673,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/truncate-utf8-bytes"
         }
       ]
@@ -26699,7 +26699,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ts-node-dev"
         }
       ],
@@ -26725,7 +26725,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/ts-node-dev/node_modules/rimraf"
             }
           ]
@@ -26753,7 +26753,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ts-node"
         }
       ]
@@ -26779,7 +26779,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tsconfig"
         }
       ]
@@ -26805,7 +26805,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tslib"
         }
       ]
@@ -26831,7 +26831,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tunnel-agent"
         }
       ]
@@ -26857,7 +26857,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tweetnacl"
         }
       ]
@@ -26883,7 +26883,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/type-check"
         }
       ]
@@ -26909,7 +26909,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/type-is"
         }
       ]
@@ -26935,7 +26935,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/typecast"
         }
       ]
@@ -26961,7 +26961,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/typedarray"
         }
       ]
@@ -26987,7 +26987,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/typescript"
         }
       ]
@@ -27013,7 +27013,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/uglify-js"
         }
       ]
@@ -27039,7 +27039,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unbox-primitive"
         }
       ]
@@ -27065,7 +27065,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unbzip2-stream"
         }
       ]
@@ -27091,7 +27091,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unc-path-regex"
         }
       ]
@@ -27117,7 +27117,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/underscore.string"
         }
       ]
@@ -27143,7 +27143,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unicode-properties"
         }
       ]
@@ -27169,7 +27169,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unicode-trie"
         }
       ]
@@ -27195,7 +27195,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/union-value"
         }
       ],
@@ -27221,7 +27221,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/union-value/node_modules/is-extendable"
             }
           ]
@@ -27249,7 +27249,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unique-filename"
         }
       ]
@@ -27275,7 +27275,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unique-slug"
         }
       ]
@@ -27301,7 +27301,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unit-compare"
         }
       ]
@@ -27327,7 +27327,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/universalify"
         }
       ]
@@ -27353,7 +27353,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unpipe"
         }
       ]
@@ -27379,7 +27379,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unset-value"
         }
       ],
@@ -27405,7 +27405,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/unset-value/node_modules/has-value"
             }
           ],
@@ -27431,7 +27431,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/unset-value/node_modules/has-value/node_modules/isobject"
                 }
               ]
@@ -27459,7 +27459,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/unset-value/node_modules/has-values"
             }
           ]
@@ -27485,7 +27485,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/unset-value/node_modules/isarray"
             }
           ]
@@ -27513,7 +27513,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/untildify"
         }
       ]
@@ -27539,7 +27539,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unzipper"
         }
       ],
@@ -27565,7 +27565,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/unzipper/node_modules/bluebird"
             }
           ]
@@ -27593,7 +27593,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/uri-js"
         }
       ]
@@ -27619,7 +27619,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/urix"
         }
       ]
@@ -27645,7 +27645,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/url-parse-lax"
         }
       ]
@@ -27671,7 +27671,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/url-to-options"
         }
       ]
@@ -27697,7 +27697,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/use"
         }
       ]
@@ -27723,7 +27723,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/utf8-byte-length"
         }
       ]
@@ -27749,7 +27749,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/util-deprecate"
         }
       ]
@@ -27775,7 +27775,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/util"
         }
       ]
@@ -27801,7 +27801,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/utils-merge"
         }
       ]
@@ -27827,7 +27827,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/uuid"
         }
       ]
@@ -27853,7 +27853,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/v8flags"
         }
       ]
@@ -27879,7 +27879,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/validate-npm-package-license"
         }
       ]
@@ -27905,7 +27905,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/validate"
         }
       ]
@@ -27931,7 +27931,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/validator"
         }
       ]
@@ -27957,7 +27957,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/vary"
         }
       ]
@@ -27983,7 +27983,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/verror"
         }
       ],
@@ -28009,7 +28009,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/verror/node_modules/core-util-is"
             }
           ]
@@ -28037,7 +28037,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/vm2"
         }
       ],
@@ -28063,7 +28063,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/vm2/node_modules/acorn"
             }
           ]
@@ -28091,7 +28091,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/void-elements"
         }
       ]
@@ -28117,7 +28117,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/walk"
         }
       ]
@@ -28143,7 +28143,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/walkdir"
         }
       ]
@@ -28169,7 +28169,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/webidl-conversions"
         }
       ]
@@ -28195,7 +28195,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/whatwg-url"
         }
       ]
@@ -28221,7 +28221,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-boxed-primitive"
         }
       ]
@@ -28247,7 +28247,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-collection"
         }
       ]
@@ -28273,7 +28273,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-module"
         }
       ]
@@ -28299,7 +28299,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-pm-runs"
         }
       ]
@@ -28325,7 +28325,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-typed-array"
         }
       ]
@@ -28351,7 +28351,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which"
         }
       ]
@@ -28377,7 +28377,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wide-align"
         }
       ]
@@ -28403,7 +28403,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/winston-transport"
         }
       ],
@@ -28429,7 +28429,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/winston-transport/node_modules/readable-stream"
             }
           ]
@@ -28457,7 +28457,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/winston"
         }
       ],
@@ -28483,7 +28483,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/winston/node_modules/async"
             }
           ]
@@ -28509,7 +28509,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/winston/node_modules/is-stream"
             }
           ]
@@ -28535,7 +28535,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/winston/node_modules/readable-stream"
             }
           ]
@@ -28563,7 +28563,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/with"
         }
       ]
@@ -28589,7 +28589,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wkx"
         }
       ]
@@ -28615,7 +28615,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/word-wrap"
         }
       ]
@@ -28641,7 +28641,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wordwrap"
         }
       ]
@@ -28667,7 +28667,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wrap-ansi"
         }
       ],
@@ -28693,7 +28693,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi/node_modules/ansi-regex"
             }
           ]
@@ -28719,7 +28719,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi/node_modules/emoji-regex"
             }
           ]
@@ -28745,7 +28745,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -28771,7 +28771,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi/node_modules/string-width"
             }
           ]
@@ -28797,7 +28797,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi/node_modules/strip-ansi"
             }
           ]
@@ -28825,7 +28825,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wrappy"
         }
       ]
@@ -28851,7 +28851,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ws"
         }
       ]
@@ -28877,7 +28877,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/xtend"
         }
       ]
@@ -28903,7 +28903,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/y18n"
         }
       ]
@@ -28929,7 +28929,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yallist"
         }
       ]
@@ -28955,7 +28955,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yaml-schema-validator"
         }
       ]
@@ -28981,7 +28981,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yargs-parser"
         }
       ]
@@ -29007,7 +29007,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yargs"
         }
       ],
@@ -29033,7 +29033,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs/node_modules/ansi-regex"
             }
           ]
@@ -29059,7 +29059,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs/node_modules/emoji-regex"
             }
           ]
@@ -29085,7 +29085,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -29111,7 +29111,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs/node_modules/string-width"
             }
           ]
@@ -29137,7 +29137,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs/node_modules/strip-ansi"
             }
           ]
@@ -29165,7 +29165,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yauzl"
         }
       ]
@@ -29191,7 +29191,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yn"
         }
       ]
@@ -29217,7 +29217,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/z85"
         }
       ]
@@ -29243,7 +29243,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/zip-stream"
         }
       ]
@@ -29269,7 +29269,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/zlibjs"
         }
       ]

--- a/tests/_data/sbom_demo-results/juice-shop_npm7_node16_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/juice-shop_npm7_node16_windows-latest.snap.json
@@ -62,6 +62,10 @@
       ],
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -88,6 +92,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@babel\\helper-string-parser"
+        }
       ]
     },
     {
@@ -108,6 +118,12 @@
           "url": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@babel\\helper-validator-identifier"
         }
       ]
     },
@@ -130,6 +146,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@babel\\parser"
+        }
       ]
     },
     {
@@ -150,6 +172,12 @@
           "url": "https://registry.npmjs.org/@babel/types/-/types-7.20.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@babel\\types"
         }
       ]
     },
@@ -172,6 +200,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@colors\\colors"
+        }
       ]
     },
     {
@@ -193,6 +227,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@dabh\\diagnostics"
+        }
       ]
     },
     {
@@ -213,6 +253,12 @@
           "url": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@gar\\promisify"
         }
       ]
     },
@@ -236,6 +282,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@mapbox\\node-pre-gyp"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -254,6 +306,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\ansi-regex"
             }
           ]
         },
@@ -275,6 +333,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\are-we-there-yet"
+            }
           ]
         },
         {
@@ -294,6 +358,12 @@
               "url": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\detect-libc"
             }
           ]
         },
@@ -315,6 +385,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\gauge"
+            }
           ]
         },
         {
@@ -334,6 +410,12 @@
               "url": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\is-fullwidth-code-point"
             }
           ]
         },
@@ -356,6 +438,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\make-dir"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -374,6 +462,12 @@
                   "url": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\make-dir\\node_modules\\semver"
                 }
               ]
             }
@@ -397,6 +491,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\nopt"
+            }
           ]
         },
         {
@@ -416,6 +516,12 @@
               "url": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\npmlog"
             }
           ]
         },
@@ -437,6 +543,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\readable-stream"
+            }
           ]
         },
         {
@@ -457,6 +569,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\string-width"
+            }
           ]
         },
         {
@@ -476,6 +594,12 @@
               "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\strip-ansi"
             }
           ]
         }
@@ -500,6 +624,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\core-loader"
+        }
       ]
     },
     {
@@ -520,6 +650,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/core/-/core-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\core"
         }
       ]
     },
@@ -542,6 +678,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\evaluator"
+        }
       ]
     },
     {
@@ -562,6 +704,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-all/-/lang-all-4.24.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-all"
         }
       ]
     },
@@ -584,6 +732,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-ar"
+        }
       ]
     },
     {
@@ -604,6 +758,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-bn/-/lang-bn-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-bn"
         }
       ]
     },
@@ -626,6 +786,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-ca"
+        }
       ]
     },
     {
@@ -646,6 +812,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-cs/-/lang-cs-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-cs"
         }
       ]
     },
@@ -668,6 +840,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-da"
+        }
       ]
     },
     {
@@ -688,6 +866,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-de/-/lang-de-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-de"
         }
       ]
     },
@@ -710,6 +894,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-el"
+        }
       ]
     },
     {
@@ -730,6 +920,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-en-min/-/lang-en-min-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-en-min"
         }
       ]
     },
@@ -752,6 +948,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-en"
+        }
       ]
     },
     {
@@ -772,6 +974,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-es/-/lang-es-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-es"
         }
       ]
     },
@@ -794,6 +1002,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-eu"
+        }
       ]
     },
     {
@@ -814,6 +1028,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-fa/-/lang-fa-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-fa"
         }
       ]
     },
@@ -836,6 +1056,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-fi"
+        }
       ]
     },
     {
@@ -856,6 +1082,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-fr/-/lang-fr-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-fr"
         }
       ]
     },
@@ -878,6 +1110,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-ga"
+        }
       ]
     },
     {
@@ -898,6 +1136,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-gl/-/lang-gl-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-gl"
         }
       ]
     },
@@ -920,6 +1164,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-hi"
+        }
       ]
     },
     {
@@ -940,6 +1190,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-hu/-/lang-hu-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-hu"
         }
       ]
     },
@@ -962,6 +1218,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-hy"
+        }
       ]
     },
     {
@@ -982,6 +1244,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-id/-/lang-id-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-id"
         }
       ]
     },
@@ -1004,6 +1272,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-it"
+        }
       ]
     },
     {
@@ -1024,6 +1298,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-ja/-/lang-ja-4.24.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-ja"
         }
       ]
     },
@@ -1046,6 +1326,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-ko"
+        }
       ]
     },
     {
@@ -1066,6 +1352,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-lt/-/lang-lt-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-lt"
         }
       ]
     },
@@ -1088,6 +1380,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-ms"
+        }
       ]
     },
     {
@@ -1108,6 +1406,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-ne/-/lang-ne-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-ne"
         }
       ]
     },
@@ -1130,6 +1434,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-nl"
+        }
       ]
     },
     {
@@ -1150,6 +1460,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-no/-/lang-no-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-no"
         }
       ]
     },
@@ -1172,6 +1488,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-pl"
+        }
       ]
     },
     {
@@ -1192,6 +1514,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-pt/-/lang-pt-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-pt"
         }
       ]
     },
@@ -1214,6 +1542,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-ro"
+        }
       ]
     },
     {
@@ -1234,6 +1568,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-ru/-/lang-ru-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-ru"
         }
       ]
     },
@@ -1256,6 +1596,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-sl"
+        }
       ]
     },
     {
@@ -1276,6 +1622,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-sr/-/lang-sr-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-sr"
         }
       ]
     },
@@ -1298,6 +1650,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-sv"
+        }
       ]
     },
     {
@@ -1318,6 +1676,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-ta/-/lang-ta-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-ta"
         }
       ]
     },
@@ -1340,6 +1704,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-th"
+        }
       ]
     },
     {
@@ -1360,6 +1730,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-tl/-/lang-tl-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-tl"
         }
       ]
     },
@@ -1382,6 +1758,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-tr"
+        }
       ]
     },
     {
@@ -1402,6 +1784,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-uk/-/lang-uk-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-uk"
         }
       ]
     },
@@ -1424,6 +1812,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-zh"
+        }
       ]
     },
     {
@@ -1444,6 +1838,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/language-min/-/language-min-4.22.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\language-min"
         }
       ]
     },
@@ -1466,6 +1866,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\language"
+        }
       ]
     },
     {
@@ -1486,6 +1892,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/ner/-/ner-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\ner"
         }
       ]
     },
@@ -1508,6 +1920,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\neural"
+        }
       ]
     },
     {
@@ -1528,6 +1946,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/nlg/-/nlg-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\nlg"
         }
       ]
     },
@@ -1550,6 +1974,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\nlp"
+        }
       ]
     },
     {
@@ -1570,6 +2000,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/nlu/-/nlu-4.23.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\nlu"
         }
       ]
     },
@@ -1592,6 +2028,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\request"
+        }
       ]
     },
     {
@@ -1612,6 +2054,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/sentiment/-/sentiment-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\sentiment"
         }
       ]
     },
@@ -1634,6 +2082,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\similarity"
+        }
       ]
     },
     {
@@ -1654,6 +2108,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/slot/-/slot-4.22.17.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\slot"
         }
       ]
     },
@@ -1676,6 +2136,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@npmcli\\fs"
+        }
       ]
     },
     {
@@ -1696,6 +2162,12 @@
           "url": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@npmcli\\move-file"
         }
       ]
     },
@@ -1718,6 +2190,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib\\core"
+        }
       ]
     },
     {
@@ -1738,6 +2216,12 @@
           "url": "https://registry.npmjs.org/@otplib/plugin-crypto/-/plugin-crypto-12.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib\\plugin-crypto"
         }
       ]
     },
@@ -1760,6 +2244,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib\\plugin-thirty-two"
+        }
       ]
     },
     {
@@ -1780,6 +2270,12 @@
           "url": "https://registry.npmjs.org/@otplib/preset-default/-/preset-default-12.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib\\preset-default"
         }
       ]
     },
@@ -1802,6 +2298,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib\\preset-v11"
+        }
       ]
     },
     {
@@ -1822,6 +2324,12 @@
           "url": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@sindresorhus\\is"
         }
       ]
     },
@@ -1844,6 +2352,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@swc\\helpers"
+        }
       ]
     },
     {
@@ -1864,6 +2378,12 @@
           "url": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@tokenizer\\token"
         }
       ]
     },
@@ -1886,6 +2406,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@tootallnate\\once"
+        }
       ]
     },
     {
@@ -1906,6 +2432,12 @@
           "url": "https://registry.npmjs.org/@types/component-emitter/-/component-emitter-1.2.11.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types\\component-emitter"
         }
       ]
     },
@@ -1928,6 +2460,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types\\cookie"
+        }
       ]
     },
     {
@@ -1948,6 +2486,12 @@
           "url": "https://registry.npmjs.org/@types/cors/-/cors-2.8.12.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types\\cors"
         }
       ]
     },
@@ -1970,6 +2514,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types\\debug"
+        }
       ]
     },
     {
@@ -1990,6 +2540,12 @@
           "url": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types\\ms"
         }
       ]
     },
@@ -2012,6 +2568,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types\\node"
+        }
       ]
     },
     {
@@ -2032,6 +2594,12 @@
           "url": "https://registry.npmjs.org/@types/strip-bom/-/strip-bom-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types\\strip-bom"
         }
       ]
     },
@@ -2054,6 +2622,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types\\strip-json-comments"
+        }
       ]
     },
     {
@@ -2075,6 +2649,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types\\validator"
+        }
       ]
     },
     {
@@ -2094,6 +2674,12 @@
           "url": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/abbrev"
         }
       ]
     },
@@ -2115,6 +2701,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/accepts"
+        }
       ]
     },
     {
@@ -2135,6 +2727,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/acorn-walk"
+        }
       ]
     },
     {
@@ -2154,6 +2752,12 @@
           "url": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/acorn"
         }
       ]
     },
@@ -2176,6 +2780,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/agent-base"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -2194,6 +2804,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agent-base\\node_modules\\debug"
             }
           ]
         },
@@ -2214,6 +2830,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agent-base\\node_modules\\ms"
             }
           ]
         }
@@ -2238,6 +2860,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/agentkeepalive"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -2256,6 +2884,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agentkeepalive\\node_modules\\debug"
             }
           ]
         },
@@ -2277,6 +2911,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agentkeepalive\\node_modules\\depd"
+            }
           ]
         },
         {
@@ -2296,6 +2936,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agentkeepalive\\node_modules\\ms"
             }
           ]
         }
@@ -2319,6 +2965,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/aggregate-error"
+        }
       ]
     },
     {
@@ -2338,6 +2990,12 @@
           "url": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ajv"
         }
       ]
     },
@@ -2359,6 +3017,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ansi-regex"
+        }
       ]
     },
     {
@@ -2378,6 +3042,12 @@
           "url": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ansi-styles"
         }
       ]
     },
@@ -2400,6 +3070,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/anymatch"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -2418,6 +3094,12 @@
               "url": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/anymatch\\node_modules\\normalize-path"
             }
           ]
         }
@@ -2441,6 +3123,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/append-field"
+        }
       ]
     },
     {
@@ -2460,6 +3148,12 @@
           "url": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/aproba"
         }
       ]
     },
@@ -2482,6 +3176,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/archive-type"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -2500,6 +3200,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-4.4.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/archive-type\\node_modules\\file-type"
             }
           ]
         }
@@ -2523,6 +3229,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/archiver-utils"
+        }
       ]
     },
     {
@@ -2542,6 +3254,12 @@
           "url": "https://registry.npmjs.org/archiver/-/archiver-1.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/archiver"
         }
       ]
     },
@@ -2563,6 +3281,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/are-we-there-yet"
+        }
       ]
     },
     {
@@ -2582,6 +3306,12 @@
           "url": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/arg"
         }
       ]
     },
@@ -2604,6 +3334,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/argparse"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -2622,6 +3358,12 @@
               "url": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/argparse\\node_modules\\sprintf-js"
             }
           ]
         }
@@ -2645,6 +3387,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/arr-diff"
+        }
       ]
     },
     {
@@ -2664,6 +3412,12 @@
           "url": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/arr-flatten"
         }
       ]
     },
@@ -2685,6 +3439,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/arr-union"
+        }
       ]
     },
     {
@@ -2704,6 +3464,12 @@
           "url": "https://registry.npmjs.org/array-each/-/array-each-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/array-each"
         }
       ]
     },
@@ -2725,6 +3491,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/array-flatten"
+        }
       ]
     },
     {
@@ -2744,6 +3516,12 @@
           "url": "https://registry.npmjs.org/array-slice/-/array-slice-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/array-slice"
         }
       ]
     },
@@ -2765,6 +3543,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/array-unique"
+        }
       ]
     },
     {
@@ -2784,6 +3568,12 @@
           "url": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/asap"
         }
       ]
     },
@@ -2805,6 +3595,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/asn1"
+        }
       ]
     },
     {
@@ -2824,6 +3620,12 @@
           "url": "https://registry.npmjs.org/assert-never/-/assert-never-1.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/assert-never"
         }
       ]
     },
@@ -2845,6 +3647,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/assert-plus"
+        }
       ]
     },
     {
@@ -2864,6 +3672,12 @@
           "url": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/assign-symbols"
         }
       ]
     },
@@ -2885,6 +3699,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/async"
+        }
       ]
     },
     {
@@ -2904,6 +3724,12 @@
           "url": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/asynckit"
         }
       ]
     },
@@ -2925,6 +3751,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/at-least-node"
+        }
       ]
     },
     {
@@ -2944,6 +3776,12 @@
           "url": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/atob"
         }
       ]
     },
@@ -2965,6 +3803,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/available-typed-arrays"
+        }
       ]
     },
     {
@@ -2984,6 +3828,12 @@
           "url": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/aws-sign2"
         }
       ]
     },
@@ -3005,6 +3855,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/aws4"
+        }
       ]
     },
     {
@@ -3025,6 +3881,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/babel-walk"
+        }
       ]
     },
     {
@@ -3044,6 +3906,12 @@
           "url": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/balanced-match"
         }
       ]
     },
@@ -3066,6 +3934,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -3084,6 +3958,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/base\\node_modules\\define-property"
             }
           ]
         }
@@ -3107,6 +3987,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base64-arraybuffer"
+        }
       ]
     },
     {
@@ -3126,6 +4012,12 @@
           "url": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base64-js"
         }
       ]
     },
@@ -3147,6 +4039,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base64id"
+        }
       ]
     },
     {
@@ -3166,6 +4064,12 @@
           "url": "https://registry.npmjs.org/base64url/-/base64url-0.0.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base64url"
         }
       ]
     },
@@ -3187,6 +4091,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/basic-auth"
+        }
       ]
     },
     {
@@ -3206,6 +4116,12 @@
           "url": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/batch"
         }
       ]
     },
@@ -3227,6 +4143,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bcrypt-pbkdf"
+        }
       ]
     },
     {
@@ -3246,6 +4168,12 @@
           "url": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/big-integer"
         }
       ]
     },
@@ -3267,6 +4195,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/binary-extensions"
+        }
       ]
     },
     {
@@ -3286,6 +4220,12 @@
           "url": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/binary"
         }
       ]
     },
@@ -3307,6 +4247,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bindings"
+        }
       ]
     },
     {
@@ -3326,6 +4272,12 @@
           "url": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bintrees"
         }
       ]
     },
@@ -3347,6 +4299,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bl"
+        }
       ]
     },
     {
@@ -3367,6 +4325,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bluebird"
+        }
       ]
     },
     {
@@ -3386,6 +4350,12 @@
           "url": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/body-parser"
         }
       ]
     },
@@ -3408,6 +4378,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bower-config"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -3426,6 +4402,12 @@
               "url": "https://registry.npmjs.org/minimist/-/minimist-0.2.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bower-config\\node_modules\\minimist"
             }
           ]
         }
@@ -3449,6 +4431,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/brace-expansion"
+        }
       ]
     },
     {
@@ -3470,6 +4458,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/braces"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -3488,6 +4482,12 @@
               "url": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/braces\\node_modules\\extend-shallow"
             }
           ]
         },
@@ -3508,6 +4508,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/braces\\node_modules\\is-extendable"
             }
           ]
         }
@@ -3531,6 +4537,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/brotli"
+        }
       ]
     },
     {
@@ -3550,6 +4562,12 @@
           "url": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-alloc-unsafe"
         }
       ]
     },
@@ -3571,6 +4589,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-alloc"
+        }
       ]
     },
     {
@@ -3590,6 +4614,12 @@
           "url": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-crc32"
         }
       ]
     },
@@ -3611,6 +4641,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-fill"
+        }
       ]
     },
     {
@@ -3630,6 +4666,12 @@
           "url": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-from"
         }
       ]
     },
@@ -3651,6 +4693,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-indexof-polyfill"
+        }
       ]
     },
     {
@@ -3671,6 +4719,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer"
+        }
       ]
     },
     {
@@ -3690,6 +4744,12 @@
           "url": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffers"
         }
       ]
     },
@@ -3712,6 +4772,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/busboy"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -3730,6 +4796,12 @@
               "url": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/busboy\\node_modules\\isarray"
             }
           ]
         },
@@ -3751,6 +4823,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/busboy\\node_modules\\readable-stream"
+            }
           ]
         },
         {
@@ -3770,6 +4848,12 @@
               "url": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/busboy\\node_modules\\string_decoder"
             }
           ]
         }
@@ -3793,6 +4877,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/byline"
+        }
       ]
     },
     {
@@ -3812,6 +4902,12 @@
           "url": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bytes"
         }
       ]
     },
@@ -3833,6 +4929,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cacache"
+        }
       ]
     },
     {
@@ -3852,6 +4954,12 @@
           "url": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cache-base"
         }
       ]
     },
@@ -3874,6 +4982,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cacheable-request"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -3892,6 +5006,12 @@
               "url": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cacheable-request\\node_modules\\get-stream"
             }
           ]
         },
@@ -3912,6 +5032,12 @@
               "url": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cacheable-request\\node_modules\\lowercase-keys"
             }
           ]
         }
@@ -3935,6 +5061,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/call-bind"
+        }
       ]
     },
     {
@@ -3954,6 +5086,12 @@
           "url": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/camelcase"
         }
       ]
     },
@@ -3975,6 +5113,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/caseless"
+        }
       ]
     },
     {
@@ -3994,6 +5138,12 @@
           "url": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/chainsaw"
         }
       ]
     },
@@ -4015,6 +5165,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/chalk"
+        }
       ]
     },
     {
@@ -4034,6 +5190,12 @@
           "url": "https://registry.npmjs.org/character-parser/-/character-parser-2.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/character-parser"
         }
       ]
     },
@@ -4056,6 +5218,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/check-dependencies"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4074,6 +5242,12 @@
               "url": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/check-dependencies\\node_modules\\semver"
             }
           ]
         }
@@ -4097,6 +5271,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/check-types"
+        }
       ]
     },
     {
@@ -4118,6 +5298,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/chokidar"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4136,6 +5322,12 @@
               "url": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar\\node_modules\\braces"
             }
           ]
         },
@@ -4157,6 +5349,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar\\node_modules\\fill-range"
+            }
           ]
         },
         {
@@ -4176,6 +5374,12 @@
               "url": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar\\node_modules\\is-glob"
             }
           ]
         },
@@ -4197,6 +5401,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar\\node_modules\\is-number"
+            }
           ]
         },
         {
@@ -4217,6 +5427,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar\\node_modules\\normalize-path"
+            }
           ]
         },
         {
@@ -4236,6 +5452,12 @@
               "url": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar\\node_modules\\to-regex-range"
             }
           ]
         }
@@ -4259,6 +5481,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/chownr"
+        }
       ]
     },
     {
@@ -4278,6 +5506,12 @@
           "url": "https://registry.npmjs.org/clarinet/-/clarinet-0.12.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/clarinet"
         }
       ]
     },
@@ -4300,6 +5534,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/class-utils"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4318,6 +5558,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils\\node_modules\\define-property"
             }
           ]
         },
@@ -4340,6 +5586,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils\\node_modules\\is-accessor-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -4358,6 +5610,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/class-utils\\node_modules\\is-accessor-descriptor\\node_modules\\kind-of"
                 }
               ]
             }
@@ -4382,6 +5640,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils\\node_modules\\is-data-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -4400,6 +5664,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/class-utils\\node_modules\\is-data-descriptor\\node_modules\\kind-of"
                 }
               ]
             }
@@ -4423,6 +5693,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils\\node_modules\\is-descriptor"
+            }
           ]
         },
         {
@@ -4442,6 +5718,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils\\node_modules\\kind-of"
             }
           ]
         }
@@ -4465,6 +5747,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/clean-stack"
+        }
       ]
     },
     {
@@ -4486,6 +5774,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cliui"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4504,6 +5798,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui\\node_modules\\ansi-regex"
             }
           ]
         },
@@ -4525,6 +5825,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui\\node_modules\\emoji-regex"
+            }
           ]
         },
         {
@@ -4544,6 +5850,12 @@
               "url": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui\\node_modules\\is-fullwidth-code-point"
             }
           ]
         },
@@ -4565,6 +5877,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui\\node_modules\\string-width"
+            }
           ]
         },
         {
@@ -4584,6 +5902,12 @@
               "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui\\node_modules\\strip-ansi"
             }
           ]
         }
@@ -4607,6 +5931,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/clone-response"
+        }
       ]
     },
     {
@@ -4626,6 +5956,12 @@
           "url": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/clone"
         }
       ]
     },
@@ -4647,6 +5983,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/code-point-at"
+        }
       ]
     },
     {
@@ -4666,6 +6008,12 @@
           "url": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/collection-visit"
         }
       ]
     },
@@ -4687,6 +6035,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color-convert"
+        }
       ]
     },
     {
@@ -4706,6 +6060,12 @@
           "url": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color-name"
         }
       ]
     },
@@ -4727,6 +6087,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color-string"
+        }
       ]
     },
     {
@@ -4746,6 +6112,12 @@
           "url": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color-support"
         }
       ]
     },
@@ -4767,6 +6139,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color"
+        }
       ]
     },
     {
@@ -4786,6 +6164,12 @@
           "url": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/colors"
         }
       ]
     },
@@ -4807,6 +6191,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/colorspace"
+        }
       ]
     },
     {
@@ -4826,6 +6216,12 @@
           "url": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/combined-stream"
         }
       ]
     },
@@ -4847,6 +6243,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/commander"
+        }
       ]
     },
     {
@@ -4866,6 +6268,12 @@
           "url": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/component-emitter"
         }
       ]
     },
@@ -4887,6 +6295,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/component-type"
+        }
       ]
     },
     {
@@ -4907,6 +6321,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/compress-commons"
+        }
       ]
     },
     {
@@ -4926,6 +6346,12 @@
           "url": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/compressible"
         }
       ]
     },
@@ -4948,6 +6374,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/compression"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4966,6 +6398,12 @@
               "url": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/compression\\node_modules\\bytes"
             }
           ]
         }
@@ -4989,6 +6427,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/concat-map"
+        }
       ]
     },
     {
@@ -5008,6 +6452,12 @@
           "url": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/concat-stream"
         }
       ]
     },
@@ -5030,6 +6480,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/concurrently"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5048,6 +6504,12 @@
               "url": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/concurrently\\node_modules\\supports-color"
             }
           ]
         }
@@ -5071,6 +6533,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/config"
+        }
       ]
     },
     {
@@ -5091,6 +6559,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/console-control-strings"
+        }
       ]
     },
     {
@@ -5110,6 +6584,12 @@
           "url": "https://registry.npmjs.org/constantinople/-/constantinople-4.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/constantinople"
         }
       ]
     },
@@ -5132,6 +6612,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/content-disposition"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5150,6 +6636,12 @@
               "url": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/content-disposition\\node_modules\\safe-buffer"
             }
           ]
         }
@@ -5173,6 +6665,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/content-type"
+        }
       ]
     },
     {
@@ -5192,6 +6690,12 @@
           "url": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cookie-parser"
         }
       ]
     },
@@ -5213,6 +6717,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cookie-signature"
+        }
       ]
     },
     {
@@ -5232,6 +6742,12 @@
           "url": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cookie"
         }
       ]
     },
@@ -5253,6 +6769,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/copy-descriptor"
+        }
       ]
     },
     {
@@ -5272,6 +6794,12 @@
           "url": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/core-util-is"
         }
       ]
     },
@@ -5293,6 +6821,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cors"
+        }
       ]
     },
     {
@@ -5312,6 +6846,12 @@
           "url": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/crc"
         }
       ]
     },
@@ -5333,6 +6873,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/crc32-stream"
+        }
       ]
     },
     {
@@ -5352,6 +6898,12 @@
           "url": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/create-require"
         }
       ]
     },
@@ -5373,6 +6925,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/crypto-js"
+        }
       ]
     },
     {
@@ -5392,6 +6950,12 @@
           "url": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dashdash"
         }
       ]
     },
@@ -5413,6 +6977,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/date-fns"
+        }
       ]
     },
     {
@@ -5432,6 +7002,12 @@
           "url": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dateformat"
         }
       ]
     },
@@ -5453,6 +7029,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/debug"
+        }
       ]
     },
     {
@@ -5472,6 +7054,12 @@
           "url": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decamelize"
         }
       ]
     },
@@ -5493,6 +7081,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decode-uri-component"
+        }
       ]
     },
     {
@@ -5512,6 +7106,12 @@
           "url": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-response"
         }
       ]
     },
@@ -5534,6 +7134,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-tar"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5552,6 +7158,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-tar\\node_modules\\file-type"
             }
           ]
         }
@@ -5576,6 +7188,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-tarbz2"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5594,6 +7212,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-6.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-tarbz2\\node_modules\\file-type"
             }
           ]
         }
@@ -5618,6 +7242,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-targz"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5636,6 +7266,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-targz\\node_modules\\file-type"
             }
           ]
         }
@@ -5660,6 +7296,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-unzip"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5678,6 +7320,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-unzip\\node_modules\\file-type"
             }
           ]
         },
@@ -5699,6 +7347,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-unzip\\node_modules\\get-stream"
+            }
           ]
         },
         {
@@ -5718,6 +7372,12 @@
               "url": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-unzip\\node_modules\\pify"
             }
           ]
         }
@@ -5742,6 +7402,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5762,6 +7428,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress\\node_modules\\make-dir"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -5780,6 +7452,12 @@
                   "url": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/decompress\\node_modules\\make-dir\\node_modules\\pify"
                 }
               ]
             }
@@ -5803,6 +7481,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress\\node_modules\\pify"
+            }
           ]
         }
       ]
@@ -5825,6 +7509,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/deep-equal"
+        }
       ]
     },
     {
@@ -5844,6 +7534,12 @@
           "url": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/deep-extend"
         }
       ]
     },
@@ -5865,6 +7561,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/deep-is"
+        }
       ]
     },
     {
@@ -5884,6 +7586,12 @@
           "url": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/define-properties"
         }
       ]
     },
@@ -5905,6 +7613,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/define-property"
+        }
       ]
     },
     {
@@ -5924,6 +7638,12 @@
           "url": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/delayed-stream"
         }
       ]
     },
@@ -5945,6 +7665,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/delegates"
+        }
       ]
     },
     {
@@ -5964,6 +7690,12 @@
           "url": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/depd"
         }
       ]
     },
@@ -5985,6 +7717,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/destroy"
+        }
       ]
     },
     {
@@ -6004,6 +7742,12 @@
           "url": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/detect-file"
         }
       ]
     },
@@ -6025,6 +7769,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/detect-libc"
+        }
       ]
     },
     {
@@ -6044,6 +7794,12 @@
           "url": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dfa"
         }
       ]
     },
@@ -6066,6 +7822,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dicer"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -6084,6 +7846,12 @@
               "url": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/dicer\\node_modules\\isarray"
             }
           ]
         },
@@ -6105,6 +7873,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/dicer\\node_modules\\readable-stream"
+            }
           ]
         },
         {
@@ -6124,6 +7898,12 @@
               "url": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/dicer\\node_modules\\string_decoder"
             }
           ]
         }
@@ -6147,6 +7927,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/diff"
+        }
       ]
     },
     {
@@ -6166,6 +7952,12 @@
           "url": "https://registry.npmjs.org/doctypes/-/doctypes-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/doctypes"
         }
       ]
     },
@@ -6187,6 +7979,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/domelementtype"
+        }
       ]
     },
     {
@@ -6206,6 +8004,12 @@
           "url": "https://registry.npmjs.org/domhandler/-/domhandler-2.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/domhandler"
         }
       ]
     },
@@ -6227,6 +8031,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/domutils"
+        }
       ]
     },
     {
@@ -6246,6 +8056,12 @@
           "url": "https://registry.npmjs.org/dottie/-/dottie-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dottie"
         }
       ]
     },
@@ -6267,6 +8083,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/double-ended-queue"
+        }
       ]
     },
     {
@@ -6286,6 +8108,12 @@
           "url": "https://registry.npmjs.org/doublearray/-/doublearray-0.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/doublearray"
         }
       ]
     },
@@ -6308,6 +8136,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/download"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -6326,6 +8160,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-11.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/download\\node_modules\\file-type"
             }
           ]
         }
@@ -6349,6 +8189,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/duplexer2"
+        }
       ]
     },
     {
@@ -6368,6 +8214,12 @@
           "url": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/duplexer3"
         }
       ]
     },
@@ -6389,6 +8241,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dynamic-dedupe"
+        }
       ]
     },
     {
@@ -6408,6 +8266,12 @@
           "url": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ecc-jsbn"
         }
       ]
     },
@@ -6429,6 +8293,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ee-first"
+        }
       ]
     },
     {
@@ -6448,6 +8318,12 @@
           "url": "https://registry.npmjs.org/eivindfjeldstad-dot/-/eivindfjeldstad-dot-0.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/eivindfjeldstad-dot"
         }
       ]
     },
@@ -6469,6 +8345,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/emoji-regex"
+        }
       ]
     },
     {
@@ -6489,6 +8371,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/enabled"
+        }
       ]
     },
     {
@@ -6508,6 +8396,12 @@
           "url": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/encodeurl"
         }
       ]
     },
@@ -6530,6 +8424,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/encoding"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -6548,6 +8448,12 @@
               "url": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/encoding\\node_modules\\iconv-lite"
             }
           ]
         }
@@ -6571,6 +8477,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/end-of-stream"
+        }
       ]
     },
     {
@@ -6590,6 +8502,12 @@
           "url": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-4.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/engine.io-parser"
         }
       ]
     },
@@ -6612,6 +8530,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/engine.io"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -6630,6 +8554,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/engine.io\\node_modules\\debug"
             }
           ]
         },
@@ -6650,6 +8580,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/engine.io\\node_modules\\ms"
             }
           ]
         }
@@ -6673,6 +8609,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/env-paths"
+        }
       ]
     },
     {
@@ -6692,6 +8634,12 @@
           "url": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/err-code"
         }
       ]
     },
@@ -6713,6 +8661,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/error-ex"
+        }
       ]
     },
     {
@@ -6732,6 +8686,12 @@
           "url": "https://registry.npmjs.org/errorhandler/-/errorhandler-1.5.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/errorhandler"
         }
       ]
     },
@@ -6753,6 +8713,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/es-abstract"
+        }
       ]
     },
     {
@@ -6772,6 +8738,12 @@
           "url": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/es-get-iterator"
         }
       ]
     },
@@ -6793,6 +8765,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/es-to-primitive"
+        }
       ]
     },
     {
@@ -6812,6 +8790,12 @@
           "url": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/escape-html"
         }
       ]
     },
@@ -6833,6 +8817,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/escape-string-regexp"
+        }
       ]
     },
     {
@@ -6852,6 +8842,12 @@
           "url": "https://registry.npmjs.org/escodegen/-/escodegen-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/escodegen"
         }
       ]
     },
@@ -6873,6 +8869,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/esprima"
+        }
       ]
     },
     {
@@ -6892,6 +8894,12 @@
           "url": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/estraverse"
         }
       ]
     },
@@ -6913,6 +8921,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/esutils"
+        }
       ]
     },
     {
@@ -6932,6 +8946,12 @@
           "url": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/etag"
         }
       ]
     },
@@ -6953,6 +8973,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/eventemitter2"
+        }
       ]
     },
     {
@@ -6972,6 +8998,12 @@
           "url": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/eventemitter3"
         }
       ]
     },
@@ -6993,6 +9025,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/exif"
+        }
       ]
     },
     {
@@ -7012,6 +9050,12 @@
           "url": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/exit"
         }
       ]
     },
@@ -7034,6 +9078,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/expand-brackets"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7052,6 +9102,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets\\node_modules\\define-property"
             }
           ]
         },
@@ -7072,6 +9128,12 @@
               "url": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets\\node_modules\\extend-shallow"
             }
           ]
         },
@@ -7094,6 +9156,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets\\node_modules\\is-accessor-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -7112,6 +9180,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/expand-brackets\\node_modules\\is-accessor-descriptor\\node_modules\\kind-of"
                 }
               ]
             }
@@ -7136,6 +9210,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets\\node_modules\\is-data-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -7154,6 +9234,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/expand-brackets\\node_modules\\is-data-descriptor\\node_modules\\kind-of"
                 }
               ]
             }
@@ -7177,6 +9263,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets\\node_modules\\is-descriptor"
+            }
           ]
         },
         {
@@ -7197,6 +9289,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets\\node_modules\\is-extendable"
+            }
           ]
         },
         {
@@ -7216,6 +9314,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets\\node_modules\\kind-of"
             }
           ]
         }
@@ -7239,6 +9343,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/expand-template"
+        }
       ]
     },
     {
@@ -7259,6 +9369,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/expand-tilde"
+        }
       ]
     },
     {
@@ -7278,6 +9394,12 @@
           "url": "https://registry.npmjs.org/express-ipfilter/-/express-ipfilter-1.3.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-ipfilter"
         }
       ]
     },
@@ -7300,6 +9422,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-jwt"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7318,6 +9446,12 @@
               "url": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-0.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/express-jwt\\node_modules\\jsonwebtoken"
             }
           ]
         },
@@ -7338,6 +9472,12 @@
               "url": "https://registry.npmjs.org/moment/-/moment-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/express-jwt\\node_modules\\moment"
             }
           ]
         }
@@ -7361,6 +9501,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-rate-limit"
+        }
       ]
     },
     {
@@ -7381,6 +9527,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-robots-txt"
+        }
       ]
     },
     {
@@ -7400,6 +9552,12 @@
           "url": "https://registry.npmjs.org/express-security.txt/-/express-security.txt-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-security.txt"
         }
       ]
     },
@@ -7422,6 +9580,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7440,6 +9604,12 @@
               "url": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/express\\node_modules\\cookie"
             }
           ]
         },
@@ -7460,6 +9630,12 @@
               "url": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/express\\node_modules\\safe-buffer"
             }
           ]
         }
@@ -7483,6 +9659,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ext-list"
+        }
       ]
     },
     {
@@ -7502,6 +9684,12 @@
           "url": "https://registry.npmjs.org/ext-name/-/ext-name-5.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ext-name"
         }
       ]
     },
@@ -7523,6 +9711,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/extend-shallow"
+        }
       ]
     },
     {
@@ -7542,6 +9736,12 @@
           "url": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/extend"
         }
       ]
     },
@@ -7564,6 +9764,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/extglob"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7582,6 +9788,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/extglob\\node_modules\\define-property"
             }
           ]
         },
@@ -7603,6 +9815,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/extglob\\node_modules\\extend-shallow"
+            }
           ]
         },
         {
@@ -7622,6 +9840,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/extglob\\node_modules\\is-extendable"
             }
           ]
         }
@@ -7645,6 +9869,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/extsprintf"
+        }
       ]
     },
     {
@@ -7664,6 +9894,12 @@
           "url": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fast-deep-equal"
         }
       ]
     },
@@ -7685,6 +9921,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fast-json-stable-stringify"
+        }
       ]
     },
     {
@@ -7704,6 +9946,12 @@
           "url": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fast-levenshtein"
         }
       ]
     },
@@ -7725,6 +9973,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fast.js"
+        }
       ]
     },
     {
@@ -7744,6 +9998,12 @@
           "url": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fd-slicer"
         }
       ]
     },
@@ -7765,6 +10025,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/feature-policy"
+        }
       ]
     },
     {
@@ -7784,6 +10050,12 @@
           "url": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fecha"
         }
       ]
     },
@@ -7806,6 +10078,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/file-js"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7824,6 +10102,12 @@
               "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/file-js\\node_modules\\brace-expansion"
             }
           ]
         },
@@ -7844,6 +10128,12 @@
               "url": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/file-js\\node_modules\\minimatch"
             }
           ]
         }
@@ -7867,6 +10157,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/file-stream-rotator"
+        }
       ]
     },
     {
@@ -7886,6 +10182,12 @@
           "url": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/file-type"
         }
       ]
     },
@@ -7907,6 +10209,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/file-uri-to-path"
+        }
       ]
     },
     {
@@ -7926,6 +10234,12 @@
           "url": "https://registry.npmjs.org/filehound/-/filehound-1.17.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/filehound"
         }
       ]
     },
@@ -7947,6 +10261,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/filename-reserved-regex"
+        }
       ]
     },
     {
@@ -7967,6 +10287,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/filenamify"
+        }
       ]
     },
     {
@@ -7986,6 +10312,12 @@
           "url": "https://registry.npmjs.org/filesniffer/-/filesniffer-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/filesniffer"
         }
       ]
     },
@@ -8008,6 +10340,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fill-range"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -8026,6 +10364,12 @@
               "url": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/fill-range\\node_modules\\extend-shallow"
             }
           ]
         },
@@ -8046,6 +10390,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/fill-range\\node_modules\\is-extendable"
             }
           ]
         }
@@ -8069,6 +10419,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/finale-rest"
+        }
       ]
     },
     {
@@ -8088,6 +10444,12 @@
           "url": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/finalhandler"
         }
       ]
     },
@@ -8109,6 +10471,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/find-up"
+        }
       ]
     },
     {
@@ -8128,6 +10496,12 @@
           "url": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/findup-sync"
         }
       ]
     },
@@ -8149,6 +10523,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fined"
+        }
       ]
     },
     {
@@ -8168,6 +10548,12 @@
           "url": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/flagged-respawn"
         }
       ]
     },
@@ -8189,6 +10575,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fn.name"
+        }
       ]
     },
     {
@@ -8208,6 +10600,12 @@
           "url": "https://registry.npmjs.org/fontkit/-/fontkit-1.9.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fontkit"
         }
       ]
     },
@@ -8229,6 +10627,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/for-each"
+        }
       ]
     },
     {
@@ -8248,6 +10652,12 @@
           "url": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/for-in"
         }
       ]
     },
@@ -8269,6 +10679,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/for-own"
+        }
       ]
     },
     {
@@ -8288,6 +10704,12 @@
           "url": "https://registry.npmjs.org/foreachasync/-/foreachasync-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/foreachasync"
         }
       ]
     },
@@ -8309,6 +10731,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/forever-agent"
+        }
       ]
     },
     {
@@ -8328,6 +10756,12 @@
           "url": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/form-data"
         }
       ]
     },
@@ -8349,6 +10783,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/formatio"
+        }
       ]
     },
     {
@@ -8368,6 +10808,12 @@
           "url": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/forwarded"
         }
       ]
     },
@@ -8389,6 +10835,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fragment-cache"
+        }
       ]
     },
     {
@@ -8408,6 +10860,12 @@
           "url": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fresh"
         }
       ]
     },
@@ -8429,6 +10887,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/from2"
+        }
       ]
     },
     {
@@ -8448,6 +10912,12 @@
           "url": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fs-constants"
         }
       ]
     },
@@ -8469,6 +10939,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fs-extra"
+        }
       ]
     },
     {
@@ -8489,6 +10965,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fs-minipass"
+        }
       ]
     },
     {
@@ -8508,6 +10990,12 @@
           "url": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fs.realpath"
         }
       ]
     },
@@ -8530,6 +11018,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fstream"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -8548,6 +11042,12 @@
               "url": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/fstream\\node_modules\\mkdirp"
             }
           ]
         },
@@ -8568,6 +11068,12 @@
               "url": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/fstream\\node_modules\\rimraf"
             }
           ]
         }
@@ -8591,6 +11097,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/function-bind"
+        }
       ]
     },
     {
@@ -8610,6 +11122,12 @@
           "url": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/function.prototype.name"
         }
       ]
     },
@@ -8631,6 +11149,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/functions-have-names"
+        }
       ]
     },
     {
@@ -8650,6 +11174,12 @@
           "url": "https://registry.npmjs.org/fuzzball/-/fuzzball-1.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fuzzball"
         }
       ]
     },
@@ -8671,6 +11201,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/gauge"
+        }
       ]
     },
     {
@@ -8690,6 +11226,12 @@
           "url": "https://registry.npmjs.org/geojson-utils/-/geojson-utils-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/geojson-utils"
         }
       ]
     },
@@ -8711,6 +11253,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-caller-file"
+        }
       ]
     },
     {
@@ -8730,6 +11278,12 @@
           "url": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-intrinsic"
         }
       ]
     },
@@ -8751,6 +11305,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-stream"
+        }
       ]
     },
     {
@@ -8770,6 +11330,12 @@
           "url": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-symbol-description"
         }
       ]
     },
@@ -8791,6 +11357,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-value"
+        }
       ]
     },
     {
@@ -8810,6 +11382,12 @@
           "url": "https://registry.npmjs.org/getobject/-/getobject-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/getobject"
         }
       ]
     },
@@ -8831,6 +11409,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/getpass"
+        }
       ]
     },
     {
@@ -8850,6 +11434,12 @@
           "url": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/github-from-package"
         }
       ]
     },
@@ -8872,6 +11462,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/glob-parent"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -8890,6 +11486,12 @@
               "url": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/glob-parent\\node_modules\\is-glob"
             }
           ]
         }
@@ -8914,6 +11516,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/glob"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -8932,6 +11540,12 @@
               "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/glob\\node_modules\\brace-expansion"
             }
           ]
         },
@@ -8952,6 +11566,12 @@
               "url": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/glob\\node_modules\\minimatch"
             }
           ]
         }
@@ -8975,6 +11595,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/global-modules"
+        }
       ]
     },
     {
@@ -8996,6 +11622,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/global-prefix"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9014,6 +11646,12 @@
               "url": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/global-prefix\\node_modules\\which"
             }
           ]
         }
@@ -9038,6 +11676,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/got"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9056,6 +11700,12 @@
               "url": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/got\\node_modules\\get-stream"
             }
           ]
         },
@@ -9076,6 +11726,12 @@
               "url": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/got\\node_modules\\pify"
             }
           ]
         }
@@ -9099,6 +11755,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/graceful-fs"
+        }
       ]
     },
     {
@@ -9120,6 +11782,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-cli"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9138,6 +11806,12 @@
               "url": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-cli\\node_modules\\nopt"
             }
           ]
         }
@@ -9162,6 +11836,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-contrib-compress"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9180,6 +11860,12 @@
               "url": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-contrib-compress\\node_modules\\ansi-styles"
             }
           ]
         },
@@ -9201,6 +11887,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-contrib-compress\\node_modules\\chalk"
+            }
           ]
         },
         {
@@ -9220,6 +11912,12 @@
               "url": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-contrib-compress\\node_modules\\supports-color"
             }
           ]
         }
@@ -9243,6 +11941,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-known-options"
+        }
       ]
     },
     {
@@ -9264,6 +11968,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-legacy-log-utils"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9282,6 +11992,12 @@
               "url": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils\\node_modules\\ansi-styles"
             }
           ]
         },
@@ -9303,6 +12019,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils\\node_modules\\chalk"
+            }
           ]
         },
         {
@@ -9322,6 +12044,12 @@
               "url": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils\\node_modules\\color-convert"
             }
           ]
         },
@@ -9343,6 +12071,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils\\node_modules\\color-name"
+            }
           ]
         },
         {
@@ -9363,6 +12097,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils\\node_modules\\has-flag"
+            }
           ]
         },
         {
@@ -9382,6 +12122,12 @@
               "url": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils\\node_modules\\supports-color"
             }
           ]
         }
@@ -9406,6 +12152,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-legacy-log"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9424,6 +12176,12 @@
               "url": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log\\node_modules\\colors"
             }
           ]
         }
@@ -9448,6 +12206,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-legacy-util"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9466,6 +12230,12 @@
               "url": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-util\\node_modules\\async"
             }
           ]
         }
@@ -9489,6 +12259,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-replace-json"
+        }
       ]
     },
     {
@@ -9510,6 +12286,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9528,6 +12310,12 @@
               "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt\\node_modules\\brace-expansion"
             }
           ]
         },
@@ -9550,6 +12338,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt\\node_modules\\findup-sync"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -9568,6 +12362,12 @@
                   "url": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/grunt\\node_modules\\findup-sync\\node_modules\\glob"
                 }
               ]
             }
@@ -9591,6 +12391,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt\\node_modules\\glob"
+            }
           ]
         },
         {
@@ -9610,6 +12416,12 @@
               "url": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.8.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt\\node_modules\\minimatch"
             }
           ]
         }
@@ -9634,6 +12446,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/handlebars"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9652,6 +12470,12 @@
               "url": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/handlebars\\node_modules\\wordwrap"
             }
           ]
         }
@@ -9675,6 +12499,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/har-schema"
+        }
       ]
     },
     {
@@ -9694,6 +12524,12 @@
           "url": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/har-validator"
         }
       ]
     },
@@ -9715,6 +12551,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-ansi"
+        }
       ]
     },
     {
@@ -9734,6 +12576,12 @@
           "url": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-bigints"
         }
       ]
     },
@@ -9755,6 +12603,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-flag"
+        }
       ]
     },
     {
@@ -9774,6 +12628,12 @@
           "url": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-property-descriptors"
         }
       ]
     },
@@ -9795,6 +12655,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-symbol-support-x"
+        }
       ]
     },
     {
@@ -9814,6 +12680,12 @@
           "url": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-symbols"
         }
       ]
     },
@@ -9835,6 +12707,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-to-string-tag-x"
+        }
       ]
     },
     {
@@ -9854,6 +12732,12 @@
           "url": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-tostringtag"
         }
       ]
     },
@@ -9875,6 +12759,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-unicode"
+        }
       ]
     },
     {
@@ -9894,6 +12784,12 @@
           "url": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-value"
         }
       ]
     },
@@ -9916,6 +12812,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-values"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9934,6 +12836,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/has-values\\node_modules\\kind-of"
             }
           ]
         }
@@ -9957,6 +12865,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has"
+        }
       ]
     },
     {
@@ -9976,6 +12890,12 @@
           "url": "https://registry.npmjs.org/hashids/-/hashids-2.2.10.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hashids"
         }
       ]
     },
@@ -9997,6 +12917,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hbs"
+        }
       ]
     },
     {
@@ -10016,6 +12942,12 @@
           "url": "https://registry.npmjs.org/he/-/he-0.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/he"
         }
       ]
     },
@@ -10037,6 +12969,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/heap"
+        }
       ]
     },
     {
@@ -10056,6 +12994,12 @@
           "url": "https://registry.npmjs.org/helmet/-/helmet-4.6.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/helmet"
         }
       ]
     },
@@ -10077,6 +13021,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hoister"
+        }
       ]
     },
     {
@@ -10096,6 +13046,12 @@
           "url": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/homedir-polyfill"
         }
       ]
     },
@@ -10117,6 +13073,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hooker"
+        }
       ]
     },
     {
@@ -10137,6 +13099,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hosted-git-info"
+        }
       ]
     },
     {
@@ -10156,6 +13124,12 @@
           "url": "https://registry.npmjs.org/html-entities/-/html-entities-1.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/html-entities"
         }
       ]
     },
@@ -10178,6 +13152,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/htmlparser2"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -10196,6 +13176,12 @@
               "url": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/htmlparser2\\node_modules\\isarray"
             }
           ]
         },
@@ -10217,6 +13203,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/htmlparser2\\node_modules\\readable-stream"
+            }
           ]
         },
         {
@@ -10236,6 +13228,12 @@
               "url": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/htmlparser2\\node_modules\\string_decoder"
             }
           ]
         }
@@ -10259,6 +13257,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/http-cache-semantics"
+        }
       ]
     },
     {
@@ -10278,6 +13282,12 @@
           "url": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/http-errors"
         }
       ]
     },
@@ -10300,6 +13310,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/http-proxy-agent"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -10318,6 +13334,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/http-proxy-agent\\node_modules\\debug"
             }
           ]
         },
@@ -10338,6 +13360,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/http-proxy-agent\\node_modules\\ms"
             }
           ]
         }
@@ -10361,6 +13389,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/http-signature"
+        }
       ]
     },
     {
@@ -10382,6 +13416,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/https-proxy-agent"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -10400,6 +13440,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/https-proxy-agent\\node_modules\\debug"
             }
           ]
         },
@@ -10420,6 +13466,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/https-proxy-agent\\node_modules\\ms"
             }
           ]
         }
@@ -10443,6 +13495,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/humanize-ms"
+        }
       ]
     },
     {
@@ -10462,6 +13520,12 @@
           "url": "https://registry.npmjs.org/i18n/-/i18n-0.11.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/i18n"
         }
       ]
     },
@@ -10483,6 +13547,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/iconv-lite"
+        }
       ]
     },
     {
@@ -10502,6 +13572,12 @@
           "url": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ieee754"
         }
       ]
     },
@@ -10524,6 +13600,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ignore-walk"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -10542,6 +13624,12 @@
               "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/ignore-walk\\node_modules\\brace-expansion"
             }
           ]
         },
@@ -10562,6 +13650,12 @@
               "url": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/ignore-walk\\node_modules\\minimatch"
             }
           ]
         }
@@ -10585,6 +13679,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/iltorb"
+        }
       ]
     },
     {
@@ -10604,6 +13704,12 @@
           "url": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/imurmurhash"
         }
       ]
     },
@@ -10625,6 +13731,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/indent-string"
+        }
       ]
     },
     {
@@ -10644,6 +13756,12 @@
           "url": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/infer-owner"
         }
       ]
     },
@@ -10665,6 +13783,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/inflection"
+        }
       ]
     },
     {
@@ -10684,6 +13808,12 @@
           "url": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/inflight"
         }
       ]
     },
@@ -10705,6 +13835,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/inherits"
+        }
       ]
     },
     {
@@ -10724,6 +13860,12 @@
           "url": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ini"
         }
       ]
     },
@@ -10745,6 +13887,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/internal-slot"
+        }
       ]
     },
     {
@@ -10764,6 +13912,12 @@
           "url": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/interpret"
         }
       ]
     },
@@ -10785,6 +13939,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/into-stream"
+        }
       ]
     },
     {
@@ -10804,6 +13964,12 @@
           "url": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/invariant"
         }
       ]
     },
@@ -10825,6 +13991,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ip"
+        }
       ]
     },
     {
@@ -10844,6 +14016,12 @@
           "url": "https://registry.npmjs.org/ip6/-/ip6-0.2.10.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ip6"
         }
       ]
     },
@@ -10865,6 +14043,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ipaddr.js"
+        }
       ]
     },
     {
@@ -10884,6 +14068,12 @@
           "url": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-absolute"
         }
       ]
     },
@@ -10905,6 +14095,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-accessor-descriptor"
+        }
       ]
     },
     {
@@ -10924,6 +14120,12 @@
           "url": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-arguments"
         }
       ]
     },
@@ -10945,6 +14147,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-arrayish"
+        }
       ]
     },
     {
@@ -10964,6 +14172,12 @@
           "url": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-bigint"
         }
       ]
     },
@@ -10985,6 +14199,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-binary-path"
+        }
       ]
     },
     {
@@ -11004,6 +14224,12 @@
           "url": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-boolean-object"
         }
       ]
     },
@@ -11025,6 +14251,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-buffer"
+        }
       ]
     },
     {
@@ -11044,6 +14276,12 @@
           "url": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-callable"
         }
       ]
     },
@@ -11065,6 +14303,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-core-module"
+        }
       ]
     },
     {
@@ -11084,6 +14328,12 @@
           "url": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-data-descriptor"
         }
       ]
     },
@@ -11105,6 +14355,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-date-object"
+        }
       ]
     },
     {
@@ -11124,6 +14380,12 @@
           "url": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-descriptor"
         }
       ]
     },
@@ -11145,6 +14407,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-docker"
+        }
       ]
     },
     {
@@ -11164,6 +14432,12 @@
           "url": "https://registry.npmjs.org/is-expression/-/is-expression-4.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-expression"
         }
       ]
     },
@@ -11185,6 +14459,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-extendable"
+        }
       ]
     },
     {
@@ -11204,6 +14484,12 @@
           "url": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-extglob"
         }
       ]
     },
@@ -11225,6 +14511,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-fullwidth-code-point"
+        }
       ]
     },
     {
@@ -11244,6 +14536,12 @@
           "url": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-generator-function"
         }
       ]
     },
@@ -11265,6 +14563,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-glob"
+        }
       ]
     },
     {
@@ -11284,6 +14588,12 @@
           "url": "https://registry.npmjs.org/is-heroku/-/is-heroku-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-heroku"
         }
       ]
     },
@@ -11305,6 +14615,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-lambda"
+        }
       ]
     },
     {
@@ -11324,6 +14640,12 @@
           "url": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-map"
         }
       ]
     },
@@ -11345,6 +14667,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-natural-number"
+        }
       ]
     },
     {
@@ -11364,6 +14692,12 @@
           "url": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-negative-zero"
         }
       ]
     },
@@ -11385,6 +14719,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-number-like"
+        }
       ]
     },
     {
@@ -11404,6 +14744,12 @@
           "url": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-number-object"
         }
       ]
     },
@@ -11426,6 +14772,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-number"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -11444,6 +14796,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/is-number\\node_modules\\kind-of"
             }
           ]
         }
@@ -11467,6 +14825,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-object"
+        }
       ]
     },
     {
@@ -11486,6 +14850,12 @@
           "url": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-plain-obj"
         }
       ]
     },
@@ -11507,6 +14877,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-plain-object"
+        }
       ]
     },
     {
@@ -11526,6 +14902,12 @@
           "url": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-promise"
         }
       ]
     },
@@ -11547,6 +14929,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-regex"
+        }
       ]
     },
     {
@@ -11566,6 +14954,12 @@
           "url": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-relative"
         }
       ]
     },
@@ -11587,6 +14981,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-retry-allowed"
+        }
       ]
     },
     {
@@ -11606,6 +15006,12 @@
           "url": "https://registry.npmjs.org/is-set/-/is-set-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-set"
         }
       ]
     },
@@ -11627,6 +15033,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-shared-array-buffer"
+        }
       ]
     },
     {
@@ -11646,6 +15058,12 @@
           "url": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-stream"
         }
       ]
     },
@@ -11667,6 +15085,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-string"
+        }
       ]
     },
     {
@@ -11686,6 +15110,12 @@
           "url": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-symbol"
         }
       ]
     },
@@ -11707,6 +15137,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-typed-array"
+        }
       ]
     },
     {
@@ -11726,6 +15162,12 @@
           "url": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-typedarray"
         }
       ]
     },
@@ -11747,6 +15189,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-unc-path"
+        }
       ]
     },
     {
@@ -11766,6 +15214,12 @@
           "url": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-weakmap"
         }
       ]
     },
@@ -11787,6 +15241,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-weakref"
+        }
       ]
     },
     {
@@ -11806,6 +15266,12 @@
           "url": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-weakset"
         }
       ]
     },
@@ -11827,6 +15293,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-windows"
+        }
       ]
     },
     {
@@ -11846,6 +15318,12 @@
           "url": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isarray"
         }
       ]
     },
@@ -11867,6 +15345,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isexe"
+        }
       ]
     },
     {
@@ -11886,6 +15370,12 @@
           "url": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isobject"
         }
       ]
     },
@@ -11907,6 +15397,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isstream"
+        }
       ]
     },
     {
@@ -11926,6 +15422,12 @@
           "url": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isurl"
         }
       ]
     },
@@ -11947,6 +15449,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/js-stringify"
+        }
       ]
     },
     {
@@ -11966,6 +15474,12 @@
           "url": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/js-tokens"
         }
       ]
     },
@@ -11987,6 +15501,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/js-yaml"
+        }
       ]
     },
     {
@@ -12006,6 +15526,12 @@
           "url": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jsbn"
         }
       ]
     },
@@ -12027,6 +15553,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-buffer"
+        }
       ]
     },
     {
@@ -12046,6 +15578,12 @@
           "url": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-parse-better-errors"
         }
       ]
     },
@@ -12067,6 +15605,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-schema-traverse"
+        }
       ]
     },
     {
@@ -12086,6 +15630,12 @@
           "url": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-schema"
         }
       ]
     },
@@ -12107,6 +15657,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-stringify-safe"
+        }
       ]
     },
     {
@@ -12126,6 +15682,12 @@
           "url": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json5"
         }
       ]
     },
@@ -12147,6 +15709,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jsonfile"
+        }
       ]
     },
     {
@@ -12166,6 +15734,12 @@
           "url": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-0.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jsonwebtoken"
         }
       ]
     },
@@ -12187,6 +15761,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jsprim"
+        }
       ]
     },
     {
@@ -12206,6 +15786,12 @@
           "url": "https://registry.npmjs.org/jssha/-/jssha-3.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jssha"
         }
       ]
     },
@@ -12227,6 +15813,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jstransformer"
+        }
       ]
     },
     {
@@ -12246,6 +15838,12 @@
           "url": "https://registry.npmjs.org/juicy-chat-bot/-/juicy-chat-bot-0.6.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/juicy-chat-bot"
         }
       ]
     },
@@ -12267,6 +15865,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jwa"
+        }
       ]
     },
     {
@@ -12286,6 +15890,12 @@
           "url": "https://registry.npmjs.org/jws/-/jws-0.2.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jws"
         }
       ]
     },
@@ -12307,6 +15917,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/keyv"
+        }
       ]
     },
     {
@@ -12326,6 +15942,12 @@
           "url": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/kind-of"
         }
       ]
     },
@@ -12347,6 +15969,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/kuler"
+        }
       ]
     },
     {
@@ -12366,6 +15994,12 @@
           "url": "https://registry.npmjs.org/kuromoji/-/kuromoji-0.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/kuromoji"
         }
       ]
     },
@@ -12387,6 +16021,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lazystream"
+        }
       ]
     },
     {
@@ -12406,6 +16046,12 @@
           "url": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/levn"
         }
       ]
     },
@@ -12428,6 +16074,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/libxmljs2"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12446,6 +16098,12 @@
               "url": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/libxmljs2\\node_modules\\nan"
             }
           ]
         }
@@ -12470,6 +16128,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/liftup"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12488,6 +16152,12 @@
               "url": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup\\node_modules\\braces"
             }
           ]
         },
@@ -12509,6 +16179,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup\\node_modules\\fill-range"
+            }
           ]
         },
         {
@@ -12528,6 +16204,12 @@
               "url": "https://registry.npmjs.org/findup-sync/-/findup-sync-4.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup\\node_modules\\findup-sync"
             }
           ]
         },
@@ -12549,6 +16231,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup\\node_modules\\is-glob"
+            }
           ]
         },
         {
@@ -12568,6 +16256,12 @@
               "url": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup\\node_modules\\is-number"
             }
           ]
         },
@@ -12589,6 +16283,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup\\node_modules\\micromatch"
+            }
           ]
         },
         {
@@ -12608,6 +16308,12 @@
               "url": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup\\node_modules\\to-regex-range"
             }
           ]
         }
@@ -12632,6 +16338,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/linebreak"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12650,6 +16362,12 @@
               "url": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/linebreak\\node_modules\\base64-js"
             }
           ]
         }
@@ -12673,6 +16391,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/listenercount"
+        }
       ]
     },
     {
@@ -12692,6 +16416,12 @@
           "url": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/locate-path"
         }
       ]
     },
@@ -12713,6 +16443,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lodash.camelcase"
+        }
       ]
     },
     {
@@ -12732,6 +16468,12 @@
           "url": "https://registry.npmjs.org/lodash.isfinite/-/lodash.isfinite-3.3.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lodash.isfinite"
         }
       ]
     },
@@ -12753,6 +16495,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lodash.set"
+        }
       ]
     },
     {
@@ -12772,6 +16520,12 @@
           "url": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lodash"
         }
       ]
     },
@@ -12794,6 +16548,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/logform"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12812,6 +16572,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/logform\\node_modules\\ms"
             }
           ]
         }
@@ -12835,6 +16601,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lolex"
+        }
       ]
     },
     {
@@ -12854,6 +16626,12 @@
           "url": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/loose-envify"
         }
       ]
     },
@@ -12875,6 +16653,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lowercase-keys"
+        }
       ]
     },
     {
@@ -12894,6 +16678,12 @@
           "url": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lru-cache"
         }
       ]
     },
@@ -12916,6 +16706,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-dir"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12934,6 +16730,12 @@
               "url": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-dir\\node_modules\\semver"
             }
           ]
         }
@@ -12957,6 +16759,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-error"
+        }
       ]
     },
     {
@@ -12976,6 +16784,12 @@
           "url": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-9.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-fetch-happen"
         }
       ],
       "components": [
@@ -12998,6 +16812,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen\\node_modules\\@tootallnate\\once"
+            }
           ]
         },
         {
@@ -13017,6 +16837,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen\\node_modules\\debug"
             }
           ]
         },
@@ -13038,6 +16864,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen\\node_modules\\http-cache-semantics"
+            }
           ]
         },
         {
@@ -13058,6 +16890,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen\\node_modules\\http-proxy-agent"
+            }
           ]
         },
         {
@@ -13077,6 +16915,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen\\node_modules\\ms"
             }
           ]
         }
@@ -13100,6 +16944,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-iterator"
+        }
       ]
     },
     {
@@ -13119,6 +16969,12 @@
           "url": "https://registry.npmjs.org/make-plural/-/make-plural-6.2.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-plural"
         }
       ]
     },
@@ -13140,6 +16996,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/map-cache"
+        }
       ]
     },
     {
@@ -13159,6 +17021,12 @@
           "url": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/map-visit"
         }
       ]
     },
@@ -13180,6 +17048,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/marsdb"
+        }
       ]
     },
     {
@@ -13199,6 +17073,12 @@
           "url": "https://registry.npmjs.org/math-interval-parser/-/math-interval-parser-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/math-interval-parser"
         }
       ]
     },
@@ -13220,6 +17100,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/media-typer"
+        }
       ]
     },
     {
@@ -13239,6 +17125,12 @@
           "url": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/merge-descriptors"
         }
       ]
     },
@@ -13260,6 +17152,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/messageformat-formatters"
+        }
       ]
     },
     {
@@ -13279,6 +17177,12 @@
           "url": "https://registry.npmjs.org/messageformat-parser/-/messageformat-parser-4.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/messageformat-parser"
         }
       ]
     },
@@ -13301,6 +17205,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/messageformat"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -13319,6 +17229,12 @@
               "url": "https://registry.npmjs.org/make-plural/-/make-plural-4.3.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/messageformat\\node_modules\\make-plural"
             }
           ]
         }
@@ -13342,6 +17258,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/methods"
+        }
       ]
     },
     {
@@ -13361,6 +17283,12 @@
           "url": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/micromatch"
         }
       ]
     },
@@ -13382,6 +17310,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mime-db"
+        }
       ]
     },
     {
@@ -13401,6 +17335,12 @@
           "url": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mime-types"
         }
       ]
     },
@@ -13422,6 +17362,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mime"
+        }
       ]
     },
     {
@@ -13441,6 +17387,12 @@
           "url": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mimic-response"
         }
       ]
     },
@@ -13462,6 +17414,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minimatch"
+        }
       ]
     },
     {
@@ -13481,6 +17439,12 @@
           "url": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minimist"
         }
       ]
     },
@@ -13502,6 +17466,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-collect"
+        }
       ]
     },
     {
@@ -13521,6 +17491,12 @@
           "url": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-1.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-fetch"
         }
       ]
     },
@@ -13542,6 +17518,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-flush"
+        }
       ]
     },
     {
@@ -13561,6 +17543,12 @@
           "url": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-pipeline"
         }
       ]
     },
@@ -13582,6 +17570,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-sized"
+        }
       ]
     },
     {
@@ -13601,6 +17595,12 @@
           "url": "https://registry.npmjs.org/minipass/-/minipass-3.3.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass"
         }
       ]
     },
@@ -13622,6 +17622,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minizlib"
+        }
       ]
     },
     {
@@ -13641,6 +17647,12 @@
           "url": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mixin-deep"
         }
       ]
     },
@@ -13662,6 +17674,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mkdirp-classic"
+        }
       ]
     },
     {
@@ -13681,6 +17699,12 @@
           "url": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mkdirp"
         }
       ]
     },
@@ -13702,6 +17726,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/moment-timezone"
+        }
       ]
     },
     {
@@ -13721,6 +17751,12 @@
           "url": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/moment"
         }
       ]
     },
@@ -13743,6 +17779,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/morgan"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -13761,6 +17803,12 @@
               "url": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/morgan\\node_modules\\on-finished"
             }
           ]
         }
@@ -13784,6 +17832,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mout"
+        }
       ]
     },
     {
@@ -13803,6 +17857,12 @@
           "url": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ms"
         }
       ]
     },
@@ -13825,6 +17885,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/multer"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -13843,6 +17909,12 @@
               "url": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/multer\\node_modules\\mkdirp"
             }
           ]
         }
@@ -13866,6 +17938,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mustache"
+        }
       ]
     },
     {
@@ -13885,6 +17963,12 @@
           "url": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/nan"
         }
       ]
     },
@@ -13906,6 +17990,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/nanomatch"
+        }
       ]
     },
     {
@@ -13925,6 +18015,12 @@
           "url": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/napi-build-utils"
         }
       ]
     },
@@ -13947,6 +18043,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/needle"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -13965,6 +18067,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/needle\\node_modules\\debug"
             }
           ]
         },
@@ -13985,6 +18093,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/needle\\node_modules\\ms"
             }
           ]
         }
@@ -14008,6 +18122,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/negotiator"
+        }
       ]
     },
     {
@@ -14027,6 +18147,12 @@
           "url": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/neo-async"
         }
       ]
     },
@@ -14049,6 +18175,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-abi"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14067,6 +18199,12 @@
               "url": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-abi\\node_modules\\semver"
             }
           ]
         }
@@ -14090,6 +18228,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-addon-api"
+        }
       ]
     },
     {
@@ -14109,6 +18253,12 @@
           "url": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-fetch"
         }
       ]
     },
@@ -14131,6 +18281,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-gyp"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14149,6 +18305,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp\\node_modules\\ansi-regex"
             }
           ]
         },
@@ -14170,6 +18332,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp\\node_modules\\are-we-there-yet"
+            }
           ]
         },
         {
@@ -14189,6 +18357,12 @@
               "url": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp\\node_modules\\gauge"
             }
           ]
         },
@@ -14210,6 +18384,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp\\node_modules\\is-fullwidth-code-point"
+            }
           ]
         },
         {
@@ -14229,6 +18409,12 @@
               "url": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp\\node_modules\\nopt"
             }
           ]
         },
@@ -14250,6 +18436,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp\\node_modules\\npmlog"
+            }
           ]
         },
         {
@@ -14269,6 +18461,12 @@
               "url": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp\\node_modules\\readable-stream"
             }
           ]
         },
@@ -14290,6 +18488,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp\\node_modules\\string-width"
+            }
           ]
         },
         {
@@ -14309,6 +18513,12 @@
               "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp\\node_modules\\strip-ansi"
             }
           ]
         }
@@ -14333,6 +18543,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-pre-gyp"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14351,6 +18567,12 @@
               "url": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp\\node_modules\\chownr"
             }
           ]
         },
@@ -14372,6 +18594,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp\\node_modules\\fs-minipass"
+            }
           ]
         },
         {
@@ -14391,6 +18619,12 @@
               "url": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp\\node_modules\\minipass"
             }
           ]
         },
@@ -14412,6 +18646,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp\\node_modules\\minizlib"
+            }
           ]
         },
         {
@@ -14431,6 +18671,12 @@
               "url": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp\\node_modules\\mkdirp"
             }
           ]
         },
@@ -14452,6 +18698,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp\\node_modules\\nopt"
+            }
           ]
         },
         {
@@ -14471,6 +18723,12 @@
               "url": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp\\node_modules\\rimraf"
             }
           ]
         },
@@ -14492,6 +18750,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp\\node_modules\\safe-buffer"
+            }
           ]
         },
         {
@@ -14511,6 +18775,12 @@
               "url": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp\\node_modules\\semver"
             }
           ]
         },
@@ -14532,6 +18802,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp\\node_modules\\tar"
+            }
           ]
         },
         {
@@ -14551,6 +18827,12 @@
               "url": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp\\node_modules\\yallist"
             }
           ]
         }
@@ -14574,6 +18856,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/noop-logger"
+        }
       ]
     },
     {
@@ -14593,6 +18881,12 @@
           "url": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/nopt"
         }
       ]
     },
@@ -14615,6 +18909,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/normalize-package-data"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14633,6 +18933,12 @@
               "url": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/normalize-package-data\\node_modules\\semver"
             }
           ]
         }
@@ -14656,6 +18962,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/normalize-path"
+        }
       ]
     },
     {
@@ -14675,6 +18987,12 @@
           "url": "https://registry.npmjs.org/normalize-url/-/normalize-url-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/normalize-url"
         }
       ]
     },
@@ -14697,6 +19015,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/notevil"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14715,6 +19039,12 @@
               "url": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/notevil\\node_modules\\esprima"
             }
           ]
         }
@@ -14738,6 +19068,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/npm-bundled"
+        }
       ]
     },
     {
@@ -14757,6 +19093,12 @@
           "url": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/npm-normalize-package-bin"
         }
       ]
     },
@@ -14778,6 +19120,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/npm-packlist"
+        }
       ]
     },
     {
@@ -14797,6 +19145,12 @@
           "url": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/npmlog"
         }
       ]
     },
@@ -14818,6 +19172,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/number-is-nan"
+        }
       ]
     },
     {
@@ -14838,6 +19198,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/oauth-sign"
+        }
       ]
     },
     {
@@ -14857,6 +19223,12 @@
           "url": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-assign"
         }
       ]
     },
@@ -14879,6 +19251,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-copy"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14897,6 +19275,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy\\node_modules\\define-property"
             }
           ]
         },
@@ -14918,6 +19302,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy\\node_modules\\is-accessor-descriptor"
+            }
           ]
         },
         {
@@ -14937,6 +19327,12 @@
               "url": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy\\node_modules\\is-data-descriptor"
             }
           ]
         },
@@ -14959,6 +19355,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy\\node_modules\\is-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -14977,6 +19379,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/object-copy\\node_modules\\is-descriptor\\node_modules\\kind-of"
                 }
               ]
             }
@@ -15000,6 +19408,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy\\node_modules\\kind-of"
+            }
           ]
         }
       ]
@@ -15022,6 +19436,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-inspect"
+        }
       ]
     },
     {
@@ -15041,6 +19461,12 @@
           "url": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-is"
         }
       ]
     },
@@ -15062,6 +19488,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-keys"
+        }
       ]
     },
     {
@@ -15081,6 +19513,12 @@
           "url": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-visit"
         }
       ]
     },
@@ -15102,6 +19540,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object.assign"
+        }
       ]
     },
     {
@@ -15121,6 +19565,12 @@
           "url": "https://registry.npmjs.org/object.defaults/-/object.defaults-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object.defaults"
         }
       ]
     },
@@ -15142,6 +19592,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object.map"
+        }
       ]
     },
     {
@@ -15161,6 +19617,12 @@
           "url": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object.pick"
         }
       ]
     },
@@ -15182,6 +19644,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/on-finished"
+        }
       ]
     },
     {
@@ -15201,6 +19669,12 @@
           "url": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/on-headers"
         }
       ]
     },
@@ -15222,6 +19696,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/once"
+        }
       ]
     },
     {
@@ -15241,6 +19721,12 @@
           "url": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/one-time"
         }
       ]
     },
@@ -15262,6 +19748,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/opentype.js"
+        }
       ]
     },
     {
@@ -15281,6 +19773,12 @@
           "url": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/optionator"
         }
       ]
     },
@@ -15302,6 +19800,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/os-homedir"
+        }
       ]
     },
     {
@@ -15321,6 +19825,12 @@
           "url": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/os-tmpdir"
         }
       ]
     },
@@ -15342,6 +19852,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/osenv"
+        }
       ]
     },
     {
@@ -15361,6 +19877,12 @@
           "url": "https://registry.npmjs.org/otplib/-/otplib-12.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/otplib"
         }
       ]
     },
@@ -15382,6 +19904,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-cancelable"
+        }
       ]
     },
     {
@@ -15401,6 +19929,12 @@
           "url": "https://registry.npmjs.org/p-event/-/p-event-2.3.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-event"
         }
       ]
     },
@@ -15422,6 +19956,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-finally"
+        }
       ]
     },
     {
@@ -15441,6 +19981,12 @@
           "url": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-is-promise"
         }
       ]
     },
@@ -15462,6 +20008,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-limit"
+        }
       ]
     },
     {
@@ -15481,6 +20033,12 @@
           "url": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-locate"
         }
       ]
     },
@@ -15502,6 +20060,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-map"
+        }
       ]
     },
     {
@@ -15521,6 +20085,12 @@
           "url": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-timeout"
         }
       ]
     },
@@ -15542,6 +20112,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-try"
+        }
       ]
     },
     {
@@ -15561,6 +20137,12 @@
           "url": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pako"
         }
       ]
     },
@@ -15582,6 +20164,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/parse-filepath"
+        }
       ]
     },
     {
@@ -15601,6 +20189,12 @@
           "url": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/parse-json"
         }
       ]
     },
@@ -15622,6 +20216,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/parse-passwd"
+        }
       ]
     },
     {
@@ -15641,6 +20241,12 @@
           "url": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/parseurl"
         }
       ]
     },
@@ -15662,6 +20268,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pascalcase"
+        }
       ]
     },
     {
@@ -15681,6 +20293,12 @@
           "url": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-exists"
         }
       ]
     },
@@ -15702,6 +20320,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-is-absolute"
+        }
       ]
     },
     {
@@ -15721,6 +20345,12 @@
           "url": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-parse"
         }
       ]
     },
@@ -15742,6 +20372,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-root-regex"
+        }
       ]
     },
     {
@@ -15761,6 +20397,12 @@
           "url": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-root"
         }
       ]
     },
@@ -15782,6 +20424,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-to-regexp"
+        }
       ]
     },
     {
@@ -15801,6 +20449,12 @@
           "url": "https://registry.npmjs.org/pdfkit/-/pdfkit-0.11.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pdfkit"
         }
       ]
     },
@@ -15822,6 +20476,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/peek-readable"
+        }
       ]
     },
     {
@@ -15841,6 +20501,12 @@
           "url": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pend"
         }
       ]
     },
@@ -15862,6 +20528,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/performance-now"
+        }
       ]
     },
     {
@@ -15881,6 +20553,12 @@
           "url": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.5.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pg-connection-string"
         }
       ]
     },
@@ -15902,6 +20580,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/picomatch"
+        }
       ]
     },
     {
@@ -15921,6 +20605,12 @@
           "url": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pify"
         }
       ]
     },
@@ -15942,6 +20632,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pinkie-promise"
+        }
       ]
     },
     {
@@ -15961,6 +20657,12 @@
           "url": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pinkie"
         }
       ]
     },
@@ -15982,6 +20684,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/png-js"
+        }
       ]
     },
     {
@@ -16001,6 +20709,12 @@
           "url": "https://registry.npmjs.org/portscanner/-/portscanner-2.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/portscanner"
         }
       ]
     },
@@ -16022,6 +20736,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/posix-character-classes"
+        }
       ]
     },
     {
@@ -16041,6 +20761,12 @@
           "url": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.3.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/prebuild-install"
         }
       ]
     },
@@ -16062,6 +20788,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/prelude-ls"
+        }
       ]
     },
     {
@@ -16081,6 +20813,12 @@
           "url": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/prepend-http"
         }
       ]
     },
@@ -16102,6 +20840,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pretty-bytes"
+        }
       ]
     },
     {
@@ -16121,6 +20865,12 @@
           "url": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/process-nextick-args"
         }
       ]
     },
@@ -16142,6 +20892,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/prom-client"
+        }
       ]
     },
     {
@@ -16161,6 +20917,12 @@
           "url": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/promise-inflight"
         }
       ]
     },
@@ -16183,6 +20945,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/promise-retry"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -16201,6 +20969,12 @@
               "url": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/promise-retry\\node_modules\\err-code"
             }
           ]
         },
@@ -16221,6 +20995,12 @@
               "url": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/promise-retry\\node_modules\\retry"
             }
           ]
         }
@@ -16244,6 +21024,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/promise"
+        }
       ]
     },
     {
@@ -16263,6 +21049,12 @@
           "url": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/proper-lockfile"
         }
       ]
     },
@@ -16284,6 +21076,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/proxy-addr"
+        }
       ]
     },
     {
@@ -16303,6 +21101,12 @@
           "url": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/psl"
         }
       ]
     },
@@ -16324,6 +21128,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-attrs"
+        }
       ]
     },
     {
@@ -16343,6 +21153,12 @@
           "url": "https://registry.npmjs.org/pug-code-gen/-/pug-code-gen-3.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-code-gen"
         }
       ]
     },
@@ -16364,6 +21180,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-error"
+        }
       ]
     },
     {
@@ -16383,6 +21205,12 @@
           "url": "https://registry.npmjs.org/pug-filters/-/pug-filters-4.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-filters"
         }
       ]
     },
@@ -16404,6 +21232,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-lexer"
+        }
       ]
     },
     {
@@ -16423,6 +21257,12 @@
           "url": "https://registry.npmjs.org/pug-linker/-/pug-linker-4.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-linker"
         }
       ]
     },
@@ -16444,6 +21284,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-load"
+        }
       ]
     },
     {
@@ -16463,6 +21309,12 @@
           "url": "https://registry.npmjs.org/pug-parser/-/pug-parser-6.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-parser"
         }
       ]
     },
@@ -16484,6 +21336,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-runtime"
+        }
       ]
     },
     {
@@ -16503,6 +21361,12 @@
           "url": "https://registry.npmjs.org/pug-strip-comments/-/pug-strip-comments-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-strip-comments"
         }
       ]
     },
@@ -16524,6 +21388,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-walk"
+        }
       ]
     },
     {
@@ -16543,6 +21413,12 @@
           "url": "https://registry.npmjs.org/pug/-/pug-3.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug"
         }
       ]
     },
@@ -16564,6 +21440,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pump"
+        }
       ]
     },
     {
@@ -16583,6 +21465,12 @@
           "url": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/punycode"
         }
       ]
     },
@@ -16604,6 +21492,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/qs"
+        }
       ]
     },
     {
@@ -16623,6 +21517,12 @@
           "url": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/query-string"
         }
       ]
     },
@@ -16644,6 +21544,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/range_check"
+        }
       ]
     },
     {
@@ -16663,6 +21569,12 @@
           "url": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/range-parser"
         }
       ]
     },
@@ -16684,6 +21596,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/raw-body"
+        }
       ]
     },
     {
@@ -16703,6 +21621,12 @@
           "url": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/rc"
         }
       ]
     },
@@ -16725,6 +21649,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/read-pkg"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -16743,6 +21673,12 @@
               "url": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/read-pkg\\node_modules\\pify"
             }
           ]
         }
@@ -16767,6 +21703,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/readable-stream"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -16785,6 +21727,12 @@
               "url": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/readable-stream\\node_modules\\isarray"
             }
           ]
         }
@@ -16809,6 +21757,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/readable-web-to-node-stream"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -16827,6 +21781,12 @@
               "url": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/readable-web-to-node-stream\\node_modules\\readable-stream"
             }
           ]
         }
@@ -16850,6 +21810,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/readdirp"
+        }
       ]
     },
     {
@@ -16869,6 +21835,12 @@
           "url": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/rechoir"
         }
       ]
     },
@@ -16890,6 +21862,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/regex-not"
+        }
       ]
     },
     {
@@ -16909,6 +21887,12 @@
           "url": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/regexp.prototype.flags"
         }
       ]
     },
@@ -16930,6 +21914,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/remove-trailing-separator"
+        }
       ]
     },
     {
@@ -16950,6 +21940,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/repeat-element"
+        }
       ]
     },
     {
@@ -16969,6 +21965,12 @@
           "url": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/repeat-string"
         }
       ]
     },
@@ -16991,6 +21993,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/replace"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17009,6 +22017,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\ansi-regex"
             }
           ]
         },
@@ -17030,6 +22044,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\ansi-styles"
+            }
           ]
         },
         {
@@ -17049,6 +22069,12 @@
               "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\brace-expansion"
             }
           ]
         },
@@ -17070,6 +22096,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\cliui"
+            }
           ]
         },
         {
@@ -17089,6 +22121,12 @@
               "url": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\color-convert"
             }
           ]
         },
@@ -17110,6 +22148,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\color-name"
+            }
           ]
         },
         {
@@ -17129,6 +22173,12 @@
               "url": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\find-up"
             }
           ]
         },
@@ -17150,6 +22200,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\is-fullwidth-code-point"
+            }
           ]
         },
         {
@@ -17169,6 +22225,12 @@
               "url": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\locate-path"
             }
           ]
         },
@@ -17190,6 +22252,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\minimatch"
+            }
           ]
         },
         {
@@ -17209,6 +22277,12 @@
               "url": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\p-locate"
             }
           ]
         },
@@ -17230,6 +22304,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\path-exists"
+            }
           ]
         },
         {
@@ -17249,6 +22329,12 @@
               "url": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\string-width"
             }
           ]
         },
@@ -17270,6 +22356,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\strip-ansi"
+            }
           ]
         },
         {
@@ -17289,6 +22381,12 @@
               "url": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\wrap-ansi"
             }
           ]
         },
@@ -17310,6 +22408,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\yargs-parser"
+            }
           ]
         },
         {
@@ -17329,6 +22433,12 @@
               "url": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\yargs"
             }
           ]
         }
@@ -17353,6 +22463,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/request"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17371,6 +22487,12 @@
               "url": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/request\\node_modules\\qs"
             }
           ]
         }
@@ -17394,6 +22516,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/require-directory"
+        }
       ]
     },
     {
@@ -17413,6 +22541,12 @@
           "url": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/require-main-filename"
         }
       ]
     },
@@ -17434,6 +22568,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/resolve-dir"
+        }
       ]
     },
     {
@@ -17453,6 +22593,12 @@
           "url": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/resolve-url"
         }
       ]
     },
@@ -17474,6 +22620,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/resolve"
+        }
       ]
     },
     {
@@ -17493,6 +22645,12 @@
           "url": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/responselike"
         }
       ]
     },
@@ -17514,6 +22672,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/restructure"
+        }
       ]
     },
     {
@@ -17533,6 +22697,12 @@
           "url": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ret"
         }
       ]
     },
@@ -17554,6 +22724,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/retry-as-promised"
+        }
       ]
     },
     {
@@ -17574,6 +22750,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/retry"
+        }
       ]
     },
     {
@@ -17593,6 +22775,12 @@
           "url": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/rimraf"
         }
       ]
     },
@@ -17615,6 +22803,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/rxjs"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17633,6 +22827,12 @@
               "url": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/rxjs\\node_modules\\tslib"
             }
           ]
         }
@@ -17656,6 +22856,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safe-buffer"
+        }
       ]
     },
     {
@@ -17675,6 +22881,12 @@
           "url": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safe-regex-test"
         }
       ]
     },
@@ -17696,6 +22908,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safe-regex"
+        }
       ]
     },
     {
@@ -17715,6 +22933,12 @@
           "url": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safe-stable-stringify"
         }
       ]
     },
@@ -17736,6 +22960,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safer-buffer"
+        }
       ]
     },
     {
@@ -17756,6 +22986,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/samsam"
+        }
       ]
     },
     {
@@ -17775,6 +23011,12 @@
           "url": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sanitize-filename"
         }
       ]
     },
@@ -17797,6 +23039,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sanitize-html"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17815,6 +23063,12 @@
               "url": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sanitize-html\\node_modules\\lodash"
             }
           ]
         }
@@ -17838,6 +23092,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sax"
+        }
       ]
     },
     {
@@ -17858,6 +23118,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/seek-bzip"
+        }
       ]
     },
     {
@@ -17877,6 +23143,12 @@
           "url": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/semver"
         }
       ]
     },
@@ -17899,6 +23171,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/send"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17917,6 +23195,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/send\\node_modules\\ms"
             }
           ]
         }
@@ -17940,6 +23224,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sequelize-pool"
+        }
       ]
     },
     {
@@ -17961,6 +23251,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sequelize"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17979,6 +23275,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sequelize\\node_modules\\debug"
             }
           ]
         },
@@ -18000,6 +23302,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sequelize\\node_modules\\ms"
+            }
           ]
         },
         {
@@ -18019,6 +23327,12 @@
               "url": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sequelize\\node_modules\\uuid"
             }
           ]
         }
@@ -18043,6 +23357,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/serve-index"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18061,6 +23381,12 @@
               "url": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index\\node_modules\\depd"
             }
           ]
         },
@@ -18082,6 +23408,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index\\node_modules\\http-errors"
+            }
           ]
         },
         {
@@ -18101,6 +23433,12 @@
               "url": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index\\node_modules\\inherits"
             }
           ]
         },
@@ -18122,6 +23460,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index\\node_modules\\setprototypeof"
+            }
           ]
         },
         {
@@ -18141,6 +23485,12 @@
               "url": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index\\node_modules\\statuses"
             }
           ]
         }
@@ -18164,6 +23514,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/serve-static"
+        }
       ]
     },
     {
@@ -18183,6 +23539,12 @@
           "url": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/set-blocking"
         }
       ]
     },
@@ -18205,6 +23567,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/set-value"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18223,6 +23591,12 @@
               "url": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/set-value\\node_modules\\extend-shallow"
             }
           ]
         },
@@ -18243,6 +23617,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/set-value\\node_modules\\is-extendable"
             }
           ]
         }
@@ -18266,6 +23646,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/setimmediate"
+        }
       ]
     },
     {
@@ -18285,6 +23671,12 @@
           "url": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/setprototypeof"
         }
       ]
     },
@@ -18306,6 +23698,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/side-channel"
+        }
       ]
     },
     {
@@ -18326,6 +23724,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/signal-exit"
+        }
       ]
     },
     {
@@ -18345,6 +23749,12 @@
           "url": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/simple-concat"
         }
       ]
     },
@@ -18367,6 +23777,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/simple-get"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18385,6 +23801,12 @@
               "url": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/simple-get\\node_modules\\decompress-response"
             }
           ]
         },
@@ -18405,6 +23827,12 @@
               "url": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/simple-get\\node_modules\\mimic-response"
             }
           ]
         }
@@ -18429,6 +23857,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/simple-swizzle"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18447,6 +23881,12 @@
               "url": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/simple-swizzle\\node_modules\\is-arrayish"
             }
           ]
         }
@@ -18470,6 +23910,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sinon"
+        }
       ]
     },
     {
@@ -18489,6 +23935,12 @@
           "url": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/smart-buffer"
         }
       ]
     },
@@ -18511,6 +23963,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/snapdragon-node"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18529,6 +23987,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon-node\\node_modules\\define-property"
             }
           ]
         }
@@ -18553,6 +24017,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/snapdragon-util"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18571,6 +24041,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon-util\\node_modules\\kind-of"
             }
           ]
         }
@@ -18595,6 +24071,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/snapdragon"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18613,6 +24095,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon\\node_modules\\define-property"
             }
           ]
         },
@@ -18633,6 +24121,12 @@
               "url": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon\\node_modules\\extend-shallow"
             }
           ]
         },
@@ -18655,6 +24149,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon\\node_modules\\is-accessor-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -18673,6 +24173,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/snapdragon\\node_modules\\is-accessor-descriptor\\node_modules\\kind-of"
                 }
               ]
             }
@@ -18697,6 +24203,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon\\node_modules\\is-data-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -18715,6 +24227,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/snapdragon\\node_modules\\is-data-descriptor\\node_modules\\kind-of"
                 }
               ]
             }
@@ -18738,6 +24256,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon\\node_modules\\is-descriptor"
+            }
           ]
         },
         {
@@ -18757,6 +24281,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon\\node_modules\\is-extendable"
             }
           ]
         },
@@ -18778,6 +24308,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon\\node_modules\\kind-of"
+            }
           ]
         },
         {
@@ -18797,6 +24333,12 @@
               "url": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon\\node_modules\\source-map"
             }
           ]
         }
@@ -18820,6 +24362,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socket.io-adapter"
+        }
       ]
     },
     {
@@ -18841,6 +24389,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socket.io-parser"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18859,6 +24413,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socket.io-parser\\node_modules\\debug"
             }
           ]
         },
@@ -18879,6 +24439,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socket.io-parser\\node_modules\\ms"
             }
           ]
         }
@@ -18903,6 +24469,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socket.io"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18921,6 +24493,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socket.io\\node_modules\\debug"
             }
           ]
         },
@@ -18941,6 +24519,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socket.io\\node_modules\\ms"
             }
           ]
         }
@@ -18965,6 +24549,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socks-proxy-agent"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18983,6 +24573,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socks-proxy-agent\\node_modules\\debug"
             }
           ]
         },
@@ -19003,6 +24599,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socks-proxy-agent\\node_modules\\ms"
             }
           ]
         }
@@ -19027,6 +24629,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socks"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -19045,6 +24653,12 @@
               "url": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socks\\node_modules\\ip"
             }
           ]
         }
@@ -19069,6 +24683,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sort-keys-length"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -19087,6 +24707,12 @@
               "url": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sort-keys-length\\node_modules\\sort-keys"
             }
           ]
         }
@@ -19110,6 +24736,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sort-keys"
+        }
       ]
     },
     {
@@ -19129,6 +24761,12 @@
           "url": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/source-map-resolve"
         }
       ]
     },
@@ -19150,6 +24788,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/source-map-support"
+        }
       ]
     },
     {
@@ -19169,6 +24813,12 @@
           "url": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/source-map-url"
         }
       ]
     },
@@ -19190,6 +24840,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/source-map"
+        }
       ]
     },
     {
@@ -19209,6 +24865,12 @@
           "url": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2-1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spawn-command"
         }
       ]
     },
@@ -19230,6 +24892,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spdx-correct"
+        }
       ]
     },
     {
@@ -19249,6 +24917,12 @@
           "url": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spdx-exceptions"
         }
       ]
     },
@@ -19270,6 +24944,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spdx-expression-parse"
+        }
       ]
     },
     {
@@ -19289,6 +24969,12 @@
           "url": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.12.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spdx-license-ids"
         }
       ]
     },
@@ -19310,6 +24996,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/split-string"
+        }
       ]
     },
     {
@@ -19329,6 +25021,12 @@
           "url": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sprintf-js"
         }
       ]
     },
@@ -19350,6 +25048,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sqlite3"
+        }
       ]
     },
     {
@@ -19369,6 +25073,12 @@
           "url": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sshpk"
         }
       ]
     },
@@ -19390,6 +25100,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ssri"
+        }
       ]
     },
     {
@@ -19409,6 +25125,12 @@
           "url": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/stack-trace"
         }
       ]
     },
@@ -19431,6 +25153,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/static-extend"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -19449,6 +25177,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend\\node_modules\\define-property"
             }
           ]
         },
@@ -19471,6 +25205,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend\\node_modules\\is-accessor-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -19489,6 +25229,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/static-extend\\node_modules\\is-accessor-descriptor\\node_modules\\kind-of"
                 }
               ]
             }
@@ -19513,6 +25259,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend\\node_modules\\is-data-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -19531,6 +25283,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/static-extend\\node_modules\\is-data-descriptor\\node_modules\\kind-of"
                 }
               ]
             }
@@ -19554,6 +25312,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend\\node_modules\\is-descriptor"
+            }
           ]
         },
         {
@@ -19573,6 +25337,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend\\node_modules\\kind-of"
             }
           ]
         }
@@ -19596,6 +25366,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/statuses"
+        }
       ]
     },
     {
@@ -19615,6 +25391,12 @@
           "url": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-2.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/stream-buffers"
         }
       ]
     },
@@ -19636,6 +25418,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/streamsearch"
+        }
       ]
     },
     {
@@ -19655,6 +25443,12 @@
           "url": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strict-uri-encode"
         }
       ]
     },
@@ -19676,6 +25470,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string_decoder"
+        }
       ]
     },
     {
@@ -19695,6 +25495,12 @@
           "url": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string-width"
         }
       ]
     },
@@ -19716,6 +25522,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string.fromcodepoint"
+        }
       ]
     },
     {
@@ -19735,6 +25547,12 @@
           "url": "https://registry.npmjs.org/string.prototype.codepointat/-/string.prototype.codepointat-0.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string.prototype.codepointat"
         }
       ]
     },
@@ -19756,6 +25574,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string.prototype.trimend"
+        }
       ]
     },
     {
@@ -19775,6 +25599,12 @@
           "url": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string.prototype.trimstart"
         }
       ]
     },
@@ -19796,6 +25626,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-ansi"
+        }
       ]
     },
     {
@@ -19815,6 +25651,12 @@
           "url": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-bom"
         }
       ]
     },
@@ -19836,6 +25678,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-dirs"
+        }
       ]
     },
     {
@@ -19855,6 +25703,12 @@
           "url": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-json-comments"
         }
       ]
     },
@@ -19876,6 +25730,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-outer"
+        }
       ]
     },
     {
@@ -19895,6 +25755,12 @@
           "url": "https://registry.npmjs.org/strtok3/-/strtok3-6.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strtok3"
         }
       ]
     },
@@ -19916,6 +25782,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/supports-color"
+        }
       ]
     },
     {
@@ -19935,6 +25807,12 @@
           "url": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/supports-preserve-symlinks-flag"
         }
       ]
     },
@@ -19956,6 +25834,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/svg-captcha"
+        }
       ]
     },
     {
@@ -19976,6 +25860,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/swagger-ui-dist"
+        }
       ]
     },
     {
@@ -19995,6 +25885,12 @@
           "url": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-4.5.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/swagger-ui-express"
         }
       ]
     },
@@ -20017,6 +25913,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tar-fs"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -20035,6 +25937,12 @@
               "url": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/tar-fs\\node_modules\\bl"
             }
           ]
         },
@@ -20056,6 +25964,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/tar-fs\\node_modules\\chownr"
+            }
           ]
         },
         {
@@ -20076,6 +25990,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/tar-fs\\node_modules\\readable-stream"
+            }
           ]
         },
         {
@@ -20095,6 +26015,12 @@
               "url": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/tar-fs\\node_modules\\tar-stream"
             }
           ]
         }
@@ -20118,6 +26044,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tar-stream"
+        }
       ]
     },
     {
@@ -20137,6 +26069,12 @@
           "url": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tar"
         }
       ]
     },
@@ -20158,6 +26096,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tdigest"
+        }
       ]
     },
     {
@@ -20177,6 +26121,12 @@
           "url": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/text-hex"
         }
       ]
     },
@@ -20198,6 +26148,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/thirty-two"
+        }
       ]
     },
     {
@@ -20217,6 +26173,12 @@
           "url": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/through"
         }
       ]
     },
@@ -20238,6 +26200,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/timed-out"
+        }
       ]
     },
     {
@@ -20257,6 +26225,12 @@
           "url": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tiny-inflate"
         }
       ]
     },
@@ -20278,6 +26252,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-buffer"
+        }
       ]
     },
     {
@@ -20297,6 +26277,12 @@
           "url": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-fast-properties"
         }
       ]
     },
@@ -20319,6 +26305,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-object-path"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -20337,6 +26329,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/to-object-path\\node_modules\\kind-of"
             }
           ]
         }
@@ -20360,6 +26358,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-regex-range"
+        }
       ]
     },
     {
@@ -20379,6 +26383,12 @@
           "url": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-regex"
         }
       ]
     },
@@ -20400,6 +26410,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/toidentifier"
+        }
       ]
     },
     {
@@ -20419,6 +26435,12 @@
           "url": "https://registry.npmjs.org/token-stream/-/token-stream-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/token-stream"
         }
       ]
     },
@@ -20440,6 +26462,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/token-types"
+        }
       ]
     },
     {
@@ -20459,6 +26487,12 @@
           "url": "https://registry.npmjs.org/toposort-class/-/toposort-class-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/toposort-class"
         }
       ]
     },
@@ -20480,6 +26514,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tough-cookie"
+        }
       ]
     },
     {
@@ -20499,6 +26539,12 @@
           "url": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tr46"
         }
       ]
     },
@@ -20520,6 +26566,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/traverse"
+        }
       ]
     },
     {
@@ -20539,6 +26591,12 @@
           "url": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tree-kill"
         }
       ]
     },
@@ -20560,6 +26618,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/trim-repeated"
+        }
       ]
     },
     {
@@ -20580,6 +26644,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/triple-beam"
+        }
       ]
     },
     {
@@ -20599,6 +26669,12 @@
           "url": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/truncate-utf8-bytes"
         }
       ]
     },
@@ -20621,6 +26697,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ts-node-dev"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -20639,6 +26721,12 @@
               "url": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/ts-node-dev\\node_modules\\rimraf"
             }
           ]
         }
@@ -20662,6 +26750,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ts-node"
+        }
       ]
     },
     {
@@ -20681,6 +26775,12 @@
           "url": "https://registry.npmjs.org/tsconfig/-/tsconfig-7.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tsconfig"
         }
       ]
     },
@@ -20702,6 +26802,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tslib"
+        }
       ]
     },
     {
@@ -20721,6 +26827,12 @@
           "url": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tunnel-agent"
         }
       ]
     },
@@ -20742,6 +26854,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tweetnacl"
+        }
       ]
     },
     {
@@ -20761,6 +26879,12 @@
           "url": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/type-check"
         }
       ]
     },
@@ -20782,6 +26906,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/type-is"
+        }
       ]
     },
     {
@@ -20801,6 +26931,12 @@
           "url": "https://registry.npmjs.org/typecast/-/typecast-0.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/typecast"
         }
       ]
     },
@@ -20822,6 +26958,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/typedarray"
+        }
       ]
     },
     {
@@ -20841,6 +26983,12 @@
           "url": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/typescript"
         }
       ]
     },
@@ -20862,6 +27010,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/uglify-js"
+        }
       ]
     },
     {
@@ -20881,6 +27035,12 @@
           "url": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unbox-primitive"
         }
       ]
     },
@@ -20902,6 +27062,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unbzip2-stream"
+        }
       ]
     },
     {
@@ -20921,6 +27087,12 @@
           "url": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unc-path-regex"
         }
       ]
     },
@@ -20942,6 +27114,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/underscore.string"
+        }
       ]
     },
     {
@@ -20962,6 +27140,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unicode-properties"
+        }
       ]
     },
     {
@@ -20981,6 +27165,12 @@
           "url": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unicode-trie"
         }
       ]
     },
@@ -21003,6 +27193,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/union-value"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21021,6 +27217,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/union-value\\node_modules\\is-extendable"
             }
           ]
         }
@@ -21044,6 +27246,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unique-filename"
+        }
       ]
     },
     {
@@ -21063,6 +27271,12 @@
           "url": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unique-slug"
         }
       ]
     },
@@ -21084,6 +27298,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unit-compare"
+        }
       ]
     },
     {
@@ -21104,6 +27324,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/universalify"
+        }
       ]
     },
     {
@@ -21123,6 +27349,12 @@
           "url": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unpipe"
         }
       ]
     },
@@ -21145,6 +27377,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unset-value"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21165,6 +27403,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/unset-value\\node_modules\\has-value"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -21183,6 +27427,12 @@
                   "url": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/unset-value\\node_modules\\has-value\\node_modules\\isobject"
                 }
               ]
             }
@@ -21206,6 +27456,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/unset-value\\node_modules\\has-values"
+            }
           ]
         },
         {
@@ -21225,6 +27481,12 @@
               "url": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/unset-value\\node_modules\\isarray"
             }
           ]
         }
@@ -21248,6 +27510,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/untildify"
+        }
       ]
     },
     {
@@ -21269,6 +27537,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unzipper"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21287,6 +27561,12 @@
               "url": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/unzipper\\node_modules\\bluebird"
             }
           ]
         }
@@ -21310,6 +27590,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/uri-js"
+        }
       ]
     },
     {
@@ -21329,6 +27615,12 @@
           "url": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/urix"
         }
       ]
     },
@@ -21350,6 +27642,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/url-parse-lax"
+        }
       ]
     },
     {
@@ -21369,6 +27667,12 @@
           "url": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/url-to-options"
         }
       ]
     },
@@ -21390,6 +27694,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/use"
+        }
       ]
     },
     {
@@ -21409,6 +27719,12 @@
           "url": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/utf8-byte-length"
         }
       ]
     },
@@ -21430,6 +27746,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/util-deprecate"
+        }
       ]
     },
     {
@@ -21449,6 +27771,12 @@
           "url": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/util"
         }
       ]
     },
@@ -21470,6 +27798,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/utils-merge"
+        }
       ]
     },
     {
@@ -21489,6 +27823,12 @@
           "url": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/uuid"
         }
       ]
     },
@@ -21510,6 +27850,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/v8flags"
+        }
       ]
     },
     {
@@ -21529,6 +27875,12 @@
           "url": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/validate-npm-package-license"
         }
       ]
     },
@@ -21550,6 +27902,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/validate"
+        }
       ]
     },
     {
@@ -21570,6 +27928,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/validator"
+        }
       ]
     },
     {
@@ -21589,6 +27953,12 @@
           "url": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/vary"
         }
       ]
     },
@@ -21611,6 +27981,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/verror"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21629,6 +28005,12 @@
               "url": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/verror\\node_modules\\core-util-is"
             }
           ]
         }
@@ -21653,6 +28035,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/vm2"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21671,6 +28059,12 @@
               "url": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/vm2\\node_modules\\acorn"
             }
           ]
         }
@@ -21694,6 +28088,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/void-elements"
+        }
       ]
     },
     {
@@ -21713,6 +28113,12 @@
           "url": "https://registry.npmjs.org/walk/-/walk-2.3.15.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/walk"
         }
       ]
     },
@@ -21734,6 +28140,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/walkdir"
+        }
       ]
     },
     {
@@ -21753,6 +28165,12 @@
           "url": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/webidl-conversions"
         }
       ]
     },
@@ -21774,6 +28192,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/whatwg-url"
+        }
       ]
     },
     {
@@ -21793,6 +28217,12 @@
           "url": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-boxed-primitive"
         }
       ]
     },
@@ -21814,6 +28244,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-collection"
+        }
       ]
     },
     {
@@ -21833,6 +28269,12 @@
           "url": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-module"
         }
       ]
     },
@@ -21854,6 +28296,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-pm-runs"
+        }
       ]
     },
     {
@@ -21873,6 +28321,12 @@
           "url": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-typed-array"
         }
       ]
     },
@@ -21894,6 +28348,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which"
+        }
       ]
     },
     {
@@ -21913,6 +28373,12 @@
           "url": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wide-align"
         }
       ]
     },
@@ -21935,6 +28401,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/winston-transport"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21953,6 +28425,12 @@
               "url": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/winston-transport\\node_modules\\readable-stream"
             }
           ]
         }
@@ -21977,6 +28455,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/winston"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21995,6 +28479,12 @@
               "url": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/winston\\node_modules\\async"
             }
           ]
         },
@@ -22016,6 +28506,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/winston\\node_modules\\is-stream"
+            }
           ]
         },
         {
@@ -22035,6 +28531,12 @@
               "url": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/winston\\node_modules\\readable-stream"
             }
           ]
         }
@@ -22058,6 +28560,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/with"
+        }
       ]
     },
     {
@@ -22077,6 +28585,12 @@
           "url": "https://registry.npmjs.org/wkx/-/wkx-0.5.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wkx"
         }
       ]
     },
@@ -22098,6 +28612,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/word-wrap"
+        }
       ]
     },
     {
@@ -22117,6 +28637,12 @@
           "url": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wordwrap"
         }
       ]
     },
@@ -22139,6 +28665,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wrap-ansi"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -22157,6 +28689,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi\\node_modules\\ansi-regex"
             }
           ]
         },
@@ -22178,6 +28716,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi\\node_modules\\emoji-regex"
+            }
           ]
         },
         {
@@ -22197,6 +28741,12 @@
               "url": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi\\node_modules\\is-fullwidth-code-point"
             }
           ]
         },
@@ -22218,6 +28768,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi\\node_modules\\string-width"
+            }
           ]
         },
         {
@@ -22237,6 +28793,12 @@
               "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi\\node_modules\\strip-ansi"
             }
           ]
         }
@@ -22260,6 +28822,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wrappy"
+        }
       ]
     },
     {
@@ -22279,6 +28847,12 @@
           "url": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ws"
         }
       ]
     },
@@ -22300,6 +28874,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/xtend"
+        }
       ]
     },
     {
@@ -22319,6 +28899,12 @@
           "url": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/y18n"
         }
       ]
     },
@@ -22340,6 +28926,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yallist"
+        }
       ]
     },
     {
@@ -22360,6 +28952,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yaml-schema-validator"
+        }
       ]
     },
     {
@@ -22379,6 +28977,12 @@
           "url": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yargs-parser"
         }
       ]
     },
@@ -22401,6 +29005,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yargs"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -22419,6 +29029,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs\\node_modules\\ansi-regex"
             }
           ]
         },
@@ -22440,6 +29056,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs\\node_modules\\emoji-regex"
+            }
           ]
         },
         {
@@ -22459,6 +29081,12 @@
               "url": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs\\node_modules\\is-fullwidth-code-point"
             }
           ]
         },
@@ -22480,6 +29108,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs\\node_modules\\string-width"
+            }
           ]
         },
         {
@@ -22499,6 +29133,12 @@
               "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs\\node_modules\\strip-ansi"
             }
           ]
         }
@@ -22522,6 +29162,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yauzl"
+        }
       ]
     },
     {
@@ -22541,6 +29187,12 @@
           "url": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yn"
         }
       ]
     },
@@ -22562,6 +29214,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/z85"
+        }
       ]
     },
     {
@@ -22582,6 +29240,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/zip-stream"
+        }
       ]
     },
     {
@@ -22601,6 +29265,12 @@
           "url": "https://registry.npmjs.org/zlibjs/-/zlibjs-0.3.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/zlibjs"
         }
       ]
     }

--- a/tests/_data/sbom_demo-results/juice-shop_npm7_node16_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/juice-shop_npm7_node16_windows-latest.snap.json
@@ -62,7 +62,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -95,7 +95,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@babel\\helper-string-parser"
         }
       ]
@@ -122,7 +122,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@babel\\helper-validator-identifier"
         }
       ]
@@ -149,7 +149,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@babel\\parser"
         }
       ]
@@ -176,7 +176,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@babel\\types"
         }
       ]
@@ -203,7 +203,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@colors\\colors"
         }
       ]
@@ -230,7 +230,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@dabh\\diagnostics"
         }
       ]
@@ -257,7 +257,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@gar\\promisify"
         }
       ]
@@ -284,7 +284,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@mapbox\\node-pre-gyp"
         }
       ],
@@ -310,7 +310,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\ansi-regex"
             }
           ]
@@ -336,7 +336,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\are-we-there-yet"
             }
           ]
@@ -362,7 +362,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\detect-libc"
             }
           ]
@@ -388,7 +388,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\gauge"
             }
           ]
@@ -414,7 +414,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\is-fullwidth-code-point"
             }
           ]
@@ -440,7 +440,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\make-dir"
             }
           ],
@@ -466,7 +466,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\make-dir\\node_modules\\semver"
                 }
               ]
@@ -494,7 +494,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\nopt"
             }
           ]
@@ -520,7 +520,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\npmlog"
             }
           ]
@@ -546,7 +546,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\readable-stream"
             }
           ]
@@ -572,7 +572,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\string-width"
             }
           ]
@@ -598,7 +598,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\strip-ansi"
             }
           ]
@@ -627,7 +627,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\core-loader"
         }
       ]
@@ -654,7 +654,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\core"
         }
       ]
@@ -681,7 +681,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\evaluator"
         }
       ]
@@ -708,7 +708,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-all"
         }
       ]
@@ -735,7 +735,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-ar"
         }
       ]
@@ -762,7 +762,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-bn"
         }
       ]
@@ -789,7 +789,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-ca"
         }
       ]
@@ -816,7 +816,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-cs"
         }
       ]
@@ -843,7 +843,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-da"
         }
       ]
@@ -870,7 +870,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-de"
         }
       ]
@@ -897,7 +897,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-el"
         }
       ]
@@ -924,7 +924,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-en-min"
         }
       ]
@@ -951,7 +951,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-en"
         }
       ]
@@ -978,7 +978,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-es"
         }
       ]
@@ -1005,7 +1005,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-eu"
         }
       ]
@@ -1032,7 +1032,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-fa"
         }
       ]
@@ -1059,7 +1059,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-fi"
         }
       ]
@@ -1086,7 +1086,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-fr"
         }
       ]
@@ -1113,7 +1113,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-ga"
         }
       ]
@@ -1140,7 +1140,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-gl"
         }
       ]
@@ -1167,7 +1167,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-hi"
         }
       ]
@@ -1194,7 +1194,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-hu"
         }
       ]
@@ -1221,7 +1221,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-hy"
         }
       ]
@@ -1248,7 +1248,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-id"
         }
       ]
@@ -1275,7 +1275,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-it"
         }
       ]
@@ -1302,7 +1302,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-ja"
         }
       ]
@@ -1329,7 +1329,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-ko"
         }
       ]
@@ -1356,7 +1356,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-lt"
         }
       ]
@@ -1383,7 +1383,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-ms"
         }
       ]
@@ -1410,7 +1410,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-ne"
         }
       ]
@@ -1437,7 +1437,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-nl"
         }
       ]
@@ -1464,7 +1464,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-no"
         }
       ]
@@ -1491,7 +1491,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-pl"
         }
       ]
@@ -1518,7 +1518,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-pt"
         }
       ]
@@ -1545,7 +1545,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-ro"
         }
       ]
@@ -1572,7 +1572,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-ru"
         }
       ]
@@ -1599,7 +1599,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-sl"
         }
       ]
@@ -1626,7 +1626,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-sr"
         }
       ]
@@ -1653,7 +1653,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-sv"
         }
       ]
@@ -1680,7 +1680,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-ta"
         }
       ]
@@ -1707,7 +1707,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-th"
         }
       ]
@@ -1734,7 +1734,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-tl"
         }
       ]
@@ -1761,7 +1761,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-tr"
         }
       ]
@@ -1788,7 +1788,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-uk"
         }
       ]
@@ -1815,7 +1815,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-zh"
         }
       ]
@@ -1842,7 +1842,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\language-min"
         }
       ]
@@ -1869,7 +1869,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\language"
         }
       ]
@@ -1896,7 +1896,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\ner"
         }
       ]
@@ -1923,7 +1923,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\neural"
         }
       ]
@@ -1950,7 +1950,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\nlg"
         }
       ]
@@ -1977,7 +1977,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\nlp"
         }
       ]
@@ -2004,7 +2004,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\nlu"
         }
       ]
@@ -2031,7 +2031,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\request"
         }
       ]
@@ -2058,7 +2058,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\sentiment"
         }
       ]
@@ -2085,7 +2085,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\similarity"
         }
       ]
@@ -2112,7 +2112,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\slot"
         }
       ]
@@ -2139,7 +2139,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@npmcli\\fs"
         }
       ]
@@ -2166,7 +2166,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@npmcli\\move-file"
         }
       ]
@@ -2193,7 +2193,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib\\core"
         }
       ]
@@ -2220,7 +2220,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib\\plugin-crypto"
         }
       ]
@@ -2247,7 +2247,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib\\plugin-thirty-two"
         }
       ]
@@ -2274,7 +2274,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib\\preset-default"
         }
       ]
@@ -2301,7 +2301,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib\\preset-v11"
         }
       ]
@@ -2328,7 +2328,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@sindresorhus\\is"
         }
       ]
@@ -2355,7 +2355,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@swc\\helpers"
         }
       ]
@@ -2382,7 +2382,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@tokenizer\\token"
         }
       ]
@@ -2409,7 +2409,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@tootallnate\\once"
         }
       ]
@@ -2436,7 +2436,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types\\component-emitter"
         }
       ]
@@ -2463,7 +2463,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types\\cookie"
         }
       ]
@@ -2490,7 +2490,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types\\cors"
         }
       ]
@@ -2517,7 +2517,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types\\debug"
         }
       ]
@@ -2544,7 +2544,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types\\ms"
         }
       ]
@@ -2571,7 +2571,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types\\node"
         }
       ]
@@ -2598,7 +2598,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types\\strip-bom"
         }
       ]
@@ -2625,7 +2625,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types\\strip-json-comments"
         }
       ]
@@ -2652,7 +2652,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types\\validator"
         }
       ]
@@ -2678,7 +2678,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/abbrev"
         }
       ]
@@ -2704,7 +2704,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/accepts"
         }
       ]
@@ -2730,7 +2730,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/acorn-walk"
         }
       ]
@@ -2756,7 +2756,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/acorn"
         }
       ]
@@ -2782,7 +2782,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/agent-base"
         }
       ],
@@ -2808,7 +2808,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agent-base\\node_modules\\debug"
             }
           ]
@@ -2834,7 +2834,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agent-base\\node_modules\\ms"
             }
           ]
@@ -2862,7 +2862,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/agentkeepalive"
         }
       ],
@@ -2888,7 +2888,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agentkeepalive\\node_modules\\debug"
             }
           ]
@@ -2914,7 +2914,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agentkeepalive\\node_modules\\depd"
             }
           ]
@@ -2940,7 +2940,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agentkeepalive\\node_modules\\ms"
             }
           ]
@@ -2968,7 +2968,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/aggregate-error"
         }
       ]
@@ -2994,7 +2994,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ajv"
         }
       ]
@@ -3020,7 +3020,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ansi-regex"
         }
       ]
@@ -3046,7 +3046,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ansi-styles"
         }
       ]
@@ -3072,7 +3072,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/anymatch"
         }
       ],
@@ -3098,7 +3098,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/anymatch\\node_modules\\normalize-path"
             }
           ]
@@ -3126,7 +3126,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/append-field"
         }
       ]
@@ -3152,7 +3152,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/aproba"
         }
       ]
@@ -3178,7 +3178,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/archive-type"
         }
       ],
@@ -3204,7 +3204,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/archive-type\\node_modules\\file-type"
             }
           ]
@@ -3232,7 +3232,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/archiver-utils"
         }
       ]
@@ -3258,7 +3258,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/archiver"
         }
       ]
@@ -3284,7 +3284,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/are-we-there-yet"
         }
       ]
@@ -3310,7 +3310,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/arg"
         }
       ]
@@ -3336,7 +3336,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/argparse"
         }
       ],
@@ -3362,7 +3362,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/argparse\\node_modules\\sprintf-js"
             }
           ]
@@ -3390,7 +3390,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/arr-diff"
         }
       ]
@@ -3416,7 +3416,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/arr-flatten"
         }
       ]
@@ -3442,7 +3442,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/arr-union"
         }
       ]
@@ -3468,7 +3468,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/array-each"
         }
       ]
@@ -3494,7 +3494,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/array-flatten"
         }
       ]
@@ -3520,7 +3520,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/array-slice"
         }
       ]
@@ -3546,7 +3546,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/array-unique"
         }
       ]
@@ -3572,7 +3572,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/asap"
         }
       ]
@@ -3598,7 +3598,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/asn1"
         }
       ]
@@ -3624,7 +3624,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/assert-never"
         }
       ]
@@ -3650,7 +3650,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/assert-plus"
         }
       ]
@@ -3676,7 +3676,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/assign-symbols"
         }
       ]
@@ -3702,7 +3702,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/async"
         }
       ]
@@ -3728,7 +3728,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/asynckit"
         }
       ]
@@ -3754,7 +3754,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/at-least-node"
         }
       ]
@@ -3780,7 +3780,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/atob"
         }
       ]
@@ -3806,7 +3806,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/available-typed-arrays"
         }
       ]
@@ -3832,7 +3832,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/aws-sign2"
         }
       ]
@@ -3858,7 +3858,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/aws4"
         }
       ]
@@ -3884,7 +3884,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/babel-walk"
         }
       ]
@@ -3910,7 +3910,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/balanced-match"
         }
       ]
@@ -3936,7 +3936,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base"
         }
       ],
@@ -3962,7 +3962,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/base\\node_modules\\define-property"
             }
           ]
@@ -3990,7 +3990,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base64-arraybuffer"
         }
       ]
@@ -4016,7 +4016,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base64-js"
         }
       ]
@@ -4042,7 +4042,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base64id"
         }
       ]
@@ -4068,7 +4068,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base64url"
         }
       ]
@@ -4094,7 +4094,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/basic-auth"
         }
       ]
@@ -4120,7 +4120,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/batch"
         }
       ]
@@ -4146,7 +4146,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bcrypt-pbkdf"
         }
       ]
@@ -4172,7 +4172,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/big-integer"
         }
       ]
@@ -4198,7 +4198,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/binary-extensions"
         }
       ]
@@ -4224,7 +4224,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/binary"
         }
       ]
@@ -4250,7 +4250,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bindings"
         }
       ]
@@ -4276,7 +4276,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bintrees"
         }
       ]
@@ -4302,7 +4302,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bl"
         }
       ]
@@ -4328,7 +4328,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bluebird"
         }
       ]
@@ -4354,7 +4354,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/body-parser"
         }
       ]
@@ -4380,7 +4380,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bower-config"
         }
       ],
@@ -4406,7 +4406,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bower-config\\node_modules\\minimist"
             }
           ]
@@ -4434,7 +4434,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/brace-expansion"
         }
       ]
@@ -4460,7 +4460,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/braces"
         }
       ],
@@ -4486,7 +4486,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/braces\\node_modules\\extend-shallow"
             }
           ]
@@ -4512,7 +4512,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/braces\\node_modules\\is-extendable"
             }
           ]
@@ -4540,7 +4540,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/brotli"
         }
       ]
@@ -4566,7 +4566,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-alloc-unsafe"
         }
       ]
@@ -4592,7 +4592,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-alloc"
         }
       ]
@@ -4618,7 +4618,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-crc32"
         }
       ]
@@ -4644,7 +4644,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-fill"
         }
       ]
@@ -4670,7 +4670,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-from"
         }
       ]
@@ -4696,7 +4696,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-indexof-polyfill"
         }
       ]
@@ -4722,7 +4722,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer"
         }
       ]
@@ -4748,7 +4748,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffers"
         }
       ]
@@ -4774,7 +4774,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/busboy"
         }
       ],
@@ -4800,7 +4800,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/busboy\\node_modules\\isarray"
             }
           ]
@@ -4826,7 +4826,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/busboy\\node_modules\\readable-stream"
             }
           ]
@@ -4852,7 +4852,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/busboy\\node_modules\\string_decoder"
             }
           ]
@@ -4880,7 +4880,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/byline"
         }
       ]
@@ -4906,7 +4906,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bytes"
         }
       ]
@@ -4932,7 +4932,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cacache"
         }
       ]
@@ -4958,7 +4958,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cache-base"
         }
       ]
@@ -4984,7 +4984,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cacheable-request"
         }
       ],
@@ -5010,7 +5010,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cacheable-request\\node_modules\\get-stream"
             }
           ]
@@ -5036,7 +5036,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cacheable-request\\node_modules\\lowercase-keys"
             }
           ]
@@ -5064,7 +5064,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/call-bind"
         }
       ]
@@ -5090,7 +5090,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/camelcase"
         }
       ]
@@ -5116,7 +5116,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/caseless"
         }
       ]
@@ -5142,7 +5142,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/chainsaw"
         }
       ]
@@ -5168,7 +5168,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/chalk"
         }
       ]
@@ -5194,7 +5194,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/character-parser"
         }
       ]
@@ -5220,7 +5220,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/check-dependencies"
         }
       ],
@@ -5246,7 +5246,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/check-dependencies\\node_modules\\semver"
             }
           ]
@@ -5274,7 +5274,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/check-types"
         }
       ]
@@ -5300,7 +5300,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/chokidar"
         }
       ],
@@ -5326,7 +5326,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar\\node_modules\\braces"
             }
           ]
@@ -5352,7 +5352,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar\\node_modules\\fill-range"
             }
           ]
@@ -5378,7 +5378,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar\\node_modules\\is-glob"
             }
           ]
@@ -5404,7 +5404,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar\\node_modules\\is-number"
             }
           ]
@@ -5430,7 +5430,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar\\node_modules\\normalize-path"
             }
           ]
@@ -5456,7 +5456,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar\\node_modules\\to-regex-range"
             }
           ]
@@ -5484,7 +5484,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/chownr"
         }
       ]
@@ -5510,7 +5510,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/clarinet"
         }
       ]
@@ -5536,7 +5536,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/class-utils"
         }
       ],
@@ -5562,7 +5562,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils\\node_modules\\define-property"
             }
           ]
@@ -5588,7 +5588,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils\\node_modules\\is-accessor-descriptor"
             }
           ],
@@ -5614,7 +5614,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/class-utils\\node_modules\\is-accessor-descriptor\\node_modules\\kind-of"
                 }
               ]
@@ -5642,7 +5642,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils\\node_modules\\is-data-descriptor"
             }
           ],
@@ -5668,7 +5668,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/class-utils\\node_modules\\is-data-descriptor\\node_modules\\kind-of"
                 }
               ]
@@ -5696,7 +5696,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils\\node_modules\\is-descriptor"
             }
           ]
@@ -5722,7 +5722,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils\\node_modules\\kind-of"
             }
           ]
@@ -5750,7 +5750,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/clean-stack"
         }
       ]
@@ -5776,7 +5776,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cliui"
         }
       ],
@@ -5802,7 +5802,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui\\node_modules\\ansi-regex"
             }
           ]
@@ -5828,7 +5828,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui\\node_modules\\emoji-regex"
             }
           ]
@@ -5854,7 +5854,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui\\node_modules\\is-fullwidth-code-point"
             }
           ]
@@ -5880,7 +5880,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui\\node_modules\\string-width"
             }
           ]
@@ -5906,7 +5906,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui\\node_modules\\strip-ansi"
             }
           ]
@@ -5934,7 +5934,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/clone-response"
         }
       ]
@@ -5960,7 +5960,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/clone"
         }
       ]
@@ -5986,7 +5986,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/code-point-at"
         }
       ]
@@ -6012,7 +6012,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/collection-visit"
         }
       ]
@@ -6038,7 +6038,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color-convert"
         }
       ]
@@ -6064,7 +6064,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color-name"
         }
       ]
@@ -6090,7 +6090,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color-string"
         }
       ]
@@ -6116,7 +6116,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color-support"
         }
       ]
@@ -6142,7 +6142,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color"
         }
       ]
@@ -6168,7 +6168,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/colors"
         }
       ]
@@ -6194,7 +6194,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/colorspace"
         }
       ]
@@ -6220,7 +6220,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/combined-stream"
         }
       ]
@@ -6246,7 +6246,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/commander"
         }
       ]
@@ -6272,7 +6272,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/component-emitter"
         }
       ]
@@ -6298,7 +6298,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/component-type"
         }
       ]
@@ -6324,7 +6324,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/compress-commons"
         }
       ]
@@ -6350,7 +6350,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/compressible"
         }
       ]
@@ -6376,7 +6376,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/compression"
         }
       ],
@@ -6402,7 +6402,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/compression\\node_modules\\bytes"
             }
           ]
@@ -6430,7 +6430,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/concat-map"
         }
       ]
@@ -6456,7 +6456,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/concat-stream"
         }
       ]
@@ -6482,7 +6482,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/concurrently"
         }
       ],
@@ -6508,7 +6508,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/concurrently\\node_modules\\supports-color"
             }
           ]
@@ -6536,7 +6536,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/config"
         }
       ]
@@ -6562,7 +6562,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/console-control-strings"
         }
       ]
@@ -6588,7 +6588,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/constantinople"
         }
       ]
@@ -6614,7 +6614,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/content-disposition"
         }
       ],
@@ -6640,7 +6640,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/content-disposition\\node_modules\\safe-buffer"
             }
           ]
@@ -6668,7 +6668,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/content-type"
         }
       ]
@@ -6694,7 +6694,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cookie-parser"
         }
       ]
@@ -6720,7 +6720,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cookie-signature"
         }
       ]
@@ -6746,7 +6746,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cookie"
         }
       ]
@@ -6772,7 +6772,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/copy-descriptor"
         }
       ]
@@ -6798,7 +6798,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/core-util-is"
         }
       ]
@@ -6824,7 +6824,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cors"
         }
       ]
@@ -6850,7 +6850,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/crc"
         }
       ]
@@ -6876,7 +6876,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/crc32-stream"
         }
       ]
@@ -6902,7 +6902,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/create-require"
         }
       ]
@@ -6928,7 +6928,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/crypto-js"
         }
       ]
@@ -6954,7 +6954,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dashdash"
         }
       ]
@@ -6980,7 +6980,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/date-fns"
         }
       ]
@@ -7006,7 +7006,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dateformat"
         }
       ]
@@ -7032,7 +7032,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/debug"
         }
       ]
@@ -7058,7 +7058,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decamelize"
         }
       ]
@@ -7084,7 +7084,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decode-uri-component"
         }
       ]
@@ -7110,7 +7110,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-response"
         }
       ]
@@ -7136,7 +7136,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-tar"
         }
       ],
@@ -7162,7 +7162,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-tar\\node_modules\\file-type"
             }
           ]
@@ -7190,7 +7190,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-tarbz2"
         }
       ],
@@ -7216,7 +7216,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-tarbz2\\node_modules\\file-type"
             }
           ]
@@ -7244,7 +7244,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-targz"
         }
       ],
@@ -7270,7 +7270,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-targz\\node_modules\\file-type"
             }
           ]
@@ -7298,7 +7298,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-unzip"
         }
       ],
@@ -7324,7 +7324,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-unzip\\node_modules\\file-type"
             }
           ]
@@ -7350,7 +7350,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-unzip\\node_modules\\get-stream"
             }
           ]
@@ -7376,7 +7376,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-unzip\\node_modules\\pify"
             }
           ]
@@ -7404,7 +7404,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress"
         }
       ],
@@ -7430,7 +7430,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress\\node_modules\\make-dir"
             }
           ],
@@ -7456,7 +7456,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/decompress\\node_modules\\make-dir\\node_modules\\pify"
                 }
               ]
@@ -7484,7 +7484,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress\\node_modules\\pify"
             }
           ]
@@ -7512,7 +7512,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/deep-equal"
         }
       ]
@@ -7538,7 +7538,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/deep-extend"
         }
       ]
@@ -7564,7 +7564,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/deep-is"
         }
       ]
@@ -7590,7 +7590,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/define-properties"
         }
       ]
@@ -7616,7 +7616,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/define-property"
         }
       ]
@@ -7642,7 +7642,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/delayed-stream"
         }
       ]
@@ -7668,7 +7668,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/delegates"
         }
       ]
@@ -7694,7 +7694,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/depd"
         }
       ]
@@ -7720,7 +7720,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/destroy"
         }
       ]
@@ -7746,7 +7746,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/detect-file"
         }
       ]
@@ -7772,7 +7772,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/detect-libc"
         }
       ]
@@ -7798,7 +7798,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dfa"
         }
       ]
@@ -7824,7 +7824,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dicer"
         }
       ],
@@ -7850,7 +7850,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/dicer\\node_modules\\isarray"
             }
           ]
@@ -7876,7 +7876,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/dicer\\node_modules\\readable-stream"
             }
           ]
@@ -7902,7 +7902,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/dicer\\node_modules\\string_decoder"
             }
           ]
@@ -7930,7 +7930,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/diff"
         }
       ]
@@ -7956,7 +7956,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/doctypes"
         }
       ]
@@ -7982,7 +7982,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/domelementtype"
         }
       ]
@@ -8008,7 +8008,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/domhandler"
         }
       ]
@@ -8034,7 +8034,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/domutils"
         }
       ]
@@ -8060,7 +8060,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dottie"
         }
       ]
@@ -8086,7 +8086,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/double-ended-queue"
         }
       ]
@@ -8112,7 +8112,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/doublearray"
         }
       ]
@@ -8138,7 +8138,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/download"
         }
       ],
@@ -8164,7 +8164,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/download\\node_modules\\file-type"
             }
           ]
@@ -8192,7 +8192,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/duplexer2"
         }
       ]
@@ -8218,7 +8218,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/duplexer3"
         }
       ]
@@ -8244,7 +8244,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dynamic-dedupe"
         }
       ]
@@ -8270,7 +8270,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ecc-jsbn"
         }
       ]
@@ -8296,7 +8296,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ee-first"
         }
       ]
@@ -8322,7 +8322,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/eivindfjeldstad-dot"
         }
       ]
@@ -8348,7 +8348,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/emoji-regex"
         }
       ]
@@ -8374,7 +8374,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/enabled"
         }
       ]
@@ -8400,7 +8400,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/encodeurl"
         }
       ]
@@ -8426,7 +8426,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/encoding"
         }
       ],
@@ -8452,7 +8452,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/encoding\\node_modules\\iconv-lite"
             }
           ]
@@ -8480,7 +8480,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/end-of-stream"
         }
       ]
@@ -8506,7 +8506,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/engine.io-parser"
         }
       ]
@@ -8532,7 +8532,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/engine.io"
         }
       ],
@@ -8558,7 +8558,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/engine.io\\node_modules\\debug"
             }
           ]
@@ -8584,7 +8584,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/engine.io\\node_modules\\ms"
             }
           ]
@@ -8612,7 +8612,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/env-paths"
         }
       ]
@@ -8638,7 +8638,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/err-code"
         }
       ]
@@ -8664,7 +8664,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/error-ex"
         }
       ]
@@ -8690,7 +8690,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/errorhandler"
         }
       ]
@@ -8716,7 +8716,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/es-abstract"
         }
       ]
@@ -8742,7 +8742,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/es-get-iterator"
         }
       ]
@@ -8768,7 +8768,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/es-to-primitive"
         }
       ]
@@ -8794,7 +8794,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/escape-html"
         }
       ]
@@ -8820,7 +8820,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/escape-string-regexp"
         }
       ]
@@ -8846,7 +8846,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/escodegen"
         }
       ]
@@ -8872,7 +8872,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/esprima"
         }
       ]
@@ -8898,7 +8898,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/estraverse"
         }
       ]
@@ -8924,7 +8924,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/esutils"
         }
       ]
@@ -8950,7 +8950,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/etag"
         }
       ]
@@ -8976,7 +8976,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/eventemitter2"
         }
       ]
@@ -9002,7 +9002,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/eventemitter3"
         }
       ]
@@ -9028,7 +9028,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/exif"
         }
       ]
@@ -9054,7 +9054,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/exit"
         }
       ]
@@ -9080,7 +9080,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/expand-brackets"
         }
       ],
@@ -9106,7 +9106,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets\\node_modules\\define-property"
             }
           ]
@@ -9132,7 +9132,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets\\node_modules\\extend-shallow"
             }
           ]
@@ -9158,7 +9158,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets\\node_modules\\is-accessor-descriptor"
             }
           ],
@@ -9184,7 +9184,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/expand-brackets\\node_modules\\is-accessor-descriptor\\node_modules\\kind-of"
                 }
               ]
@@ -9212,7 +9212,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets\\node_modules\\is-data-descriptor"
             }
           ],
@@ -9238,7 +9238,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/expand-brackets\\node_modules\\is-data-descriptor\\node_modules\\kind-of"
                 }
               ]
@@ -9266,7 +9266,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets\\node_modules\\is-descriptor"
             }
           ]
@@ -9292,7 +9292,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets\\node_modules\\is-extendable"
             }
           ]
@@ -9318,7 +9318,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets\\node_modules\\kind-of"
             }
           ]
@@ -9346,7 +9346,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/expand-template"
         }
       ]
@@ -9372,7 +9372,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/expand-tilde"
         }
       ]
@@ -9398,7 +9398,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-ipfilter"
         }
       ]
@@ -9424,7 +9424,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-jwt"
         }
       ],
@@ -9450,7 +9450,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/express-jwt\\node_modules\\jsonwebtoken"
             }
           ]
@@ -9476,7 +9476,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/express-jwt\\node_modules\\moment"
             }
           ]
@@ -9504,7 +9504,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-rate-limit"
         }
       ]
@@ -9530,7 +9530,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-robots-txt"
         }
       ]
@@ -9556,7 +9556,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-security.txt"
         }
       ]
@@ -9582,7 +9582,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express"
         }
       ],
@@ -9608,7 +9608,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/express\\node_modules\\cookie"
             }
           ]
@@ -9634,7 +9634,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/express\\node_modules\\safe-buffer"
             }
           ]
@@ -9662,7 +9662,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ext-list"
         }
       ]
@@ -9688,7 +9688,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ext-name"
         }
       ]
@@ -9714,7 +9714,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/extend-shallow"
         }
       ]
@@ -9740,7 +9740,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/extend"
         }
       ]
@@ -9766,7 +9766,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/extglob"
         }
       ],
@@ -9792,7 +9792,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/extglob\\node_modules\\define-property"
             }
           ]
@@ -9818,7 +9818,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/extglob\\node_modules\\extend-shallow"
             }
           ]
@@ -9844,7 +9844,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/extglob\\node_modules\\is-extendable"
             }
           ]
@@ -9872,7 +9872,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/extsprintf"
         }
       ]
@@ -9898,7 +9898,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fast-deep-equal"
         }
       ]
@@ -9924,7 +9924,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fast-json-stable-stringify"
         }
       ]
@@ -9950,7 +9950,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fast-levenshtein"
         }
       ]
@@ -9976,7 +9976,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fast.js"
         }
       ]
@@ -10002,7 +10002,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fd-slicer"
         }
       ]
@@ -10028,7 +10028,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/feature-policy"
         }
       ]
@@ -10054,7 +10054,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fecha"
         }
       ]
@@ -10080,7 +10080,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/file-js"
         }
       ],
@@ -10106,7 +10106,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/file-js\\node_modules\\brace-expansion"
             }
           ]
@@ -10132,7 +10132,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/file-js\\node_modules\\minimatch"
             }
           ]
@@ -10160,7 +10160,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/file-stream-rotator"
         }
       ]
@@ -10186,7 +10186,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/file-type"
         }
       ]
@@ -10212,7 +10212,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/file-uri-to-path"
         }
       ]
@@ -10238,7 +10238,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/filehound"
         }
       ]
@@ -10264,7 +10264,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/filename-reserved-regex"
         }
       ]
@@ -10290,7 +10290,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/filenamify"
         }
       ]
@@ -10316,7 +10316,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/filesniffer"
         }
       ]
@@ -10342,7 +10342,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fill-range"
         }
       ],
@@ -10368,7 +10368,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/fill-range\\node_modules\\extend-shallow"
             }
           ]
@@ -10394,7 +10394,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/fill-range\\node_modules\\is-extendable"
             }
           ]
@@ -10422,7 +10422,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/finale-rest"
         }
       ]
@@ -10448,7 +10448,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/finalhandler"
         }
       ]
@@ -10474,7 +10474,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/find-up"
         }
       ]
@@ -10500,7 +10500,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/findup-sync"
         }
       ]
@@ -10526,7 +10526,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fined"
         }
       ]
@@ -10552,7 +10552,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/flagged-respawn"
         }
       ]
@@ -10578,7 +10578,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fn.name"
         }
       ]
@@ -10604,7 +10604,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fontkit"
         }
       ]
@@ -10630,7 +10630,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/for-each"
         }
       ]
@@ -10656,7 +10656,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/for-in"
         }
       ]
@@ -10682,7 +10682,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/for-own"
         }
       ]
@@ -10708,7 +10708,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/foreachasync"
         }
       ]
@@ -10734,7 +10734,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/forever-agent"
         }
       ]
@@ -10760,7 +10760,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/form-data"
         }
       ]
@@ -10786,7 +10786,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/formatio"
         }
       ]
@@ -10812,7 +10812,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/forwarded"
         }
       ]
@@ -10838,7 +10838,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fragment-cache"
         }
       ]
@@ -10864,7 +10864,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fresh"
         }
       ]
@@ -10890,7 +10890,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/from2"
         }
       ]
@@ -10916,7 +10916,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fs-constants"
         }
       ]
@@ -10942,7 +10942,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fs-extra"
         }
       ]
@@ -10968,7 +10968,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fs-minipass"
         }
       ]
@@ -10994,7 +10994,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fs.realpath"
         }
       ]
@@ -11020,7 +11020,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fstream"
         }
       ],
@@ -11046,7 +11046,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/fstream\\node_modules\\mkdirp"
             }
           ]
@@ -11072,7 +11072,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/fstream\\node_modules\\rimraf"
             }
           ]
@@ -11100,7 +11100,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/function-bind"
         }
       ]
@@ -11126,7 +11126,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/function.prototype.name"
         }
       ]
@@ -11152,7 +11152,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/functions-have-names"
         }
       ]
@@ -11178,7 +11178,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fuzzball"
         }
       ]
@@ -11204,7 +11204,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/gauge"
         }
       ]
@@ -11230,7 +11230,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/geojson-utils"
         }
       ]
@@ -11256,7 +11256,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-caller-file"
         }
       ]
@@ -11282,7 +11282,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-intrinsic"
         }
       ]
@@ -11308,7 +11308,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-stream"
         }
       ]
@@ -11334,7 +11334,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-symbol-description"
         }
       ]
@@ -11360,7 +11360,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-value"
         }
       ]
@@ -11386,7 +11386,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/getobject"
         }
       ]
@@ -11412,7 +11412,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/getpass"
         }
       ]
@@ -11438,7 +11438,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/github-from-package"
         }
       ]
@@ -11464,7 +11464,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/glob-parent"
         }
       ],
@@ -11490,7 +11490,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/glob-parent\\node_modules\\is-glob"
             }
           ]
@@ -11518,7 +11518,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/glob"
         }
       ],
@@ -11544,7 +11544,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/glob\\node_modules\\brace-expansion"
             }
           ]
@@ -11570,7 +11570,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/glob\\node_modules\\minimatch"
             }
           ]
@@ -11598,7 +11598,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/global-modules"
         }
       ]
@@ -11624,7 +11624,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/global-prefix"
         }
       ],
@@ -11650,7 +11650,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/global-prefix\\node_modules\\which"
             }
           ]
@@ -11678,7 +11678,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/got"
         }
       ],
@@ -11704,7 +11704,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/got\\node_modules\\get-stream"
             }
           ]
@@ -11730,7 +11730,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/got\\node_modules\\pify"
             }
           ]
@@ -11758,7 +11758,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/graceful-fs"
         }
       ]
@@ -11784,7 +11784,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-cli"
         }
       ],
@@ -11810,7 +11810,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-cli\\node_modules\\nopt"
             }
           ]
@@ -11838,7 +11838,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-contrib-compress"
         }
       ],
@@ -11864,7 +11864,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-contrib-compress\\node_modules\\ansi-styles"
             }
           ]
@@ -11890,7 +11890,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-contrib-compress\\node_modules\\chalk"
             }
           ]
@@ -11916,7 +11916,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-contrib-compress\\node_modules\\supports-color"
             }
           ]
@@ -11944,7 +11944,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-known-options"
         }
       ]
@@ -11970,7 +11970,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-legacy-log-utils"
         }
       ],
@@ -11996,7 +11996,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils\\node_modules\\ansi-styles"
             }
           ]
@@ -12022,7 +12022,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils\\node_modules\\chalk"
             }
           ]
@@ -12048,7 +12048,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils\\node_modules\\color-convert"
             }
           ]
@@ -12074,7 +12074,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils\\node_modules\\color-name"
             }
           ]
@@ -12100,7 +12100,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils\\node_modules\\has-flag"
             }
           ]
@@ -12126,7 +12126,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils\\node_modules\\supports-color"
             }
           ]
@@ -12154,7 +12154,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-legacy-log"
         }
       ],
@@ -12180,7 +12180,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log\\node_modules\\colors"
             }
           ]
@@ -12208,7 +12208,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-legacy-util"
         }
       ],
@@ -12234,7 +12234,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-util\\node_modules\\async"
             }
           ]
@@ -12262,7 +12262,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-replace-json"
         }
       ]
@@ -12288,7 +12288,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt"
         }
       ],
@@ -12314,7 +12314,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt\\node_modules\\brace-expansion"
             }
           ]
@@ -12340,7 +12340,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt\\node_modules\\findup-sync"
             }
           ],
@@ -12366,7 +12366,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/grunt\\node_modules\\findup-sync\\node_modules\\glob"
                 }
               ]
@@ -12394,7 +12394,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt\\node_modules\\glob"
             }
           ]
@@ -12420,7 +12420,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt\\node_modules\\minimatch"
             }
           ]
@@ -12448,7 +12448,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/handlebars"
         }
       ],
@@ -12474,7 +12474,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/handlebars\\node_modules\\wordwrap"
             }
           ]
@@ -12502,7 +12502,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/har-schema"
         }
       ]
@@ -12528,7 +12528,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/har-validator"
         }
       ]
@@ -12554,7 +12554,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-ansi"
         }
       ]
@@ -12580,7 +12580,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-bigints"
         }
       ]
@@ -12606,7 +12606,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-flag"
         }
       ]
@@ -12632,7 +12632,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-property-descriptors"
         }
       ]
@@ -12658,7 +12658,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-symbol-support-x"
         }
       ]
@@ -12684,7 +12684,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-symbols"
         }
       ]
@@ -12710,7 +12710,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-to-string-tag-x"
         }
       ]
@@ -12736,7 +12736,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-tostringtag"
         }
       ]
@@ -12762,7 +12762,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-unicode"
         }
       ]
@@ -12788,7 +12788,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-value"
         }
       ]
@@ -12814,7 +12814,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-values"
         }
       ],
@@ -12840,7 +12840,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/has-values\\node_modules\\kind-of"
             }
           ]
@@ -12868,7 +12868,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has"
         }
       ]
@@ -12894,7 +12894,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hashids"
         }
       ]
@@ -12920,7 +12920,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hbs"
         }
       ]
@@ -12946,7 +12946,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/he"
         }
       ]
@@ -12972,7 +12972,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/heap"
         }
       ]
@@ -12998,7 +12998,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/helmet"
         }
       ]
@@ -13024,7 +13024,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hoister"
         }
       ]
@@ -13050,7 +13050,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/homedir-polyfill"
         }
       ]
@@ -13076,7 +13076,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hooker"
         }
       ]
@@ -13102,7 +13102,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hosted-git-info"
         }
       ]
@@ -13128,7 +13128,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/html-entities"
         }
       ]
@@ -13154,7 +13154,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/htmlparser2"
         }
       ],
@@ -13180,7 +13180,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/htmlparser2\\node_modules\\isarray"
             }
           ]
@@ -13206,7 +13206,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/htmlparser2\\node_modules\\readable-stream"
             }
           ]
@@ -13232,7 +13232,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/htmlparser2\\node_modules\\string_decoder"
             }
           ]
@@ -13260,7 +13260,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/http-cache-semantics"
         }
       ]
@@ -13286,7 +13286,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/http-errors"
         }
       ]
@@ -13312,7 +13312,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/http-proxy-agent"
         }
       ],
@@ -13338,7 +13338,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/http-proxy-agent\\node_modules\\debug"
             }
           ]
@@ -13364,7 +13364,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/http-proxy-agent\\node_modules\\ms"
             }
           ]
@@ -13392,7 +13392,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/http-signature"
         }
       ]
@@ -13418,7 +13418,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/https-proxy-agent"
         }
       ],
@@ -13444,7 +13444,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/https-proxy-agent\\node_modules\\debug"
             }
           ]
@@ -13470,7 +13470,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/https-proxy-agent\\node_modules\\ms"
             }
           ]
@@ -13498,7 +13498,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/humanize-ms"
         }
       ]
@@ -13524,7 +13524,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/i18n"
         }
       ]
@@ -13550,7 +13550,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/iconv-lite"
         }
       ]
@@ -13576,7 +13576,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ieee754"
         }
       ]
@@ -13602,7 +13602,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ignore-walk"
         }
       ],
@@ -13628,7 +13628,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/ignore-walk\\node_modules\\brace-expansion"
             }
           ]
@@ -13654,7 +13654,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/ignore-walk\\node_modules\\minimatch"
             }
           ]
@@ -13682,7 +13682,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/iltorb"
         }
       ]
@@ -13708,7 +13708,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/imurmurhash"
         }
       ]
@@ -13734,7 +13734,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/indent-string"
         }
       ]
@@ -13760,7 +13760,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/infer-owner"
         }
       ]
@@ -13786,7 +13786,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/inflection"
         }
       ]
@@ -13812,7 +13812,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/inflight"
         }
       ]
@@ -13838,7 +13838,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/inherits"
         }
       ]
@@ -13864,7 +13864,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ini"
         }
       ]
@@ -13890,7 +13890,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/internal-slot"
         }
       ]
@@ -13916,7 +13916,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/interpret"
         }
       ]
@@ -13942,7 +13942,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/into-stream"
         }
       ]
@@ -13968,7 +13968,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/invariant"
         }
       ]
@@ -13994,7 +13994,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ip"
         }
       ]
@@ -14020,7 +14020,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ip6"
         }
       ]
@@ -14046,7 +14046,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ipaddr.js"
         }
       ]
@@ -14072,7 +14072,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-absolute"
         }
       ]
@@ -14098,7 +14098,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-accessor-descriptor"
         }
       ]
@@ -14124,7 +14124,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-arguments"
         }
       ]
@@ -14150,7 +14150,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-arrayish"
         }
       ]
@@ -14176,7 +14176,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-bigint"
         }
       ]
@@ -14202,7 +14202,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-binary-path"
         }
       ]
@@ -14228,7 +14228,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-boolean-object"
         }
       ]
@@ -14254,7 +14254,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-buffer"
         }
       ]
@@ -14280,7 +14280,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-callable"
         }
       ]
@@ -14306,7 +14306,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-core-module"
         }
       ]
@@ -14332,7 +14332,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-data-descriptor"
         }
       ]
@@ -14358,7 +14358,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-date-object"
         }
       ]
@@ -14384,7 +14384,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-descriptor"
         }
       ]
@@ -14410,7 +14410,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-docker"
         }
       ]
@@ -14436,7 +14436,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-expression"
         }
       ]
@@ -14462,7 +14462,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-extendable"
         }
       ]
@@ -14488,7 +14488,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-extglob"
         }
       ]
@@ -14514,7 +14514,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-fullwidth-code-point"
         }
       ]
@@ -14540,7 +14540,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-generator-function"
         }
       ]
@@ -14566,7 +14566,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-glob"
         }
       ]
@@ -14592,7 +14592,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-heroku"
         }
       ]
@@ -14618,7 +14618,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-lambda"
         }
       ]
@@ -14644,7 +14644,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-map"
         }
       ]
@@ -14670,7 +14670,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-natural-number"
         }
       ]
@@ -14696,7 +14696,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-negative-zero"
         }
       ]
@@ -14722,7 +14722,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-number-like"
         }
       ]
@@ -14748,7 +14748,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-number-object"
         }
       ]
@@ -14774,7 +14774,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-number"
         }
       ],
@@ -14800,7 +14800,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/is-number\\node_modules\\kind-of"
             }
           ]
@@ -14828,7 +14828,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-object"
         }
       ]
@@ -14854,7 +14854,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-plain-obj"
         }
       ]
@@ -14880,7 +14880,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-plain-object"
         }
       ]
@@ -14906,7 +14906,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-promise"
         }
       ]
@@ -14932,7 +14932,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-regex"
         }
       ]
@@ -14958,7 +14958,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-relative"
         }
       ]
@@ -14984,7 +14984,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-retry-allowed"
         }
       ]
@@ -15010,7 +15010,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-set"
         }
       ]
@@ -15036,7 +15036,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-shared-array-buffer"
         }
       ]
@@ -15062,7 +15062,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-stream"
         }
       ]
@@ -15088,7 +15088,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-string"
         }
       ]
@@ -15114,7 +15114,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-symbol"
         }
       ]
@@ -15140,7 +15140,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-typed-array"
         }
       ]
@@ -15166,7 +15166,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-typedarray"
         }
       ]
@@ -15192,7 +15192,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-unc-path"
         }
       ]
@@ -15218,7 +15218,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-weakmap"
         }
       ]
@@ -15244,7 +15244,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-weakref"
         }
       ]
@@ -15270,7 +15270,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-weakset"
         }
       ]
@@ -15296,7 +15296,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-windows"
         }
       ]
@@ -15322,7 +15322,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isarray"
         }
       ]
@@ -15348,7 +15348,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isexe"
         }
       ]
@@ -15374,7 +15374,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isobject"
         }
       ]
@@ -15400,7 +15400,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isstream"
         }
       ]
@@ -15426,7 +15426,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isurl"
         }
       ]
@@ -15452,7 +15452,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/js-stringify"
         }
       ]
@@ -15478,7 +15478,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/js-tokens"
         }
       ]
@@ -15504,7 +15504,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/js-yaml"
         }
       ]
@@ -15530,7 +15530,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jsbn"
         }
       ]
@@ -15556,7 +15556,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-buffer"
         }
       ]
@@ -15582,7 +15582,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-parse-better-errors"
         }
       ]
@@ -15608,7 +15608,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-schema-traverse"
         }
       ]
@@ -15634,7 +15634,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-schema"
         }
       ]
@@ -15660,7 +15660,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-stringify-safe"
         }
       ]
@@ -15686,7 +15686,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json5"
         }
       ]
@@ -15712,7 +15712,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jsonfile"
         }
       ]
@@ -15738,7 +15738,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jsonwebtoken"
         }
       ]
@@ -15764,7 +15764,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jsprim"
         }
       ]
@@ -15790,7 +15790,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jssha"
         }
       ]
@@ -15816,7 +15816,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jstransformer"
         }
       ]
@@ -15842,7 +15842,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/juicy-chat-bot"
         }
       ]
@@ -15868,7 +15868,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jwa"
         }
       ]
@@ -15894,7 +15894,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jws"
         }
       ]
@@ -15920,7 +15920,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/keyv"
         }
       ]
@@ -15946,7 +15946,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/kind-of"
         }
       ]
@@ -15972,7 +15972,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/kuler"
         }
       ]
@@ -15998,7 +15998,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/kuromoji"
         }
       ]
@@ -16024,7 +16024,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lazystream"
         }
       ]
@@ -16050,7 +16050,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/levn"
         }
       ]
@@ -16076,7 +16076,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/libxmljs2"
         }
       ],
@@ -16102,7 +16102,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/libxmljs2\\node_modules\\nan"
             }
           ]
@@ -16130,7 +16130,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/liftup"
         }
       ],
@@ -16156,7 +16156,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup\\node_modules\\braces"
             }
           ]
@@ -16182,7 +16182,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup\\node_modules\\fill-range"
             }
           ]
@@ -16208,7 +16208,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup\\node_modules\\findup-sync"
             }
           ]
@@ -16234,7 +16234,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup\\node_modules\\is-glob"
             }
           ]
@@ -16260,7 +16260,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup\\node_modules\\is-number"
             }
           ]
@@ -16286,7 +16286,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup\\node_modules\\micromatch"
             }
           ]
@@ -16312,7 +16312,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup\\node_modules\\to-regex-range"
             }
           ]
@@ -16340,7 +16340,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/linebreak"
         }
       ],
@@ -16366,7 +16366,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/linebreak\\node_modules\\base64-js"
             }
           ]
@@ -16394,7 +16394,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/listenercount"
         }
       ]
@@ -16420,7 +16420,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/locate-path"
         }
       ]
@@ -16446,7 +16446,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lodash.camelcase"
         }
       ]
@@ -16472,7 +16472,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lodash.isfinite"
         }
       ]
@@ -16498,7 +16498,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lodash.set"
         }
       ]
@@ -16524,7 +16524,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lodash"
         }
       ]
@@ -16550,7 +16550,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/logform"
         }
       ],
@@ -16576,7 +16576,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/logform\\node_modules\\ms"
             }
           ]
@@ -16604,7 +16604,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lolex"
         }
       ]
@@ -16630,7 +16630,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/loose-envify"
         }
       ]
@@ -16656,7 +16656,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lowercase-keys"
         }
       ]
@@ -16682,7 +16682,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lru-cache"
         }
       ]
@@ -16708,7 +16708,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-dir"
         }
       ],
@@ -16734,7 +16734,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-dir\\node_modules\\semver"
             }
           ]
@@ -16762,7 +16762,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-error"
         }
       ]
@@ -16788,7 +16788,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-fetch-happen"
         }
       ],
@@ -16815,7 +16815,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen\\node_modules\\@tootallnate\\once"
             }
           ]
@@ -16841,7 +16841,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen\\node_modules\\debug"
             }
           ]
@@ -16867,7 +16867,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen\\node_modules\\http-cache-semantics"
             }
           ]
@@ -16893,7 +16893,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen\\node_modules\\http-proxy-agent"
             }
           ]
@@ -16919,7 +16919,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen\\node_modules\\ms"
             }
           ]
@@ -16947,7 +16947,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-iterator"
         }
       ]
@@ -16973,7 +16973,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-plural"
         }
       ]
@@ -16999,7 +16999,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/map-cache"
         }
       ]
@@ -17025,7 +17025,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/map-visit"
         }
       ]
@@ -17051,7 +17051,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/marsdb"
         }
       ]
@@ -17077,7 +17077,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/math-interval-parser"
         }
       ]
@@ -17103,7 +17103,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/media-typer"
         }
       ]
@@ -17129,7 +17129,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/merge-descriptors"
         }
       ]
@@ -17155,7 +17155,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/messageformat-formatters"
         }
       ]
@@ -17181,7 +17181,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/messageformat-parser"
         }
       ]
@@ -17207,7 +17207,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/messageformat"
         }
       ],
@@ -17233,7 +17233,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/messageformat\\node_modules\\make-plural"
             }
           ]
@@ -17261,7 +17261,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/methods"
         }
       ]
@@ -17287,7 +17287,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/micromatch"
         }
       ]
@@ -17313,7 +17313,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mime-db"
         }
       ]
@@ -17339,7 +17339,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mime-types"
         }
       ]
@@ -17365,7 +17365,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mime"
         }
       ]
@@ -17391,7 +17391,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mimic-response"
         }
       ]
@@ -17417,7 +17417,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minimatch"
         }
       ]
@@ -17443,7 +17443,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minimist"
         }
       ]
@@ -17469,7 +17469,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-collect"
         }
       ]
@@ -17495,7 +17495,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-fetch"
         }
       ]
@@ -17521,7 +17521,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-flush"
         }
       ]
@@ -17547,7 +17547,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-pipeline"
         }
       ]
@@ -17573,7 +17573,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-sized"
         }
       ]
@@ -17599,7 +17599,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass"
         }
       ]
@@ -17625,7 +17625,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minizlib"
         }
       ]
@@ -17651,7 +17651,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mixin-deep"
         }
       ]
@@ -17677,7 +17677,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mkdirp-classic"
         }
       ]
@@ -17703,7 +17703,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mkdirp"
         }
       ]
@@ -17729,7 +17729,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/moment-timezone"
         }
       ]
@@ -17755,7 +17755,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/moment"
         }
       ]
@@ -17781,7 +17781,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/morgan"
         }
       ],
@@ -17807,7 +17807,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/morgan\\node_modules\\on-finished"
             }
           ]
@@ -17835,7 +17835,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mout"
         }
       ]
@@ -17861,7 +17861,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ms"
         }
       ]
@@ -17887,7 +17887,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/multer"
         }
       ],
@@ -17913,7 +17913,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/multer\\node_modules\\mkdirp"
             }
           ]
@@ -17941,7 +17941,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mustache"
         }
       ]
@@ -17967,7 +17967,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/nan"
         }
       ]
@@ -17993,7 +17993,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/nanomatch"
         }
       ]
@@ -18019,7 +18019,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/napi-build-utils"
         }
       ]
@@ -18045,7 +18045,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/needle"
         }
       ],
@@ -18071,7 +18071,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/needle\\node_modules\\debug"
             }
           ]
@@ -18097,7 +18097,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/needle\\node_modules\\ms"
             }
           ]
@@ -18125,7 +18125,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/negotiator"
         }
       ]
@@ -18151,7 +18151,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/neo-async"
         }
       ]
@@ -18177,7 +18177,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-abi"
         }
       ],
@@ -18203,7 +18203,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-abi\\node_modules\\semver"
             }
           ]
@@ -18231,7 +18231,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-addon-api"
         }
       ]
@@ -18257,7 +18257,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-fetch"
         }
       ]
@@ -18283,7 +18283,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-gyp"
         }
       ],
@@ -18309,7 +18309,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp\\node_modules\\ansi-regex"
             }
           ]
@@ -18335,7 +18335,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp\\node_modules\\are-we-there-yet"
             }
           ]
@@ -18361,7 +18361,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp\\node_modules\\gauge"
             }
           ]
@@ -18387,7 +18387,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp\\node_modules\\is-fullwidth-code-point"
             }
           ]
@@ -18413,7 +18413,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp\\node_modules\\nopt"
             }
           ]
@@ -18439,7 +18439,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp\\node_modules\\npmlog"
             }
           ]
@@ -18465,7 +18465,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp\\node_modules\\readable-stream"
             }
           ]
@@ -18491,7 +18491,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp\\node_modules\\string-width"
             }
           ]
@@ -18517,7 +18517,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp\\node_modules\\strip-ansi"
             }
           ]
@@ -18545,7 +18545,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-pre-gyp"
         }
       ],
@@ -18571,7 +18571,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp\\node_modules\\chownr"
             }
           ]
@@ -18597,7 +18597,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp\\node_modules\\fs-minipass"
             }
           ]
@@ -18623,7 +18623,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp\\node_modules\\minipass"
             }
           ]
@@ -18649,7 +18649,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp\\node_modules\\minizlib"
             }
           ]
@@ -18675,7 +18675,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp\\node_modules\\mkdirp"
             }
           ]
@@ -18701,7 +18701,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp\\node_modules\\nopt"
             }
           ]
@@ -18727,7 +18727,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp\\node_modules\\rimraf"
             }
           ]
@@ -18753,7 +18753,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp\\node_modules\\safe-buffer"
             }
           ]
@@ -18779,7 +18779,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp\\node_modules\\semver"
             }
           ]
@@ -18805,7 +18805,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp\\node_modules\\tar"
             }
           ]
@@ -18831,7 +18831,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp\\node_modules\\yallist"
             }
           ]
@@ -18859,7 +18859,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/noop-logger"
         }
       ]
@@ -18885,7 +18885,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/nopt"
         }
       ]
@@ -18911,7 +18911,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/normalize-package-data"
         }
       ],
@@ -18937,7 +18937,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/normalize-package-data\\node_modules\\semver"
             }
           ]
@@ -18965,7 +18965,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/normalize-path"
         }
       ]
@@ -18991,7 +18991,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/normalize-url"
         }
       ]
@@ -19017,7 +19017,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/notevil"
         }
       ],
@@ -19043,7 +19043,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/notevil\\node_modules\\esprima"
             }
           ]
@@ -19071,7 +19071,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/npm-bundled"
         }
       ]
@@ -19097,7 +19097,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/npm-normalize-package-bin"
         }
       ]
@@ -19123,7 +19123,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/npm-packlist"
         }
       ]
@@ -19149,7 +19149,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/npmlog"
         }
       ]
@@ -19175,7 +19175,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/number-is-nan"
         }
       ]
@@ -19201,7 +19201,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/oauth-sign"
         }
       ]
@@ -19227,7 +19227,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-assign"
         }
       ]
@@ -19253,7 +19253,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-copy"
         }
       ],
@@ -19279,7 +19279,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy\\node_modules\\define-property"
             }
           ]
@@ -19305,7 +19305,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy\\node_modules\\is-accessor-descriptor"
             }
           ]
@@ -19331,7 +19331,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy\\node_modules\\is-data-descriptor"
             }
           ]
@@ -19357,7 +19357,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy\\node_modules\\is-descriptor"
             }
           ],
@@ -19383,7 +19383,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/object-copy\\node_modules\\is-descriptor\\node_modules\\kind-of"
                 }
               ]
@@ -19411,7 +19411,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy\\node_modules\\kind-of"
             }
           ]
@@ -19439,7 +19439,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-inspect"
         }
       ]
@@ -19465,7 +19465,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-is"
         }
       ]
@@ -19491,7 +19491,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-keys"
         }
       ]
@@ -19517,7 +19517,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-visit"
         }
       ]
@@ -19543,7 +19543,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object.assign"
         }
       ]
@@ -19569,7 +19569,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object.defaults"
         }
       ]
@@ -19595,7 +19595,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object.map"
         }
       ]
@@ -19621,7 +19621,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object.pick"
         }
       ]
@@ -19647,7 +19647,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/on-finished"
         }
       ]
@@ -19673,7 +19673,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/on-headers"
         }
       ]
@@ -19699,7 +19699,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/once"
         }
       ]
@@ -19725,7 +19725,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/one-time"
         }
       ]
@@ -19751,7 +19751,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/opentype.js"
         }
       ]
@@ -19777,7 +19777,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/optionator"
         }
       ]
@@ -19803,7 +19803,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/os-homedir"
         }
       ]
@@ -19829,7 +19829,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/os-tmpdir"
         }
       ]
@@ -19855,7 +19855,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/osenv"
         }
       ]
@@ -19881,7 +19881,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/otplib"
         }
       ]
@@ -19907,7 +19907,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-cancelable"
         }
       ]
@@ -19933,7 +19933,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-event"
         }
       ]
@@ -19959,7 +19959,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-finally"
         }
       ]
@@ -19985,7 +19985,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-is-promise"
         }
       ]
@@ -20011,7 +20011,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-limit"
         }
       ]
@@ -20037,7 +20037,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-locate"
         }
       ]
@@ -20063,7 +20063,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-map"
         }
       ]
@@ -20089,7 +20089,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-timeout"
         }
       ]
@@ -20115,7 +20115,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-try"
         }
       ]
@@ -20141,7 +20141,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pako"
         }
       ]
@@ -20167,7 +20167,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/parse-filepath"
         }
       ]
@@ -20193,7 +20193,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/parse-json"
         }
       ]
@@ -20219,7 +20219,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/parse-passwd"
         }
       ]
@@ -20245,7 +20245,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/parseurl"
         }
       ]
@@ -20271,7 +20271,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pascalcase"
         }
       ]
@@ -20297,7 +20297,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-exists"
         }
       ]
@@ -20323,7 +20323,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-is-absolute"
         }
       ]
@@ -20349,7 +20349,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-parse"
         }
       ]
@@ -20375,7 +20375,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-root-regex"
         }
       ]
@@ -20401,7 +20401,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-root"
         }
       ]
@@ -20427,7 +20427,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-to-regexp"
         }
       ]
@@ -20453,7 +20453,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pdfkit"
         }
       ]
@@ -20479,7 +20479,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/peek-readable"
         }
       ]
@@ -20505,7 +20505,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pend"
         }
       ]
@@ -20531,7 +20531,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/performance-now"
         }
       ]
@@ -20557,7 +20557,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pg-connection-string"
         }
       ]
@@ -20583,7 +20583,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/picomatch"
         }
       ]
@@ -20609,7 +20609,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pify"
         }
       ]
@@ -20635,7 +20635,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pinkie-promise"
         }
       ]
@@ -20661,7 +20661,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pinkie"
         }
       ]
@@ -20687,7 +20687,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/png-js"
         }
       ]
@@ -20713,7 +20713,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/portscanner"
         }
       ]
@@ -20739,7 +20739,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/posix-character-classes"
         }
       ]
@@ -20765,7 +20765,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/prebuild-install"
         }
       ]
@@ -20791,7 +20791,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/prelude-ls"
         }
       ]
@@ -20817,7 +20817,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/prepend-http"
         }
       ]
@@ -20843,7 +20843,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pretty-bytes"
         }
       ]
@@ -20869,7 +20869,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/process-nextick-args"
         }
       ]
@@ -20895,7 +20895,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/prom-client"
         }
       ]
@@ -20921,7 +20921,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/promise-inflight"
         }
       ]
@@ -20947,7 +20947,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/promise-retry"
         }
       ],
@@ -20973,7 +20973,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/promise-retry\\node_modules\\err-code"
             }
           ]
@@ -20999,7 +20999,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/promise-retry\\node_modules\\retry"
             }
           ]
@@ -21027,7 +21027,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/promise"
         }
       ]
@@ -21053,7 +21053,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/proper-lockfile"
         }
       ]
@@ -21079,7 +21079,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/proxy-addr"
         }
       ]
@@ -21105,7 +21105,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/psl"
         }
       ]
@@ -21131,7 +21131,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-attrs"
         }
       ]
@@ -21157,7 +21157,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-code-gen"
         }
       ]
@@ -21183,7 +21183,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-error"
         }
       ]
@@ -21209,7 +21209,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-filters"
         }
       ]
@@ -21235,7 +21235,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-lexer"
         }
       ]
@@ -21261,7 +21261,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-linker"
         }
       ]
@@ -21287,7 +21287,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-load"
         }
       ]
@@ -21313,7 +21313,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-parser"
         }
       ]
@@ -21339,7 +21339,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-runtime"
         }
       ]
@@ -21365,7 +21365,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-strip-comments"
         }
       ]
@@ -21391,7 +21391,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-walk"
         }
       ]
@@ -21417,7 +21417,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug"
         }
       ]
@@ -21443,7 +21443,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pump"
         }
       ]
@@ -21469,7 +21469,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/punycode"
         }
       ]
@@ -21495,7 +21495,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/qs"
         }
       ]
@@ -21521,7 +21521,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/query-string"
         }
       ]
@@ -21547,7 +21547,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/range_check"
         }
       ]
@@ -21573,7 +21573,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/range-parser"
         }
       ]
@@ -21599,7 +21599,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/raw-body"
         }
       ]
@@ -21625,7 +21625,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/rc"
         }
       ]
@@ -21651,7 +21651,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/read-pkg"
         }
       ],
@@ -21677,7 +21677,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/read-pkg\\node_modules\\pify"
             }
           ]
@@ -21705,7 +21705,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/readable-stream"
         }
       ],
@@ -21731,7 +21731,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/readable-stream\\node_modules\\isarray"
             }
           ]
@@ -21759,7 +21759,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/readable-web-to-node-stream"
         }
       ],
@@ -21785,7 +21785,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/readable-web-to-node-stream\\node_modules\\readable-stream"
             }
           ]
@@ -21813,7 +21813,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/readdirp"
         }
       ]
@@ -21839,7 +21839,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/rechoir"
         }
       ]
@@ -21865,7 +21865,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/regex-not"
         }
       ]
@@ -21891,7 +21891,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/regexp.prototype.flags"
         }
       ]
@@ -21917,7 +21917,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/remove-trailing-separator"
         }
       ]
@@ -21943,7 +21943,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/repeat-element"
         }
       ]
@@ -21969,7 +21969,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/repeat-string"
         }
       ]
@@ -21995,7 +21995,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/replace"
         }
       ],
@@ -22021,7 +22021,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\ansi-regex"
             }
           ]
@@ -22047,7 +22047,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\ansi-styles"
             }
           ]
@@ -22073,7 +22073,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\brace-expansion"
             }
           ]
@@ -22099,7 +22099,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\cliui"
             }
           ]
@@ -22125,7 +22125,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\color-convert"
             }
           ]
@@ -22151,7 +22151,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\color-name"
             }
           ]
@@ -22177,7 +22177,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\find-up"
             }
           ]
@@ -22203,7 +22203,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\is-fullwidth-code-point"
             }
           ]
@@ -22229,7 +22229,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\locate-path"
             }
           ]
@@ -22255,7 +22255,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\minimatch"
             }
           ]
@@ -22281,7 +22281,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\p-locate"
             }
           ]
@@ -22307,7 +22307,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\path-exists"
             }
           ]
@@ -22333,7 +22333,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\string-width"
             }
           ]
@@ -22359,7 +22359,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\strip-ansi"
             }
           ]
@@ -22385,7 +22385,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\wrap-ansi"
             }
           ]
@@ -22411,7 +22411,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\yargs-parser"
             }
           ]
@@ -22437,7 +22437,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\yargs"
             }
           ]
@@ -22465,7 +22465,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/request"
         }
       ],
@@ -22491,7 +22491,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/request\\node_modules\\qs"
             }
           ]
@@ -22519,7 +22519,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/require-directory"
         }
       ]
@@ -22545,7 +22545,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/require-main-filename"
         }
       ]
@@ -22571,7 +22571,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/resolve-dir"
         }
       ]
@@ -22597,7 +22597,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/resolve-url"
         }
       ]
@@ -22623,7 +22623,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/resolve"
         }
       ]
@@ -22649,7 +22649,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/responselike"
         }
       ]
@@ -22675,7 +22675,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/restructure"
         }
       ]
@@ -22701,7 +22701,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ret"
         }
       ]
@@ -22727,7 +22727,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/retry-as-promised"
         }
       ]
@@ -22753,7 +22753,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/retry"
         }
       ]
@@ -22779,7 +22779,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/rimraf"
         }
       ]
@@ -22805,7 +22805,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/rxjs"
         }
       ],
@@ -22831,7 +22831,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/rxjs\\node_modules\\tslib"
             }
           ]
@@ -22859,7 +22859,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safe-buffer"
         }
       ]
@@ -22885,7 +22885,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safe-regex-test"
         }
       ]
@@ -22911,7 +22911,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safe-regex"
         }
       ]
@@ -22937,7 +22937,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safe-stable-stringify"
         }
       ]
@@ -22963,7 +22963,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safer-buffer"
         }
       ]
@@ -22989,7 +22989,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/samsam"
         }
       ]
@@ -23015,7 +23015,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sanitize-filename"
         }
       ]
@@ -23041,7 +23041,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sanitize-html"
         }
       ],
@@ -23067,7 +23067,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sanitize-html\\node_modules\\lodash"
             }
           ]
@@ -23095,7 +23095,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sax"
         }
       ]
@@ -23121,7 +23121,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/seek-bzip"
         }
       ]
@@ -23147,7 +23147,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/semver"
         }
       ]
@@ -23173,7 +23173,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/send"
         }
       ],
@@ -23199,7 +23199,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/send\\node_modules\\ms"
             }
           ]
@@ -23227,7 +23227,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sequelize-pool"
         }
       ]
@@ -23253,7 +23253,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sequelize"
         }
       ],
@@ -23279,7 +23279,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sequelize\\node_modules\\debug"
             }
           ]
@@ -23305,7 +23305,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sequelize\\node_modules\\ms"
             }
           ]
@@ -23331,7 +23331,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sequelize\\node_modules\\uuid"
             }
           ]
@@ -23359,7 +23359,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/serve-index"
         }
       ],
@@ -23385,7 +23385,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index\\node_modules\\depd"
             }
           ]
@@ -23411,7 +23411,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index\\node_modules\\http-errors"
             }
           ]
@@ -23437,7 +23437,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index\\node_modules\\inherits"
             }
           ]
@@ -23463,7 +23463,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index\\node_modules\\setprototypeof"
             }
           ]
@@ -23489,7 +23489,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index\\node_modules\\statuses"
             }
           ]
@@ -23517,7 +23517,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/serve-static"
         }
       ]
@@ -23543,7 +23543,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/set-blocking"
         }
       ]
@@ -23569,7 +23569,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/set-value"
         }
       ],
@@ -23595,7 +23595,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/set-value\\node_modules\\extend-shallow"
             }
           ]
@@ -23621,7 +23621,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/set-value\\node_modules\\is-extendable"
             }
           ]
@@ -23649,7 +23649,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/setimmediate"
         }
       ]
@@ -23675,7 +23675,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/setprototypeof"
         }
       ]
@@ -23701,7 +23701,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/side-channel"
         }
       ]
@@ -23727,7 +23727,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/signal-exit"
         }
       ]
@@ -23753,7 +23753,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/simple-concat"
         }
       ]
@@ -23779,7 +23779,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/simple-get"
         }
       ],
@@ -23805,7 +23805,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/simple-get\\node_modules\\decompress-response"
             }
           ]
@@ -23831,7 +23831,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/simple-get\\node_modules\\mimic-response"
             }
           ]
@@ -23859,7 +23859,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/simple-swizzle"
         }
       ],
@@ -23885,7 +23885,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/simple-swizzle\\node_modules\\is-arrayish"
             }
           ]
@@ -23913,7 +23913,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sinon"
         }
       ]
@@ -23939,7 +23939,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/smart-buffer"
         }
       ]
@@ -23965,7 +23965,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/snapdragon-node"
         }
       ],
@@ -23991,7 +23991,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon-node\\node_modules\\define-property"
             }
           ]
@@ -24019,7 +24019,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/snapdragon-util"
         }
       ],
@@ -24045,7 +24045,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon-util\\node_modules\\kind-of"
             }
           ]
@@ -24073,7 +24073,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/snapdragon"
         }
       ],
@@ -24099,7 +24099,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon\\node_modules\\define-property"
             }
           ]
@@ -24125,7 +24125,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon\\node_modules\\extend-shallow"
             }
           ]
@@ -24151,7 +24151,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon\\node_modules\\is-accessor-descriptor"
             }
           ],
@@ -24177,7 +24177,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/snapdragon\\node_modules\\is-accessor-descriptor\\node_modules\\kind-of"
                 }
               ]
@@ -24205,7 +24205,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon\\node_modules\\is-data-descriptor"
             }
           ],
@@ -24231,7 +24231,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/snapdragon\\node_modules\\is-data-descriptor\\node_modules\\kind-of"
                 }
               ]
@@ -24259,7 +24259,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon\\node_modules\\is-descriptor"
             }
           ]
@@ -24285,7 +24285,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon\\node_modules\\is-extendable"
             }
           ]
@@ -24311,7 +24311,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon\\node_modules\\kind-of"
             }
           ]
@@ -24337,7 +24337,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon\\node_modules\\source-map"
             }
           ]
@@ -24365,7 +24365,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socket.io-adapter"
         }
       ]
@@ -24391,7 +24391,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socket.io-parser"
         }
       ],
@@ -24417,7 +24417,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socket.io-parser\\node_modules\\debug"
             }
           ]
@@ -24443,7 +24443,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socket.io-parser\\node_modules\\ms"
             }
           ]
@@ -24471,7 +24471,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socket.io"
         }
       ],
@@ -24497,7 +24497,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socket.io\\node_modules\\debug"
             }
           ]
@@ -24523,7 +24523,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socket.io\\node_modules\\ms"
             }
           ]
@@ -24551,7 +24551,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socks-proxy-agent"
         }
       ],
@@ -24577,7 +24577,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socks-proxy-agent\\node_modules\\debug"
             }
           ]
@@ -24603,7 +24603,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socks-proxy-agent\\node_modules\\ms"
             }
           ]
@@ -24631,7 +24631,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socks"
         }
       ],
@@ -24657,7 +24657,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socks\\node_modules\\ip"
             }
           ]
@@ -24685,7 +24685,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sort-keys-length"
         }
       ],
@@ -24711,7 +24711,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sort-keys-length\\node_modules\\sort-keys"
             }
           ]
@@ -24739,7 +24739,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sort-keys"
         }
       ]
@@ -24765,7 +24765,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/source-map-resolve"
         }
       ]
@@ -24791,7 +24791,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/source-map-support"
         }
       ]
@@ -24817,7 +24817,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/source-map-url"
         }
       ]
@@ -24843,7 +24843,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/source-map"
         }
       ]
@@ -24869,7 +24869,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spawn-command"
         }
       ]
@@ -24895,7 +24895,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spdx-correct"
         }
       ]
@@ -24921,7 +24921,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spdx-exceptions"
         }
       ]
@@ -24947,7 +24947,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spdx-expression-parse"
         }
       ]
@@ -24973,7 +24973,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spdx-license-ids"
         }
       ]
@@ -24999,7 +24999,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/split-string"
         }
       ]
@@ -25025,7 +25025,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sprintf-js"
         }
       ]
@@ -25051,7 +25051,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sqlite3"
         }
       ]
@@ -25077,7 +25077,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sshpk"
         }
       ]
@@ -25103,7 +25103,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ssri"
         }
       ]
@@ -25129,7 +25129,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/stack-trace"
         }
       ]
@@ -25155,7 +25155,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/static-extend"
         }
       ],
@@ -25181,7 +25181,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend\\node_modules\\define-property"
             }
           ]
@@ -25207,7 +25207,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend\\node_modules\\is-accessor-descriptor"
             }
           ],
@@ -25233,7 +25233,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/static-extend\\node_modules\\is-accessor-descriptor\\node_modules\\kind-of"
                 }
               ]
@@ -25261,7 +25261,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend\\node_modules\\is-data-descriptor"
             }
           ],
@@ -25287,7 +25287,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/static-extend\\node_modules\\is-data-descriptor\\node_modules\\kind-of"
                 }
               ]
@@ -25315,7 +25315,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend\\node_modules\\is-descriptor"
             }
           ]
@@ -25341,7 +25341,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend\\node_modules\\kind-of"
             }
           ]
@@ -25369,7 +25369,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/statuses"
         }
       ]
@@ -25395,7 +25395,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/stream-buffers"
         }
       ]
@@ -25421,7 +25421,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/streamsearch"
         }
       ]
@@ -25447,7 +25447,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strict-uri-encode"
         }
       ]
@@ -25473,7 +25473,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string_decoder"
         }
       ]
@@ -25499,7 +25499,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string-width"
         }
       ]
@@ -25525,7 +25525,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string.fromcodepoint"
         }
       ]
@@ -25551,7 +25551,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string.prototype.codepointat"
         }
       ]
@@ -25577,7 +25577,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string.prototype.trimend"
         }
       ]
@@ -25603,7 +25603,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string.prototype.trimstart"
         }
       ]
@@ -25629,7 +25629,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-ansi"
         }
       ]
@@ -25655,7 +25655,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-bom"
         }
       ]
@@ -25681,7 +25681,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-dirs"
         }
       ]
@@ -25707,7 +25707,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-json-comments"
         }
       ]
@@ -25733,7 +25733,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-outer"
         }
       ]
@@ -25759,7 +25759,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strtok3"
         }
       ]
@@ -25785,7 +25785,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/supports-color"
         }
       ]
@@ -25811,7 +25811,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/supports-preserve-symlinks-flag"
         }
       ]
@@ -25837,7 +25837,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/svg-captcha"
         }
       ]
@@ -25863,7 +25863,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/swagger-ui-dist"
         }
       ]
@@ -25889,7 +25889,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/swagger-ui-express"
         }
       ]
@@ -25915,7 +25915,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tar-fs"
         }
       ],
@@ -25941,7 +25941,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/tar-fs\\node_modules\\bl"
             }
           ]
@@ -25967,7 +25967,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/tar-fs\\node_modules\\chownr"
             }
           ]
@@ -25993,7 +25993,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/tar-fs\\node_modules\\readable-stream"
             }
           ]
@@ -26019,7 +26019,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/tar-fs\\node_modules\\tar-stream"
             }
           ]
@@ -26047,7 +26047,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tar-stream"
         }
       ]
@@ -26073,7 +26073,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tar"
         }
       ]
@@ -26099,7 +26099,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tdigest"
         }
       ]
@@ -26125,7 +26125,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/text-hex"
         }
       ]
@@ -26151,7 +26151,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/thirty-two"
         }
       ]
@@ -26177,7 +26177,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/through"
         }
       ]
@@ -26203,7 +26203,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/timed-out"
         }
       ]
@@ -26229,7 +26229,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tiny-inflate"
         }
       ]
@@ -26255,7 +26255,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-buffer"
         }
       ]
@@ -26281,7 +26281,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-fast-properties"
         }
       ]
@@ -26307,7 +26307,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-object-path"
         }
       ],
@@ -26333,7 +26333,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/to-object-path\\node_modules\\kind-of"
             }
           ]
@@ -26361,7 +26361,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-regex-range"
         }
       ]
@@ -26387,7 +26387,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-regex"
         }
       ]
@@ -26413,7 +26413,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/toidentifier"
         }
       ]
@@ -26439,7 +26439,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/token-stream"
         }
       ]
@@ -26465,7 +26465,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/token-types"
         }
       ]
@@ -26491,7 +26491,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/toposort-class"
         }
       ]
@@ -26517,7 +26517,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tough-cookie"
         }
       ]
@@ -26543,7 +26543,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tr46"
         }
       ]
@@ -26569,7 +26569,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/traverse"
         }
       ]
@@ -26595,7 +26595,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tree-kill"
         }
       ]
@@ -26621,7 +26621,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/trim-repeated"
         }
       ]
@@ -26647,7 +26647,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/triple-beam"
         }
       ]
@@ -26673,7 +26673,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/truncate-utf8-bytes"
         }
       ]
@@ -26699,7 +26699,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ts-node-dev"
         }
       ],
@@ -26725,7 +26725,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/ts-node-dev\\node_modules\\rimraf"
             }
           ]
@@ -26753,7 +26753,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ts-node"
         }
       ]
@@ -26779,7 +26779,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tsconfig"
         }
       ]
@@ -26805,7 +26805,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tslib"
         }
       ]
@@ -26831,7 +26831,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tunnel-agent"
         }
       ]
@@ -26857,7 +26857,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tweetnacl"
         }
       ]
@@ -26883,7 +26883,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/type-check"
         }
       ]
@@ -26909,7 +26909,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/type-is"
         }
       ]
@@ -26935,7 +26935,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/typecast"
         }
       ]
@@ -26961,7 +26961,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/typedarray"
         }
       ]
@@ -26987,7 +26987,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/typescript"
         }
       ]
@@ -27013,7 +27013,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/uglify-js"
         }
       ]
@@ -27039,7 +27039,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unbox-primitive"
         }
       ]
@@ -27065,7 +27065,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unbzip2-stream"
         }
       ]
@@ -27091,7 +27091,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unc-path-regex"
         }
       ]
@@ -27117,7 +27117,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/underscore.string"
         }
       ]
@@ -27143,7 +27143,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unicode-properties"
         }
       ]
@@ -27169,7 +27169,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unicode-trie"
         }
       ]
@@ -27195,7 +27195,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/union-value"
         }
       ],
@@ -27221,7 +27221,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/union-value\\node_modules\\is-extendable"
             }
           ]
@@ -27249,7 +27249,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unique-filename"
         }
       ]
@@ -27275,7 +27275,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unique-slug"
         }
       ]
@@ -27301,7 +27301,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unit-compare"
         }
       ]
@@ -27327,7 +27327,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/universalify"
         }
       ]
@@ -27353,7 +27353,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unpipe"
         }
       ]
@@ -27379,7 +27379,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unset-value"
         }
       ],
@@ -27405,7 +27405,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/unset-value\\node_modules\\has-value"
             }
           ],
@@ -27431,7 +27431,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/unset-value\\node_modules\\has-value\\node_modules\\isobject"
                 }
               ]
@@ -27459,7 +27459,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/unset-value\\node_modules\\has-values"
             }
           ]
@@ -27485,7 +27485,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/unset-value\\node_modules\\isarray"
             }
           ]
@@ -27513,7 +27513,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/untildify"
         }
       ]
@@ -27539,7 +27539,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unzipper"
         }
       ],
@@ -27565,7 +27565,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/unzipper\\node_modules\\bluebird"
             }
           ]
@@ -27593,7 +27593,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/uri-js"
         }
       ]
@@ -27619,7 +27619,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/urix"
         }
       ]
@@ -27645,7 +27645,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/url-parse-lax"
         }
       ]
@@ -27671,7 +27671,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/url-to-options"
         }
       ]
@@ -27697,7 +27697,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/use"
         }
       ]
@@ -27723,7 +27723,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/utf8-byte-length"
         }
       ]
@@ -27749,7 +27749,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/util-deprecate"
         }
       ]
@@ -27775,7 +27775,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/util"
         }
       ]
@@ -27801,7 +27801,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/utils-merge"
         }
       ]
@@ -27827,7 +27827,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/uuid"
         }
       ]
@@ -27853,7 +27853,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/v8flags"
         }
       ]
@@ -27879,7 +27879,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/validate-npm-package-license"
         }
       ]
@@ -27905,7 +27905,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/validate"
         }
       ]
@@ -27931,7 +27931,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/validator"
         }
       ]
@@ -27957,7 +27957,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/vary"
         }
       ]
@@ -27983,7 +27983,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/verror"
         }
       ],
@@ -28009,7 +28009,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/verror\\node_modules\\core-util-is"
             }
           ]
@@ -28037,7 +28037,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/vm2"
         }
       ],
@@ -28063,7 +28063,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/vm2\\node_modules\\acorn"
             }
           ]
@@ -28091,7 +28091,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/void-elements"
         }
       ]
@@ -28117,7 +28117,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/walk"
         }
       ]
@@ -28143,7 +28143,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/walkdir"
         }
       ]
@@ -28169,7 +28169,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/webidl-conversions"
         }
       ]
@@ -28195,7 +28195,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/whatwg-url"
         }
       ]
@@ -28221,7 +28221,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-boxed-primitive"
         }
       ]
@@ -28247,7 +28247,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-collection"
         }
       ]
@@ -28273,7 +28273,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-module"
         }
       ]
@@ -28299,7 +28299,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-pm-runs"
         }
       ]
@@ -28325,7 +28325,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-typed-array"
         }
       ]
@@ -28351,7 +28351,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which"
         }
       ]
@@ -28377,7 +28377,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wide-align"
         }
       ]
@@ -28403,7 +28403,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/winston-transport"
         }
       ],
@@ -28429,7 +28429,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/winston-transport\\node_modules\\readable-stream"
             }
           ]
@@ -28457,7 +28457,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/winston"
         }
       ],
@@ -28483,7 +28483,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/winston\\node_modules\\async"
             }
           ]
@@ -28509,7 +28509,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/winston\\node_modules\\is-stream"
             }
           ]
@@ -28535,7 +28535,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/winston\\node_modules\\readable-stream"
             }
           ]
@@ -28563,7 +28563,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/with"
         }
       ]
@@ -28589,7 +28589,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wkx"
         }
       ]
@@ -28615,7 +28615,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/word-wrap"
         }
       ]
@@ -28641,7 +28641,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wordwrap"
         }
       ]
@@ -28667,7 +28667,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wrap-ansi"
         }
       ],
@@ -28693,7 +28693,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi\\node_modules\\ansi-regex"
             }
           ]
@@ -28719,7 +28719,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi\\node_modules\\emoji-regex"
             }
           ]
@@ -28745,7 +28745,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi\\node_modules\\is-fullwidth-code-point"
             }
           ]
@@ -28771,7 +28771,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi\\node_modules\\string-width"
             }
           ]
@@ -28797,7 +28797,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi\\node_modules\\strip-ansi"
             }
           ]
@@ -28825,7 +28825,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wrappy"
         }
       ]
@@ -28851,7 +28851,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ws"
         }
       ]
@@ -28877,7 +28877,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/xtend"
         }
       ]
@@ -28903,7 +28903,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/y18n"
         }
       ]
@@ -28929,7 +28929,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yallist"
         }
       ]
@@ -28955,7 +28955,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yaml-schema-validator"
         }
       ]
@@ -28981,7 +28981,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yargs-parser"
         }
       ]
@@ -29007,7 +29007,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yargs"
         }
       ],
@@ -29033,7 +29033,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs\\node_modules\\ansi-regex"
             }
           ]
@@ -29059,7 +29059,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs\\node_modules\\emoji-regex"
             }
           ]
@@ -29085,7 +29085,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs\\node_modules\\is-fullwidth-code-point"
             }
           ]
@@ -29111,7 +29111,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs\\node_modules\\string-width"
             }
           ]
@@ -29137,7 +29137,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs\\node_modules\\strip-ansi"
             }
           ]
@@ -29165,7 +29165,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yauzl"
         }
       ]
@@ -29191,7 +29191,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yn"
         }
       ]
@@ -29217,7 +29217,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/z85"
         }
       ]
@@ -29243,7 +29243,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/zip-stream"
         }
       ]
@@ -29269,7 +29269,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/zlibjs"
         }
       ]

--- a/tests/_data/sbom_demo-results/juice-shop_npm7_node18_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/juice-shop_npm7_node18_macos-latest.snap.json
@@ -62,7 +62,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -95,7 +95,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@babel/helper-string-parser"
         }
       ]
@@ -122,7 +122,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@babel/helper-validator-identifier"
         }
       ]
@@ -149,7 +149,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@babel/parser"
         }
       ]
@@ -176,7 +176,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@babel/types"
         }
       ]
@@ -203,7 +203,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@colors/colors"
         }
       ]
@@ -230,7 +230,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@dabh/diagnostics"
         }
       ]
@@ -257,7 +257,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@gar/promisify"
         }
       ]
@@ -284,7 +284,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@mapbox/node-pre-gyp"
         }
       ],
@@ -310,7 +310,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/ansi-regex"
             }
           ]
@@ -336,7 +336,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/are-we-there-yet"
             }
           ]
@@ -362,7 +362,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/detect-libc"
             }
           ]
@@ -388,7 +388,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/gauge"
             }
           ]
@@ -414,7 +414,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -440,7 +440,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/make-dir"
             }
           ],
@@ -466,7 +466,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/@mapbox/node-pre-gyp/node_modules/make-dir/node_modules/semver"
                 }
               ]
@@ -494,7 +494,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/nopt"
             }
           ]
@@ -520,7 +520,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/npmlog"
             }
           ]
@@ -546,7 +546,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/readable-stream"
             }
           ]
@@ -572,7 +572,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/string-width"
             }
           ]
@@ -598,7 +598,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/strip-ansi"
             }
           ]
@@ -627,7 +627,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/core-loader"
         }
       ]
@@ -654,7 +654,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/core"
         }
       ]
@@ -681,7 +681,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/evaluator"
         }
       ]
@@ -708,7 +708,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-all"
         }
       ]
@@ -735,7 +735,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ar"
         }
       ]
@@ -762,7 +762,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-bn"
         }
       ]
@@ -789,7 +789,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ca"
         }
       ]
@@ -816,7 +816,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-cs"
         }
       ]
@@ -843,7 +843,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-da"
         }
       ]
@@ -870,7 +870,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-de"
         }
       ]
@@ -897,7 +897,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-el"
         }
       ]
@@ -924,7 +924,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-en-min"
         }
       ]
@@ -951,7 +951,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-en"
         }
       ]
@@ -978,7 +978,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-es"
         }
       ]
@@ -1005,7 +1005,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-eu"
         }
       ]
@@ -1032,7 +1032,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-fa"
         }
       ]
@@ -1059,7 +1059,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-fi"
         }
       ]
@@ -1086,7 +1086,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-fr"
         }
       ]
@@ -1113,7 +1113,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ga"
         }
       ]
@@ -1140,7 +1140,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-gl"
         }
       ]
@@ -1167,7 +1167,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-hi"
         }
       ]
@@ -1194,7 +1194,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-hu"
         }
       ]
@@ -1221,7 +1221,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-hy"
         }
       ]
@@ -1248,7 +1248,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-id"
         }
       ]
@@ -1275,7 +1275,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-it"
         }
       ]
@@ -1302,7 +1302,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ja"
         }
       ]
@@ -1329,7 +1329,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ko"
         }
       ]
@@ -1356,7 +1356,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-lt"
         }
       ]
@@ -1383,7 +1383,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ms"
         }
       ]
@@ -1410,7 +1410,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ne"
         }
       ]
@@ -1437,7 +1437,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-nl"
         }
       ]
@@ -1464,7 +1464,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-no"
         }
       ]
@@ -1491,7 +1491,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-pl"
         }
       ]
@@ -1518,7 +1518,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-pt"
         }
       ]
@@ -1545,7 +1545,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ro"
         }
       ]
@@ -1572,7 +1572,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ru"
         }
       ]
@@ -1599,7 +1599,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-sl"
         }
       ]
@@ -1626,7 +1626,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-sr"
         }
       ]
@@ -1653,7 +1653,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-sv"
         }
       ]
@@ -1680,7 +1680,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ta"
         }
       ]
@@ -1707,7 +1707,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-th"
         }
       ]
@@ -1734,7 +1734,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-tl"
         }
       ]
@@ -1761,7 +1761,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-tr"
         }
       ]
@@ -1788,7 +1788,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-uk"
         }
       ]
@@ -1815,7 +1815,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-zh"
         }
       ]
@@ -1842,7 +1842,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/language-min"
         }
       ]
@@ -1869,7 +1869,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/language"
         }
       ]
@@ -1896,7 +1896,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/ner"
         }
       ]
@@ -1923,7 +1923,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/neural"
         }
       ]
@@ -1950,7 +1950,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/nlg"
         }
       ]
@@ -1977,7 +1977,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/nlp"
         }
       ]
@@ -2004,7 +2004,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/nlu"
         }
       ]
@@ -2031,7 +2031,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/request"
         }
       ]
@@ -2058,7 +2058,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/sentiment"
         }
       ]
@@ -2085,7 +2085,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/similarity"
         }
       ]
@@ -2112,7 +2112,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/slot"
         }
       ]
@@ -2139,7 +2139,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@npmcli/fs"
         }
       ]
@@ -2166,7 +2166,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@npmcli/move-file"
         }
       ]
@@ -2193,7 +2193,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib/core"
         }
       ]
@@ -2220,7 +2220,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib/plugin-crypto"
         }
       ]
@@ -2247,7 +2247,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib/plugin-thirty-two"
         }
       ]
@@ -2274,7 +2274,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib/preset-default"
         }
       ]
@@ -2301,7 +2301,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib/preset-v11"
         }
       ]
@@ -2328,7 +2328,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@sindresorhus/is"
         }
       ]
@@ -2355,7 +2355,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@swc/helpers"
         }
       ]
@@ -2382,7 +2382,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@tokenizer/token"
         }
       ]
@@ -2409,7 +2409,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@tootallnate/once"
         }
       ]
@@ -2436,7 +2436,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/component-emitter"
         }
       ]
@@ -2463,7 +2463,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/cookie"
         }
       ]
@@ -2490,7 +2490,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/cors"
         }
       ]
@@ -2517,7 +2517,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/debug"
         }
       ]
@@ -2544,7 +2544,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/ms"
         }
       ]
@@ -2571,7 +2571,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/node"
         }
       ]
@@ -2598,7 +2598,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/strip-bom"
         }
       ]
@@ -2625,7 +2625,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/strip-json-comments"
         }
       ]
@@ -2652,7 +2652,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/validator"
         }
       ]
@@ -2678,7 +2678,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/abbrev"
         }
       ]
@@ -2704,7 +2704,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/accepts"
         }
       ]
@@ -2730,7 +2730,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/acorn-walk"
         }
       ]
@@ -2756,7 +2756,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/acorn"
         }
       ]
@@ -2782,7 +2782,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/agent-base"
         }
       ],
@@ -2808,7 +2808,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agent-base/node_modules/debug"
             }
           ]
@@ -2834,7 +2834,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agent-base/node_modules/ms"
             }
           ]
@@ -2862,7 +2862,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/agentkeepalive"
         }
       ],
@@ -2888,7 +2888,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agentkeepalive/node_modules/debug"
             }
           ]
@@ -2914,7 +2914,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agentkeepalive/node_modules/depd"
             }
           ]
@@ -2940,7 +2940,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agentkeepalive/node_modules/ms"
             }
           ]
@@ -2968,7 +2968,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/aggregate-error"
         }
       ]
@@ -2994,7 +2994,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ajv"
         }
       ]
@@ -3020,7 +3020,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ansi-regex"
         }
       ]
@@ -3046,7 +3046,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ansi-styles"
         }
       ]
@@ -3072,7 +3072,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/anymatch"
         }
       ],
@@ -3098,7 +3098,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/anymatch/node_modules/normalize-path"
             }
           ]
@@ -3126,7 +3126,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/append-field"
         }
       ]
@@ -3152,7 +3152,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/aproba"
         }
       ]
@@ -3178,7 +3178,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/archive-type"
         }
       ],
@@ -3204,7 +3204,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/archive-type/node_modules/file-type"
             }
           ]
@@ -3232,7 +3232,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/archiver-utils"
         }
       ]
@@ -3258,7 +3258,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/archiver"
         }
       ]
@@ -3284,7 +3284,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/are-we-there-yet"
         }
       ]
@@ -3310,7 +3310,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/arg"
         }
       ]
@@ -3336,7 +3336,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/argparse"
         }
       ],
@@ -3362,7 +3362,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/argparse/node_modules/sprintf-js"
             }
           ]
@@ -3390,7 +3390,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/arr-diff"
         }
       ]
@@ -3416,7 +3416,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/arr-flatten"
         }
       ]
@@ -3442,7 +3442,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/arr-union"
         }
       ]
@@ -3468,7 +3468,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/array-each"
         }
       ]
@@ -3494,7 +3494,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/array-flatten"
         }
       ]
@@ -3520,7 +3520,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/array-slice"
         }
       ]
@@ -3546,7 +3546,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/array-unique"
         }
       ]
@@ -3572,7 +3572,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/asap"
         }
       ]
@@ -3598,7 +3598,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/asn1"
         }
       ]
@@ -3624,7 +3624,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/assert-never"
         }
       ]
@@ -3650,7 +3650,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/assert-plus"
         }
       ]
@@ -3676,7 +3676,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/assign-symbols"
         }
       ]
@@ -3702,7 +3702,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/async"
         }
       ]
@@ -3728,7 +3728,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/asynckit"
         }
       ]
@@ -3754,7 +3754,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/at-least-node"
         }
       ]
@@ -3780,7 +3780,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/atob"
         }
       ]
@@ -3806,7 +3806,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/available-typed-arrays"
         }
       ]
@@ -3832,7 +3832,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/aws-sign2"
         }
       ]
@@ -3858,7 +3858,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/aws4"
         }
       ]
@@ -3884,7 +3884,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/babel-walk"
         }
       ]
@@ -3910,7 +3910,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/balanced-match"
         }
       ]
@@ -3936,7 +3936,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base"
         }
       ],
@@ -3962,7 +3962,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/base/node_modules/define-property"
             }
           ]
@@ -3990,7 +3990,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base64-arraybuffer"
         }
       ]
@@ -4016,7 +4016,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base64-js"
         }
       ]
@@ -4042,7 +4042,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base64id"
         }
       ]
@@ -4068,7 +4068,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base64url"
         }
       ]
@@ -4094,7 +4094,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/basic-auth"
         }
       ]
@@ -4120,7 +4120,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/batch"
         }
       ]
@@ -4146,7 +4146,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bcrypt-pbkdf"
         }
       ]
@@ -4172,7 +4172,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/big-integer"
         }
       ]
@@ -4198,7 +4198,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/binary-extensions"
         }
       ]
@@ -4224,7 +4224,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/binary"
         }
       ]
@@ -4250,7 +4250,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bindings"
         }
       ]
@@ -4276,7 +4276,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bintrees"
         }
       ]
@@ -4302,7 +4302,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bl"
         }
       ]
@@ -4328,7 +4328,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bluebird"
         }
       ]
@@ -4354,7 +4354,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/body-parser"
         }
       ]
@@ -4380,7 +4380,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bower-config"
         }
       ],
@@ -4406,7 +4406,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bower-config/node_modules/minimist"
             }
           ]
@@ -4434,7 +4434,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/brace-expansion"
         }
       ]
@@ -4460,7 +4460,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/braces"
         }
       ],
@@ -4486,7 +4486,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/braces/node_modules/extend-shallow"
             }
           ]
@@ -4512,7 +4512,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/braces/node_modules/is-extendable"
             }
           ]
@@ -4540,7 +4540,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/brotli"
         }
       ]
@@ -4566,7 +4566,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-alloc-unsafe"
         }
       ]
@@ -4592,7 +4592,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-alloc"
         }
       ]
@@ -4618,7 +4618,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-crc32"
         }
       ]
@@ -4644,7 +4644,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-fill"
         }
       ]
@@ -4670,7 +4670,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-from"
         }
       ]
@@ -4696,7 +4696,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-indexof-polyfill"
         }
       ]
@@ -4722,7 +4722,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer"
         }
       ]
@@ -4748,7 +4748,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffers"
         }
       ]
@@ -4774,7 +4774,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/busboy"
         }
       ],
@@ -4800,7 +4800,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/busboy/node_modules/isarray"
             }
           ]
@@ -4826,7 +4826,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/busboy/node_modules/readable-stream"
             }
           ]
@@ -4852,7 +4852,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/busboy/node_modules/string_decoder"
             }
           ]
@@ -4880,7 +4880,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/byline"
         }
       ]
@@ -4906,7 +4906,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bytes"
         }
       ]
@@ -4932,7 +4932,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cacache"
         }
       ]
@@ -4958,7 +4958,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cache-base"
         }
       ]
@@ -4984,7 +4984,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cacheable-request"
         }
       ],
@@ -5010,7 +5010,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cacheable-request/node_modules/get-stream"
             }
           ]
@@ -5036,7 +5036,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cacheable-request/node_modules/lowercase-keys"
             }
           ]
@@ -5064,7 +5064,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/call-bind"
         }
       ]
@@ -5090,7 +5090,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/camelcase"
         }
       ]
@@ -5116,7 +5116,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/caseless"
         }
       ]
@@ -5142,7 +5142,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/chainsaw"
         }
       ]
@@ -5168,7 +5168,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/chalk"
         }
       ]
@@ -5194,7 +5194,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/character-parser"
         }
       ]
@@ -5220,7 +5220,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/check-dependencies"
         }
       ],
@@ -5246,7 +5246,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/check-dependencies/node_modules/semver"
             }
           ]
@@ -5274,7 +5274,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/check-types"
         }
       ]
@@ -5300,7 +5300,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/chokidar"
         }
       ],
@@ -5326,7 +5326,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar/node_modules/braces"
             }
           ]
@@ -5352,7 +5352,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar/node_modules/fill-range"
             }
           ]
@@ -5378,7 +5378,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar/node_modules/is-glob"
             }
           ]
@@ -5404,7 +5404,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar/node_modules/is-number"
             }
           ]
@@ -5430,7 +5430,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar/node_modules/normalize-path"
             }
           ]
@@ -5456,7 +5456,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar/node_modules/to-regex-range"
             }
           ]
@@ -5484,7 +5484,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/chownr"
         }
       ]
@@ -5510,7 +5510,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/clarinet"
         }
       ]
@@ -5536,7 +5536,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/class-utils"
         }
       ],
@@ -5562,7 +5562,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils/node_modules/define-property"
             }
           ]
@@ -5588,7 +5588,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils/node_modules/is-accessor-descriptor"
             }
           ],
@@ -5614,7 +5614,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/class-utils/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
@@ -5642,7 +5642,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils/node_modules/is-data-descriptor"
             }
           ],
@@ -5668,7 +5668,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/class-utils/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
@@ -5696,7 +5696,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils/node_modules/is-descriptor"
             }
           ]
@@ -5722,7 +5722,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils/node_modules/kind-of"
             }
           ]
@@ -5750,7 +5750,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/clean-stack"
         }
       ]
@@ -5776,7 +5776,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cliui"
         }
       ],
@@ -5802,7 +5802,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui/node_modules/ansi-regex"
             }
           ]
@@ -5828,7 +5828,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui/node_modules/emoji-regex"
             }
           ]
@@ -5854,7 +5854,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -5880,7 +5880,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui/node_modules/string-width"
             }
           ]
@@ -5906,7 +5906,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui/node_modules/strip-ansi"
             }
           ]
@@ -5934,7 +5934,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/clone-response"
         }
       ]
@@ -5960,7 +5960,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/clone"
         }
       ]
@@ -5986,7 +5986,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/code-point-at"
         }
       ]
@@ -6012,7 +6012,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/collection-visit"
         }
       ]
@@ -6038,7 +6038,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color-convert"
         }
       ]
@@ -6064,7 +6064,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color-name"
         }
       ]
@@ -6090,7 +6090,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color-string"
         }
       ]
@@ -6116,7 +6116,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color-support"
         }
       ]
@@ -6142,7 +6142,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color"
         }
       ]
@@ -6168,7 +6168,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/colors"
         }
       ]
@@ -6194,7 +6194,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/colorspace"
         }
       ]
@@ -6220,7 +6220,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/combined-stream"
         }
       ]
@@ -6246,7 +6246,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/commander"
         }
       ]
@@ -6272,7 +6272,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/component-emitter"
         }
       ]
@@ -6298,7 +6298,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/component-type"
         }
       ]
@@ -6324,7 +6324,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/compress-commons"
         }
       ]
@@ -6350,7 +6350,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/compressible"
         }
       ]
@@ -6376,7 +6376,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/compression"
         }
       ],
@@ -6402,7 +6402,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/compression/node_modules/bytes"
             }
           ]
@@ -6430,7 +6430,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/concat-map"
         }
       ]
@@ -6456,7 +6456,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/concat-stream"
         }
       ]
@@ -6482,7 +6482,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/concurrently"
         }
       ],
@@ -6508,7 +6508,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/concurrently/node_modules/supports-color"
             }
           ]
@@ -6536,7 +6536,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/config"
         }
       ]
@@ -6562,7 +6562,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/console-control-strings"
         }
       ]
@@ -6588,7 +6588,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/constantinople"
         }
       ]
@@ -6614,7 +6614,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/content-disposition"
         }
       ],
@@ -6640,7 +6640,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/content-disposition/node_modules/safe-buffer"
             }
           ]
@@ -6668,7 +6668,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/content-type"
         }
       ]
@@ -6694,7 +6694,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cookie-parser"
         }
       ]
@@ -6720,7 +6720,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cookie-signature"
         }
       ]
@@ -6746,7 +6746,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cookie"
         }
       ]
@@ -6772,7 +6772,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/copy-descriptor"
         }
       ]
@@ -6798,7 +6798,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/core-util-is"
         }
       ]
@@ -6824,7 +6824,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cors"
         }
       ]
@@ -6850,7 +6850,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/crc"
         }
       ]
@@ -6876,7 +6876,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/crc32-stream"
         }
       ]
@@ -6902,7 +6902,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/create-require"
         }
       ]
@@ -6928,7 +6928,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/crypto-js"
         }
       ]
@@ -6954,7 +6954,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dashdash"
         }
       ]
@@ -6980,7 +6980,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/date-fns"
         }
       ]
@@ -7006,7 +7006,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dateformat"
         }
       ]
@@ -7032,7 +7032,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/debug"
         }
       ]
@@ -7058,7 +7058,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decamelize"
         }
       ]
@@ -7084,7 +7084,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decode-uri-component"
         }
       ]
@@ -7110,7 +7110,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-response"
         }
       ]
@@ -7136,7 +7136,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-tar"
         }
       ],
@@ -7162,7 +7162,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-tar/node_modules/file-type"
             }
           ]
@@ -7190,7 +7190,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-tarbz2"
         }
       ],
@@ -7216,7 +7216,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-tarbz2/node_modules/file-type"
             }
           ]
@@ -7244,7 +7244,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-targz"
         }
       ],
@@ -7270,7 +7270,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-targz/node_modules/file-type"
             }
           ]
@@ -7298,7 +7298,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-unzip"
         }
       ],
@@ -7324,7 +7324,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-unzip/node_modules/file-type"
             }
           ]
@@ -7350,7 +7350,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-unzip/node_modules/get-stream"
             }
           ]
@@ -7376,7 +7376,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-unzip/node_modules/pify"
             }
           ]
@@ -7404,7 +7404,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress"
         }
       ],
@@ -7430,7 +7430,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress/node_modules/make-dir"
             }
           ],
@@ -7456,7 +7456,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/decompress/node_modules/make-dir/node_modules/pify"
                 }
               ]
@@ -7484,7 +7484,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress/node_modules/pify"
             }
           ]
@@ -7512,7 +7512,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/deep-equal"
         }
       ]
@@ -7538,7 +7538,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/deep-extend"
         }
       ]
@@ -7564,7 +7564,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/deep-is"
         }
       ]
@@ -7590,7 +7590,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/define-properties"
         }
       ]
@@ -7616,7 +7616,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/define-property"
         }
       ]
@@ -7642,7 +7642,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/delayed-stream"
         }
       ]
@@ -7668,7 +7668,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/delegates"
         }
       ]
@@ -7694,7 +7694,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/depd"
         }
       ]
@@ -7720,7 +7720,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/destroy"
         }
       ]
@@ -7746,7 +7746,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/detect-file"
         }
       ]
@@ -7772,7 +7772,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/detect-libc"
         }
       ]
@@ -7798,7 +7798,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dfa"
         }
       ]
@@ -7824,7 +7824,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dicer"
         }
       ],
@@ -7850,7 +7850,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/dicer/node_modules/isarray"
             }
           ]
@@ -7876,7 +7876,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/dicer/node_modules/readable-stream"
             }
           ]
@@ -7902,7 +7902,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/dicer/node_modules/string_decoder"
             }
           ]
@@ -7930,7 +7930,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/diff"
         }
       ]
@@ -7956,7 +7956,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/doctypes"
         }
       ]
@@ -7982,7 +7982,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/domelementtype"
         }
       ]
@@ -8008,7 +8008,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/domhandler"
         }
       ]
@@ -8034,7 +8034,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/domutils"
         }
       ]
@@ -8060,7 +8060,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dottie"
         }
       ]
@@ -8086,7 +8086,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/double-ended-queue"
         }
       ]
@@ -8112,7 +8112,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/doublearray"
         }
       ]
@@ -8138,7 +8138,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/download"
         }
       ],
@@ -8164,7 +8164,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/download/node_modules/file-type"
             }
           ]
@@ -8192,7 +8192,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/duplexer2"
         }
       ]
@@ -8218,7 +8218,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/duplexer3"
         }
       ]
@@ -8244,7 +8244,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dynamic-dedupe"
         }
       ]
@@ -8270,7 +8270,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ecc-jsbn"
         }
       ]
@@ -8296,7 +8296,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ee-first"
         }
       ]
@@ -8322,7 +8322,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/eivindfjeldstad-dot"
         }
       ]
@@ -8348,7 +8348,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/emoji-regex"
         }
       ]
@@ -8374,7 +8374,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/enabled"
         }
       ]
@@ -8400,7 +8400,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/encodeurl"
         }
       ]
@@ -8426,7 +8426,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/encoding"
         }
       ],
@@ -8452,7 +8452,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/encoding/node_modules/iconv-lite"
             }
           ]
@@ -8480,7 +8480,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/end-of-stream"
         }
       ]
@@ -8506,7 +8506,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/engine.io-parser"
         }
       ]
@@ -8532,7 +8532,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/engine.io"
         }
       ],
@@ -8558,7 +8558,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/engine.io/node_modules/debug"
             }
           ]
@@ -8584,7 +8584,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/engine.io/node_modules/ms"
             }
           ]
@@ -8612,7 +8612,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/env-paths"
         }
       ]
@@ -8638,7 +8638,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/err-code"
         }
       ]
@@ -8664,7 +8664,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/error-ex"
         }
       ]
@@ -8690,7 +8690,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/errorhandler"
         }
       ]
@@ -8716,7 +8716,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/es-abstract"
         }
       ]
@@ -8742,7 +8742,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/es-get-iterator"
         }
       ]
@@ -8768,7 +8768,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/es-to-primitive"
         }
       ]
@@ -8794,7 +8794,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/escape-html"
         }
       ]
@@ -8820,7 +8820,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/escape-string-regexp"
         }
       ]
@@ -8846,7 +8846,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/escodegen"
         }
       ]
@@ -8872,7 +8872,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/esprima"
         }
       ]
@@ -8898,7 +8898,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/estraverse"
         }
       ]
@@ -8924,7 +8924,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/esutils"
         }
       ]
@@ -8950,7 +8950,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/etag"
         }
       ]
@@ -8976,7 +8976,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/eventemitter2"
         }
       ]
@@ -9002,7 +9002,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/eventemitter3"
         }
       ]
@@ -9028,7 +9028,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/exif"
         }
       ]
@@ -9054,7 +9054,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/exit"
         }
       ]
@@ -9080,7 +9080,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/expand-brackets"
         }
       ],
@@ -9106,7 +9106,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/define-property"
             }
           ]
@@ -9132,7 +9132,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/extend-shallow"
             }
           ]
@@ -9158,7 +9158,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/is-accessor-descriptor"
             }
           ],
@@ -9184,7 +9184,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/expand-brackets/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
@@ -9212,7 +9212,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/is-data-descriptor"
             }
           ],
@@ -9238,7 +9238,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/expand-brackets/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
@@ -9266,7 +9266,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/is-descriptor"
             }
           ]
@@ -9292,7 +9292,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/is-extendable"
             }
           ]
@@ -9318,7 +9318,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/kind-of"
             }
           ]
@@ -9346,7 +9346,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/expand-template"
         }
       ]
@@ -9372,7 +9372,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/expand-tilde"
         }
       ]
@@ -9398,7 +9398,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-ipfilter"
         }
       ]
@@ -9424,7 +9424,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-jwt"
         }
       ],
@@ -9450,7 +9450,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/express-jwt/node_modules/jsonwebtoken"
             }
           ]
@@ -9476,7 +9476,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/express-jwt/node_modules/moment"
             }
           ]
@@ -9504,7 +9504,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-rate-limit"
         }
       ]
@@ -9530,7 +9530,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-robots-txt"
         }
       ]
@@ -9556,7 +9556,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-security.txt"
         }
       ]
@@ -9582,7 +9582,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express"
         }
       ],
@@ -9608,7 +9608,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/express/node_modules/cookie"
             }
           ]
@@ -9634,7 +9634,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/express/node_modules/safe-buffer"
             }
           ]
@@ -9662,7 +9662,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ext-list"
         }
       ]
@@ -9688,7 +9688,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ext-name"
         }
       ]
@@ -9714,7 +9714,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/extend-shallow"
         }
       ]
@@ -9740,7 +9740,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/extend"
         }
       ]
@@ -9766,7 +9766,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/extglob"
         }
       ],
@@ -9792,7 +9792,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/extglob/node_modules/define-property"
             }
           ]
@@ -9818,7 +9818,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/extglob/node_modules/extend-shallow"
             }
           ]
@@ -9844,7 +9844,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/extglob/node_modules/is-extendable"
             }
           ]
@@ -9872,7 +9872,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/extsprintf"
         }
       ]
@@ -9898,7 +9898,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fast-deep-equal"
         }
       ]
@@ -9924,7 +9924,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fast-json-stable-stringify"
         }
       ]
@@ -9950,7 +9950,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fast-levenshtein"
         }
       ]
@@ -9976,7 +9976,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fast.js"
         }
       ]
@@ -10002,7 +10002,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fd-slicer"
         }
       ]
@@ -10028,7 +10028,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/feature-policy"
         }
       ]
@@ -10054,7 +10054,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fecha"
         }
       ]
@@ -10080,7 +10080,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/file-js"
         }
       ],
@@ -10106,7 +10106,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/file-js/node_modules/brace-expansion"
             }
           ]
@@ -10132,7 +10132,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/file-js/node_modules/minimatch"
             }
           ]
@@ -10160,7 +10160,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/file-stream-rotator"
         }
       ]
@@ -10186,7 +10186,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/file-type"
         }
       ]
@@ -10212,7 +10212,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/file-uri-to-path"
         }
       ]
@@ -10238,7 +10238,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/filehound"
         }
       ]
@@ -10264,7 +10264,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/filename-reserved-regex"
         }
       ]
@@ -10290,7 +10290,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/filenamify"
         }
       ]
@@ -10316,7 +10316,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/filesniffer"
         }
       ]
@@ -10342,7 +10342,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fill-range"
         }
       ],
@@ -10368,7 +10368,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/fill-range/node_modules/extend-shallow"
             }
           ]
@@ -10394,7 +10394,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/fill-range/node_modules/is-extendable"
             }
           ]
@@ -10422,7 +10422,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/finale-rest"
         }
       ]
@@ -10448,7 +10448,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/finalhandler"
         }
       ]
@@ -10474,7 +10474,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/find-up"
         }
       ]
@@ -10500,7 +10500,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/findup-sync"
         }
       ]
@@ -10526,7 +10526,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fined"
         }
       ]
@@ -10552,7 +10552,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/flagged-respawn"
         }
       ]
@@ -10578,7 +10578,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fn.name"
         }
       ]
@@ -10604,7 +10604,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fontkit"
         }
       ]
@@ -10630,7 +10630,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/for-each"
         }
       ]
@@ -10656,7 +10656,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/for-in"
         }
       ]
@@ -10682,7 +10682,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/for-own"
         }
       ]
@@ -10708,7 +10708,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/foreachasync"
         }
       ]
@@ -10734,7 +10734,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/forever-agent"
         }
       ]
@@ -10760,7 +10760,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/form-data"
         }
       ]
@@ -10786,7 +10786,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/formatio"
         }
       ]
@@ -10812,7 +10812,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/forwarded"
         }
       ]
@@ -10838,7 +10838,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fragment-cache"
         }
       ]
@@ -10864,7 +10864,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fresh"
         }
       ]
@@ -10890,7 +10890,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/from2"
         }
       ]
@@ -10916,7 +10916,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fs-constants"
         }
       ]
@@ -10942,7 +10942,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fs-extra"
         }
       ]
@@ -10968,7 +10968,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fs-minipass"
         }
       ]
@@ -10994,7 +10994,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fs.realpath"
         }
       ]
@@ -11020,7 +11020,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fsevents"
         }
       ]
@@ -11046,7 +11046,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fstream"
         }
       ],
@@ -11072,7 +11072,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/fstream/node_modules/mkdirp"
             }
           ]
@@ -11098,7 +11098,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/fstream/node_modules/rimraf"
             }
           ]
@@ -11126,7 +11126,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/function-bind"
         }
       ]
@@ -11152,7 +11152,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/function.prototype.name"
         }
       ]
@@ -11178,7 +11178,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/functions-have-names"
         }
       ]
@@ -11204,7 +11204,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fuzzball"
         }
       ]
@@ -11230,7 +11230,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/gauge"
         }
       ]
@@ -11256,7 +11256,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/geojson-utils"
         }
       ]
@@ -11282,7 +11282,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-caller-file"
         }
       ]
@@ -11308,7 +11308,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-intrinsic"
         }
       ]
@@ -11334,7 +11334,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-stream"
         }
       ]
@@ -11360,7 +11360,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-symbol-description"
         }
       ]
@@ -11386,7 +11386,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-value"
         }
       ]
@@ -11412,7 +11412,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/getobject"
         }
       ]
@@ -11438,7 +11438,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/getpass"
         }
       ]
@@ -11464,7 +11464,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/github-from-package"
         }
       ]
@@ -11490,7 +11490,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/glob-parent"
         }
       ],
@@ -11516,7 +11516,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/glob-parent/node_modules/is-glob"
             }
           ]
@@ -11544,7 +11544,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/glob"
         }
       ],
@@ -11570,7 +11570,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/glob/node_modules/brace-expansion"
             }
           ]
@@ -11596,7 +11596,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/glob/node_modules/minimatch"
             }
           ]
@@ -11624,7 +11624,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/global-modules"
         }
       ]
@@ -11650,7 +11650,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/global-prefix"
         }
       ],
@@ -11676,7 +11676,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/global-prefix/node_modules/which"
             }
           ]
@@ -11704,7 +11704,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/got"
         }
       ],
@@ -11730,7 +11730,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/got/node_modules/get-stream"
             }
           ]
@@ -11756,7 +11756,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/got/node_modules/pify"
             }
           ]
@@ -11784,7 +11784,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/graceful-fs"
         }
       ]
@@ -11810,7 +11810,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-cli"
         }
       ],
@@ -11836,7 +11836,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-cli/node_modules/nopt"
             }
           ]
@@ -11864,7 +11864,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-contrib-compress"
         }
       ],
@@ -11890,7 +11890,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-contrib-compress/node_modules/ansi-styles"
             }
           ]
@@ -11916,7 +11916,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-contrib-compress/node_modules/chalk"
             }
           ]
@@ -11942,7 +11942,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-contrib-compress/node_modules/supports-color"
             }
           ]
@@ -11970,7 +11970,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-known-options"
         }
       ]
@@ -11996,7 +11996,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-legacy-log-utils"
         }
       ],
@@ -12022,7 +12022,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils/node_modules/ansi-styles"
             }
           ]
@@ -12048,7 +12048,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils/node_modules/chalk"
             }
           ]
@@ -12074,7 +12074,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils/node_modules/color-convert"
             }
           ]
@@ -12100,7 +12100,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils/node_modules/color-name"
             }
           ]
@@ -12126,7 +12126,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils/node_modules/has-flag"
             }
           ]
@@ -12152,7 +12152,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils/node_modules/supports-color"
             }
           ]
@@ -12180,7 +12180,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-legacy-log"
         }
       ],
@@ -12206,7 +12206,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log/node_modules/colors"
             }
           ]
@@ -12234,7 +12234,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-legacy-util"
         }
       ],
@@ -12260,7 +12260,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-util/node_modules/async"
             }
           ]
@@ -12288,7 +12288,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-replace-json"
         }
       ]
@@ -12314,7 +12314,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt"
         }
       ],
@@ -12340,7 +12340,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt/node_modules/brace-expansion"
             }
           ]
@@ -12366,7 +12366,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt/node_modules/findup-sync"
             }
           ],
@@ -12392,7 +12392,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/grunt/node_modules/findup-sync/node_modules/glob"
                 }
               ]
@@ -12420,7 +12420,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt/node_modules/glob"
             }
           ]
@@ -12446,7 +12446,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt/node_modules/minimatch"
             }
           ]
@@ -12474,7 +12474,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/handlebars"
         }
       ],
@@ -12500,7 +12500,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/handlebars/node_modules/wordwrap"
             }
           ]
@@ -12528,7 +12528,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/har-schema"
         }
       ]
@@ -12554,7 +12554,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/har-validator"
         }
       ]
@@ -12580,7 +12580,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-ansi"
         }
       ]
@@ -12606,7 +12606,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-bigints"
         }
       ]
@@ -12632,7 +12632,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-flag"
         }
       ]
@@ -12658,7 +12658,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-property-descriptors"
         }
       ]
@@ -12684,7 +12684,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-symbol-support-x"
         }
       ]
@@ -12710,7 +12710,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-symbols"
         }
       ]
@@ -12736,7 +12736,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-to-string-tag-x"
         }
       ]
@@ -12762,7 +12762,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-tostringtag"
         }
       ]
@@ -12788,7 +12788,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-unicode"
         }
       ]
@@ -12814,7 +12814,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-value"
         }
       ]
@@ -12840,7 +12840,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-values"
         }
       ],
@@ -12866,7 +12866,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/has-values/node_modules/kind-of"
             }
           ]
@@ -12894,7 +12894,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has"
         }
       ]
@@ -12920,7 +12920,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hashids"
         }
       ]
@@ -12946,7 +12946,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hbs"
         }
       ]
@@ -12972,7 +12972,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/he"
         }
       ]
@@ -12998,7 +12998,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/heap"
         }
       ]
@@ -13024,7 +13024,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/helmet"
         }
       ]
@@ -13050,7 +13050,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hoister"
         }
       ]
@@ -13076,7 +13076,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/homedir-polyfill"
         }
       ]
@@ -13102,7 +13102,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hooker"
         }
       ]
@@ -13128,7 +13128,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hosted-git-info"
         }
       ]
@@ -13154,7 +13154,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/html-entities"
         }
       ]
@@ -13180,7 +13180,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/htmlparser2"
         }
       ],
@@ -13206,7 +13206,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/htmlparser2/node_modules/isarray"
             }
           ]
@@ -13232,7 +13232,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/htmlparser2/node_modules/readable-stream"
             }
           ]
@@ -13258,7 +13258,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/htmlparser2/node_modules/string_decoder"
             }
           ]
@@ -13286,7 +13286,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/http-cache-semantics"
         }
       ]
@@ -13312,7 +13312,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/http-errors"
         }
       ]
@@ -13338,7 +13338,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/http-proxy-agent"
         }
       ],
@@ -13364,7 +13364,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/http-proxy-agent/node_modules/debug"
             }
           ]
@@ -13390,7 +13390,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/http-proxy-agent/node_modules/ms"
             }
           ]
@@ -13418,7 +13418,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/http-signature"
         }
       ]
@@ -13444,7 +13444,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/https-proxy-agent"
         }
       ],
@@ -13470,7 +13470,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/https-proxy-agent/node_modules/debug"
             }
           ]
@@ -13496,7 +13496,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/https-proxy-agent/node_modules/ms"
             }
           ]
@@ -13524,7 +13524,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/humanize-ms"
         }
       ]
@@ -13550,7 +13550,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/i18n"
         }
       ]
@@ -13576,7 +13576,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/iconv-lite"
         }
       ]
@@ -13602,7 +13602,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ieee754"
         }
       ]
@@ -13628,7 +13628,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ignore-walk"
         }
       ],
@@ -13654,7 +13654,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/ignore-walk/node_modules/brace-expansion"
             }
           ]
@@ -13680,7 +13680,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/ignore-walk/node_modules/minimatch"
             }
           ]
@@ -13708,7 +13708,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/iltorb"
         }
       ]
@@ -13734,7 +13734,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/imurmurhash"
         }
       ]
@@ -13760,7 +13760,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/indent-string"
         }
       ]
@@ -13786,7 +13786,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/infer-owner"
         }
       ]
@@ -13812,7 +13812,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/inflection"
         }
       ]
@@ -13838,7 +13838,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/inflight"
         }
       ]
@@ -13864,7 +13864,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/inherits"
         }
       ]
@@ -13890,7 +13890,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ini"
         }
       ]
@@ -13916,7 +13916,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/internal-slot"
         }
       ]
@@ -13942,7 +13942,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/interpret"
         }
       ]
@@ -13968,7 +13968,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/into-stream"
         }
       ]
@@ -13994,7 +13994,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/invariant"
         }
       ]
@@ -14020,7 +14020,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ip"
         }
       ]
@@ -14046,7 +14046,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ip6"
         }
       ]
@@ -14072,7 +14072,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ipaddr.js"
         }
       ]
@@ -14098,7 +14098,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-absolute"
         }
       ]
@@ -14124,7 +14124,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-accessor-descriptor"
         }
       ]
@@ -14150,7 +14150,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-arguments"
         }
       ]
@@ -14176,7 +14176,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-arrayish"
         }
       ]
@@ -14202,7 +14202,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-bigint"
         }
       ]
@@ -14228,7 +14228,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-binary-path"
         }
       ]
@@ -14254,7 +14254,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-boolean-object"
         }
       ]
@@ -14280,7 +14280,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-buffer"
         }
       ]
@@ -14306,7 +14306,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-callable"
         }
       ]
@@ -14332,7 +14332,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-core-module"
         }
       ]
@@ -14358,7 +14358,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-data-descriptor"
         }
       ]
@@ -14384,7 +14384,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-date-object"
         }
       ]
@@ -14410,7 +14410,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-descriptor"
         }
       ]
@@ -14436,7 +14436,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-docker"
         }
       ]
@@ -14462,7 +14462,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-expression"
         }
       ]
@@ -14488,7 +14488,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-extendable"
         }
       ]
@@ -14514,7 +14514,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-extglob"
         }
       ]
@@ -14540,7 +14540,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-fullwidth-code-point"
         }
       ]
@@ -14566,7 +14566,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-generator-function"
         }
       ]
@@ -14592,7 +14592,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-glob"
         }
       ]
@@ -14618,7 +14618,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-heroku"
         }
       ]
@@ -14644,7 +14644,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-lambda"
         }
       ]
@@ -14670,7 +14670,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-map"
         }
       ]
@@ -14696,7 +14696,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-natural-number"
         }
       ]
@@ -14722,7 +14722,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-negative-zero"
         }
       ]
@@ -14748,7 +14748,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-number-like"
         }
       ]
@@ -14774,7 +14774,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-number-object"
         }
       ]
@@ -14800,7 +14800,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-number"
         }
       ],
@@ -14826,7 +14826,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/is-number/node_modules/kind-of"
             }
           ]
@@ -14854,7 +14854,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-object"
         }
       ]
@@ -14880,7 +14880,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-plain-obj"
         }
       ]
@@ -14906,7 +14906,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-plain-object"
         }
       ]
@@ -14932,7 +14932,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-promise"
         }
       ]
@@ -14958,7 +14958,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-regex"
         }
       ]
@@ -14984,7 +14984,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-relative"
         }
       ]
@@ -15010,7 +15010,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-retry-allowed"
         }
       ]
@@ -15036,7 +15036,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-set"
         }
       ]
@@ -15062,7 +15062,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-shared-array-buffer"
         }
       ]
@@ -15088,7 +15088,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-stream"
         }
       ]
@@ -15114,7 +15114,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-string"
         }
       ]
@@ -15140,7 +15140,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-symbol"
         }
       ]
@@ -15166,7 +15166,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-typed-array"
         }
       ]
@@ -15192,7 +15192,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-typedarray"
         }
       ]
@@ -15218,7 +15218,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-unc-path"
         }
       ]
@@ -15244,7 +15244,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-weakmap"
         }
       ]
@@ -15270,7 +15270,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-weakref"
         }
       ]
@@ -15296,7 +15296,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-weakset"
         }
       ]
@@ -15322,7 +15322,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-windows"
         }
       ]
@@ -15348,7 +15348,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isarray"
         }
       ]
@@ -15374,7 +15374,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isexe"
         }
       ]
@@ -15400,7 +15400,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isobject"
         }
       ]
@@ -15426,7 +15426,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isstream"
         }
       ]
@@ -15452,7 +15452,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isurl"
         }
       ]
@@ -15478,7 +15478,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/js-stringify"
         }
       ]
@@ -15504,7 +15504,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/js-tokens"
         }
       ]
@@ -15530,7 +15530,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/js-yaml"
         }
       ]
@@ -15556,7 +15556,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jsbn"
         }
       ]
@@ -15582,7 +15582,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-buffer"
         }
       ]
@@ -15608,7 +15608,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-parse-better-errors"
         }
       ]
@@ -15634,7 +15634,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-schema-traverse"
         }
       ]
@@ -15660,7 +15660,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-schema"
         }
       ]
@@ -15686,7 +15686,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-stringify-safe"
         }
       ]
@@ -15712,7 +15712,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json5"
         }
       ]
@@ -15738,7 +15738,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jsonfile"
         }
       ]
@@ -15764,7 +15764,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jsonwebtoken"
         }
       ]
@@ -15790,7 +15790,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jsprim"
         }
       ]
@@ -15816,7 +15816,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jssha"
         }
       ]
@@ -15842,7 +15842,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jstransformer"
         }
       ]
@@ -15868,7 +15868,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/juicy-chat-bot"
         }
       ]
@@ -15894,7 +15894,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jwa"
         }
       ]
@@ -15920,7 +15920,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jws"
         }
       ]
@@ -15946,7 +15946,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/keyv"
         }
       ]
@@ -15972,7 +15972,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/kind-of"
         }
       ]
@@ -15998,7 +15998,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/kuler"
         }
       ]
@@ -16024,7 +16024,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/kuromoji"
         }
       ]
@@ -16050,7 +16050,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lazystream"
         }
       ]
@@ -16076,7 +16076,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/levn"
         }
       ]
@@ -16102,7 +16102,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/libxmljs2"
         }
       ],
@@ -16128,7 +16128,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/libxmljs2/node_modules/nan"
             }
           ]
@@ -16156,7 +16156,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/liftup"
         }
       ],
@@ -16182,7 +16182,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/braces"
             }
           ]
@@ -16208,7 +16208,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/fill-range"
             }
           ]
@@ -16234,7 +16234,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/findup-sync"
             }
           ]
@@ -16260,7 +16260,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/is-glob"
             }
           ]
@@ -16286,7 +16286,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/is-number"
             }
           ]
@@ -16312,7 +16312,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/micromatch"
             }
           ]
@@ -16338,7 +16338,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/to-regex-range"
             }
           ]
@@ -16366,7 +16366,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/linebreak"
         }
       ],
@@ -16392,7 +16392,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/linebreak/node_modules/base64-js"
             }
           ]
@@ -16420,7 +16420,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/listenercount"
         }
       ]
@@ -16446,7 +16446,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/locate-path"
         }
       ]
@@ -16472,7 +16472,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lodash.camelcase"
         }
       ]
@@ -16498,7 +16498,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lodash.isfinite"
         }
       ]
@@ -16524,7 +16524,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lodash.set"
         }
       ]
@@ -16550,7 +16550,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lodash"
         }
       ]
@@ -16576,7 +16576,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/logform"
         }
       ],
@@ -16602,7 +16602,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/logform/node_modules/ms"
             }
           ]
@@ -16630,7 +16630,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lolex"
         }
       ]
@@ -16656,7 +16656,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/loose-envify"
         }
       ]
@@ -16682,7 +16682,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lowercase-keys"
         }
       ]
@@ -16708,7 +16708,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lru-cache"
         }
       ]
@@ -16734,7 +16734,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-dir"
         }
       ],
@@ -16760,7 +16760,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-dir/node_modules/semver"
             }
           ]
@@ -16788,7 +16788,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-error"
         }
       ]
@@ -16814,7 +16814,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-fetch-happen"
         }
       ],
@@ -16841,7 +16841,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen/node_modules/@tootallnate/once"
             }
           ]
@@ -16867,7 +16867,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen/node_modules/debug"
             }
           ]
@@ -16893,7 +16893,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen/node_modules/http-cache-semantics"
             }
           ]
@@ -16919,7 +16919,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen/node_modules/http-proxy-agent"
             }
           ]
@@ -16945,7 +16945,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen/node_modules/ms"
             }
           ]
@@ -16973,7 +16973,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-iterator"
         }
       ]
@@ -16999,7 +16999,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-plural"
         }
       ]
@@ -17025,7 +17025,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/map-cache"
         }
       ]
@@ -17051,7 +17051,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/map-visit"
         }
       ]
@@ -17077,7 +17077,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/marsdb"
         }
       ]
@@ -17103,7 +17103,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/math-interval-parser"
         }
       ]
@@ -17129,7 +17129,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/media-typer"
         }
       ]
@@ -17155,7 +17155,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/merge-descriptors"
         }
       ]
@@ -17181,7 +17181,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/messageformat-formatters"
         }
       ]
@@ -17207,7 +17207,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/messageformat-parser"
         }
       ]
@@ -17233,7 +17233,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/messageformat"
         }
       ],
@@ -17259,7 +17259,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/messageformat/node_modules/make-plural"
             }
           ]
@@ -17287,7 +17287,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/methods"
         }
       ]
@@ -17313,7 +17313,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/micromatch"
         }
       ]
@@ -17339,7 +17339,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mime-db"
         }
       ]
@@ -17365,7 +17365,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mime-types"
         }
       ]
@@ -17391,7 +17391,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mime"
         }
       ]
@@ -17417,7 +17417,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mimic-response"
         }
       ]
@@ -17443,7 +17443,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minimatch"
         }
       ]
@@ -17469,7 +17469,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minimist"
         }
       ]
@@ -17495,7 +17495,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-collect"
         }
       ]
@@ -17521,7 +17521,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-fetch"
         }
       ]
@@ -17547,7 +17547,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-flush"
         }
       ]
@@ -17573,7 +17573,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-pipeline"
         }
       ]
@@ -17599,7 +17599,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-sized"
         }
       ]
@@ -17625,7 +17625,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass"
         }
       ]
@@ -17651,7 +17651,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minizlib"
         }
       ]
@@ -17677,7 +17677,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mixin-deep"
         }
       ]
@@ -17703,7 +17703,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mkdirp-classic"
         }
       ]
@@ -17729,7 +17729,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mkdirp"
         }
       ]
@@ -17755,7 +17755,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/moment-timezone"
         }
       ]
@@ -17781,7 +17781,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/moment"
         }
       ]
@@ -17807,7 +17807,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/morgan"
         }
       ],
@@ -17833,7 +17833,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/morgan/node_modules/on-finished"
             }
           ]
@@ -17861,7 +17861,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mout"
         }
       ]
@@ -17887,7 +17887,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ms"
         }
       ]
@@ -17913,7 +17913,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/multer"
         }
       ],
@@ -17939,7 +17939,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/multer/node_modules/mkdirp"
             }
           ]
@@ -17967,7 +17967,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mustache"
         }
       ]
@@ -17993,7 +17993,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/nan"
         }
       ]
@@ -18019,7 +18019,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/nanomatch"
         }
       ]
@@ -18045,7 +18045,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/napi-build-utils"
         }
       ]
@@ -18071,7 +18071,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/needle"
         }
       ],
@@ -18097,7 +18097,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/needle/node_modules/debug"
             }
           ]
@@ -18123,7 +18123,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/needle/node_modules/ms"
             }
           ]
@@ -18151,7 +18151,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/negotiator"
         }
       ]
@@ -18177,7 +18177,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/neo-async"
         }
       ]
@@ -18203,7 +18203,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-abi"
         }
       ],
@@ -18229,7 +18229,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-abi/node_modules/semver"
             }
           ]
@@ -18257,7 +18257,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-addon-api"
         }
       ]
@@ -18283,7 +18283,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-fetch"
         }
       ]
@@ -18309,7 +18309,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-gyp"
         }
       ],
@@ -18335,7 +18335,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/ansi-regex"
             }
           ]
@@ -18361,7 +18361,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/are-we-there-yet"
             }
           ]
@@ -18387,7 +18387,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/gauge"
             }
           ]
@@ -18413,7 +18413,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -18439,7 +18439,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/nopt"
             }
           ]
@@ -18465,7 +18465,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/npmlog"
             }
           ]
@@ -18491,7 +18491,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/readable-stream"
             }
           ]
@@ -18517,7 +18517,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/string-width"
             }
           ]
@@ -18543,7 +18543,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/strip-ansi"
             }
           ]
@@ -18571,7 +18571,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-pre-gyp"
         }
       ],
@@ -18597,7 +18597,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/chownr"
             }
           ]
@@ -18623,7 +18623,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/fs-minipass"
             }
           ]
@@ -18649,7 +18649,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/minipass"
             }
           ]
@@ -18675,7 +18675,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/minizlib"
             }
           ]
@@ -18701,7 +18701,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/mkdirp"
             }
           ]
@@ -18727,7 +18727,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/nopt"
             }
           ]
@@ -18753,7 +18753,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/rimraf"
             }
           ]
@@ -18779,7 +18779,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/safe-buffer"
             }
           ]
@@ -18805,7 +18805,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/semver"
             }
           ]
@@ -18831,7 +18831,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/tar"
             }
           ]
@@ -18857,7 +18857,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/yallist"
             }
           ]
@@ -18885,7 +18885,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/noop-logger"
         }
       ]
@@ -18911,7 +18911,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/nopt"
         }
       ]
@@ -18937,7 +18937,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/normalize-package-data"
         }
       ],
@@ -18963,7 +18963,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/normalize-package-data/node_modules/semver"
             }
           ]
@@ -18991,7 +18991,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/normalize-path"
         }
       ]
@@ -19017,7 +19017,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/normalize-url"
         }
       ]
@@ -19043,7 +19043,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/notevil"
         }
       ],
@@ -19069,7 +19069,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/notevil/node_modules/esprima"
             }
           ]
@@ -19097,7 +19097,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/npm-bundled"
         }
       ]
@@ -19123,7 +19123,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/npm-normalize-package-bin"
         }
       ]
@@ -19149,7 +19149,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/npm-packlist"
         }
       ]
@@ -19175,7 +19175,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/npmlog"
         }
       ]
@@ -19201,7 +19201,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/number-is-nan"
         }
       ]
@@ -19227,7 +19227,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/oauth-sign"
         }
       ]
@@ -19253,7 +19253,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-assign"
         }
       ]
@@ -19279,7 +19279,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-copy"
         }
       ],
@@ -19305,7 +19305,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy/node_modules/define-property"
             }
           ]
@@ -19331,7 +19331,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy/node_modules/is-accessor-descriptor"
             }
           ]
@@ -19357,7 +19357,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy/node_modules/is-data-descriptor"
             }
           ]
@@ -19383,7 +19383,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy/node_modules/is-descriptor"
             }
           ],
@@ -19409,7 +19409,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/object-copy/node_modules/is-descriptor/node_modules/kind-of"
                 }
               ]
@@ -19437,7 +19437,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy/node_modules/kind-of"
             }
           ]
@@ -19465,7 +19465,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-inspect"
         }
       ]
@@ -19491,7 +19491,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-is"
         }
       ]
@@ -19517,7 +19517,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-keys"
         }
       ]
@@ -19543,7 +19543,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-visit"
         }
       ]
@@ -19569,7 +19569,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object.assign"
         }
       ]
@@ -19595,7 +19595,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object.defaults"
         }
       ]
@@ -19621,7 +19621,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object.map"
         }
       ]
@@ -19647,7 +19647,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object.pick"
         }
       ]
@@ -19673,7 +19673,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/on-finished"
         }
       ]
@@ -19699,7 +19699,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/on-headers"
         }
       ]
@@ -19725,7 +19725,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/once"
         }
       ]
@@ -19751,7 +19751,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/one-time"
         }
       ]
@@ -19777,7 +19777,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/opentype.js"
         }
       ]
@@ -19803,7 +19803,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/optionator"
         }
       ]
@@ -19829,7 +19829,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/os-homedir"
         }
       ]
@@ -19855,7 +19855,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/os-tmpdir"
         }
       ]
@@ -19881,7 +19881,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/osenv"
         }
       ]
@@ -19907,7 +19907,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/otplib"
         }
       ]
@@ -19933,7 +19933,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-cancelable"
         }
       ]
@@ -19959,7 +19959,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-event"
         }
       ]
@@ -19985,7 +19985,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-finally"
         }
       ]
@@ -20011,7 +20011,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-is-promise"
         }
       ]
@@ -20037,7 +20037,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-limit"
         }
       ]
@@ -20063,7 +20063,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-locate"
         }
       ]
@@ -20089,7 +20089,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-map"
         }
       ]
@@ -20115,7 +20115,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-timeout"
         }
       ]
@@ -20141,7 +20141,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-try"
         }
       ]
@@ -20167,7 +20167,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pako"
         }
       ]
@@ -20193,7 +20193,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/parse-filepath"
         }
       ]
@@ -20219,7 +20219,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/parse-json"
         }
       ]
@@ -20245,7 +20245,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/parse-passwd"
         }
       ]
@@ -20271,7 +20271,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/parseurl"
         }
       ]
@@ -20297,7 +20297,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pascalcase"
         }
       ]
@@ -20323,7 +20323,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-exists"
         }
       ]
@@ -20349,7 +20349,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-is-absolute"
         }
       ]
@@ -20375,7 +20375,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-parse"
         }
       ]
@@ -20401,7 +20401,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-root-regex"
         }
       ]
@@ -20427,7 +20427,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-root"
         }
       ]
@@ -20453,7 +20453,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-to-regexp"
         }
       ]
@@ -20479,7 +20479,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pdfkit"
         }
       ]
@@ -20505,7 +20505,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/peek-readable"
         }
       ]
@@ -20531,7 +20531,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pend"
         }
       ]
@@ -20557,7 +20557,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/performance-now"
         }
       ]
@@ -20583,7 +20583,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pg-connection-string"
         }
       ]
@@ -20609,7 +20609,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/picomatch"
         }
       ]
@@ -20635,7 +20635,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pify"
         }
       ]
@@ -20661,7 +20661,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pinkie-promise"
         }
       ]
@@ -20687,7 +20687,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pinkie"
         }
       ]
@@ -20713,7 +20713,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/png-js"
         }
       ]
@@ -20739,7 +20739,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/portscanner"
         }
       ]
@@ -20765,7 +20765,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/posix-character-classes"
         }
       ]
@@ -20791,7 +20791,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/prebuild-install"
         }
       ]
@@ -20817,7 +20817,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/prelude-ls"
         }
       ]
@@ -20843,7 +20843,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/prepend-http"
         }
       ]
@@ -20869,7 +20869,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pretty-bytes"
         }
       ]
@@ -20895,7 +20895,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/process-nextick-args"
         }
       ]
@@ -20921,7 +20921,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/prom-client"
         }
       ]
@@ -20947,7 +20947,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/promise-inflight"
         }
       ]
@@ -20973,7 +20973,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/promise-retry"
         }
       ],
@@ -20999,7 +20999,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/promise-retry/node_modules/err-code"
             }
           ]
@@ -21025,7 +21025,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/promise-retry/node_modules/retry"
             }
           ]
@@ -21053,7 +21053,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/promise"
         }
       ]
@@ -21079,7 +21079,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/proper-lockfile"
         }
       ]
@@ -21105,7 +21105,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/proxy-addr"
         }
       ]
@@ -21131,7 +21131,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/psl"
         }
       ]
@@ -21157,7 +21157,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-attrs"
         }
       ]
@@ -21183,7 +21183,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-code-gen"
         }
       ]
@@ -21209,7 +21209,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-error"
         }
       ]
@@ -21235,7 +21235,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-filters"
         }
       ]
@@ -21261,7 +21261,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-lexer"
         }
       ]
@@ -21287,7 +21287,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-linker"
         }
       ]
@@ -21313,7 +21313,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-load"
         }
       ]
@@ -21339,7 +21339,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-parser"
         }
       ]
@@ -21365,7 +21365,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-runtime"
         }
       ]
@@ -21391,7 +21391,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-strip-comments"
         }
       ]
@@ -21417,7 +21417,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-walk"
         }
       ]
@@ -21443,7 +21443,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug"
         }
       ]
@@ -21469,7 +21469,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pump"
         }
       ]
@@ -21495,7 +21495,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/punycode"
         }
       ]
@@ -21521,7 +21521,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/qs"
         }
       ]
@@ -21547,7 +21547,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/query-string"
         }
       ]
@@ -21573,7 +21573,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/range_check"
         }
       ]
@@ -21599,7 +21599,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/range-parser"
         }
       ]
@@ -21625,7 +21625,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/raw-body"
         }
       ]
@@ -21651,7 +21651,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/rc"
         }
       ]
@@ -21677,7 +21677,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/read-pkg"
         }
       ],
@@ -21703,7 +21703,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/read-pkg/node_modules/pify"
             }
           ]
@@ -21731,7 +21731,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/readable-stream"
         }
       ],
@@ -21757,7 +21757,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/readable-stream/node_modules/isarray"
             }
           ]
@@ -21785,7 +21785,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/readable-web-to-node-stream"
         }
       ],
@@ -21811,7 +21811,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/readable-web-to-node-stream/node_modules/readable-stream"
             }
           ]
@@ -21839,7 +21839,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/readdirp"
         }
       ]
@@ -21865,7 +21865,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/rechoir"
         }
       ]
@@ -21891,7 +21891,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/regex-not"
         }
       ]
@@ -21917,7 +21917,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/regexp.prototype.flags"
         }
       ]
@@ -21943,7 +21943,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/remove-trailing-separator"
         }
       ]
@@ -21969,7 +21969,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/repeat-element"
         }
       ]
@@ -21995,7 +21995,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/repeat-string"
         }
       ]
@@ -22021,7 +22021,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/replace"
         }
       ],
@@ -22047,7 +22047,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/ansi-regex"
             }
           ]
@@ -22073,7 +22073,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/ansi-styles"
             }
           ]
@@ -22099,7 +22099,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/brace-expansion"
             }
           ]
@@ -22125,7 +22125,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/cliui"
             }
           ]
@@ -22151,7 +22151,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/color-convert"
             }
           ]
@@ -22177,7 +22177,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/color-name"
             }
           ]
@@ -22203,7 +22203,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/find-up"
             }
           ]
@@ -22229,7 +22229,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -22255,7 +22255,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/locate-path"
             }
           ]
@@ -22281,7 +22281,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/minimatch"
             }
           ]
@@ -22307,7 +22307,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/p-locate"
             }
           ]
@@ -22333,7 +22333,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/path-exists"
             }
           ]
@@ -22359,7 +22359,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/string-width"
             }
           ]
@@ -22385,7 +22385,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/strip-ansi"
             }
           ]
@@ -22411,7 +22411,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/wrap-ansi"
             }
           ]
@@ -22437,7 +22437,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/yargs-parser"
             }
           ]
@@ -22463,7 +22463,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/yargs"
             }
           ]
@@ -22491,7 +22491,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/request"
         }
       ],
@@ -22517,7 +22517,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/request/node_modules/qs"
             }
           ]
@@ -22545,7 +22545,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/require-directory"
         }
       ]
@@ -22571,7 +22571,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/require-main-filename"
         }
       ]
@@ -22597,7 +22597,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/resolve-dir"
         }
       ]
@@ -22623,7 +22623,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/resolve-url"
         }
       ]
@@ -22649,7 +22649,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/resolve"
         }
       ]
@@ -22675,7 +22675,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/responselike"
         }
       ]
@@ -22701,7 +22701,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/restructure"
         }
       ]
@@ -22727,7 +22727,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ret"
         }
       ]
@@ -22753,7 +22753,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/retry-as-promised"
         }
       ]
@@ -22779,7 +22779,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/retry"
         }
       ]
@@ -22805,7 +22805,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/rimraf"
         }
       ]
@@ -22831,7 +22831,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/rxjs"
         }
       ],
@@ -22857,7 +22857,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/rxjs/node_modules/tslib"
             }
           ]
@@ -22885,7 +22885,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safe-buffer"
         }
       ]
@@ -22911,7 +22911,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safe-regex-test"
         }
       ]
@@ -22937,7 +22937,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safe-regex"
         }
       ]
@@ -22963,7 +22963,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safe-stable-stringify"
         }
       ]
@@ -22989,7 +22989,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safer-buffer"
         }
       ]
@@ -23015,7 +23015,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/samsam"
         }
       ]
@@ -23041,7 +23041,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sanitize-filename"
         }
       ]
@@ -23067,7 +23067,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sanitize-html"
         }
       ],
@@ -23093,7 +23093,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sanitize-html/node_modules/lodash"
             }
           ]
@@ -23121,7 +23121,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sax"
         }
       ]
@@ -23147,7 +23147,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/seek-bzip"
         }
       ]
@@ -23173,7 +23173,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/semver"
         }
       ]
@@ -23199,7 +23199,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/send"
         }
       ],
@@ -23225,7 +23225,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/send/node_modules/ms"
             }
           ]
@@ -23253,7 +23253,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sequelize-pool"
         }
       ]
@@ -23279,7 +23279,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sequelize"
         }
       ],
@@ -23305,7 +23305,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sequelize/node_modules/debug"
             }
           ]
@@ -23331,7 +23331,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sequelize/node_modules/ms"
             }
           ]
@@ -23357,7 +23357,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sequelize/node_modules/uuid"
             }
           ]
@@ -23385,7 +23385,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/serve-index"
         }
       ],
@@ -23411,7 +23411,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index/node_modules/depd"
             }
           ]
@@ -23437,7 +23437,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index/node_modules/http-errors"
             }
           ]
@@ -23463,7 +23463,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index/node_modules/inherits"
             }
           ]
@@ -23489,7 +23489,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index/node_modules/setprototypeof"
             }
           ]
@@ -23515,7 +23515,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index/node_modules/statuses"
             }
           ]
@@ -23543,7 +23543,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/serve-static"
         }
       ]
@@ -23569,7 +23569,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/set-blocking"
         }
       ]
@@ -23595,7 +23595,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/set-value"
         }
       ],
@@ -23621,7 +23621,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/set-value/node_modules/extend-shallow"
             }
           ]
@@ -23647,7 +23647,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/set-value/node_modules/is-extendable"
             }
           ]
@@ -23675,7 +23675,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/setimmediate"
         }
       ]
@@ -23701,7 +23701,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/setprototypeof"
         }
       ]
@@ -23727,7 +23727,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/side-channel"
         }
       ]
@@ -23753,7 +23753,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/signal-exit"
         }
       ]
@@ -23779,7 +23779,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/simple-concat"
         }
       ]
@@ -23805,7 +23805,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/simple-get"
         }
       ],
@@ -23831,7 +23831,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/simple-get/node_modules/decompress-response"
             }
           ]
@@ -23857,7 +23857,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/simple-get/node_modules/mimic-response"
             }
           ]
@@ -23885,7 +23885,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/simple-swizzle"
         }
       ],
@@ -23911,7 +23911,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/simple-swizzle/node_modules/is-arrayish"
             }
           ]
@@ -23939,7 +23939,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sinon"
         }
       ]
@@ -23965,7 +23965,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/smart-buffer"
         }
       ]
@@ -23991,7 +23991,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/snapdragon-node"
         }
       ],
@@ -24017,7 +24017,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon-node/node_modules/define-property"
             }
           ]
@@ -24045,7 +24045,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/snapdragon-util"
         }
       ],
@@ -24071,7 +24071,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon-util/node_modules/kind-of"
             }
           ]
@@ -24099,7 +24099,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/snapdragon"
         }
       ],
@@ -24125,7 +24125,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/define-property"
             }
           ]
@@ -24151,7 +24151,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/extend-shallow"
             }
           ]
@@ -24177,7 +24177,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/is-accessor-descriptor"
             }
           ],
@@ -24203,7 +24203,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/snapdragon/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
@@ -24231,7 +24231,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/is-data-descriptor"
             }
           ],
@@ -24257,7 +24257,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/snapdragon/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
@@ -24285,7 +24285,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/is-descriptor"
             }
           ]
@@ -24311,7 +24311,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/is-extendable"
             }
           ]
@@ -24337,7 +24337,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/kind-of"
             }
           ]
@@ -24363,7 +24363,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/source-map"
             }
           ]
@@ -24391,7 +24391,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socket.io-adapter"
         }
       ]
@@ -24417,7 +24417,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socket.io-parser"
         }
       ],
@@ -24443,7 +24443,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socket.io-parser/node_modules/debug"
             }
           ]
@@ -24469,7 +24469,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socket.io-parser/node_modules/ms"
             }
           ]
@@ -24497,7 +24497,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socket.io"
         }
       ],
@@ -24523,7 +24523,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socket.io/node_modules/debug"
             }
           ]
@@ -24549,7 +24549,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socket.io/node_modules/ms"
             }
           ]
@@ -24577,7 +24577,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socks-proxy-agent"
         }
       ],
@@ -24603,7 +24603,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socks-proxy-agent/node_modules/debug"
             }
           ]
@@ -24629,7 +24629,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socks-proxy-agent/node_modules/ms"
             }
           ]
@@ -24657,7 +24657,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socks"
         }
       ],
@@ -24683,7 +24683,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socks/node_modules/ip"
             }
           ]
@@ -24711,7 +24711,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sort-keys-length"
         }
       ],
@@ -24737,7 +24737,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sort-keys-length/node_modules/sort-keys"
             }
           ]
@@ -24765,7 +24765,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sort-keys"
         }
       ]
@@ -24791,7 +24791,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/source-map-resolve"
         }
       ]
@@ -24817,7 +24817,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/source-map-support"
         }
       ]
@@ -24843,7 +24843,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/source-map-url"
         }
       ]
@@ -24869,7 +24869,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/source-map"
         }
       ]
@@ -24895,7 +24895,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spawn-command"
         }
       ]
@@ -24921,7 +24921,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spdx-correct"
         }
       ]
@@ -24947,7 +24947,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spdx-exceptions"
         }
       ]
@@ -24973,7 +24973,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spdx-expression-parse"
         }
       ]
@@ -24999,7 +24999,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spdx-license-ids"
         }
       ]
@@ -25025,7 +25025,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/split-string"
         }
       ]
@@ -25051,7 +25051,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sprintf-js"
         }
       ]
@@ -25077,7 +25077,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sqlite3"
         }
       ]
@@ -25103,7 +25103,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sshpk"
         }
       ]
@@ -25129,7 +25129,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ssri"
         }
       ]
@@ -25155,7 +25155,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/stack-trace"
         }
       ]
@@ -25181,7 +25181,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/static-extend"
         }
       ],
@@ -25207,7 +25207,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend/node_modules/define-property"
             }
           ]
@@ -25233,7 +25233,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend/node_modules/is-accessor-descriptor"
             }
           ],
@@ -25259,7 +25259,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/static-extend/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
@@ -25287,7 +25287,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend/node_modules/is-data-descriptor"
             }
           ],
@@ -25313,7 +25313,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/static-extend/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
@@ -25341,7 +25341,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend/node_modules/is-descriptor"
             }
           ]
@@ -25367,7 +25367,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend/node_modules/kind-of"
             }
           ]
@@ -25395,7 +25395,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/statuses"
         }
       ]
@@ -25421,7 +25421,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/stream-buffers"
         }
       ]
@@ -25447,7 +25447,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/streamsearch"
         }
       ]
@@ -25473,7 +25473,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strict-uri-encode"
         }
       ]
@@ -25499,7 +25499,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string_decoder"
         }
       ]
@@ -25525,7 +25525,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string-width"
         }
       ]
@@ -25551,7 +25551,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string.fromcodepoint"
         }
       ]
@@ -25577,7 +25577,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string.prototype.codepointat"
         }
       ]
@@ -25603,7 +25603,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string.prototype.trimend"
         }
       ]
@@ -25629,7 +25629,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string.prototype.trimstart"
         }
       ]
@@ -25655,7 +25655,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-ansi"
         }
       ]
@@ -25681,7 +25681,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-bom"
         }
       ]
@@ -25707,7 +25707,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-dirs"
         }
       ]
@@ -25733,7 +25733,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-json-comments"
         }
       ]
@@ -25759,7 +25759,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-outer"
         }
       ]
@@ -25785,7 +25785,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strtok3"
         }
       ]
@@ -25811,7 +25811,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/supports-color"
         }
       ]
@@ -25837,7 +25837,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/supports-preserve-symlinks-flag"
         }
       ]
@@ -25863,7 +25863,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/svg-captcha"
         }
       ]
@@ -25889,7 +25889,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/swagger-ui-dist"
         }
       ]
@@ -25915,7 +25915,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/swagger-ui-express"
         }
       ]
@@ -25941,7 +25941,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tar-fs"
         }
       ],
@@ -25967,7 +25967,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/tar-fs/node_modules/bl"
             }
           ]
@@ -25993,7 +25993,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/tar-fs/node_modules/chownr"
             }
           ]
@@ -26019,7 +26019,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/tar-fs/node_modules/readable-stream"
             }
           ]
@@ -26045,7 +26045,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/tar-fs/node_modules/tar-stream"
             }
           ]
@@ -26073,7 +26073,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tar-stream"
         }
       ]
@@ -26099,7 +26099,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tar"
         }
       ]
@@ -26125,7 +26125,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tdigest"
         }
       ]
@@ -26151,7 +26151,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/text-hex"
         }
       ]
@@ -26177,7 +26177,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/thirty-two"
         }
       ]
@@ -26203,7 +26203,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/through"
         }
       ]
@@ -26229,7 +26229,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/timed-out"
         }
       ]
@@ -26255,7 +26255,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tiny-inflate"
         }
       ]
@@ -26281,7 +26281,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-buffer"
         }
       ]
@@ -26307,7 +26307,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-fast-properties"
         }
       ]
@@ -26333,7 +26333,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-object-path"
         }
       ],
@@ -26359,7 +26359,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/to-object-path/node_modules/kind-of"
             }
           ]
@@ -26387,7 +26387,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-regex-range"
         }
       ]
@@ -26413,7 +26413,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-regex"
         }
       ]
@@ -26439,7 +26439,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/toidentifier"
         }
       ]
@@ -26465,7 +26465,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/token-stream"
         }
       ]
@@ -26491,7 +26491,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/token-types"
         }
       ]
@@ -26517,7 +26517,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/toposort-class"
         }
       ]
@@ -26543,7 +26543,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tough-cookie"
         }
       ]
@@ -26569,7 +26569,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tr46"
         }
       ]
@@ -26595,7 +26595,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/traverse"
         }
       ]
@@ -26621,7 +26621,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tree-kill"
         }
       ]
@@ -26647,7 +26647,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/trim-repeated"
         }
       ]
@@ -26673,7 +26673,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/triple-beam"
         }
       ]
@@ -26699,7 +26699,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/truncate-utf8-bytes"
         }
       ]
@@ -26725,7 +26725,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ts-node-dev"
         }
       ],
@@ -26751,7 +26751,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/ts-node-dev/node_modules/rimraf"
             }
           ]
@@ -26779,7 +26779,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ts-node"
         }
       ]
@@ -26805,7 +26805,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tsconfig"
         }
       ]
@@ -26831,7 +26831,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tslib"
         }
       ]
@@ -26857,7 +26857,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tunnel-agent"
         }
       ]
@@ -26883,7 +26883,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tweetnacl"
         }
       ]
@@ -26909,7 +26909,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/type-check"
         }
       ]
@@ -26935,7 +26935,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/type-is"
         }
       ]
@@ -26961,7 +26961,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/typecast"
         }
       ]
@@ -26987,7 +26987,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/typedarray"
         }
       ]
@@ -27013,7 +27013,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/typescript"
         }
       ]
@@ -27039,7 +27039,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/uglify-js"
         }
       ]
@@ -27065,7 +27065,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unbox-primitive"
         }
       ]
@@ -27091,7 +27091,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unbzip2-stream"
         }
       ]
@@ -27117,7 +27117,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unc-path-regex"
         }
       ]
@@ -27143,7 +27143,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/underscore.string"
         }
       ]
@@ -27169,7 +27169,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unicode-properties"
         }
       ]
@@ -27195,7 +27195,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unicode-trie"
         }
       ]
@@ -27221,7 +27221,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/union-value"
         }
       ],
@@ -27247,7 +27247,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/union-value/node_modules/is-extendable"
             }
           ]
@@ -27275,7 +27275,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unique-filename"
         }
       ]
@@ -27301,7 +27301,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unique-slug"
         }
       ]
@@ -27327,7 +27327,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unit-compare"
         }
       ]
@@ -27353,7 +27353,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/universalify"
         }
       ]
@@ -27379,7 +27379,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unpipe"
         }
       ]
@@ -27405,7 +27405,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unset-value"
         }
       ],
@@ -27431,7 +27431,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/unset-value/node_modules/has-value"
             }
           ],
@@ -27457,7 +27457,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/unset-value/node_modules/has-value/node_modules/isobject"
                 }
               ]
@@ -27485,7 +27485,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/unset-value/node_modules/has-values"
             }
           ]
@@ -27511,7 +27511,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/unset-value/node_modules/isarray"
             }
           ]
@@ -27539,7 +27539,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/untildify"
         }
       ]
@@ -27565,7 +27565,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unzipper"
         }
       ],
@@ -27591,7 +27591,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/unzipper/node_modules/bluebird"
             }
           ]
@@ -27619,7 +27619,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/uri-js"
         }
       ]
@@ -27645,7 +27645,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/urix"
         }
       ]
@@ -27671,7 +27671,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/url-parse-lax"
         }
       ]
@@ -27697,7 +27697,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/url-to-options"
         }
       ]
@@ -27723,7 +27723,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/use"
         }
       ]
@@ -27749,7 +27749,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/utf8-byte-length"
         }
       ]
@@ -27775,7 +27775,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/util-deprecate"
         }
       ]
@@ -27801,7 +27801,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/util"
         }
       ]
@@ -27827,7 +27827,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/utils-merge"
         }
       ]
@@ -27853,7 +27853,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/uuid"
         }
       ]
@@ -27879,7 +27879,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/v8flags"
         }
       ]
@@ -27905,7 +27905,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/validate-npm-package-license"
         }
       ]
@@ -27931,7 +27931,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/validate"
         }
       ]
@@ -27957,7 +27957,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/validator"
         }
       ]
@@ -27983,7 +27983,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/vary"
         }
       ]
@@ -28009,7 +28009,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/verror"
         }
       ],
@@ -28035,7 +28035,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/verror/node_modules/core-util-is"
             }
           ]
@@ -28063,7 +28063,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/vm2"
         }
       ],
@@ -28089,7 +28089,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/vm2/node_modules/acorn"
             }
           ]
@@ -28117,7 +28117,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/void-elements"
         }
       ]
@@ -28143,7 +28143,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/walk"
         }
       ]
@@ -28169,7 +28169,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/walkdir"
         }
       ]
@@ -28195,7 +28195,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/webidl-conversions"
         }
       ]
@@ -28221,7 +28221,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/whatwg-url"
         }
       ]
@@ -28247,7 +28247,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-boxed-primitive"
         }
       ]
@@ -28273,7 +28273,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-collection"
         }
       ]
@@ -28299,7 +28299,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-module"
         }
       ]
@@ -28325,7 +28325,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-pm-runs"
         }
       ]
@@ -28351,7 +28351,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-typed-array"
         }
       ]
@@ -28377,7 +28377,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which"
         }
       ]
@@ -28403,7 +28403,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wide-align"
         }
       ]
@@ -28429,7 +28429,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/winston-transport"
         }
       ],
@@ -28455,7 +28455,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/winston-transport/node_modules/readable-stream"
             }
           ]
@@ -28483,7 +28483,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/winston"
         }
       ],
@@ -28509,7 +28509,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/winston/node_modules/async"
             }
           ]
@@ -28535,7 +28535,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/winston/node_modules/is-stream"
             }
           ]
@@ -28561,7 +28561,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/winston/node_modules/readable-stream"
             }
           ]
@@ -28589,7 +28589,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/with"
         }
       ]
@@ -28615,7 +28615,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wkx"
         }
       ]
@@ -28641,7 +28641,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/word-wrap"
         }
       ]
@@ -28667,7 +28667,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wordwrap"
         }
       ]
@@ -28693,7 +28693,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wrap-ansi"
         }
       ],
@@ -28719,7 +28719,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi/node_modules/ansi-regex"
             }
           ]
@@ -28745,7 +28745,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi/node_modules/emoji-regex"
             }
           ]
@@ -28771,7 +28771,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -28797,7 +28797,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi/node_modules/string-width"
             }
           ]
@@ -28823,7 +28823,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi/node_modules/strip-ansi"
             }
           ]
@@ -28851,7 +28851,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wrappy"
         }
       ]
@@ -28877,7 +28877,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ws"
         }
       ]
@@ -28903,7 +28903,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/xtend"
         }
       ]
@@ -28929,7 +28929,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/y18n"
         }
       ]
@@ -28955,7 +28955,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yallist"
         }
       ]
@@ -28981,7 +28981,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yaml-schema-validator"
         }
       ]
@@ -29007,7 +29007,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yargs-parser"
         }
       ]
@@ -29033,7 +29033,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yargs"
         }
       ],
@@ -29059,7 +29059,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs/node_modules/ansi-regex"
             }
           ]
@@ -29085,7 +29085,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs/node_modules/emoji-regex"
             }
           ]
@@ -29111,7 +29111,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -29137,7 +29137,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs/node_modules/string-width"
             }
           ]
@@ -29163,7 +29163,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs/node_modules/strip-ansi"
             }
           ]
@@ -29191,7 +29191,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yauzl"
         }
       ]
@@ -29217,7 +29217,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yn"
         }
       ]
@@ -29243,7 +29243,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/z85"
         }
       ]
@@ -29269,7 +29269,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/zip-stream"
         }
       ]
@@ -29295,7 +29295,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/zlibjs"
         }
       ]

--- a/tests/_data/sbom_demo-results/juice-shop_npm7_node18_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/juice-shop_npm7_node18_macos-latest.snap.json
@@ -62,6 +62,10 @@
       ],
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -88,6 +92,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@babel/helper-string-parser"
+        }
       ]
     },
     {
@@ -108,6 +118,12 @@
           "url": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@babel/helper-validator-identifier"
         }
       ]
     },
@@ -130,6 +146,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@babel/parser"
+        }
       ]
     },
     {
@@ -150,6 +172,12 @@
           "url": "https://registry.npmjs.org/@babel/types/-/types-7.20.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@babel/types"
         }
       ]
     },
@@ -172,6 +200,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@colors/colors"
+        }
       ]
     },
     {
@@ -193,6 +227,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@dabh/diagnostics"
+        }
       ]
     },
     {
@@ -213,6 +253,12 @@
           "url": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@gar/promisify"
         }
       ]
     },
@@ -236,6 +282,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@mapbox/node-pre-gyp"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -254,6 +306,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/ansi-regex"
             }
           ]
         },
@@ -275,6 +333,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/are-we-there-yet"
+            }
           ]
         },
         {
@@ -294,6 +358,12 @@
               "url": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/detect-libc"
             }
           ]
         },
@@ -315,6 +385,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/gauge"
+            }
           ]
         },
         {
@@ -334,6 +410,12 @@
               "url": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/is-fullwidth-code-point"
             }
           ]
         },
@@ -356,6 +438,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/make-dir"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -374,6 +462,12 @@
                   "url": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/@mapbox/node-pre-gyp/node_modules/make-dir/node_modules/semver"
                 }
               ]
             }
@@ -397,6 +491,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/nopt"
+            }
           ]
         },
         {
@@ -416,6 +516,12 @@
               "url": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/npmlog"
             }
           ]
         },
@@ -437,6 +543,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/readable-stream"
+            }
           ]
         },
         {
@@ -457,6 +569,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/string-width"
+            }
           ]
         },
         {
@@ -476,6 +594,12 @@
               "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/strip-ansi"
             }
           ]
         }
@@ -500,6 +624,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/core-loader"
+        }
       ]
     },
     {
@@ -520,6 +650,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/core/-/core-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/core"
         }
       ]
     },
@@ -542,6 +678,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/evaluator"
+        }
       ]
     },
     {
@@ -562,6 +704,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-all/-/lang-all-4.24.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-all"
         }
       ]
     },
@@ -584,6 +732,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ar"
+        }
       ]
     },
     {
@@ -604,6 +758,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-bn/-/lang-bn-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-bn"
         }
       ]
     },
@@ -626,6 +786,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ca"
+        }
       ]
     },
     {
@@ -646,6 +812,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-cs/-/lang-cs-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-cs"
         }
       ]
     },
@@ -668,6 +840,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-da"
+        }
       ]
     },
     {
@@ -688,6 +866,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-de/-/lang-de-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-de"
         }
       ]
     },
@@ -710,6 +894,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-el"
+        }
       ]
     },
     {
@@ -730,6 +920,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-en-min/-/lang-en-min-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-en-min"
         }
       ]
     },
@@ -752,6 +948,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-en"
+        }
       ]
     },
     {
@@ -772,6 +974,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-es/-/lang-es-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-es"
         }
       ]
     },
@@ -794,6 +1002,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-eu"
+        }
       ]
     },
     {
@@ -814,6 +1028,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-fa/-/lang-fa-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-fa"
         }
       ]
     },
@@ -836,6 +1056,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-fi"
+        }
       ]
     },
     {
@@ -856,6 +1082,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-fr/-/lang-fr-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-fr"
         }
       ]
     },
@@ -878,6 +1110,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ga"
+        }
       ]
     },
     {
@@ -898,6 +1136,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-gl/-/lang-gl-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-gl"
         }
       ]
     },
@@ -920,6 +1164,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-hi"
+        }
       ]
     },
     {
@@ -940,6 +1190,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-hu/-/lang-hu-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-hu"
         }
       ]
     },
@@ -962,6 +1218,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-hy"
+        }
       ]
     },
     {
@@ -982,6 +1244,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-id/-/lang-id-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-id"
         }
       ]
     },
@@ -1004,6 +1272,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-it"
+        }
       ]
     },
     {
@@ -1024,6 +1298,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-ja/-/lang-ja-4.24.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ja"
         }
       ]
     },
@@ -1046,6 +1326,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ko"
+        }
       ]
     },
     {
@@ -1066,6 +1352,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-lt/-/lang-lt-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-lt"
         }
       ]
     },
@@ -1088,6 +1380,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ms"
+        }
       ]
     },
     {
@@ -1108,6 +1406,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-ne/-/lang-ne-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ne"
         }
       ]
     },
@@ -1130,6 +1434,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-nl"
+        }
       ]
     },
     {
@@ -1150,6 +1460,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-no/-/lang-no-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-no"
         }
       ]
     },
@@ -1172,6 +1488,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-pl"
+        }
       ]
     },
     {
@@ -1192,6 +1514,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-pt/-/lang-pt-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-pt"
         }
       ]
     },
@@ -1214,6 +1542,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ro"
+        }
       ]
     },
     {
@@ -1234,6 +1568,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-ru/-/lang-ru-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ru"
         }
       ]
     },
@@ -1256,6 +1596,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-sl"
+        }
       ]
     },
     {
@@ -1276,6 +1622,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-sr/-/lang-sr-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-sr"
         }
       ]
     },
@@ -1298,6 +1650,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-sv"
+        }
       ]
     },
     {
@@ -1318,6 +1676,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-ta/-/lang-ta-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ta"
         }
       ]
     },
@@ -1340,6 +1704,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-th"
+        }
       ]
     },
     {
@@ -1360,6 +1730,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-tl/-/lang-tl-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-tl"
         }
       ]
     },
@@ -1382,6 +1758,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-tr"
+        }
       ]
     },
     {
@@ -1402,6 +1784,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-uk/-/lang-uk-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-uk"
         }
       ]
     },
@@ -1424,6 +1812,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-zh"
+        }
       ]
     },
     {
@@ -1444,6 +1838,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/language-min/-/language-min-4.22.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/language-min"
         }
       ]
     },
@@ -1466,6 +1866,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/language"
+        }
       ]
     },
     {
@@ -1486,6 +1892,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/ner/-/ner-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/ner"
         }
       ]
     },
@@ -1508,6 +1920,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/neural"
+        }
       ]
     },
     {
@@ -1528,6 +1946,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/nlg/-/nlg-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/nlg"
         }
       ]
     },
@@ -1550,6 +1974,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/nlp"
+        }
       ]
     },
     {
@@ -1570,6 +2000,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/nlu/-/nlu-4.23.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/nlu"
         }
       ]
     },
@@ -1592,6 +2028,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/request"
+        }
       ]
     },
     {
@@ -1612,6 +2054,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/sentiment/-/sentiment-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/sentiment"
         }
       ]
     },
@@ -1634,6 +2082,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/similarity"
+        }
       ]
     },
     {
@@ -1654,6 +2108,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/slot/-/slot-4.22.17.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/slot"
         }
       ]
     },
@@ -1676,6 +2136,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@npmcli/fs"
+        }
       ]
     },
     {
@@ -1696,6 +2162,12 @@
           "url": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@npmcli/move-file"
         }
       ]
     },
@@ -1718,6 +2190,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib/core"
+        }
       ]
     },
     {
@@ -1738,6 +2216,12 @@
           "url": "https://registry.npmjs.org/@otplib/plugin-crypto/-/plugin-crypto-12.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib/plugin-crypto"
         }
       ]
     },
@@ -1760,6 +2244,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib/plugin-thirty-two"
+        }
       ]
     },
     {
@@ -1780,6 +2270,12 @@
           "url": "https://registry.npmjs.org/@otplib/preset-default/-/preset-default-12.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib/preset-default"
         }
       ]
     },
@@ -1802,6 +2298,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib/preset-v11"
+        }
       ]
     },
     {
@@ -1822,6 +2324,12 @@
           "url": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@sindresorhus/is"
         }
       ]
     },
@@ -1844,6 +2352,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@swc/helpers"
+        }
       ]
     },
     {
@@ -1864,6 +2378,12 @@
           "url": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@tokenizer/token"
         }
       ]
     },
@@ -1886,6 +2406,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@tootallnate/once"
+        }
       ]
     },
     {
@@ -1906,6 +2432,12 @@
           "url": "https://registry.npmjs.org/@types/component-emitter/-/component-emitter-1.2.11.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/component-emitter"
         }
       ]
     },
@@ -1928,6 +2460,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/cookie"
+        }
       ]
     },
     {
@@ -1948,6 +2486,12 @@
           "url": "https://registry.npmjs.org/@types/cors/-/cors-2.8.12.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/cors"
         }
       ]
     },
@@ -1970,6 +2514,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/debug"
+        }
       ]
     },
     {
@@ -1990,6 +2540,12 @@
           "url": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/ms"
         }
       ]
     },
@@ -2012,6 +2568,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/node"
+        }
       ]
     },
     {
@@ -2032,6 +2594,12 @@
           "url": "https://registry.npmjs.org/@types/strip-bom/-/strip-bom-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/strip-bom"
         }
       ]
     },
@@ -2054,6 +2622,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/strip-json-comments"
+        }
       ]
     },
     {
@@ -2075,6 +2649,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/validator"
+        }
       ]
     },
     {
@@ -2094,6 +2674,12 @@
           "url": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/abbrev"
         }
       ]
     },
@@ -2115,6 +2701,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/accepts"
+        }
       ]
     },
     {
@@ -2135,6 +2727,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/acorn-walk"
+        }
       ]
     },
     {
@@ -2154,6 +2752,12 @@
           "url": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/acorn"
         }
       ]
     },
@@ -2176,6 +2780,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/agent-base"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -2194,6 +2804,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agent-base/node_modules/debug"
             }
           ]
         },
@@ -2214,6 +2830,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agent-base/node_modules/ms"
             }
           ]
         }
@@ -2238,6 +2860,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/agentkeepalive"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -2256,6 +2884,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agentkeepalive/node_modules/debug"
             }
           ]
         },
@@ -2277,6 +2911,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agentkeepalive/node_modules/depd"
+            }
           ]
         },
         {
@@ -2296,6 +2936,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agentkeepalive/node_modules/ms"
             }
           ]
         }
@@ -2319,6 +2965,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/aggregate-error"
+        }
       ]
     },
     {
@@ -2338,6 +2990,12 @@
           "url": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ajv"
         }
       ]
     },
@@ -2359,6 +3017,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ansi-regex"
+        }
       ]
     },
     {
@@ -2378,6 +3042,12 @@
           "url": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ansi-styles"
         }
       ]
     },
@@ -2400,6 +3070,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/anymatch"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -2418,6 +3094,12 @@
               "url": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/anymatch/node_modules/normalize-path"
             }
           ]
         }
@@ -2441,6 +3123,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/append-field"
+        }
       ]
     },
     {
@@ -2460,6 +3148,12 @@
           "url": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/aproba"
         }
       ]
     },
@@ -2482,6 +3176,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/archive-type"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -2500,6 +3200,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-4.4.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/archive-type/node_modules/file-type"
             }
           ]
         }
@@ -2523,6 +3229,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/archiver-utils"
+        }
       ]
     },
     {
@@ -2542,6 +3254,12 @@
           "url": "https://registry.npmjs.org/archiver/-/archiver-1.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/archiver"
         }
       ]
     },
@@ -2563,6 +3281,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/are-we-there-yet"
+        }
       ]
     },
     {
@@ -2582,6 +3306,12 @@
           "url": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/arg"
         }
       ]
     },
@@ -2604,6 +3334,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/argparse"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -2622,6 +3358,12 @@
               "url": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/argparse/node_modules/sprintf-js"
             }
           ]
         }
@@ -2645,6 +3387,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/arr-diff"
+        }
       ]
     },
     {
@@ -2664,6 +3412,12 @@
           "url": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/arr-flatten"
         }
       ]
     },
@@ -2685,6 +3439,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/arr-union"
+        }
       ]
     },
     {
@@ -2704,6 +3464,12 @@
           "url": "https://registry.npmjs.org/array-each/-/array-each-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/array-each"
         }
       ]
     },
@@ -2725,6 +3491,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/array-flatten"
+        }
       ]
     },
     {
@@ -2744,6 +3516,12 @@
           "url": "https://registry.npmjs.org/array-slice/-/array-slice-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/array-slice"
         }
       ]
     },
@@ -2765,6 +3543,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/array-unique"
+        }
       ]
     },
     {
@@ -2784,6 +3568,12 @@
           "url": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/asap"
         }
       ]
     },
@@ -2805,6 +3595,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/asn1"
+        }
       ]
     },
     {
@@ -2824,6 +3620,12 @@
           "url": "https://registry.npmjs.org/assert-never/-/assert-never-1.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/assert-never"
         }
       ]
     },
@@ -2845,6 +3647,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/assert-plus"
+        }
       ]
     },
     {
@@ -2864,6 +3672,12 @@
           "url": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/assign-symbols"
         }
       ]
     },
@@ -2885,6 +3699,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/async"
+        }
       ]
     },
     {
@@ -2904,6 +3724,12 @@
           "url": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/asynckit"
         }
       ]
     },
@@ -2925,6 +3751,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/at-least-node"
+        }
       ]
     },
     {
@@ -2944,6 +3776,12 @@
           "url": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/atob"
         }
       ]
     },
@@ -2965,6 +3803,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/available-typed-arrays"
+        }
       ]
     },
     {
@@ -2984,6 +3828,12 @@
           "url": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/aws-sign2"
         }
       ]
     },
@@ -3005,6 +3855,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/aws4"
+        }
       ]
     },
     {
@@ -3025,6 +3881,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/babel-walk"
+        }
       ]
     },
     {
@@ -3044,6 +3906,12 @@
           "url": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/balanced-match"
         }
       ]
     },
@@ -3066,6 +3934,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -3084,6 +3958,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/base/node_modules/define-property"
             }
           ]
         }
@@ -3107,6 +3987,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base64-arraybuffer"
+        }
       ]
     },
     {
@@ -3126,6 +4012,12 @@
           "url": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base64-js"
         }
       ]
     },
@@ -3147,6 +4039,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base64id"
+        }
       ]
     },
     {
@@ -3166,6 +4064,12 @@
           "url": "https://registry.npmjs.org/base64url/-/base64url-0.0.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base64url"
         }
       ]
     },
@@ -3187,6 +4091,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/basic-auth"
+        }
       ]
     },
     {
@@ -3206,6 +4116,12 @@
           "url": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/batch"
         }
       ]
     },
@@ -3227,6 +4143,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bcrypt-pbkdf"
+        }
       ]
     },
     {
@@ -3246,6 +4168,12 @@
           "url": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/big-integer"
         }
       ]
     },
@@ -3267,6 +4195,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/binary-extensions"
+        }
       ]
     },
     {
@@ -3286,6 +4220,12 @@
           "url": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/binary"
         }
       ]
     },
@@ -3307,6 +4247,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bindings"
+        }
       ]
     },
     {
@@ -3326,6 +4272,12 @@
           "url": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bintrees"
         }
       ]
     },
@@ -3347,6 +4299,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bl"
+        }
       ]
     },
     {
@@ -3367,6 +4325,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bluebird"
+        }
       ]
     },
     {
@@ -3386,6 +4350,12 @@
           "url": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/body-parser"
         }
       ]
     },
@@ -3408,6 +4378,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bower-config"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -3426,6 +4402,12 @@
               "url": "https://registry.npmjs.org/minimist/-/minimist-0.2.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bower-config/node_modules/minimist"
             }
           ]
         }
@@ -3449,6 +4431,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/brace-expansion"
+        }
       ]
     },
     {
@@ -3470,6 +4458,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/braces"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -3488,6 +4482,12 @@
               "url": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/braces/node_modules/extend-shallow"
             }
           ]
         },
@@ -3508,6 +4508,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/braces/node_modules/is-extendable"
             }
           ]
         }
@@ -3531,6 +4537,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/brotli"
+        }
       ]
     },
     {
@@ -3550,6 +4562,12 @@
           "url": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-alloc-unsafe"
         }
       ]
     },
@@ -3571,6 +4589,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-alloc"
+        }
       ]
     },
     {
@@ -3590,6 +4614,12 @@
           "url": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-crc32"
         }
       ]
     },
@@ -3611,6 +4641,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-fill"
+        }
       ]
     },
     {
@@ -3630,6 +4666,12 @@
           "url": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-from"
         }
       ]
     },
@@ -3651,6 +4693,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-indexof-polyfill"
+        }
       ]
     },
     {
@@ -3671,6 +4719,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer"
+        }
       ]
     },
     {
@@ -3690,6 +4744,12 @@
           "url": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffers"
         }
       ]
     },
@@ -3712,6 +4772,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/busboy"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -3730,6 +4796,12 @@
               "url": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/busboy/node_modules/isarray"
             }
           ]
         },
@@ -3751,6 +4823,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/busboy/node_modules/readable-stream"
+            }
           ]
         },
         {
@@ -3770,6 +4848,12 @@
               "url": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/busboy/node_modules/string_decoder"
             }
           ]
         }
@@ -3793,6 +4877,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/byline"
+        }
       ]
     },
     {
@@ -3812,6 +4902,12 @@
           "url": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bytes"
         }
       ]
     },
@@ -3833,6 +4929,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cacache"
+        }
       ]
     },
     {
@@ -3852,6 +4954,12 @@
           "url": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cache-base"
         }
       ]
     },
@@ -3874,6 +4982,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cacheable-request"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -3892,6 +5006,12 @@
               "url": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cacheable-request/node_modules/get-stream"
             }
           ]
         },
@@ -3912,6 +5032,12 @@
               "url": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cacheable-request/node_modules/lowercase-keys"
             }
           ]
         }
@@ -3935,6 +5061,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/call-bind"
+        }
       ]
     },
     {
@@ -3954,6 +5086,12 @@
           "url": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/camelcase"
         }
       ]
     },
@@ -3975,6 +5113,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/caseless"
+        }
       ]
     },
     {
@@ -3994,6 +5138,12 @@
           "url": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/chainsaw"
         }
       ]
     },
@@ -4015,6 +5165,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/chalk"
+        }
       ]
     },
     {
@@ -4034,6 +5190,12 @@
           "url": "https://registry.npmjs.org/character-parser/-/character-parser-2.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/character-parser"
         }
       ]
     },
@@ -4056,6 +5218,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/check-dependencies"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4074,6 +5242,12 @@
               "url": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/check-dependencies/node_modules/semver"
             }
           ]
         }
@@ -4097,6 +5271,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/check-types"
+        }
       ]
     },
     {
@@ -4118,6 +5298,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/chokidar"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4136,6 +5322,12 @@
               "url": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar/node_modules/braces"
             }
           ]
         },
@@ -4157,6 +5349,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar/node_modules/fill-range"
+            }
           ]
         },
         {
@@ -4176,6 +5374,12 @@
               "url": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar/node_modules/is-glob"
             }
           ]
         },
@@ -4197,6 +5401,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar/node_modules/is-number"
+            }
           ]
         },
         {
@@ -4217,6 +5427,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar/node_modules/normalize-path"
+            }
           ]
         },
         {
@@ -4236,6 +5452,12 @@
               "url": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar/node_modules/to-regex-range"
             }
           ]
         }
@@ -4259,6 +5481,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/chownr"
+        }
       ]
     },
     {
@@ -4278,6 +5506,12 @@
           "url": "https://registry.npmjs.org/clarinet/-/clarinet-0.12.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/clarinet"
         }
       ]
     },
@@ -4300,6 +5534,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/class-utils"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4318,6 +5558,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils/node_modules/define-property"
             }
           ]
         },
@@ -4340,6 +5586,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils/node_modules/is-accessor-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -4358,6 +5610,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/class-utils/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -4382,6 +5640,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils/node_modules/is-data-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -4400,6 +5664,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/class-utils/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -4423,6 +5693,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils/node_modules/is-descriptor"
+            }
           ]
         },
         {
@@ -4442,6 +5718,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils/node_modules/kind-of"
             }
           ]
         }
@@ -4465,6 +5747,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/clean-stack"
+        }
       ]
     },
     {
@@ -4486,6 +5774,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cliui"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4504,6 +5798,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui/node_modules/ansi-regex"
             }
           ]
         },
@@ -4525,6 +5825,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui/node_modules/emoji-regex"
+            }
           ]
         },
         {
@@ -4544,6 +5850,12 @@
               "url": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui/node_modules/is-fullwidth-code-point"
             }
           ]
         },
@@ -4565,6 +5877,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui/node_modules/string-width"
+            }
           ]
         },
         {
@@ -4584,6 +5902,12 @@
               "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui/node_modules/strip-ansi"
             }
           ]
         }
@@ -4607,6 +5931,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/clone-response"
+        }
       ]
     },
     {
@@ -4626,6 +5956,12 @@
           "url": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/clone"
         }
       ]
     },
@@ -4647,6 +5983,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/code-point-at"
+        }
       ]
     },
     {
@@ -4666,6 +6008,12 @@
           "url": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/collection-visit"
         }
       ]
     },
@@ -4687,6 +6035,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color-convert"
+        }
       ]
     },
     {
@@ -4706,6 +6060,12 @@
           "url": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color-name"
         }
       ]
     },
@@ -4727,6 +6087,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color-string"
+        }
       ]
     },
     {
@@ -4746,6 +6112,12 @@
           "url": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color-support"
         }
       ]
     },
@@ -4767,6 +6139,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color"
+        }
       ]
     },
     {
@@ -4786,6 +6164,12 @@
           "url": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/colors"
         }
       ]
     },
@@ -4807,6 +6191,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/colorspace"
+        }
       ]
     },
     {
@@ -4826,6 +6216,12 @@
           "url": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/combined-stream"
         }
       ]
     },
@@ -4847,6 +6243,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/commander"
+        }
       ]
     },
     {
@@ -4866,6 +6268,12 @@
           "url": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/component-emitter"
         }
       ]
     },
@@ -4887,6 +6295,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/component-type"
+        }
       ]
     },
     {
@@ -4907,6 +6321,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/compress-commons"
+        }
       ]
     },
     {
@@ -4926,6 +6346,12 @@
           "url": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/compressible"
         }
       ]
     },
@@ -4948,6 +6374,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/compression"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4966,6 +6398,12 @@
               "url": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/compression/node_modules/bytes"
             }
           ]
         }
@@ -4989,6 +6427,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/concat-map"
+        }
       ]
     },
     {
@@ -5008,6 +6452,12 @@
           "url": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/concat-stream"
         }
       ]
     },
@@ -5030,6 +6480,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/concurrently"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5048,6 +6504,12 @@
               "url": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/concurrently/node_modules/supports-color"
             }
           ]
         }
@@ -5071,6 +6533,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/config"
+        }
       ]
     },
     {
@@ -5091,6 +6559,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/console-control-strings"
+        }
       ]
     },
     {
@@ -5110,6 +6584,12 @@
           "url": "https://registry.npmjs.org/constantinople/-/constantinople-4.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/constantinople"
         }
       ]
     },
@@ -5132,6 +6612,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/content-disposition"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5150,6 +6636,12 @@
               "url": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/content-disposition/node_modules/safe-buffer"
             }
           ]
         }
@@ -5173,6 +6665,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/content-type"
+        }
       ]
     },
     {
@@ -5192,6 +6690,12 @@
           "url": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cookie-parser"
         }
       ]
     },
@@ -5213,6 +6717,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cookie-signature"
+        }
       ]
     },
     {
@@ -5232,6 +6742,12 @@
           "url": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cookie"
         }
       ]
     },
@@ -5253,6 +6769,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/copy-descriptor"
+        }
       ]
     },
     {
@@ -5272,6 +6794,12 @@
           "url": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/core-util-is"
         }
       ]
     },
@@ -5293,6 +6821,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cors"
+        }
       ]
     },
     {
@@ -5312,6 +6846,12 @@
           "url": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/crc"
         }
       ]
     },
@@ -5333,6 +6873,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/crc32-stream"
+        }
       ]
     },
     {
@@ -5352,6 +6898,12 @@
           "url": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/create-require"
         }
       ]
     },
@@ -5373,6 +6925,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/crypto-js"
+        }
       ]
     },
     {
@@ -5392,6 +6950,12 @@
           "url": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dashdash"
         }
       ]
     },
@@ -5413,6 +6977,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/date-fns"
+        }
       ]
     },
     {
@@ -5432,6 +7002,12 @@
           "url": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dateformat"
         }
       ]
     },
@@ -5453,6 +7029,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/debug"
+        }
       ]
     },
     {
@@ -5472,6 +7054,12 @@
           "url": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decamelize"
         }
       ]
     },
@@ -5493,6 +7081,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decode-uri-component"
+        }
       ]
     },
     {
@@ -5512,6 +7106,12 @@
           "url": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-response"
         }
       ]
     },
@@ -5534,6 +7134,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-tar"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5552,6 +7158,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-tar/node_modules/file-type"
             }
           ]
         }
@@ -5576,6 +7188,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-tarbz2"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5594,6 +7212,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-6.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-tarbz2/node_modules/file-type"
             }
           ]
         }
@@ -5618,6 +7242,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-targz"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5636,6 +7266,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-targz/node_modules/file-type"
             }
           ]
         }
@@ -5660,6 +7296,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-unzip"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5678,6 +7320,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-unzip/node_modules/file-type"
             }
           ]
         },
@@ -5699,6 +7347,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-unzip/node_modules/get-stream"
+            }
           ]
         },
         {
@@ -5718,6 +7372,12 @@
               "url": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-unzip/node_modules/pify"
             }
           ]
         }
@@ -5742,6 +7402,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5762,6 +7428,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress/node_modules/make-dir"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -5780,6 +7452,12 @@
                   "url": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/decompress/node_modules/make-dir/node_modules/pify"
                 }
               ]
             }
@@ -5803,6 +7481,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress/node_modules/pify"
+            }
           ]
         }
       ]
@@ -5825,6 +7509,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/deep-equal"
+        }
       ]
     },
     {
@@ -5844,6 +7534,12 @@
           "url": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/deep-extend"
         }
       ]
     },
@@ -5865,6 +7561,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/deep-is"
+        }
       ]
     },
     {
@@ -5884,6 +7586,12 @@
           "url": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/define-properties"
         }
       ]
     },
@@ -5905,6 +7613,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/define-property"
+        }
       ]
     },
     {
@@ -5924,6 +7638,12 @@
           "url": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/delayed-stream"
         }
       ]
     },
@@ -5945,6 +7665,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/delegates"
+        }
       ]
     },
     {
@@ -5964,6 +7690,12 @@
           "url": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/depd"
         }
       ]
     },
@@ -5985,6 +7717,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/destroy"
+        }
       ]
     },
     {
@@ -6004,6 +7742,12 @@
           "url": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/detect-file"
         }
       ]
     },
@@ -6025,6 +7769,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/detect-libc"
+        }
       ]
     },
     {
@@ -6044,6 +7794,12 @@
           "url": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dfa"
         }
       ]
     },
@@ -6066,6 +7822,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dicer"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -6084,6 +7846,12 @@
               "url": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/dicer/node_modules/isarray"
             }
           ]
         },
@@ -6105,6 +7873,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/dicer/node_modules/readable-stream"
+            }
           ]
         },
         {
@@ -6124,6 +7898,12 @@
               "url": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/dicer/node_modules/string_decoder"
             }
           ]
         }
@@ -6147,6 +7927,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/diff"
+        }
       ]
     },
     {
@@ -6166,6 +7952,12 @@
           "url": "https://registry.npmjs.org/doctypes/-/doctypes-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/doctypes"
         }
       ]
     },
@@ -6187,6 +7979,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/domelementtype"
+        }
       ]
     },
     {
@@ -6206,6 +8004,12 @@
           "url": "https://registry.npmjs.org/domhandler/-/domhandler-2.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/domhandler"
         }
       ]
     },
@@ -6227,6 +8031,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/domutils"
+        }
       ]
     },
     {
@@ -6246,6 +8056,12 @@
           "url": "https://registry.npmjs.org/dottie/-/dottie-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dottie"
         }
       ]
     },
@@ -6267,6 +8083,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/double-ended-queue"
+        }
       ]
     },
     {
@@ -6286,6 +8108,12 @@
           "url": "https://registry.npmjs.org/doublearray/-/doublearray-0.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/doublearray"
         }
       ]
     },
@@ -6308,6 +8136,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/download"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -6326,6 +8160,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-11.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/download/node_modules/file-type"
             }
           ]
         }
@@ -6349,6 +8189,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/duplexer2"
+        }
       ]
     },
     {
@@ -6368,6 +8214,12 @@
           "url": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/duplexer3"
         }
       ]
     },
@@ -6389,6 +8241,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dynamic-dedupe"
+        }
       ]
     },
     {
@@ -6408,6 +8266,12 @@
           "url": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ecc-jsbn"
         }
       ]
     },
@@ -6429,6 +8293,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ee-first"
+        }
       ]
     },
     {
@@ -6448,6 +8318,12 @@
           "url": "https://registry.npmjs.org/eivindfjeldstad-dot/-/eivindfjeldstad-dot-0.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/eivindfjeldstad-dot"
         }
       ]
     },
@@ -6469,6 +8345,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/emoji-regex"
+        }
       ]
     },
     {
@@ -6489,6 +8371,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/enabled"
+        }
       ]
     },
     {
@@ -6508,6 +8396,12 @@
           "url": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/encodeurl"
         }
       ]
     },
@@ -6530,6 +8424,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/encoding"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -6548,6 +8448,12 @@
               "url": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/encoding/node_modules/iconv-lite"
             }
           ]
         }
@@ -6571,6 +8477,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/end-of-stream"
+        }
       ]
     },
     {
@@ -6590,6 +8502,12 @@
           "url": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-4.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/engine.io-parser"
         }
       ]
     },
@@ -6612,6 +8530,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/engine.io"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -6630,6 +8554,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/engine.io/node_modules/debug"
             }
           ]
         },
@@ -6650,6 +8580,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/engine.io/node_modules/ms"
             }
           ]
         }
@@ -6673,6 +8609,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/env-paths"
+        }
       ]
     },
     {
@@ -6692,6 +8634,12 @@
           "url": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/err-code"
         }
       ]
     },
@@ -6713,6 +8661,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/error-ex"
+        }
       ]
     },
     {
@@ -6732,6 +8686,12 @@
           "url": "https://registry.npmjs.org/errorhandler/-/errorhandler-1.5.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/errorhandler"
         }
       ]
     },
@@ -6753,6 +8713,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/es-abstract"
+        }
       ]
     },
     {
@@ -6772,6 +8738,12 @@
           "url": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/es-get-iterator"
         }
       ]
     },
@@ -6793,6 +8765,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/es-to-primitive"
+        }
       ]
     },
     {
@@ -6812,6 +8790,12 @@
           "url": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/escape-html"
         }
       ]
     },
@@ -6833,6 +8817,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/escape-string-regexp"
+        }
       ]
     },
     {
@@ -6852,6 +8842,12 @@
           "url": "https://registry.npmjs.org/escodegen/-/escodegen-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/escodegen"
         }
       ]
     },
@@ -6873,6 +8869,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/esprima"
+        }
       ]
     },
     {
@@ -6892,6 +8894,12 @@
           "url": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/estraverse"
         }
       ]
     },
@@ -6913,6 +8921,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/esutils"
+        }
       ]
     },
     {
@@ -6932,6 +8946,12 @@
           "url": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/etag"
         }
       ]
     },
@@ -6953,6 +8973,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/eventemitter2"
+        }
       ]
     },
     {
@@ -6972,6 +8998,12 @@
           "url": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/eventemitter3"
         }
       ]
     },
@@ -6993,6 +9025,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/exif"
+        }
       ]
     },
     {
@@ -7012,6 +9050,12 @@
           "url": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/exit"
         }
       ]
     },
@@ -7034,6 +9078,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/expand-brackets"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7052,6 +9102,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/define-property"
             }
           ]
         },
@@ -7072,6 +9128,12 @@
               "url": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/extend-shallow"
             }
           ]
         },
@@ -7094,6 +9156,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/is-accessor-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -7112,6 +9180,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/expand-brackets/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -7136,6 +9210,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/is-data-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -7154,6 +9234,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/expand-brackets/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -7177,6 +9263,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/is-descriptor"
+            }
           ]
         },
         {
@@ -7197,6 +9289,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/is-extendable"
+            }
           ]
         },
         {
@@ -7216,6 +9314,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/kind-of"
             }
           ]
         }
@@ -7239,6 +9343,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/expand-template"
+        }
       ]
     },
     {
@@ -7259,6 +9369,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/expand-tilde"
+        }
       ]
     },
     {
@@ -7278,6 +9394,12 @@
           "url": "https://registry.npmjs.org/express-ipfilter/-/express-ipfilter-1.3.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-ipfilter"
         }
       ]
     },
@@ -7300,6 +9422,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-jwt"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7318,6 +9446,12 @@
               "url": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-0.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/express-jwt/node_modules/jsonwebtoken"
             }
           ]
         },
@@ -7338,6 +9472,12 @@
               "url": "https://registry.npmjs.org/moment/-/moment-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/express-jwt/node_modules/moment"
             }
           ]
         }
@@ -7361,6 +9501,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-rate-limit"
+        }
       ]
     },
     {
@@ -7381,6 +9527,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-robots-txt"
+        }
       ]
     },
     {
@@ -7400,6 +9552,12 @@
           "url": "https://registry.npmjs.org/express-security.txt/-/express-security.txt-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-security.txt"
         }
       ]
     },
@@ -7422,6 +9580,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7440,6 +9604,12 @@
               "url": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/express/node_modules/cookie"
             }
           ]
         },
@@ -7460,6 +9630,12 @@
               "url": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/express/node_modules/safe-buffer"
             }
           ]
         }
@@ -7483,6 +9659,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ext-list"
+        }
       ]
     },
     {
@@ -7502,6 +9684,12 @@
           "url": "https://registry.npmjs.org/ext-name/-/ext-name-5.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ext-name"
         }
       ]
     },
@@ -7523,6 +9711,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/extend-shallow"
+        }
       ]
     },
     {
@@ -7542,6 +9736,12 @@
           "url": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/extend"
         }
       ]
     },
@@ -7564,6 +9764,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/extglob"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7582,6 +9788,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/extglob/node_modules/define-property"
             }
           ]
         },
@@ -7603,6 +9815,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/extglob/node_modules/extend-shallow"
+            }
           ]
         },
         {
@@ -7622,6 +9840,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/extglob/node_modules/is-extendable"
             }
           ]
         }
@@ -7645,6 +9869,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/extsprintf"
+        }
       ]
     },
     {
@@ -7664,6 +9894,12 @@
           "url": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fast-deep-equal"
         }
       ]
     },
@@ -7685,6 +9921,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fast-json-stable-stringify"
+        }
       ]
     },
     {
@@ -7704,6 +9946,12 @@
           "url": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fast-levenshtein"
         }
       ]
     },
@@ -7725,6 +9973,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fast.js"
+        }
       ]
     },
     {
@@ -7744,6 +9998,12 @@
           "url": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fd-slicer"
         }
       ]
     },
@@ -7765,6 +10025,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/feature-policy"
+        }
       ]
     },
     {
@@ -7784,6 +10050,12 @@
           "url": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fecha"
         }
       ]
     },
@@ -7806,6 +10078,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/file-js"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7824,6 +10102,12 @@
               "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/file-js/node_modules/brace-expansion"
             }
           ]
         },
@@ -7844,6 +10128,12 @@
               "url": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/file-js/node_modules/minimatch"
             }
           ]
         }
@@ -7867,6 +10157,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/file-stream-rotator"
+        }
       ]
     },
     {
@@ -7886,6 +10182,12 @@
           "url": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/file-type"
         }
       ]
     },
@@ -7907,6 +10209,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/file-uri-to-path"
+        }
       ]
     },
     {
@@ -7926,6 +10234,12 @@
           "url": "https://registry.npmjs.org/filehound/-/filehound-1.17.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/filehound"
         }
       ]
     },
@@ -7947,6 +10261,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/filename-reserved-regex"
+        }
       ]
     },
     {
@@ -7967,6 +10287,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/filenamify"
+        }
       ]
     },
     {
@@ -7986,6 +10312,12 @@
           "url": "https://registry.npmjs.org/filesniffer/-/filesniffer-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/filesniffer"
         }
       ]
     },
@@ -8008,6 +10340,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fill-range"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -8026,6 +10364,12 @@
               "url": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/fill-range/node_modules/extend-shallow"
             }
           ]
         },
@@ -8046,6 +10390,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/fill-range/node_modules/is-extendable"
             }
           ]
         }
@@ -8069,6 +10419,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/finale-rest"
+        }
       ]
     },
     {
@@ -8088,6 +10444,12 @@
           "url": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/finalhandler"
         }
       ]
     },
@@ -8109,6 +10471,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/find-up"
+        }
       ]
     },
     {
@@ -8128,6 +10496,12 @@
           "url": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/findup-sync"
         }
       ]
     },
@@ -8149,6 +10523,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fined"
+        }
       ]
     },
     {
@@ -8168,6 +10548,12 @@
           "url": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/flagged-respawn"
         }
       ]
     },
@@ -8189,6 +10575,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fn.name"
+        }
       ]
     },
     {
@@ -8208,6 +10600,12 @@
           "url": "https://registry.npmjs.org/fontkit/-/fontkit-1.9.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fontkit"
         }
       ]
     },
@@ -8229,6 +10627,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/for-each"
+        }
       ]
     },
     {
@@ -8248,6 +10652,12 @@
           "url": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/for-in"
         }
       ]
     },
@@ -8269,6 +10679,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/for-own"
+        }
       ]
     },
     {
@@ -8288,6 +10704,12 @@
           "url": "https://registry.npmjs.org/foreachasync/-/foreachasync-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/foreachasync"
         }
       ]
     },
@@ -8309,6 +10731,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/forever-agent"
+        }
       ]
     },
     {
@@ -8328,6 +10756,12 @@
           "url": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/form-data"
         }
       ]
     },
@@ -8349,6 +10783,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/formatio"
+        }
       ]
     },
     {
@@ -8368,6 +10808,12 @@
           "url": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/forwarded"
         }
       ]
     },
@@ -8389,6 +10835,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fragment-cache"
+        }
       ]
     },
     {
@@ -8408,6 +10860,12 @@
           "url": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fresh"
         }
       ]
     },
@@ -8429,6 +10887,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/from2"
+        }
       ]
     },
     {
@@ -8448,6 +10912,12 @@
           "url": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fs-constants"
         }
       ]
     },
@@ -8469,6 +10939,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fs-extra"
+        }
       ]
     },
     {
@@ -8488,6 +10964,12 @@
           "url": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fs-minipass"
         }
       ]
     },
@@ -8509,6 +10991,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fs.realpath"
+        }
       ]
     },
     {
@@ -8528,6 +11016,12 @@
           "url": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fsevents"
         }
       ]
     },
@@ -8550,6 +11044,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fstream"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -8568,6 +11068,12 @@
               "url": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/fstream/node_modules/mkdirp"
             }
           ]
         },
@@ -8588,6 +11094,12 @@
               "url": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/fstream/node_modules/rimraf"
             }
           ]
         }
@@ -8611,6 +11123,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/function-bind"
+        }
       ]
     },
     {
@@ -8630,6 +11148,12 @@
           "url": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/function.prototype.name"
         }
       ]
     },
@@ -8651,6 +11175,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/functions-have-names"
+        }
       ]
     },
     {
@@ -8670,6 +11200,12 @@
           "url": "https://registry.npmjs.org/fuzzball/-/fuzzball-1.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fuzzball"
         }
       ]
     },
@@ -8691,6 +11227,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/gauge"
+        }
       ]
     },
     {
@@ -8710,6 +11252,12 @@
           "url": "https://registry.npmjs.org/geojson-utils/-/geojson-utils-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/geojson-utils"
         }
       ]
     },
@@ -8731,6 +11279,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-caller-file"
+        }
       ]
     },
     {
@@ -8750,6 +11304,12 @@
           "url": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-intrinsic"
         }
       ]
     },
@@ -8771,6 +11331,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-stream"
+        }
       ]
     },
     {
@@ -8790,6 +11356,12 @@
           "url": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-symbol-description"
         }
       ]
     },
@@ -8811,6 +11383,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-value"
+        }
       ]
     },
     {
@@ -8830,6 +11408,12 @@
           "url": "https://registry.npmjs.org/getobject/-/getobject-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/getobject"
         }
       ]
     },
@@ -8851,6 +11435,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/getpass"
+        }
       ]
     },
     {
@@ -8870,6 +11460,12 @@
           "url": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/github-from-package"
         }
       ]
     },
@@ -8892,6 +11488,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/glob-parent"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -8910,6 +11512,12 @@
               "url": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/glob-parent/node_modules/is-glob"
             }
           ]
         }
@@ -8934,6 +11542,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/glob"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -8952,6 +11566,12 @@
               "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/glob/node_modules/brace-expansion"
             }
           ]
         },
@@ -8972,6 +11592,12 @@
               "url": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/glob/node_modules/minimatch"
             }
           ]
         }
@@ -8995,6 +11621,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/global-modules"
+        }
       ]
     },
     {
@@ -9016,6 +11648,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/global-prefix"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9034,6 +11672,12 @@
               "url": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/global-prefix/node_modules/which"
             }
           ]
         }
@@ -9058,6 +11702,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/got"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9076,6 +11726,12 @@
               "url": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/got/node_modules/get-stream"
             }
           ]
         },
@@ -9096,6 +11752,12 @@
               "url": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/got/node_modules/pify"
             }
           ]
         }
@@ -9119,6 +11781,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/graceful-fs"
+        }
       ]
     },
     {
@@ -9140,6 +11808,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-cli"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9158,6 +11832,12 @@
               "url": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-cli/node_modules/nopt"
             }
           ]
         }
@@ -9182,6 +11862,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-contrib-compress"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9200,6 +11886,12 @@
               "url": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-contrib-compress/node_modules/ansi-styles"
             }
           ]
         },
@@ -9221,6 +11913,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-contrib-compress/node_modules/chalk"
+            }
           ]
         },
         {
@@ -9240,6 +11938,12 @@
               "url": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-contrib-compress/node_modules/supports-color"
             }
           ]
         }
@@ -9263,6 +11967,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-known-options"
+        }
       ]
     },
     {
@@ -9284,6 +11994,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-legacy-log-utils"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9302,6 +12018,12 @@
               "url": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils/node_modules/ansi-styles"
             }
           ]
         },
@@ -9323,6 +12045,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils/node_modules/chalk"
+            }
           ]
         },
         {
@@ -9342,6 +12070,12 @@
               "url": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils/node_modules/color-convert"
             }
           ]
         },
@@ -9363,6 +12097,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils/node_modules/color-name"
+            }
           ]
         },
         {
@@ -9383,6 +12123,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils/node_modules/has-flag"
+            }
           ]
         },
         {
@@ -9402,6 +12148,12 @@
               "url": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils/node_modules/supports-color"
             }
           ]
         }
@@ -9426,6 +12178,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-legacy-log"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9444,6 +12202,12 @@
               "url": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log/node_modules/colors"
             }
           ]
         }
@@ -9468,6 +12232,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-legacy-util"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9486,6 +12256,12 @@
               "url": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-util/node_modules/async"
             }
           ]
         }
@@ -9509,6 +12285,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-replace-json"
+        }
       ]
     },
     {
@@ -9530,6 +12312,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9548,6 +12336,12 @@
               "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt/node_modules/brace-expansion"
             }
           ]
         },
@@ -9570,6 +12364,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt/node_modules/findup-sync"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -9588,6 +12388,12 @@
                   "url": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/grunt/node_modules/findup-sync/node_modules/glob"
                 }
               ]
             }
@@ -9611,6 +12417,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt/node_modules/glob"
+            }
           ]
         },
         {
@@ -9630,6 +12442,12 @@
               "url": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.8.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt/node_modules/minimatch"
             }
           ]
         }
@@ -9654,6 +12472,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/handlebars"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9672,6 +12496,12 @@
               "url": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/handlebars/node_modules/wordwrap"
             }
           ]
         }
@@ -9695,6 +12525,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/har-schema"
+        }
       ]
     },
     {
@@ -9714,6 +12550,12 @@
           "url": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/har-validator"
         }
       ]
     },
@@ -9735,6 +12577,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-ansi"
+        }
       ]
     },
     {
@@ -9754,6 +12602,12 @@
           "url": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-bigints"
         }
       ]
     },
@@ -9775,6 +12629,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-flag"
+        }
       ]
     },
     {
@@ -9794,6 +12654,12 @@
           "url": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-property-descriptors"
         }
       ]
     },
@@ -9815,6 +12681,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-symbol-support-x"
+        }
       ]
     },
     {
@@ -9834,6 +12706,12 @@
           "url": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-symbols"
         }
       ]
     },
@@ -9855,6 +12733,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-to-string-tag-x"
+        }
       ]
     },
     {
@@ -9874,6 +12758,12 @@
           "url": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-tostringtag"
         }
       ]
     },
@@ -9895,6 +12785,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-unicode"
+        }
       ]
     },
     {
@@ -9914,6 +12810,12 @@
           "url": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-value"
         }
       ]
     },
@@ -9936,6 +12838,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-values"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9954,6 +12862,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/has-values/node_modules/kind-of"
             }
           ]
         }
@@ -9977,6 +12891,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has"
+        }
       ]
     },
     {
@@ -9996,6 +12916,12 @@
           "url": "https://registry.npmjs.org/hashids/-/hashids-2.2.10.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hashids"
         }
       ]
     },
@@ -10017,6 +12943,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hbs"
+        }
       ]
     },
     {
@@ -10036,6 +12968,12 @@
           "url": "https://registry.npmjs.org/he/-/he-0.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/he"
         }
       ]
     },
@@ -10057,6 +12995,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/heap"
+        }
       ]
     },
     {
@@ -10076,6 +13020,12 @@
           "url": "https://registry.npmjs.org/helmet/-/helmet-4.6.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/helmet"
         }
       ]
     },
@@ -10097,6 +13047,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hoister"
+        }
       ]
     },
     {
@@ -10116,6 +13072,12 @@
           "url": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/homedir-polyfill"
         }
       ]
     },
@@ -10137,6 +13099,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hooker"
+        }
       ]
     },
     {
@@ -10157,6 +13125,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hosted-git-info"
+        }
       ]
     },
     {
@@ -10176,6 +13150,12 @@
           "url": "https://registry.npmjs.org/html-entities/-/html-entities-1.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/html-entities"
         }
       ]
     },
@@ -10198,6 +13178,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/htmlparser2"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -10216,6 +13202,12 @@
               "url": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/htmlparser2/node_modules/isarray"
             }
           ]
         },
@@ -10237,6 +13229,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/htmlparser2/node_modules/readable-stream"
+            }
           ]
         },
         {
@@ -10256,6 +13254,12 @@
               "url": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/htmlparser2/node_modules/string_decoder"
             }
           ]
         }
@@ -10279,6 +13283,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/http-cache-semantics"
+        }
       ]
     },
     {
@@ -10298,6 +13308,12 @@
           "url": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/http-errors"
         }
       ]
     },
@@ -10320,6 +13336,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/http-proxy-agent"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -10338,6 +13360,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/http-proxy-agent/node_modules/debug"
             }
           ]
         },
@@ -10358,6 +13386,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/http-proxy-agent/node_modules/ms"
             }
           ]
         }
@@ -10381,6 +13415,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/http-signature"
+        }
       ]
     },
     {
@@ -10402,6 +13442,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/https-proxy-agent"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -10420,6 +13466,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/https-proxy-agent/node_modules/debug"
             }
           ]
         },
@@ -10440,6 +13492,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/https-proxy-agent/node_modules/ms"
             }
           ]
         }
@@ -10463,6 +13521,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/humanize-ms"
+        }
       ]
     },
     {
@@ -10482,6 +13546,12 @@
           "url": "https://registry.npmjs.org/i18n/-/i18n-0.11.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/i18n"
         }
       ]
     },
@@ -10503,6 +13573,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/iconv-lite"
+        }
       ]
     },
     {
@@ -10522,6 +13598,12 @@
           "url": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ieee754"
         }
       ]
     },
@@ -10544,6 +13626,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ignore-walk"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -10562,6 +13650,12 @@
               "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/ignore-walk/node_modules/brace-expansion"
             }
           ]
         },
@@ -10582,6 +13676,12 @@
               "url": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/ignore-walk/node_modules/minimatch"
             }
           ]
         }
@@ -10605,6 +13705,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/iltorb"
+        }
       ]
     },
     {
@@ -10624,6 +13730,12 @@
           "url": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/imurmurhash"
         }
       ]
     },
@@ -10645,6 +13757,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/indent-string"
+        }
       ]
     },
     {
@@ -10664,6 +13782,12 @@
           "url": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/infer-owner"
         }
       ]
     },
@@ -10685,6 +13809,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/inflection"
+        }
       ]
     },
     {
@@ -10704,6 +13834,12 @@
           "url": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/inflight"
         }
       ]
     },
@@ -10725,6 +13861,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/inherits"
+        }
       ]
     },
     {
@@ -10744,6 +13886,12 @@
           "url": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ini"
         }
       ]
     },
@@ -10765,6 +13913,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/internal-slot"
+        }
       ]
     },
     {
@@ -10784,6 +13938,12 @@
           "url": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/interpret"
         }
       ]
     },
@@ -10805,6 +13965,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/into-stream"
+        }
       ]
     },
     {
@@ -10824,6 +13990,12 @@
           "url": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/invariant"
         }
       ]
     },
@@ -10845,6 +14017,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ip"
+        }
       ]
     },
     {
@@ -10864,6 +14042,12 @@
           "url": "https://registry.npmjs.org/ip6/-/ip6-0.2.10.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ip6"
         }
       ]
     },
@@ -10885,6 +14069,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ipaddr.js"
+        }
       ]
     },
     {
@@ -10904,6 +14094,12 @@
           "url": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-absolute"
         }
       ]
     },
@@ -10925,6 +14121,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-accessor-descriptor"
+        }
       ]
     },
     {
@@ -10944,6 +14146,12 @@
           "url": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-arguments"
         }
       ]
     },
@@ -10965,6 +14173,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-arrayish"
+        }
       ]
     },
     {
@@ -10984,6 +14198,12 @@
           "url": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-bigint"
         }
       ]
     },
@@ -11005,6 +14225,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-binary-path"
+        }
       ]
     },
     {
@@ -11024,6 +14250,12 @@
           "url": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-boolean-object"
         }
       ]
     },
@@ -11045,6 +14277,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-buffer"
+        }
       ]
     },
     {
@@ -11064,6 +14302,12 @@
           "url": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-callable"
         }
       ]
     },
@@ -11085,6 +14329,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-core-module"
+        }
       ]
     },
     {
@@ -11104,6 +14354,12 @@
           "url": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-data-descriptor"
         }
       ]
     },
@@ -11125,6 +14381,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-date-object"
+        }
       ]
     },
     {
@@ -11144,6 +14406,12 @@
           "url": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-descriptor"
         }
       ]
     },
@@ -11165,6 +14433,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-docker"
+        }
       ]
     },
     {
@@ -11184,6 +14458,12 @@
           "url": "https://registry.npmjs.org/is-expression/-/is-expression-4.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-expression"
         }
       ]
     },
@@ -11205,6 +14485,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-extendable"
+        }
       ]
     },
     {
@@ -11224,6 +14510,12 @@
           "url": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-extglob"
         }
       ]
     },
@@ -11245,6 +14537,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-fullwidth-code-point"
+        }
       ]
     },
     {
@@ -11264,6 +14562,12 @@
           "url": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-generator-function"
         }
       ]
     },
@@ -11285,6 +14589,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-glob"
+        }
       ]
     },
     {
@@ -11304,6 +14614,12 @@
           "url": "https://registry.npmjs.org/is-heroku/-/is-heroku-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-heroku"
         }
       ]
     },
@@ -11325,6 +14641,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-lambda"
+        }
       ]
     },
     {
@@ -11344,6 +14666,12 @@
           "url": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-map"
         }
       ]
     },
@@ -11365,6 +14693,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-natural-number"
+        }
       ]
     },
     {
@@ -11384,6 +14718,12 @@
           "url": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-negative-zero"
         }
       ]
     },
@@ -11405,6 +14745,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-number-like"
+        }
       ]
     },
     {
@@ -11424,6 +14770,12 @@
           "url": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-number-object"
         }
       ]
     },
@@ -11446,6 +14798,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-number"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -11464,6 +14822,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/is-number/node_modules/kind-of"
             }
           ]
         }
@@ -11487,6 +14851,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-object"
+        }
       ]
     },
     {
@@ -11506,6 +14876,12 @@
           "url": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-plain-obj"
         }
       ]
     },
@@ -11527,6 +14903,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-plain-object"
+        }
       ]
     },
     {
@@ -11546,6 +14928,12 @@
           "url": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-promise"
         }
       ]
     },
@@ -11567,6 +14955,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-regex"
+        }
       ]
     },
     {
@@ -11586,6 +14980,12 @@
           "url": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-relative"
         }
       ]
     },
@@ -11607,6 +15007,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-retry-allowed"
+        }
       ]
     },
     {
@@ -11626,6 +15032,12 @@
           "url": "https://registry.npmjs.org/is-set/-/is-set-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-set"
         }
       ]
     },
@@ -11647,6 +15059,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-shared-array-buffer"
+        }
       ]
     },
     {
@@ -11666,6 +15084,12 @@
           "url": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-stream"
         }
       ]
     },
@@ -11687,6 +15111,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-string"
+        }
       ]
     },
     {
@@ -11706,6 +15136,12 @@
           "url": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-symbol"
         }
       ]
     },
@@ -11727,6 +15163,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-typed-array"
+        }
       ]
     },
     {
@@ -11746,6 +15188,12 @@
           "url": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-typedarray"
         }
       ]
     },
@@ -11767,6 +15215,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-unc-path"
+        }
       ]
     },
     {
@@ -11786,6 +15240,12 @@
           "url": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-weakmap"
         }
       ]
     },
@@ -11807,6 +15267,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-weakref"
+        }
       ]
     },
     {
@@ -11826,6 +15292,12 @@
           "url": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-weakset"
         }
       ]
     },
@@ -11847,6 +15319,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-windows"
+        }
       ]
     },
     {
@@ -11866,6 +15344,12 @@
           "url": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isarray"
         }
       ]
     },
@@ -11887,6 +15371,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isexe"
+        }
       ]
     },
     {
@@ -11906,6 +15396,12 @@
           "url": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isobject"
         }
       ]
     },
@@ -11927,6 +15423,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isstream"
+        }
       ]
     },
     {
@@ -11946,6 +15448,12 @@
           "url": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isurl"
         }
       ]
     },
@@ -11967,6 +15475,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/js-stringify"
+        }
       ]
     },
     {
@@ -11986,6 +15500,12 @@
           "url": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/js-tokens"
         }
       ]
     },
@@ -12007,6 +15527,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/js-yaml"
+        }
       ]
     },
     {
@@ -12026,6 +15552,12 @@
           "url": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jsbn"
         }
       ]
     },
@@ -12047,6 +15579,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-buffer"
+        }
       ]
     },
     {
@@ -12066,6 +15604,12 @@
           "url": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-parse-better-errors"
         }
       ]
     },
@@ -12087,6 +15631,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-schema-traverse"
+        }
       ]
     },
     {
@@ -12106,6 +15656,12 @@
           "url": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-schema"
         }
       ]
     },
@@ -12127,6 +15683,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-stringify-safe"
+        }
       ]
     },
     {
@@ -12146,6 +15708,12 @@
           "url": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json5"
         }
       ]
     },
@@ -12167,6 +15735,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jsonfile"
+        }
       ]
     },
     {
@@ -12186,6 +15760,12 @@
           "url": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-0.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jsonwebtoken"
         }
       ]
     },
@@ -12207,6 +15787,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jsprim"
+        }
       ]
     },
     {
@@ -12226,6 +15812,12 @@
           "url": "https://registry.npmjs.org/jssha/-/jssha-3.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jssha"
         }
       ]
     },
@@ -12247,6 +15839,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jstransformer"
+        }
       ]
     },
     {
@@ -12266,6 +15864,12 @@
           "url": "https://registry.npmjs.org/juicy-chat-bot/-/juicy-chat-bot-0.6.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/juicy-chat-bot"
         }
       ]
     },
@@ -12287,6 +15891,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jwa"
+        }
       ]
     },
     {
@@ -12306,6 +15916,12 @@
           "url": "https://registry.npmjs.org/jws/-/jws-0.2.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jws"
         }
       ]
     },
@@ -12327,6 +15943,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/keyv"
+        }
       ]
     },
     {
@@ -12346,6 +15968,12 @@
           "url": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/kind-of"
         }
       ]
     },
@@ -12367,6 +15995,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/kuler"
+        }
       ]
     },
     {
@@ -12386,6 +16020,12 @@
           "url": "https://registry.npmjs.org/kuromoji/-/kuromoji-0.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/kuromoji"
         }
       ]
     },
@@ -12407,6 +16047,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lazystream"
+        }
       ]
     },
     {
@@ -12426,6 +16072,12 @@
           "url": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/levn"
         }
       ]
     },
@@ -12448,6 +16100,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/libxmljs2"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12466,6 +16124,12 @@
               "url": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/libxmljs2/node_modules/nan"
             }
           ]
         }
@@ -12490,6 +16154,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/liftup"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12508,6 +16178,12 @@
               "url": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/braces"
             }
           ]
         },
@@ -12529,6 +16205,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/fill-range"
+            }
           ]
         },
         {
@@ -12548,6 +16230,12 @@
               "url": "https://registry.npmjs.org/findup-sync/-/findup-sync-4.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/findup-sync"
             }
           ]
         },
@@ -12569,6 +16257,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/is-glob"
+            }
           ]
         },
         {
@@ -12588,6 +16282,12 @@
               "url": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/is-number"
             }
           ]
         },
@@ -12609,6 +16309,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/micromatch"
+            }
           ]
         },
         {
@@ -12628,6 +16334,12 @@
               "url": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/to-regex-range"
             }
           ]
         }
@@ -12652,6 +16364,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/linebreak"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12670,6 +16388,12 @@
               "url": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/linebreak/node_modules/base64-js"
             }
           ]
         }
@@ -12693,6 +16417,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/listenercount"
+        }
       ]
     },
     {
@@ -12712,6 +16442,12 @@
           "url": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/locate-path"
         }
       ]
     },
@@ -12733,6 +16469,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lodash.camelcase"
+        }
       ]
     },
     {
@@ -12752,6 +16494,12 @@
           "url": "https://registry.npmjs.org/lodash.isfinite/-/lodash.isfinite-3.3.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lodash.isfinite"
         }
       ]
     },
@@ -12773,6 +16521,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lodash.set"
+        }
       ]
     },
     {
@@ -12792,6 +16546,12 @@
           "url": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lodash"
         }
       ]
     },
@@ -12814,6 +16574,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/logform"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12832,6 +16598,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/logform/node_modules/ms"
             }
           ]
         }
@@ -12855,6 +16627,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lolex"
+        }
       ]
     },
     {
@@ -12874,6 +16652,12 @@
           "url": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/loose-envify"
         }
       ]
     },
@@ -12895,6 +16679,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lowercase-keys"
+        }
       ]
     },
     {
@@ -12914,6 +16704,12 @@
           "url": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lru-cache"
         }
       ]
     },
@@ -12936,6 +16732,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-dir"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12954,6 +16756,12 @@
               "url": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-dir/node_modules/semver"
             }
           ]
         }
@@ -12977,6 +16785,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-error"
+        }
       ]
     },
     {
@@ -12996,6 +16810,12 @@
           "url": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-9.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-fetch-happen"
         }
       ],
       "components": [
@@ -13018,6 +16838,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen/node_modules/@tootallnate/once"
+            }
           ]
         },
         {
@@ -13037,6 +16863,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen/node_modules/debug"
             }
           ]
         },
@@ -13058,6 +16890,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen/node_modules/http-cache-semantics"
+            }
           ]
         },
         {
@@ -13078,6 +16916,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen/node_modules/http-proxy-agent"
+            }
           ]
         },
         {
@@ -13097,6 +16941,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen/node_modules/ms"
             }
           ]
         }
@@ -13120,6 +16970,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-iterator"
+        }
       ]
     },
     {
@@ -13139,6 +16995,12 @@
           "url": "https://registry.npmjs.org/make-plural/-/make-plural-6.2.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-plural"
         }
       ]
     },
@@ -13160,6 +17022,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/map-cache"
+        }
       ]
     },
     {
@@ -13179,6 +17047,12 @@
           "url": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/map-visit"
         }
       ]
     },
@@ -13200,6 +17074,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/marsdb"
+        }
       ]
     },
     {
@@ -13219,6 +17099,12 @@
           "url": "https://registry.npmjs.org/math-interval-parser/-/math-interval-parser-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/math-interval-parser"
         }
       ]
     },
@@ -13240,6 +17126,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/media-typer"
+        }
       ]
     },
     {
@@ -13259,6 +17151,12 @@
           "url": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/merge-descriptors"
         }
       ]
     },
@@ -13280,6 +17178,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/messageformat-formatters"
+        }
       ]
     },
     {
@@ -13299,6 +17203,12 @@
           "url": "https://registry.npmjs.org/messageformat-parser/-/messageformat-parser-4.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/messageformat-parser"
         }
       ]
     },
@@ -13321,6 +17231,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/messageformat"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -13339,6 +17255,12 @@
               "url": "https://registry.npmjs.org/make-plural/-/make-plural-4.3.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/messageformat/node_modules/make-plural"
             }
           ]
         }
@@ -13362,6 +17284,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/methods"
+        }
       ]
     },
     {
@@ -13381,6 +17309,12 @@
           "url": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/micromatch"
         }
       ]
     },
@@ -13402,6 +17336,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mime-db"
+        }
       ]
     },
     {
@@ -13421,6 +17361,12 @@
           "url": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mime-types"
         }
       ]
     },
@@ -13442,6 +17388,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mime"
+        }
       ]
     },
     {
@@ -13461,6 +17413,12 @@
           "url": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mimic-response"
         }
       ]
     },
@@ -13482,6 +17440,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minimatch"
+        }
       ]
     },
     {
@@ -13501,6 +17465,12 @@
           "url": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minimist"
         }
       ]
     },
@@ -13522,6 +17492,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-collect"
+        }
       ]
     },
     {
@@ -13541,6 +17517,12 @@
           "url": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-1.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-fetch"
         }
       ]
     },
@@ -13562,6 +17544,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-flush"
+        }
       ]
     },
     {
@@ -13581,6 +17569,12 @@
           "url": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-pipeline"
         }
       ]
     },
@@ -13602,6 +17596,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-sized"
+        }
       ]
     },
     {
@@ -13621,6 +17621,12 @@
           "url": "https://registry.npmjs.org/minipass/-/minipass-3.3.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass"
         }
       ]
     },
@@ -13642,6 +17648,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minizlib"
+        }
       ]
     },
     {
@@ -13661,6 +17673,12 @@
           "url": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mixin-deep"
         }
       ]
     },
@@ -13682,6 +17700,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mkdirp-classic"
+        }
       ]
     },
     {
@@ -13701,6 +17725,12 @@
           "url": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mkdirp"
         }
       ]
     },
@@ -13722,6 +17752,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/moment-timezone"
+        }
       ]
     },
     {
@@ -13741,6 +17777,12 @@
           "url": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/moment"
         }
       ]
     },
@@ -13763,6 +17805,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/morgan"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -13781,6 +17829,12 @@
               "url": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/morgan/node_modules/on-finished"
             }
           ]
         }
@@ -13804,6 +17858,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mout"
+        }
       ]
     },
     {
@@ -13823,6 +17883,12 @@
           "url": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ms"
         }
       ]
     },
@@ -13845,6 +17911,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/multer"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -13863,6 +17935,12 @@
               "url": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/multer/node_modules/mkdirp"
             }
           ]
         }
@@ -13886,6 +17964,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mustache"
+        }
       ]
     },
     {
@@ -13905,6 +17989,12 @@
           "url": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/nan"
         }
       ]
     },
@@ -13926,6 +18016,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/nanomatch"
+        }
       ]
     },
     {
@@ -13945,6 +18041,12 @@
           "url": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/napi-build-utils"
         }
       ]
     },
@@ -13967,6 +18069,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/needle"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -13985,6 +18093,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/needle/node_modules/debug"
             }
           ]
         },
@@ -14005,6 +18119,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/needle/node_modules/ms"
             }
           ]
         }
@@ -14028,6 +18148,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/negotiator"
+        }
       ]
     },
     {
@@ -14047,6 +18173,12 @@
           "url": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/neo-async"
         }
       ]
     },
@@ -14069,6 +18201,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-abi"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14087,6 +18225,12 @@
               "url": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-abi/node_modules/semver"
             }
           ]
         }
@@ -14110,6 +18254,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-addon-api"
+        }
       ]
     },
     {
@@ -14129,6 +18279,12 @@
           "url": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-fetch"
         }
       ]
     },
@@ -14151,6 +18307,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-gyp"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14169,6 +18331,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/ansi-regex"
             }
           ]
         },
@@ -14190,6 +18358,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/are-we-there-yet"
+            }
           ]
         },
         {
@@ -14209,6 +18383,12 @@
               "url": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/gauge"
             }
           ]
         },
@@ -14230,6 +18410,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/is-fullwidth-code-point"
+            }
           ]
         },
         {
@@ -14249,6 +18435,12 @@
               "url": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/nopt"
             }
           ]
         },
@@ -14270,6 +18462,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/npmlog"
+            }
           ]
         },
         {
@@ -14289,6 +18487,12 @@
               "url": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/readable-stream"
             }
           ]
         },
@@ -14310,6 +18514,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/string-width"
+            }
           ]
         },
         {
@@ -14329,6 +18539,12 @@
               "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/strip-ansi"
             }
           ]
         }
@@ -14353,6 +18569,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-pre-gyp"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14371,6 +18593,12 @@
               "url": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/chownr"
             }
           ]
         },
@@ -14392,6 +18620,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/fs-minipass"
+            }
           ]
         },
         {
@@ -14411,6 +18645,12 @@
               "url": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/minipass"
             }
           ]
         },
@@ -14432,6 +18672,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/minizlib"
+            }
           ]
         },
         {
@@ -14451,6 +18697,12 @@
               "url": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/mkdirp"
             }
           ]
         },
@@ -14472,6 +18724,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/nopt"
+            }
           ]
         },
         {
@@ -14491,6 +18749,12 @@
               "url": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/rimraf"
             }
           ]
         },
@@ -14512,6 +18776,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/safe-buffer"
+            }
           ]
         },
         {
@@ -14531,6 +18801,12 @@
               "url": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/semver"
             }
           ]
         },
@@ -14552,6 +18828,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/tar"
+            }
           ]
         },
         {
@@ -14571,6 +18853,12 @@
               "url": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/yallist"
             }
           ]
         }
@@ -14594,6 +18882,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/noop-logger"
+        }
       ]
     },
     {
@@ -14613,6 +18907,12 @@
           "url": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/nopt"
         }
       ]
     },
@@ -14635,6 +18935,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/normalize-package-data"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14653,6 +18959,12 @@
               "url": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/normalize-package-data/node_modules/semver"
             }
           ]
         }
@@ -14676,6 +18988,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/normalize-path"
+        }
       ]
     },
     {
@@ -14695,6 +19013,12 @@
           "url": "https://registry.npmjs.org/normalize-url/-/normalize-url-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/normalize-url"
         }
       ]
     },
@@ -14717,6 +19041,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/notevil"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14735,6 +19065,12 @@
               "url": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/notevil/node_modules/esprima"
             }
           ]
         }
@@ -14758,6 +19094,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/npm-bundled"
+        }
       ]
     },
     {
@@ -14777,6 +19119,12 @@
           "url": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/npm-normalize-package-bin"
         }
       ]
     },
@@ -14798,6 +19146,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/npm-packlist"
+        }
       ]
     },
     {
@@ -14817,6 +19171,12 @@
           "url": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/npmlog"
         }
       ]
     },
@@ -14838,6 +19198,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/number-is-nan"
+        }
       ]
     },
     {
@@ -14858,6 +19224,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/oauth-sign"
+        }
       ]
     },
     {
@@ -14877,6 +19249,12 @@
           "url": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-assign"
         }
       ]
     },
@@ -14899,6 +19277,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-copy"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14917,6 +19301,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy/node_modules/define-property"
             }
           ]
         },
@@ -14938,6 +19328,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy/node_modules/is-accessor-descriptor"
+            }
           ]
         },
         {
@@ -14957,6 +19353,12 @@
               "url": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy/node_modules/is-data-descriptor"
             }
           ]
         },
@@ -14979,6 +19381,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy/node_modules/is-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -14997,6 +19405,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/object-copy/node_modules/is-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -15020,6 +19434,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy/node_modules/kind-of"
+            }
           ]
         }
       ]
@@ -15042,6 +19462,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-inspect"
+        }
       ]
     },
     {
@@ -15061,6 +19487,12 @@
           "url": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-is"
         }
       ]
     },
@@ -15082,6 +19514,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-keys"
+        }
       ]
     },
     {
@@ -15101,6 +19539,12 @@
           "url": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-visit"
         }
       ]
     },
@@ -15122,6 +19566,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object.assign"
+        }
       ]
     },
     {
@@ -15141,6 +19591,12 @@
           "url": "https://registry.npmjs.org/object.defaults/-/object.defaults-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object.defaults"
         }
       ]
     },
@@ -15162,6 +19618,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object.map"
+        }
       ]
     },
     {
@@ -15181,6 +19643,12 @@
           "url": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object.pick"
         }
       ]
     },
@@ -15202,6 +19670,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/on-finished"
+        }
       ]
     },
     {
@@ -15221,6 +19695,12 @@
           "url": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/on-headers"
         }
       ]
     },
@@ -15242,6 +19722,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/once"
+        }
       ]
     },
     {
@@ -15261,6 +19747,12 @@
           "url": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/one-time"
         }
       ]
     },
@@ -15282,6 +19774,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/opentype.js"
+        }
       ]
     },
     {
@@ -15301,6 +19799,12 @@
           "url": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/optionator"
         }
       ]
     },
@@ -15322,6 +19826,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/os-homedir"
+        }
       ]
     },
     {
@@ -15341,6 +19851,12 @@
           "url": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/os-tmpdir"
         }
       ]
     },
@@ -15362,6 +19878,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/osenv"
+        }
       ]
     },
     {
@@ -15381,6 +19903,12 @@
           "url": "https://registry.npmjs.org/otplib/-/otplib-12.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/otplib"
         }
       ]
     },
@@ -15402,6 +19930,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-cancelable"
+        }
       ]
     },
     {
@@ -15421,6 +19955,12 @@
           "url": "https://registry.npmjs.org/p-event/-/p-event-2.3.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-event"
         }
       ]
     },
@@ -15442,6 +19982,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-finally"
+        }
       ]
     },
     {
@@ -15461,6 +20007,12 @@
           "url": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-is-promise"
         }
       ]
     },
@@ -15482,6 +20034,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-limit"
+        }
       ]
     },
     {
@@ -15501,6 +20059,12 @@
           "url": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-locate"
         }
       ]
     },
@@ -15522,6 +20086,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-map"
+        }
       ]
     },
     {
@@ -15541,6 +20111,12 @@
           "url": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-timeout"
         }
       ]
     },
@@ -15562,6 +20138,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-try"
+        }
       ]
     },
     {
@@ -15581,6 +20163,12 @@
           "url": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pako"
         }
       ]
     },
@@ -15602,6 +20190,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/parse-filepath"
+        }
       ]
     },
     {
@@ -15621,6 +20215,12 @@
           "url": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/parse-json"
         }
       ]
     },
@@ -15642,6 +20242,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/parse-passwd"
+        }
       ]
     },
     {
@@ -15661,6 +20267,12 @@
           "url": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/parseurl"
         }
       ]
     },
@@ -15682,6 +20294,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pascalcase"
+        }
       ]
     },
     {
@@ -15701,6 +20319,12 @@
           "url": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-exists"
         }
       ]
     },
@@ -15722,6 +20346,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-is-absolute"
+        }
       ]
     },
     {
@@ -15741,6 +20371,12 @@
           "url": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-parse"
         }
       ]
     },
@@ -15762,6 +20398,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-root-regex"
+        }
       ]
     },
     {
@@ -15781,6 +20423,12 @@
           "url": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-root"
         }
       ]
     },
@@ -15802,6 +20450,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-to-regexp"
+        }
       ]
     },
     {
@@ -15821,6 +20475,12 @@
           "url": "https://registry.npmjs.org/pdfkit/-/pdfkit-0.11.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pdfkit"
         }
       ]
     },
@@ -15842,6 +20502,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/peek-readable"
+        }
       ]
     },
     {
@@ -15861,6 +20527,12 @@
           "url": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pend"
         }
       ]
     },
@@ -15882,6 +20554,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/performance-now"
+        }
       ]
     },
     {
@@ -15901,6 +20579,12 @@
           "url": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.5.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pg-connection-string"
         }
       ]
     },
@@ -15922,6 +20606,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/picomatch"
+        }
       ]
     },
     {
@@ -15941,6 +20631,12 @@
           "url": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pify"
         }
       ]
     },
@@ -15962,6 +20658,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pinkie-promise"
+        }
       ]
     },
     {
@@ -15981,6 +20683,12 @@
           "url": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pinkie"
         }
       ]
     },
@@ -16002,6 +20710,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/png-js"
+        }
       ]
     },
     {
@@ -16021,6 +20735,12 @@
           "url": "https://registry.npmjs.org/portscanner/-/portscanner-2.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/portscanner"
         }
       ]
     },
@@ -16042,6 +20762,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/posix-character-classes"
+        }
       ]
     },
     {
@@ -16061,6 +20787,12 @@
           "url": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.3.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/prebuild-install"
         }
       ]
     },
@@ -16082,6 +20814,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/prelude-ls"
+        }
       ]
     },
     {
@@ -16101,6 +20839,12 @@
           "url": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/prepend-http"
         }
       ]
     },
@@ -16122,6 +20866,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pretty-bytes"
+        }
       ]
     },
     {
@@ -16141,6 +20891,12 @@
           "url": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/process-nextick-args"
         }
       ]
     },
@@ -16162,6 +20918,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/prom-client"
+        }
       ]
     },
     {
@@ -16181,6 +20943,12 @@
           "url": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/promise-inflight"
         }
       ]
     },
@@ -16203,6 +20971,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/promise-retry"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -16221,6 +20995,12 @@
               "url": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/promise-retry/node_modules/err-code"
             }
           ]
         },
@@ -16241,6 +21021,12 @@
               "url": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/promise-retry/node_modules/retry"
             }
           ]
         }
@@ -16264,6 +21050,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/promise"
+        }
       ]
     },
     {
@@ -16283,6 +21075,12 @@
           "url": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/proper-lockfile"
         }
       ]
     },
@@ -16304,6 +21102,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/proxy-addr"
+        }
       ]
     },
     {
@@ -16323,6 +21127,12 @@
           "url": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/psl"
         }
       ]
     },
@@ -16344,6 +21154,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-attrs"
+        }
       ]
     },
     {
@@ -16363,6 +21179,12 @@
           "url": "https://registry.npmjs.org/pug-code-gen/-/pug-code-gen-3.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-code-gen"
         }
       ]
     },
@@ -16384,6 +21206,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-error"
+        }
       ]
     },
     {
@@ -16403,6 +21231,12 @@
           "url": "https://registry.npmjs.org/pug-filters/-/pug-filters-4.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-filters"
         }
       ]
     },
@@ -16424,6 +21258,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-lexer"
+        }
       ]
     },
     {
@@ -16443,6 +21283,12 @@
           "url": "https://registry.npmjs.org/pug-linker/-/pug-linker-4.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-linker"
         }
       ]
     },
@@ -16464,6 +21310,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-load"
+        }
       ]
     },
     {
@@ -16483,6 +21335,12 @@
           "url": "https://registry.npmjs.org/pug-parser/-/pug-parser-6.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-parser"
         }
       ]
     },
@@ -16504,6 +21362,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-runtime"
+        }
       ]
     },
     {
@@ -16523,6 +21387,12 @@
           "url": "https://registry.npmjs.org/pug-strip-comments/-/pug-strip-comments-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-strip-comments"
         }
       ]
     },
@@ -16544,6 +21414,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-walk"
+        }
       ]
     },
     {
@@ -16563,6 +21439,12 @@
           "url": "https://registry.npmjs.org/pug/-/pug-3.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug"
         }
       ]
     },
@@ -16584,6 +21466,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pump"
+        }
       ]
     },
     {
@@ -16603,6 +21491,12 @@
           "url": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/punycode"
         }
       ]
     },
@@ -16624,6 +21518,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/qs"
+        }
       ]
     },
     {
@@ -16643,6 +21543,12 @@
           "url": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/query-string"
         }
       ]
     },
@@ -16664,6 +21570,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/range_check"
+        }
       ]
     },
     {
@@ -16683,6 +21595,12 @@
           "url": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/range-parser"
         }
       ]
     },
@@ -16704,6 +21622,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/raw-body"
+        }
       ]
     },
     {
@@ -16723,6 +21647,12 @@
           "url": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/rc"
         }
       ]
     },
@@ -16745,6 +21675,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/read-pkg"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -16763,6 +21699,12 @@
               "url": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/read-pkg/node_modules/pify"
             }
           ]
         }
@@ -16787,6 +21729,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/readable-stream"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -16805,6 +21753,12 @@
               "url": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/readable-stream/node_modules/isarray"
             }
           ]
         }
@@ -16829,6 +21783,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/readable-web-to-node-stream"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -16847,6 +21807,12 @@
               "url": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/readable-web-to-node-stream/node_modules/readable-stream"
             }
           ]
         }
@@ -16870,6 +21836,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/readdirp"
+        }
       ]
     },
     {
@@ -16889,6 +21861,12 @@
           "url": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/rechoir"
         }
       ]
     },
@@ -16910,6 +21888,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/regex-not"
+        }
       ]
     },
     {
@@ -16929,6 +21913,12 @@
           "url": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/regexp.prototype.flags"
         }
       ]
     },
@@ -16950,6 +21940,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/remove-trailing-separator"
+        }
       ]
     },
     {
@@ -16970,6 +21966,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/repeat-element"
+        }
       ]
     },
     {
@@ -16989,6 +21991,12 @@
           "url": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/repeat-string"
         }
       ]
     },
@@ -17011,6 +22019,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/replace"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17029,6 +22043,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/ansi-regex"
             }
           ]
         },
@@ -17050,6 +22070,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/ansi-styles"
+            }
           ]
         },
         {
@@ -17069,6 +22095,12 @@
               "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/brace-expansion"
             }
           ]
         },
@@ -17090,6 +22122,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/cliui"
+            }
           ]
         },
         {
@@ -17109,6 +22147,12 @@
               "url": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/color-convert"
             }
           ]
         },
@@ -17130,6 +22174,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/color-name"
+            }
           ]
         },
         {
@@ -17149,6 +22199,12 @@
               "url": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/find-up"
             }
           ]
         },
@@ -17170,6 +22226,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/is-fullwidth-code-point"
+            }
           ]
         },
         {
@@ -17189,6 +22251,12 @@
               "url": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/locate-path"
             }
           ]
         },
@@ -17210,6 +22278,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/minimatch"
+            }
           ]
         },
         {
@@ -17229,6 +22303,12 @@
               "url": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/p-locate"
             }
           ]
         },
@@ -17250,6 +22330,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/path-exists"
+            }
           ]
         },
         {
@@ -17269,6 +22355,12 @@
               "url": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/string-width"
             }
           ]
         },
@@ -17290,6 +22382,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/strip-ansi"
+            }
           ]
         },
         {
@@ -17309,6 +22407,12 @@
               "url": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/wrap-ansi"
             }
           ]
         },
@@ -17330,6 +22434,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/yargs-parser"
+            }
           ]
         },
         {
@@ -17349,6 +22459,12 @@
               "url": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/yargs"
             }
           ]
         }
@@ -17373,6 +22489,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/request"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17391,6 +22513,12 @@
               "url": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/request/node_modules/qs"
             }
           ]
         }
@@ -17414,6 +22542,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/require-directory"
+        }
       ]
     },
     {
@@ -17433,6 +22567,12 @@
           "url": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/require-main-filename"
         }
       ]
     },
@@ -17454,6 +22594,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/resolve-dir"
+        }
       ]
     },
     {
@@ -17473,6 +22619,12 @@
           "url": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/resolve-url"
         }
       ]
     },
@@ -17494,6 +22646,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/resolve"
+        }
       ]
     },
     {
@@ -17513,6 +22671,12 @@
           "url": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/responselike"
         }
       ]
     },
@@ -17534,6 +22698,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/restructure"
+        }
       ]
     },
     {
@@ -17553,6 +22723,12 @@
           "url": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ret"
         }
       ]
     },
@@ -17574,6 +22750,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/retry-as-promised"
+        }
       ]
     },
     {
@@ -17594,6 +22776,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/retry"
+        }
       ]
     },
     {
@@ -17613,6 +22801,12 @@
           "url": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/rimraf"
         }
       ]
     },
@@ -17635,6 +22829,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/rxjs"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17653,6 +22853,12 @@
               "url": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/rxjs/node_modules/tslib"
             }
           ]
         }
@@ -17676,6 +22882,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safe-buffer"
+        }
       ]
     },
     {
@@ -17695,6 +22907,12 @@
           "url": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safe-regex-test"
         }
       ]
     },
@@ -17716,6 +22934,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safe-regex"
+        }
       ]
     },
     {
@@ -17735,6 +22959,12 @@
           "url": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safe-stable-stringify"
         }
       ]
     },
@@ -17756,6 +22986,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safer-buffer"
+        }
       ]
     },
     {
@@ -17776,6 +23012,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/samsam"
+        }
       ]
     },
     {
@@ -17795,6 +23037,12 @@
           "url": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sanitize-filename"
         }
       ]
     },
@@ -17817,6 +23065,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sanitize-html"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17835,6 +23089,12 @@
               "url": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sanitize-html/node_modules/lodash"
             }
           ]
         }
@@ -17858,6 +23118,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sax"
+        }
       ]
     },
     {
@@ -17878,6 +23144,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/seek-bzip"
+        }
       ]
     },
     {
@@ -17897,6 +23169,12 @@
           "url": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/semver"
         }
       ]
     },
@@ -17919,6 +23197,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/send"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17937,6 +23221,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/send/node_modules/ms"
             }
           ]
         }
@@ -17960,6 +23250,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sequelize-pool"
+        }
       ]
     },
     {
@@ -17981,6 +23277,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sequelize"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17999,6 +23301,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sequelize/node_modules/debug"
             }
           ]
         },
@@ -18020,6 +23328,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sequelize/node_modules/ms"
+            }
           ]
         },
         {
@@ -18039,6 +23353,12 @@
               "url": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sequelize/node_modules/uuid"
             }
           ]
         }
@@ -18063,6 +23383,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/serve-index"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18081,6 +23407,12 @@
               "url": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index/node_modules/depd"
             }
           ]
         },
@@ -18102,6 +23434,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index/node_modules/http-errors"
+            }
           ]
         },
         {
@@ -18121,6 +23459,12 @@
               "url": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index/node_modules/inherits"
             }
           ]
         },
@@ -18142,6 +23486,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index/node_modules/setprototypeof"
+            }
           ]
         },
         {
@@ -18161,6 +23511,12 @@
               "url": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index/node_modules/statuses"
             }
           ]
         }
@@ -18184,6 +23540,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/serve-static"
+        }
       ]
     },
     {
@@ -18203,6 +23565,12 @@
           "url": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/set-blocking"
         }
       ]
     },
@@ -18225,6 +23593,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/set-value"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18243,6 +23617,12 @@
               "url": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/set-value/node_modules/extend-shallow"
             }
           ]
         },
@@ -18263,6 +23643,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/set-value/node_modules/is-extendable"
             }
           ]
         }
@@ -18286,6 +23672,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/setimmediate"
+        }
       ]
     },
     {
@@ -18305,6 +23697,12 @@
           "url": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/setprototypeof"
         }
       ]
     },
@@ -18326,6 +23724,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/side-channel"
+        }
       ]
     },
     {
@@ -18346,6 +23750,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/signal-exit"
+        }
       ]
     },
     {
@@ -18365,6 +23775,12 @@
           "url": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/simple-concat"
         }
       ]
     },
@@ -18387,6 +23803,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/simple-get"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18405,6 +23827,12 @@
               "url": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/simple-get/node_modules/decompress-response"
             }
           ]
         },
@@ -18425,6 +23853,12 @@
               "url": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/simple-get/node_modules/mimic-response"
             }
           ]
         }
@@ -18449,6 +23883,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/simple-swizzle"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18467,6 +23907,12 @@
               "url": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/simple-swizzle/node_modules/is-arrayish"
             }
           ]
         }
@@ -18490,6 +23936,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sinon"
+        }
       ]
     },
     {
@@ -18509,6 +23961,12 @@
           "url": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/smart-buffer"
         }
       ]
     },
@@ -18531,6 +23989,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/snapdragon-node"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18549,6 +24013,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon-node/node_modules/define-property"
             }
           ]
         }
@@ -18573,6 +24043,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/snapdragon-util"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18591,6 +24067,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon-util/node_modules/kind-of"
             }
           ]
         }
@@ -18615,6 +24097,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/snapdragon"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18633,6 +24121,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/define-property"
             }
           ]
         },
@@ -18653,6 +24147,12 @@
               "url": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/extend-shallow"
             }
           ]
         },
@@ -18675,6 +24175,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/is-accessor-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -18693,6 +24199,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/snapdragon/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -18717,6 +24229,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/is-data-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -18735,6 +24253,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/snapdragon/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -18758,6 +24282,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/is-descriptor"
+            }
           ]
         },
         {
@@ -18777,6 +24307,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/is-extendable"
             }
           ]
         },
@@ -18798,6 +24334,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/kind-of"
+            }
           ]
         },
         {
@@ -18817,6 +24359,12 @@
               "url": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/source-map"
             }
           ]
         }
@@ -18840,6 +24388,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socket.io-adapter"
+        }
       ]
     },
     {
@@ -18861,6 +24415,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socket.io-parser"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18879,6 +24439,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socket.io-parser/node_modules/debug"
             }
           ]
         },
@@ -18899,6 +24465,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socket.io-parser/node_modules/ms"
             }
           ]
         }
@@ -18923,6 +24495,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socket.io"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18941,6 +24519,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socket.io/node_modules/debug"
             }
           ]
         },
@@ -18961,6 +24545,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socket.io/node_modules/ms"
             }
           ]
         }
@@ -18985,6 +24575,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socks-proxy-agent"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -19003,6 +24599,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socks-proxy-agent/node_modules/debug"
             }
           ]
         },
@@ -19023,6 +24625,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socks-proxy-agent/node_modules/ms"
             }
           ]
         }
@@ -19047,6 +24655,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socks"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -19065,6 +24679,12 @@
               "url": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socks/node_modules/ip"
             }
           ]
         }
@@ -19089,6 +24709,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sort-keys-length"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -19107,6 +24733,12 @@
               "url": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sort-keys-length/node_modules/sort-keys"
             }
           ]
         }
@@ -19130,6 +24762,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sort-keys"
+        }
       ]
     },
     {
@@ -19149,6 +24787,12 @@
           "url": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/source-map-resolve"
         }
       ]
     },
@@ -19170,6 +24814,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/source-map-support"
+        }
       ]
     },
     {
@@ -19189,6 +24839,12 @@
           "url": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/source-map-url"
         }
       ]
     },
@@ -19210,6 +24866,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/source-map"
+        }
       ]
     },
     {
@@ -19229,6 +24891,12 @@
           "url": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2-1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spawn-command"
         }
       ]
     },
@@ -19250,6 +24918,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spdx-correct"
+        }
       ]
     },
     {
@@ -19269,6 +24943,12 @@
           "url": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spdx-exceptions"
         }
       ]
     },
@@ -19290,6 +24970,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spdx-expression-parse"
+        }
       ]
     },
     {
@@ -19309,6 +24995,12 @@
           "url": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.12.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spdx-license-ids"
         }
       ]
     },
@@ -19330,6 +25022,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/split-string"
+        }
       ]
     },
     {
@@ -19349,6 +25047,12 @@
           "url": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sprintf-js"
         }
       ]
     },
@@ -19370,6 +25074,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sqlite3"
+        }
       ]
     },
     {
@@ -19389,6 +25099,12 @@
           "url": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sshpk"
         }
       ]
     },
@@ -19410,6 +25126,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ssri"
+        }
       ]
     },
     {
@@ -19429,6 +25151,12 @@
           "url": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/stack-trace"
         }
       ]
     },
@@ -19451,6 +25179,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/static-extend"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -19469,6 +25203,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend/node_modules/define-property"
             }
           ]
         },
@@ -19491,6 +25231,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend/node_modules/is-accessor-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -19509,6 +25255,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/static-extend/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -19533,6 +25285,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend/node_modules/is-data-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -19551,6 +25309,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/static-extend/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -19574,6 +25338,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend/node_modules/is-descriptor"
+            }
           ]
         },
         {
@@ -19593,6 +25363,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend/node_modules/kind-of"
             }
           ]
         }
@@ -19616,6 +25392,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/statuses"
+        }
       ]
     },
     {
@@ -19635,6 +25417,12 @@
           "url": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-2.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/stream-buffers"
         }
       ]
     },
@@ -19656,6 +25444,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/streamsearch"
+        }
       ]
     },
     {
@@ -19675,6 +25469,12 @@
           "url": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strict-uri-encode"
         }
       ]
     },
@@ -19696,6 +25496,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string_decoder"
+        }
       ]
     },
     {
@@ -19715,6 +25521,12 @@
           "url": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string-width"
         }
       ]
     },
@@ -19736,6 +25548,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string.fromcodepoint"
+        }
       ]
     },
     {
@@ -19755,6 +25573,12 @@
           "url": "https://registry.npmjs.org/string.prototype.codepointat/-/string.prototype.codepointat-0.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string.prototype.codepointat"
         }
       ]
     },
@@ -19776,6 +25600,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string.prototype.trimend"
+        }
       ]
     },
     {
@@ -19795,6 +25625,12 @@
           "url": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string.prototype.trimstart"
         }
       ]
     },
@@ -19816,6 +25652,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-ansi"
+        }
       ]
     },
     {
@@ -19835,6 +25677,12 @@
           "url": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-bom"
         }
       ]
     },
@@ -19856,6 +25704,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-dirs"
+        }
       ]
     },
     {
@@ -19875,6 +25729,12 @@
           "url": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-json-comments"
         }
       ]
     },
@@ -19896,6 +25756,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-outer"
+        }
       ]
     },
     {
@@ -19915,6 +25781,12 @@
           "url": "https://registry.npmjs.org/strtok3/-/strtok3-6.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strtok3"
         }
       ]
     },
@@ -19936,6 +25808,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/supports-color"
+        }
       ]
     },
     {
@@ -19955,6 +25833,12 @@
           "url": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/supports-preserve-symlinks-flag"
         }
       ]
     },
@@ -19976,6 +25860,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/svg-captcha"
+        }
       ]
     },
     {
@@ -19996,6 +25886,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/swagger-ui-dist"
+        }
       ]
     },
     {
@@ -20015,6 +25911,12 @@
           "url": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-4.5.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/swagger-ui-express"
         }
       ]
     },
@@ -20037,6 +25939,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tar-fs"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -20055,6 +25963,12 @@
               "url": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/tar-fs/node_modules/bl"
             }
           ]
         },
@@ -20076,6 +25990,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/tar-fs/node_modules/chownr"
+            }
           ]
         },
         {
@@ -20096,6 +26016,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/tar-fs/node_modules/readable-stream"
+            }
           ]
         },
         {
@@ -20115,6 +26041,12 @@
               "url": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/tar-fs/node_modules/tar-stream"
             }
           ]
         }
@@ -20138,6 +26070,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tar-stream"
+        }
       ]
     },
     {
@@ -20157,6 +26095,12 @@
           "url": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tar"
         }
       ]
     },
@@ -20178,6 +26122,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tdigest"
+        }
       ]
     },
     {
@@ -20197,6 +26147,12 @@
           "url": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/text-hex"
         }
       ]
     },
@@ -20218,6 +26174,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/thirty-two"
+        }
       ]
     },
     {
@@ -20237,6 +26199,12 @@
           "url": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/through"
         }
       ]
     },
@@ -20258,6 +26226,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/timed-out"
+        }
       ]
     },
     {
@@ -20277,6 +26251,12 @@
           "url": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tiny-inflate"
         }
       ]
     },
@@ -20298,6 +26278,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-buffer"
+        }
       ]
     },
     {
@@ -20317,6 +26303,12 @@
           "url": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-fast-properties"
         }
       ]
     },
@@ -20339,6 +26331,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-object-path"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -20357,6 +26355,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/to-object-path/node_modules/kind-of"
             }
           ]
         }
@@ -20380,6 +26384,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-regex-range"
+        }
       ]
     },
     {
@@ -20399,6 +26409,12 @@
           "url": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-regex"
         }
       ]
     },
@@ -20420,6 +26436,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/toidentifier"
+        }
       ]
     },
     {
@@ -20439,6 +26461,12 @@
           "url": "https://registry.npmjs.org/token-stream/-/token-stream-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/token-stream"
         }
       ]
     },
@@ -20460,6 +26488,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/token-types"
+        }
       ]
     },
     {
@@ -20479,6 +26513,12 @@
           "url": "https://registry.npmjs.org/toposort-class/-/toposort-class-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/toposort-class"
         }
       ]
     },
@@ -20500,6 +26540,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tough-cookie"
+        }
       ]
     },
     {
@@ -20519,6 +26565,12 @@
           "url": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tr46"
         }
       ]
     },
@@ -20540,6 +26592,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/traverse"
+        }
       ]
     },
     {
@@ -20559,6 +26617,12 @@
           "url": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tree-kill"
         }
       ]
     },
@@ -20580,6 +26644,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/trim-repeated"
+        }
       ]
     },
     {
@@ -20600,6 +26670,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/triple-beam"
+        }
       ]
     },
     {
@@ -20619,6 +26695,12 @@
           "url": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/truncate-utf8-bytes"
         }
       ]
     },
@@ -20641,6 +26723,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ts-node-dev"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -20659,6 +26747,12 @@
               "url": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/ts-node-dev/node_modules/rimraf"
             }
           ]
         }
@@ -20682,6 +26776,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ts-node"
+        }
       ]
     },
     {
@@ -20701,6 +26801,12 @@
           "url": "https://registry.npmjs.org/tsconfig/-/tsconfig-7.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tsconfig"
         }
       ]
     },
@@ -20722,6 +26828,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tslib"
+        }
       ]
     },
     {
@@ -20741,6 +26853,12 @@
           "url": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tunnel-agent"
         }
       ]
     },
@@ -20762,6 +26880,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tweetnacl"
+        }
       ]
     },
     {
@@ -20781,6 +26905,12 @@
           "url": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/type-check"
         }
       ]
     },
@@ -20802,6 +26932,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/type-is"
+        }
       ]
     },
     {
@@ -20821,6 +26957,12 @@
           "url": "https://registry.npmjs.org/typecast/-/typecast-0.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/typecast"
         }
       ]
     },
@@ -20842,6 +26984,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/typedarray"
+        }
       ]
     },
     {
@@ -20861,6 +27009,12 @@
           "url": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/typescript"
         }
       ]
     },
@@ -20882,6 +27036,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/uglify-js"
+        }
       ]
     },
     {
@@ -20901,6 +27061,12 @@
           "url": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unbox-primitive"
         }
       ]
     },
@@ -20922,6 +27088,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unbzip2-stream"
+        }
       ]
     },
     {
@@ -20941,6 +27113,12 @@
           "url": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unc-path-regex"
         }
       ]
     },
@@ -20962,6 +27140,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/underscore.string"
+        }
       ]
     },
     {
@@ -20982,6 +27166,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unicode-properties"
+        }
       ]
     },
     {
@@ -21001,6 +27191,12 @@
           "url": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unicode-trie"
         }
       ]
     },
@@ -21023,6 +27219,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/union-value"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21041,6 +27243,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/union-value/node_modules/is-extendable"
             }
           ]
         }
@@ -21064,6 +27272,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unique-filename"
+        }
       ]
     },
     {
@@ -21083,6 +27297,12 @@
           "url": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unique-slug"
         }
       ]
     },
@@ -21104,6 +27324,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unit-compare"
+        }
       ]
     },
     {
@@ -21124,6 +27350,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/universalify"
+        }
       ]
     },
     {
@@ -21143,6 +27375,12 @@
           "url": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unpipe"
         }
       ]
     },
@@ -21165,6 +27403,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unset-value"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21185,6 +27429,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/unset-value/node_modules/has-value"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -21203,6 +27453,12 @@
                   "url": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/unset-value/node_modules/has-value/node_modules/isobject"
                 }
               ]
             }
@@ -21226,6 +27482,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/unset-value/node_modules/has-values"
+            }
           ]
         },
         {
@@ -21245,6 +27507,12 @@
               "url": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/unset-value/node_modules/isarray"
             }
           ]
         }
@@ -21268,6 +27536,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/untildify"
+        }
       ]
     },
     {
@@ -21289,6 +27563,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unzipper"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21307,6 +27587,12 @@
               "url": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/unzipper/node_modules/bluebird"
             }
           ]
         }
@@ -21330,6 +27616,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/uri-js"
+        }
       ]
     },
     {
@@ -21349,6 +27641,12 @@
           "url": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/urix"
         }
       ]
     },
@@ -21370,6 +27668,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/url-parse-lax"
+        }
       ]
     },
     {
@@ -21389,6 +27693,12 @@
           "url": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/url-to-options"
         }
       ]
     },
@@ -21410,6 +27720,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/use"
+        }
       ]
     },
     {
@@ -21429,6 +27745,12 @@
           "url": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/utf8-byte-length"
         }
       ]
     },
@@ -21450,6 +27772,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/util-deprecate"
+        }
       ]
     },
     {
@@ -21469,6 +27797,12 @@
           "url": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/util"
         }
       ]
     },
@@ -21490,6 +27824,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/utils-merge"
+        }
       ]
     },
     {
@@ -21509,6 +27849,12 @@
           "url": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/uuid"
         }
       ]
     },
@@ -21530,6 +27876,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/v8flags"
+        }
       ]
     },
     {
@@ -21549,6 +27901,12 @@
           "url": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/validate-npm-package-license"
         }
       ]
     },
@@ -21570,6 +27928,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/validate"
+        }
       ]
     },
     {
@@ -21590,6 +27954,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/validator"
+        }
       ]
     },
     {
@@ -21609,6 +27979,12 @@
           "url": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/vary"
         }
       ]
     },
@@ -21631,6 +28007,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/verror"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21649,6 +28031,12 @@
               "url": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/verror/node_modules/core-util-is"
             }
           ]
         }
@@ -21673,6 +28061,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/vm2"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21691,6 +28085,12 @@
               "url": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/vm2/node_modules/acorn"
             }
           ]
         }
@@ -21714,6 +28114,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/void-elements"
+        }
       ]
     },
     {
@@ -21733,6 +28139,12 @@
           "url": "https://registry.npmjs.org/walk/-/walk-2.3.15.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/walk"
         }
       ]
     },
@@ -21754,6 +28166,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/walkdir"
+        }
       ]
     },
     {
@@ -21773,6 +28191,12 @@
           "url": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/webidl-conversions"
         }
       ]
     },
@@ -21794,6 +28218,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/whatwg-url"
+        }
       ]
     },
     {
@@ -21813,6 +28243,12 @@
           "url": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-boxed-primitive"
         }
       ]
     },
@@ -21834,6 +28270,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-collection"
+        }
       ]
     },
     {
@@ -21853,6 +28295,12 @@
           "url": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-module"
         }
       ]
     },
@@ -21874,6 +28322,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-pm-runs"
+        }
       ]
     },
     {
@@ -21893,6 +28347,12 @@
           "url": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-typed-array"
         }
       ]
     },
@@ -21914,6 +28374,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which"
+        }
       ]
     },
     {
@@ -21933,6 +28399,12 @@
           "url": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wide-align"
         }
       ]
     },
@@ -21955,6 +28427,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/winston-transport"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21973,6 +28451,12 @@
               "url": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/winston-transport/node_modules/readable-stream"
             }
           ]
         }
@@ -21997,6 +28481,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/winston"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -22015,6 +28505,12 @@
               "url": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/winston/node_modules/async"
             }
           ]
         },
@@ -22036,6 +28532,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/winston/node_modules/is-stream"
+            }
           ]
         },
         {
@@ -22055,6 +28557,12 @@
               "url": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/winston/node_modules/readable-stream"
             }
           ]
         }
@@ -22078,6 +28586,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/with"
+        }
       ]
     },
     {
@@ -22097,6 +28611,12 @@
           "url": "https://registry.npmjs.org/wkx/-/wkx-0.5.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wkx"
         }
       ]
     },
@@ -22118,6 +28638,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/word-wrap"
+        }
       ]
     },
     {
@@ -22137,6 +28663,12 @@
           "url": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wordwrap"
         }
       ]
     },
@@ -22159,6 +28691,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wrap-ansi"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -22177,6 +28715,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi/node_modules/ansi-regex"
             }
           ]
         },
@@ -22198,6 +28742,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi/node_modules/emoji-regex"
+            }
           ]
         },
         {
@@ -22217,6 +28767,12 @@
               "url": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi/node_modules/is-fullwidth-code-point"
             }
           ]
         },
@@ -22238,6 +28794,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi/node_modules/string-width"
+            }
           ]
         },
         {
@@ -22257,6 +28819,12 @@
               "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi/node_modules/strip-ansi"
             }
           ]
         }
@@ -22280,6 +28848,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wrappy"
+        }
       ]
     },
     {
@@ -22299,6 +28873,12 @@
           "url": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ws"
         }
       ]
     },
@@ -22320,6 +28900,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/xtend"
+        }
       ]
     },
     {
@@ -22339,6 +28925,12 @@
           "url": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/y18n"
         }
       ]
     },
@@ -22360,6 +28952,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yallist"
+        }
       ]
     },
     {
@@ -22380,6 +28978,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yaml-schema-validator"
+        }
       ]
     },
     {
@@ -22399,6 +29003,12 @@
           "url": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yargs-parser"
         }
       ]
     },
@@ -22421,6 +29031,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yargs"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -22439,6 +29055,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs/node_modules/ansi-regex"
             }
           ]
         },
@@ -22460,6 +29082,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs/node_modules/emoji-regex"
+            }
           ]
         },
         {
@@ -22479,6 +29107,12 @@
               "url": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs/node_modules/is-fullwidth-code-point"
             }
           ]
         },
@@ -22500,6 +29134,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs/node_modules/string-width"
+            }
           ]
         },
         {
@@ -22519,6 +29159,12 @@
               "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs/node_modules/strip-ansi"
             }
           ]
         }
@@ -22542,6 +29188,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yauzl"
+        }
       ]
     },
     {
@@ -22561,6 +29213,12 @@
           "url": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yn"
         }
       ]
     },
@@ -22582,6 +29240,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/z85"
+        }
       ]
     },
     {
@@ -22602,6 +29266,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/zip-stream"
+        }
       ]
     },
     {
@@ -22621,6 +29291,12 @@
           "url": "https://registry.npmjs.org/zlibjs/-/zlibjs-0.3.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/zlibjs"
         }
       ]
     }

--- a/tests/_data/sbom_demo-results/juice-shop_npm7_node18_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/juice-shop_npm7_node18_ubuntu-latest.snap.json
@@ -62,6 +62,10 @@
       ],
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -88,6 +92,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@babel/helper-string-parser"
+        }
       ]
     },
     {
@@ -108,6 +118,12 @@
           "url": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@babel/helper-validator-identifier"
         }
       ]
     },
@@ -130,6 +146,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@babel/parser"
+        }
       ]
     },
     {
@@ -150,6 +172,12 @@
           "url": "https://registry.npmjs.org/@babel/types/-/types-7.20.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@babel/types"
         }
       ]
     },
@@ -172,6 +200,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@colors/colors"
+        }
       ]
     },
     {
@@ -193,6 +227,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@dabh/diagnostics"
+        }
       ]
     },
     {
@@ -213,6 +253,12 @@
           "url": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@gar/promisify"
         }
       ]
     },
@@ -236,6 +282,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@mapbox/node-pre-gyp"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -254,6 +306,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/ansi-regex"
             }
           ]
         },
@@ -275,6 +333,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/are-we-there-yet"
+            }
           ]
         },
         {
@@ -294,6 +358,12 @@
               "url": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/detect-libc"
             }
           ]
         },
@@ -315,6 +385,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/gauge"
+            }
           ]
         },
         {
@@ -334,6 +410,12 @@
               "url": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/is-fullwidth-code-point"
             }
           ]
         },
@@ -356,6 +438,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/make-dir"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -374,6 +462,12 @@
                   "url": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/@mapbox/node-pre-gyp/node_modules/make-dir/node_modules/semver"
                 }
               ]
             }
@@ -397,6 +491,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/nopt"
+            }
           ]
         },
         {
@@ -416,6 +516,12 @@
               "url": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/npmlog"
             }
           ]
         },
@@ -437,6 +543,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/readable-stream"
+            }
           ]
         },
         {
@@ -457,6 +569,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/string-width"
+            }
           ]
         },
         {
@@ -476,6 +594,12 @@
               "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/strip-ansi"
             }
           ]
         }
@@ -500,6 +624,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/core-loader"
+        }
       ]
     },
     {
@@ -520,6 +650,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/core/-/core-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/core"
         }
       ]
     },
@@ -542,6 +678,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/evaluator"
+        }
       ]
     },
     {
@@ -562,6 +704,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-all/-/lang-all-4.24.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-all"
         }
       ]
     },
@@ -584,6 +732,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ar"
+        }
       ]
     },
     {
@@ -604,6 +758,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-bn/-/lang-bn-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-bn"
         }
       ]
     },
@@ -626,6 +786,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ca"
+        }
       ]
     },
     {
@@ -646,6 +812,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-cs/-/lang-cs-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-cs"
         }
       ]
     },
@@ -668,6 +840,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-da"
+        }
       ]
     },
     {
@@ -688,6 +866,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-de/-/lang-de-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-de"
         }
       ]
     },
@@ -710,6 +894,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-el"
+        }
       ]
     },
     {
@@ -730,6 +920,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-en-min/-/lang-en-min-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-en-min"
         }
       ]
     },
@@ -752,6 +948,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-en"
+        }
       ]
     },
     {
@@ -772,6 +974,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-es/-/lang-es-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-es"
         }
       ]
     },
@@ -794,6 +1002,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-eu"
+        }
       ]
     },
     {
@@ -814,6 +1028,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-fa/-/lang-fa-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-fa"
         }
       ]
     },
@@ -836,6 +1056,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-fi"
+        }
       ]
     },
     {
@@ -856,6 +1082,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-fr/-/lang-fr-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-fr"
         }
       ]
     },
@@ -878,6 +1110,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ga"
+        }
       ]
     },
     {
@@ -898,6 +1136,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-gl/-/lang-gl-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-gl"
         }
       ]
     },
@@ -920,6 +1164,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-hi"
+        }
       ]
     },
     {
@@ -940,6 +1190,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-hu/-/lang-hu-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-hu"
         }
       ]
     },
@@ -962,6 +1218,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-hy"
+        }
       ]
     },
     {
@@ -982,6 +1244,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-id/-/lang-id-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-id"
         }
       ]
     },
@@ -1004,6 +1272,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-it"
+        }
       ]
     },
     {
@@ -1024,6 +1298,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-ja/-/lang-ja-4.24.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ja"
         }
       ]
     },
@@ -1046,6 +1326,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ko"
+        }
       ]
     },
     {
@@ -1066,6 +1352,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-lt/-/lang-lt-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-lt"
         }
       ]
     },
@@ -1088,6 +1380,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ms"
+        }
       ]
     },
     {
@@ -1108,6 +1406,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-ne/-/lang-ne-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ne"
         }
       ]
     },
@@ -1130,6 +1434,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-nl"
+        }
       ]
     },
     {
@@ -1150,6 +1460,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-no/-/lang-no-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-no"
         }
       ]
     },
@@ -1172,6 +1488,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-pl"
+        }
       ]
     },
     {
@@ -1192,6 +1514,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-pt/-/lang-pt-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-pt"
         }
       ]
     },
@@ -1214,6 +1542,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ro"
+        }
       ]
     },
     {
@@ -1234,6 +1568,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-ru/-/lang-ru-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ru"
         }
       ]
     },
@@ -1256,6 +1596,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-sl"
+        }
       ]
     },
     {
@@ -1276,6 +1622,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-sr/-/lang-sr-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-sr"
         }
       ]
     },
@@ -1298,6 +1650,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-sv"
+        }
       ]
     },
     {
@@ -1318,6 +1676,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-ta/-/lang-ta-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ta"
         }
       ]
     },
@@ -1340,6 +1704,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-th"
+        }
       ]
     },
     {
@@ -1360,6 +1730,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-tl/-/lang-tl-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-tl"
         }
       ]
     },
@@ -1382,6 +1758,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-tr"
+        }
       ]
     },
     {
@@ -1402,6 +1784,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-uk/-/lang-uk-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-uk"
         }
       ]
     },
@@ -1424,6 +1812,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-zh"
+        }
       ]
     },
     {
@@ -1444,6 +1838,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/language-min/-/language-min-4.22.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/language-min"
         }
       ]
     },
@@ -1466,6 +1866,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/language"
+        }
       ]
     },
     {
@@ -1486,6 +1892,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/ner/-/ner-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/ner"
         }
       ]
     },
@@ -1508,6 +1920,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/neural"
+        }
       ]
     },
     {
@@ -1528,6 +1946,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/nlg/-/nlg-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/nlg"
         }
       ]
     },
@@ -1550,6 +1974,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/nlp"
+        }
       ]
     },
     {
@@ -1570,6 +2000,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/nlu/-/nlu-4.23.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/nlu"
         }
       ]
     },
@@ -1592,6 +2028,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/request"
+        }
       ]
     },
     {
@@ -1612,6 +2054,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/sentiment/-/sentiment-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/sentiment"
         }
       ]
     },
@@ -1634,6 +2082,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/similarity"
+        }
       ]
     },
     {
@@ -1654,6 +2108,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/slot/-/slot-4.22.17.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/slot"
         }
       ]
     },
@@ -1676,6 +2136,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@npmcli/fs"
+        }
       ]
     },
     {
@@ -1696,6 +2162,12 @@
           "url": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@npmcli/move-file"
         }
       ]
     },
@@ -1718,6 +2190,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib/core"
+        }
       ]
     },
     {
@@ -1738,6 +2216,12 @@
           "url": "https://registry.npmjs.org/@otplib/plugin-crypto/-/plugin-crypto-12.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib/plugin-crypto"
         }
       ]
     },
@@ -1760,6 +2244,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib/plugin-thirty-two"
+        }
       ]
     },
     {
@@ -1780,6 +2270,12 @@
           "url": "https://registry.npmjs.org/@otplib/preset-default/-/preset-default-12.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib/preset-default"
         }
       ]
     },
@@ -1802,6 +2298,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib/preset-v11"
+        }
       ]
     },
     {
@@ -1822,6 +2324,12 @@
           "url": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@sindresorhus/is"
         }
       ]
     },
@@ -1844,6 +2352,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@swc/helpers"
+        }
       ]
     },
     {
@@ -1864,6 +2378,12 @@
           "url": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@tokenizer/token"
         }
       ]
     },
@@ -1886,6 +2406,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@tootallnate/once"
+        }
       ]
     },
     {
@@ -1906,6 +2432,12 @@
           "url": "https://registry.npmjs.org/@types/component-emitter/-/component-emitter-1.2.11.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/component-emitter"
         }
       ]
     },
@@ -1928,6 +2460,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/cookie"
+        }
       ]
     },
     {
@@ -1948,6 +2486,12 @@
           "url": "https://registry.npmjs.org/@types/cors/-/cors-2.8.12.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/cors"
         }
       ]
     },
@@ -1970,6 +2514,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/debug"
+        }
       ]
     },
     {
@@ -1990,6 +2540,12 @@
           "url": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/ms"
         }
       ]
     },
@@ -2012,6 +2568,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/node"
+        }
       ]
     },
     {
@@ -2032,6 +2594,12 @@
           "url": "https://registry.npmjs.org/@types/strip-bom/-/strip-bom-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/strip-bom"
         }
       ]
     },
@@ -2054,6 +2622,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/strip-json-comments"
+        }
       ]
     },
     {
@@ -2075,6 +2649,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/validator"
+        }
       ]
     },
     {
@@ -2094,6 +2674,12 @@
           "url": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/abbrev"
         }
       ]
     },
@@ -2115,6 +2701,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/accepts"
+        }
       ]
     },
     {
@@ -2135,6 +2727,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/acorn-walk"
+        }
       ]
     },
     {
@@ -2154,6 +2752,12 @@
           "url": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/acorn"
         }
       ]
     },
@@ -2176,6 +2780,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/agent-base"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -2194,6 +2804,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agent-base/node_modules/debug"
             }
           ]
         },
@@ -2214,6 +2830,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agent-base/node_modules/ms"
             }
           ]
         }
@@ -2238,6 +2860,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/agentkeepalive"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -2256,6 +2884,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agentkeepalive/node_modules/debug"
             }
           ]
         },
@@ -2277,6 +2911,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agentkeepalive/node_modules/depd"
+            }
           ]
         },
         {
@@ -2296,6 +2936,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agentkeepalive/node_modules/ms"
             }
           ]
         }
@@ -2319,6 +2965,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/aggregate-error"
+        }
       ]
     },
     {
@@ -2338,6 +2990,12 @@
           "url": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ajv"
         }
       ]
     },
@@ -2359,6 +3017,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ansi-regex"
+        }
       ]
     },
     {
@@ -2378,6 +3042,12 @@
           "url": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ansi-styles"
         }
       ]
     },
@@ -2400,6 +3070,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/anymatch"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -2418,6 +3094,12 @@
               "url": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/anymatch/node_modules/normalize-path"
             }
           ]
         }
@@ -2441,6 +3123,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/append-field"
+        }
       ]
     },
     {
@@ -2460,6 +3148,12 @@
           "url": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/aproba"
         }
       ]
     },
@@ -2482,6 +3176,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/archive-type"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -2500,6 +3200,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-4.4.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/archive-type/node_modules/file-type"
             }
           ]
         }
@@ -2523,6 +3229,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/archiver-utils"
+        }
       ]
     },
     {
@@ -2542,6 +3254,12 @@
           "url": "https://registry.npmjs.org/archiver/-/archiver-1.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/archiver"
         }
       ]
     },
@@ -2563,6 +3281,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/are-we-there-yet"
+        }
       ]
     },
     {
@@ -2582,6 +3306,12 @@
           "url": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/arg"
         }
       ]
     },
@@ -2604,6 +3334,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/argparse"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -2622,6 +3358,12 @@
               "url": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/argparse/node_modules/sprintf-js"
             }
           ]
         }
@@ -2645,6 +3387,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/arr-diff"
+        }
       ]
     },
     {
@@ -2664,6 +3412,12 @@
           "url": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/arr-flatten"
         }
       ]
     },
@@ -2685,6 +3439,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/arr-union"
+        }
       ]
     },
     {
@@ -2704,6 +3464,12 @@
           "url": "https://registry.npmjs.org/array-each/-/array-each-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/array-each"
         }
       ]
     },
@@ -2725,6 +3491,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/array-flatten"
+        }
       ]
     },
     {
@@ -2744,6 +3516,12 @@
           "url": "https://registry.npmjs.org/array-slice/-/array-slice-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/array-slice"
         }
       ]
     },
@@ -2765,6 +3543,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/array-unique"
+        }
       ]
     },
     {
@@ -2784,6 +3568,12 @@
           "url": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/asap"
         }
       ]
     },
@@ -2805,6 +3595,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/asn1"
+        }
       ]
     },
     {
@@ -2824,6 +3620,12 @@
           "url": "https://registry.npmjs.org/assert-never/-/assert-never-1.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/assert-never"
         }
       ]
     },
@@ -2845,6 +3647,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/assert-plus"
+        }
       ]
     },
     {
@@ -2864,6 +3672,12 @@
           "url": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/assign-symbols"
         }
       ]
     },
@@ -2885,6 +3699,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/async"
+        }
       ]
     },
     {
@@ -2904,6 +3724,12 @@
           "url": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/asynckit"
         }
       ]
     },
@@ -2925,6 +3751,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/at-least-node"
+        }
       ]
     },
     {
@@ -2944,6 +3776,12 @@
           "url": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/atob"
         }
       ]
     },
@@ -2965,6 +3803,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/available-typed-arrays"
+        }
       ]
     },
     {
@@ -2984,6 +3828,12 @@
           "url": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/aws-sign2"
         }
       ]
     },
@@ -3005,6 +3855,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/aws4"
+        }
       ]
     },
     {
@@ -3025,6 +3881,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/babel-walk"
+        }
       ]
     },
     {
@@ -3044,6 +3906,12 @@
           "url": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/balanced-match"
         }
       ]
     },
@@ -3066,6 +3934,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -3084,6 +3958,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/base/node_modules/define-property"
             }
           ]
         }
@@ -3107,6 +3987,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base64-arraybuffer"
+        }
       ]
     },
     {
@@ -3126,6 +4012,12 @@
           "url": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base64-js"
         }
       ]
     },
@@ -3147,6 +4039,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base64id"
+        }
       ]
     },
     {
@@ -3166,6 +4064,12 @@
           "url": "https://registry.npmjs.org/base64url/-/base64url-0.0.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base64url"
         }
       ]
     },
@@ -3187,6 +4091,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/basic-auth"
+        }
       ]
     },
     {
@@ -3206,6 +4116,12 @@
           "url": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/batch"
         }
       ]
     },
@@ -3227,6 +4143,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bcrypt-pbkdf"
+        }
       ]
     },
     {
@@ -3246,6 +4168,12 @@
           "url": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/big-integer"
         }
       ]
     },
@@ -3267,6 +4195,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/binary-extensions"
+        }
       ]
     },
     {
@@ -3286,6 +4220,12 @@
           "url": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/binary"
         }
       ]
     },
@@ -3307,6 +4247,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bindings"
+        }
       ]
     },
     {
@@ -3326,6 +4272,12 @@
           "url": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bintrees"
         }
       ]
     },
@@ -3347,6 +4299,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bl"
+        }
       ]
     },
     {
@@ -3367,6 +4325,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bluebird"
+        }
       ]
     },
     {
@@ -3386,6 +4350,12 @@
           "url": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/body-parser"
         }
       ]
     },
@@ -3408,6 +4378,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bower-config"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -3426,6 +4402,12 @@
               "url": "https://registry.npmjs.org/minimist/-/minimist-0.2.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bower-config/node_modules/minimist"
             }
           ]
         }
@@ -3449,6 +4431,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/brace-expansion"
+        }
       ]
     },
     {
@@ -3470,6 +4458,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/braces"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -3488,6 +4482,12 @@
               "url": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/braces/node_modules/extend-shallow"
             }
           ]
         },
@@ -3508,6 +4508,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/braces/node_modules/is-extendable"
             }
           ]
         }
@@ -3531,6 +4537,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/brotli"
+        }
       ]
     },
     {
@@ -3550,6 +4562,12 @@
           "url": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-alloc-unsafe"
         }
       ]
     },
@@ -3571,6 +4589,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-alloc"
+        }
       ]
     },
     {
@@ -3590,6 +4614,12 @@
           "url": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-crc32"
         }
       ]
     },
@@ -3611,6 +4641,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-fill"
+        }
       ]
     },
     {
@@ -3630,6 +4666,12 @@
           "url": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-from"
         }
       ]
     },
@@ -3651,6 +4693,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-indexof-polyfill"
+        }
       ]
     },
     {
@@ -3671,6 +4719,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer"
+        }
       ]
     },
     {
@@ -3690,6 +4744,12 @@
           "url": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffers"
         }
       ]
     },
@@ -3712,6 +4772,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/busboy"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -3730,6 +4796,12 @@
               "url": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/busboy/node_modules/isarray"
             }
           ]
         },
@@ -3751,6 +4823,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/busboy/node_modules/readable-stream"
+            }
           ]
         },
         {
@@ -3770,6 +4848,12 @@
               "url": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/busboy/node_modules/string_decoder"
             }
           ]
         }
@@ -3793,6 +4877,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/byline"
+        }
       ]
     },
     {
@@ -3812,6 +4902,12 @@
           "url": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bytes"
         }
       ]
     },
@@ -3833,6 +4929,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cacache"
+        }
       ]
     },
     {
@@ -3852,6 +4954,12 @@
           "url": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cache-base"
         }
       ]
     },
@@ -3874,6 +4982,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cacheable-request"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -3892,6 +5006,12 @@
               "url": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cacheable-request/node_modules/get-stream"
             }
           ]
         },
@@ -3912,6 +5032,12 @@
               "url": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cacheable-request/node_modules/lowercase-keys"
             }
           ]
         }
@@ -3935,6 +5061,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/call-bind"
+        }
       ]
     },
     {
@@ -3954,6 +5086,12 @@
           "url": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/camelcase"
         }
       ]
     },
@@ -3975,6 +5113,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/caseless"
+        }
       ]
     },
     {
@@ -3994,6 +5138,12 @@
           "url": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/chainsaw"
         }
       ]
     },
@@ -4015,6 +5165,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/chalk"
+        }
       ]
     },
     {
@@ -4034,6 +5190,12 @@
           "url": "https://registry.npmjs.org/character-parser/-/character-parser-2.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/character-parser"
         }
       ]
     },
@@ -4056,6 +5218,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/check-dependencies"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4074,6 +5242,12 @@
               "url": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/check-dependencies/node_modules/semver"
             }
           ]
         }
@@ -4097,6 +5271,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/check-types"
+        }
       ]
     },
     {
@@ -4118,6 +5298,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/chokidar"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4136,6 +5322,12 @@
               "url": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar/node_modules/braces"
             }
           ]
         },
@@ -4157,6 +5349,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar/node_modules/fill-range"
+            }
           ]
         },
         {
@@ -4176,6 +5374,12 @@
               "url": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar/node_modules/is-glob"
             }
           ]
         },
@@ -4197,6 +5401,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar/node_modules/is-number"
+            }
           ]
         },
         {
@@ -4217,6 +5427,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar/node_modules/normalize-path"
+            }
           ]
         },
         {
@@ -4236,6 +5452,12 @@
               "url": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar/node_modules/to-regex-range"
             }
           ]
         }
@@ -4259,6 +5481,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/chownr"
+        }
       ]
     },
     {
@@ -4278,6 +5506,12 @@
           "url": "https://registry.npmjs.org/clarinet/-/clarinet-0.12.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/clarinet"
         }
       ]
     },
@@ -4300,6 +5534,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/class-utils"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4318,6 +5558,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils/node_modules/define-property"
             }
           ]
         },
@@ -4340,6 +5586,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils/node_modules/is-accessor-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -4358,6 +5610,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/class-utils/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -4382,6 +5640,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils/node_modules/is-data-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -4400,6 +5664,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/class-utils/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -4423,6 +5693,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils/node_modules/is-descriptor"
+            }
           ]
         },
         {
@@ -4442,6 +5718,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils/node_modules/kind-of"
             }
           ]
         }
@@ -4465,6 +5747,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/clean-stack"
+        }
       ]
     },
     {
@@ -4486,6 +5774,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cliui"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4504,6 +5798,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui/node_modules/ansi-regex"
             }
           ]
         },
@@ -4525,6 +5825,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui/node_modules/emoji-regex"
+            }
           ]
         },
         {
@@ -4544,6 +5850,12 @@
               "url": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui/node_modules/is-fullwidth-code-point"
             }
           ]
         },
@@ -4565,6 +5877,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui/node_modules/string-width"
+            }
           ]
         },
         {
@@ -4584,6 +5902,12 @@
               "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui/node_modules/strip-ansi"
             }
           ]
         }
@@ -4607,6 +5931,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/clone-response"
+        }
       ]
     },
     {
@@ -4626,6 +5956,12 @@
           "url": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/clone"
         }
       ]
     },
@@ -4647,6 +5983,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/code-point-at"
+        }
       ]
     },
     {
@@ -4666,6 +6008,12 @@
           "url": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/collection-visit"
         }
       ]
     },
@@ -4687,6 +6035,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color-convert"
+        }
       ]
     },
     {
@@ -4706,6 +6060,12 @@
           "url": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color-name"
         }
       ]
     },
@@ -4727,6 +6087,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color-string"
+        }
       ]
     },
     {
@@ -4746,6 +6112,12 @@
           "url": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color-support"
         }
       ]
     },
@@ -4767,6 +6139,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color"
+        }
       ]
     },
     {
@@ -4786,6 +6164,12 @@
           "url": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/colors"
         }
       ]
     },
@@ -4807,6 +6191,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/colorspace"
+        }
       ]
     },
     {
@@ -4826,6 +6216,12 @@
           "url": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/combined-stream"
         }
       ]
     },
@@ -4847,6 +6243,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/commander"
+        }
       ]
     },
     {
@@ -4866,6 +6268,12 @@
           "url": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/component-emitter"
         }
       ]
     },
@@ -4887,6 +6295,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/component-type"
+        }
       ]
     },
     {
@@ -4907,6 +6321,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/compress-commons"
+        }
       ]
     },
     {
@@ -4926,6 +6346,12 @@
           "url": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/compressible"
         }
       ]
     },
@@ -4948,6 +6374,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/compression"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4966,6 +6398,12 @@
               "url": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/compression/node_modules/bytes"
             }
           ]
         }
@@ -4989,6 +6427,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/concat-map"
+        }
       ]
     },
     {
@@ -5008,6 +6452,12 @@
           "url": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/concat-stream"
         }
       ]
     },
@@ -5030,6 +6480,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/concurrently"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5048,6 +6504,12 @@
               "url": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/concurrently/node_modules/supports-color"
             }
           ]
         }
@@ -5071,6 +6533,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/config"
+        }
       ]
     },
     {
@@ -5091,6 +6559,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/console-control-strings"
+        }
       ]
     },
     {
@@ -5110,6 +6584,12 @@
           "url": "https://registry.npmjs.org/constantinople/-/constantinople-4.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/constantinople"
         }
       ]
     },
@@ -5132,6 +6612,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/content-disposition"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5150,6 +6636,12 @@
               "url": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/content-disposition/node_modules/safe-buffer"
             }
           ]
         }
@@ -5173,6 +6665,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/content-type"
+        }
       ]
     },
     {
@@ -5192,6 +6690,12 @@
           "url": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cookie-parser"
         }
       ]
     },
@@ -5213,6 +6717,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cookie-signature"
+        }
       ]
     },
     {
@@ -5232,6 +6742,12 @@
           "url": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cookie"
         }
       ]
     },
@@ -5253,6 +6769,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/copy-descriptor"
+        }
       ]
     },
     {
@@ -5272,6 +6794,12 @@
           "url": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/core-util-is"
         }
       ]
     },
@@ -5293,6 +6821,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cors"
+        }
       ]
     },
     {
@@ -5312,6 +6846,12 @@
           "url": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/crc"
         }
       ]
     },
@@ -5333,6 +6873,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/crc32-stream"
+        }
       ]
     },
     {
@@ -5352,6 +6898,12 @@
           "url": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/create-require"
         }
       ]
     },
@@ -5373,6 +6925,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/crypto-js"
+        }
       ]
     },
     {
@@ -5392,6 +6950,12 @@
           "url": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dashdash"
         }
       ]
     },
@@ -5413,6 +6977,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/date-fns"
+        }
       ]
     },
     {
@@ -5432,6 +7002,12 @@
           "url": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dateformat"
         }
       ]
     },
@@ -5453,6 +7029,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/debug"
+        }
       ]
     },
     {
@@ -5472,6 +7054,12 @@
           "url": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decamelize"
         }
       ]
     },
@@ -5493,6 +7081,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decode-uri-component"
+        }
       ]
     },
     {
@@ -5512,6 +7106,12 @@
           "url": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-response"
         }
       ]
     },
@@ -5534,6 +7134,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-tar"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5552,6 +7158,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-tar/node_modules/file-type"
             }
           ]
         }
@@ -5576,6 +7188,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-tarbz2"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5594,6 +7212,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-6.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-tarbz2/node_modules/file-type"
             }
           ]
         }
@@ -5618,6 +7242,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-targz"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5636,6 +7266,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-targz/node_modules/file-type"
             }
           ]
         }
@@ -5660,6 +7296,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-unzip"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5678,6 +7320,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-unzip/node_modules/file-type"
             }
           ]
         },
@@ -5699,6 +7347,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-unzip/node_modules/get-stream"
+            }
           ]
         },
         {
@@ -5718,6 +7372,12 @@
               "url": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-unzip/node_modules/pify"
             }
           ]
         }
@@ -5742,6 +7402,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5762,6 +7428,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress/node_modules/make-dir"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -5780,6 +7452,12 @@
                   "url": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/decompress/node_modules/make-dir/node_modules/pify"
                 }
               ]
             }
@@ -5803,6 +7481,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress/node_modules/pify"
+            }
           ]
         }
       ]
@@ -5825,6 +7509,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/deep-equal"
+        }
       ]
     },
     {
@@ -5844,6 +7534,12 @@
           "url": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/deep-extend"
         }
       ]
     },
@@ -5865,6 +7561,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/deep-is"
+        }
       ]
     },
     {
@@ -5884,6 +7586,12 @@
           "url": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/define-properties"
         }
       ]
     },
@@ -5905,6 +7613,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/define-property"
+        }
       ]
     },
     {
@@ -5924,6 +7638,12 @@
           "url": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/delayed-stream"
         }
       ]
     },
@@ -5945,6 +7665,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/delegates"
+        }
       ]
     },
     {
@@ -5964,6 +7690,12 @@
           "url": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/depd"
         }
       ]
     },
@@ -5985,6 +7717,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/destroy"
+        }
       ]
     },
     {
@@ -6004,6 +7742,12 @@
           "url": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/detect-file"
         }
       ]
     },
@@ -6025,6 +7769,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/detect-libc"
+        }
       ]
     },
     {
@@ -6044,6 +7794,12 @@
           "url": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dfa"
         }
       ]
     },
@@ -6066,6 +7822,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dicer"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -6084,6 +7846,12 @@
               "url": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/dicer/node_modules/isarray"
             }
           ]
         },
@@ -6105,6 +7873,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/dicer/node_modules/readable-stream"
+            }
           ]
         },
         {
@@ -6124,6 +7898,12 @@
               "url": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/dicer/node_modules/string_decoder"
             }
           ]
         }
@@ -6147,6 +7927,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/diff"
+        }
       ]
     },
     {
@@ -6166,6 +7952,12 @@
           "url": "https://registry.npmjs.org/doctypes/-/doctypes-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/doctypes"
         }
       ]
     },
@@ -6187,6 +7979,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/domelementtype"
+        }
       ]
     },
     {
@@ -6206,6 +8004,12 @@
           "url": "https://registry.npmjs.org/domhandler/-/domhandler-2.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/domhandler"
         }
       ]
     },
@@ -6227,6 +8031,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/domutils"
+        }
       ]
     },
     {
@@ -6246,6 +8056,12 @@
           "url": "https://registry.npmjs.org/dottie/-/dottie-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dottie"
         }
       ]
     },
@@ -6267,6 +8083,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/double-ended-queue"
+        }
       ]
     },
     {
@@ -6286,6 +8108,12 @@
           "url": "https://registry.npmjs.org/doublearray/-/doublearray-0.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/doublearray"
         }
       ]
     },
@@ -6308,6 +8136,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/download"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -6326,6 +8160,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-11.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/download/node_modules/file-type"
             }
           ]
         }
@@ -6349,6 +8189,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/duplexer2"
+        }
       ]
     },
     {
@@ -6368,6 +8214,12 @@
           "url": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/duplexer3"
         }
       ]
     },
@@ -6389,6 +8241,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dynamic-dedupe"
+        }
       ]
     },
     {
@@ -6408,6 +8266,12 @@
           "url": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ecc-jsbn"
         }
       ]
     },
@@ -6429,6 +8293,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ee-first"
+        }
       ]
     },
     {
@@ -6448,6 +8318,12 @@
           "url": "https://registry.npmjs.org/eivindfjeldstad-dot/-/eivindfjeldstad-dot-0.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/eivindfjeldstad-dot"
         }
       ]
     },
@@ -6469,6 +8345,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/emoji-regex"
+        }
       ]
     },
     {
@@ -6489,6 +8371,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/enabled"
+        }
       ]
     },
     {
@@ -6508,6 +8396,12 @@
           "url": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/encodeurl"
         }
       ]
     },
@@ -6530,6 +8424,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/encoding"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -6548,6 +8448,12 @@
               "url": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/encoding/node_modules/iconv-lite"
             }
           ]
         }
@@ -6571,6 +8477,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/end-of-stream"
+        }
       ]
     },
     {
@@ -6590,6 +8502,12 @@
           "url": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-4.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/engine.io-parser"
         }
       ]
     },
@@ -6612,6 +8530,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/engine.io"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -6630,6 +8554,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/engine.io/node_modules/debug"
             }
           ]
         },
@@ -6650,6 +8580,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/engine.io/node_modules/ms"
             }
           ]
         }
@@ -6673,6 +8609,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/env-paths"
+        }
       ]
     },
     {
@@ -6692,6 +8634,12 @@
           "url": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/err-code"
         }
       ]
     },
@@ -6713,6 +8661,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/error-ex"
+        }
       ]
     },
     {
@@ -6732,6 +8686,12 @@
           "url": "https://registry.npmjs.org/errorhandler/-/errorhandler-1.5.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/errorhandler"
         }
       ]
     },
@@ -6753,6 +8713,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/es-abstract"
+        }
       ]
     },
     {
@@ -6772,6 +8738,12 @@
           "url": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/es-get-iterator"
         }
       ]
     },
@@ -6793,6 +8765,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/es-to-primitive"
+        }
       ]
     },
     {
@@ -6812,6 +8790,12 @@
           "url": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/escape-html"
         }
       ]
     },
@@ -6833,6 +8817,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/escape-string-regexp"
+        }
       ]
     },
     {
@@ -6852,6 +8842,12 @@
           "url": "https://registry.npmjs.org/escodegen/-/escodegen-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/escodegen"
         }
       ]
     },
@@ -6873,6 +8869,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/esprima"
+        }
       ]
     },
     {
@@ -6892,6 +8894,12 @@
           "url": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/estraverse"
         }
       ]
     },
@@ -6913,6 +8921,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/esutils"
+        }
       ]
     },
     {
@@ -6932,6 +8946,12 @@
           "url": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/etag"
         }
       ]
     },
@@ -6953,6 +8973,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/eventemitter2"
+        }
       ]
     },
     {
@@ -6972,6 +8998,12 @@
           "url": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/eventemitter3"
         }
       ]
     },
@@ -6993,6 +9025,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/exif"
+        }
       ]
     },
     {
@@ -7012,6 +9050,12 @@
           "url": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/exit"
         }
       ]
     },
@@ -7034,6 +9078,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/expand-brackets"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7052,6 +9102,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/define-property"
             }
           ]
         },
@@ -7072,6 +9128,12 @@
               "url": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/extend-shallow"
             }
           ]
         },
@@ -7094,6 +9156,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/is-accessor-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -7112,6 +9180,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/expand-brackets/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -7136,6 +9210,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/is-data-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -7154,6 +9234,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/expand-brackets/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -7177,6 +9263,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/is-descriptor"
+            }
           ]
         },
         {
@@ -7197,6 +9289,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/is-extendable"
+            }
           ]
         },
         {
@@ -7216,6 +9314,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/kind-of"
             }
           ]
         }
@@ -7239,6 +9343,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/expand-template"
+        }
       ]
     },
     {
@@ -7259,6 +9369,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/expand-tilde"
+        }
       ]
     },
     {
@@ -7278,6 +9394,12 @@
           "url": "https://registry.npmjs.org/express-ipfilter/-/express-ipfilter-1.3.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-ipfilter"
         }
       ]
     },
@@ -7300,6 +9422,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-jwt"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7318,6 +9446,12 @@
               "url": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-0.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/express-jwt/node_modules/jsonwebtoken"
             }
           ]
         },
@@ -7338,6 +9472,12 @@
               "url": "https://registry.npmjs.org/moment/-/moment-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/express-jwt/node_modules/moment"
             }
           ]
         }
@@ -7361,6 +9501,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-rate-limit"
+        }
       ]
     },
     {
@@ -7381,6 +9527,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-robots-txt"
+        }
       ]
     },
     {
@@ -7400,6 +9552,12 @@
           "url": "https://registry.npmjs.org/express-security.txt/-/express-security.txt-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-security.txt"
         }
       ]
     },
@@ -7422,6 +9580,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7440,6 +9604,12 @@
               "url": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/express/node_modules/cookie"
             }
           ]
         },
@@ -7460,6 +9630,12 @@
               "url": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/express/node_modules/safe-buffer"
             }
           ]
         }
@@ -7483,6 +9659,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ext-list"
+        }
       ]
     },
     {
@@ -7502,6 +9684,12 @@
           "url": "https://registry.npmjs.org/ext-name/-/ext-name-5.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ext-name"
         }
       ]
     },
@@ -7523,6 +9711,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/extend-shallow"
+        }
       ]
     },
     {
@@ -7542,6 +9736,12 @@
           "url": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/extend"
         }
       ]
     },
@@ -7564,6 +9764,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/extglob"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7582,6 +9788,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/extglob/node_modules/define-property"
             }
           ]
         },
@@ -7603,6 +9815,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/extglob/node_modules/extend-shallow"
+            }
           ]
         },
         {
@@ -7622,6 +9840,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/extglob/node_modules/is-extendable"
             }
           ]
         }
@@ -7645,6 +9869,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/extsprintf"
+        }
       ]
     },
     {
@@ -7664,6 +9894,12 @@
           "url": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fast-deep-equal"
         }
       ]
     },
@@ -7685,6 +9921,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fast-json-stable-stringify"
+        }
       ]
     },
     {
@@ -7704,6 +9946,12 @@
           "url": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fast-levenshtein"
         }
       ]
     },
@@ -7725,6 +9973,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fast.js"
+        }
       ]
     },
     {
@@ -7744,6 +9998,12 @@
           "url": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fd-slicer"
         }
       ]
     },
@@ -7765,6 +10025,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/feature-policy"
+        }
       ]
     },
     {
@@ -7784,6 +10050,12 @@
           "url": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fecha"
         }
       ]
     },
@@ -7806,6 +10078,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/file-js"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7824,6 +10102,12 @@
               "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/file-js/node_modules/brace-expansion"
             }
           ]
         },
@@ -7844,6 +10128,12 @@
               "url": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/file-js/node_modules/minimatch"
             }
           ]
         }
@@ -7867,6 +10157,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/file-stream-rotator"
+        }
       ]
     },
     {
@@ -7886,6 +10182,12 @@
           "url": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/file-type"
         }
       ]
     },
@@ -7907,6 +10209,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/file-uri-to-path"
+        }
       ]
     },
     {
@@ -7926,6 +10234,12 @@
           "url": "https://registry.npmjs.org/filehound/-/filehound-1.17.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/filehound"
         }
       ]
     },
@@ -7947,6 +10261,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/filename-reserved-regex"
+        }
       ]
     },
     {
@@ -7967,6 +10287,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/filenamify"
+        }
       ]
     },
     {
@@ -7986,6 +10312,12 @@
           "url": "https://registry.npmjs.org/filesniffer/-/filesniffer-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/filesniffer"
         }
       ]
     },
@@ -8008,6 +10340,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fill-range"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -8026,6 +10364,12 @@
               "url": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/fill-range/node_modules/extend-shallow"
             }
           ]
         },
@@ -8046,6 +10390,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/fill-range/node_modules/is-extendable"
             }
           ]
         }
@@ -8069,6 +10419,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/finale-rest"
+        }
       ]
     },
     {
@@ -8088,6 +10444,12 @@
           "url": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/finalhandler"
         }
       ]
     },
@@ -8109,6 +10471,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/find-up"
+        }
       ]
     },
     {
@@ -8128,6 +10496,12 @@
           "url": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/findup-sync"
         }
       ]
     },
@@ -8149,6 +10523,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fined"
+        }
       ]
     },
     {
@@ -8168,6 +10548,12 @@
           "url": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/flagged-respawn"
         }
       ]
     },
@@ -8189,6 +10575,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fn.name"
+        }
       ]
     },
     {
@@ -8208,6 +10600,12 @@
           "url": "https://registry.npmjs.org/fontkit/-/fontkit-1.9.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fontkit"
         }
       ]
     },
@@ -8229,6 +10627,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/for-each"
+        }
       ]
     },
     {
@@ -8248,6 +10652,12 @@
           "url": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/for-in"
         }
       ]
     },
@@ -8269,6 +10679,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/for-own"
+        }
       ]
     },
     {
@@ -8288,6 +10704,12 @@
           "url": "https://registry.npmjs.org/foreachasync/-/foreachasync-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/foreachasync"
         }
       ]
     },
@@ -8309,6 +10731,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/forever-agent"
+        }
       ]
     },
     {
@@ -8328,6 +10756,12 @@
           "url": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/form-data"
         }
       ]
     },
@@ -8349,6 +10783,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/formatio"
+        }
       ]
     },
     {
@@ -8368,6 +10808,12 @@
           "url": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/forwarded"
         }
       ]
     },
@@ -8389,6 +10835,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fragment-cache"
+        }
       ]
     },
     {
@@ -8408,6 +10860,12 @@
           "url": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fresh"
         }
       ]
     },
@@ -8429,6 +10887,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/from2"
+        }
       ]
     },
     {
@@ -8448,6 +10912,12 @@
           "url": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fs-constants"
         }
       ]
     },
@@ -8469,6 +10939,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fs-extra"
+        }
       ]
     },
     {
@@ -8489,6 +10965,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fs-minipass"
+        }
       ]
     },
     {
@@ -8508,6 +10990,12 @@
           "url": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fs.realpath"
         }
       ]
     },
@@ -8530,6 +11018,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fstream"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -8548,6 +11042,12 @@
               "url": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/fstream/node_modules/mkdirp"
             }
           ]
         },
@@ -8568,6 +11068,12 @@
               "url": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/fstream/node_modules/rimraf"
             }
           ]
         }
@@ -8591,6 +11097,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/function-bind"
+        }
       ]
     },
     {
@@ -8610,6 +11122,12 @@
           "url": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/function.prototype.name"
         }
       ]
     },
@@ -8631,6 +11149,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/functions-have-names"
+        }
       ]
     },
     {
@@ -8650,6 +11174,12 @@
           "url": "https://registry.npmjs.org/fuzzball/-/fuzzball-1.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fuzzball"
         }
       ]
     },
@@ -8671,6 +11201,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/gauge"
+        }
       ]
     },
     {
@@ -8690,6 +11226,12 @@
           "url": "https://registry.npmjs.org/geojson-utils/-/geojson-utils-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/geojson-utils"
         }
       ]
     },
@@ -8711,6 +11253,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-caller-file"
+        }
       ]
     },
     {
@@ -8730,6 +11278,12 @@
           "url": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-intrinsic"
         }
       ]
     },
@@ -8751,6 +11305,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-stream"
+        }
       ]
     },
     {
@@ -8770,6 +11330,12 @@
           "url": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-symbol-description"
         }
       ]
     },
@@ -8791,6 +11357,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-value"
+        }
       ]
     },
     {
@@ -8810,6 +11382,12 @@
           "url": "https://registry.npmjs.org/getobject/-/getobject-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/getobject"
         }
       ]
     },
@@ -8831,6 +11409,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/getpass"
+        }
       ]
     },
     {
@@ -8850,6 +11434,12 @@
           "url": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/github-from-package"
         }
       ]
     },
@@ -8872,6 +11462,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/glob-parent"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -8890,6 +11486,12 @@
               "url": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/glob-parent/node_modules/is-glob"
             }
           ]
         }
@@ -8914,6 +11516,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/glob"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -8932,6 +11540,12 @@
               "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/glob/node_modules/brace-expansion"
             }
           ]
         },
@@ -8952,6 +11566,12 @@
               "url": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/glob/node_modules/minimatch"
             }
           ]
         }
@@ -8975,6 +11595,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/global-modules"
+        }
       ]
     },
     {
@@ -8996,6 +11622,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/global-prefix"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9014,6 +11646,12 @@
               "url": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/global-prefix/node_modules/which"
             }
           ]
         }
@@ -9038,6 +11676,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/got"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9056,6 +11700,12 @@
               "url": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/got/node_modules/get-stream"
             }
           ]
         },
@@ -9076,6 +11726,12 @@
               "url": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/got/node_modules/pify"
             }
           ]
         }
@@ -9099,6 +11755,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/graceful-fs"
+        }
       ]
     },
     {
@@ -9120,6 +11782,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-cli"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9138,6 +11806,12 @@
               "url": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-cli/node_modules/nopt"
             }
           ]
         }
@@ -9162,6 +11836,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-contrib-compress"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9180,6 +11860,12 @@
               "url": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-contrib-compress/node_modules/ansi-styles"
             }
           ]
         },
@@ -9201,6 +11887,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-contrib-compress/node_modules/chalk"
+            }
           ]
         },
         {
@@ -9220,6 +11912,12 @@
               "url": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-contrib-compress/node_modules/supports-color"
             }
           ]
         }
@@ -9243,6 +11941,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-known-options"
+        }
       ]
     },
     {
@@ -9264,6 +11968,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-legacy-log-utils"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9282,6 +11992,12 @@
               "url": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils/node_modules/ansi-styles"
             }
           ]
         },
@@ -9303,6 +12019,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils/node_modules/chalk"
+            }
           ]
         },
         {
@@ -9322,6 +12044,12 @@
               "url": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils/node_modules/color-convert"
             }
           ]
         },
@@ -9343,6 +12071,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils/node_modules/color-name"
+            }
           ]
         },
         {
@@ -9363,6 +12097,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils/node_modules/has-flag"
+            }
           ]
         },
         {
@@ -9382,6 +12122,12 @@
               "url": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils/node_modules/supports-color"
             }
           ]
         }
@@ -9406,6 +12152,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-legacy-log"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9424,6 +12176,12 @@
               "url": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log/node_modules/colors"
             }
           ]
         }
@@ -9448,6 +12206,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-legacy-util"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9466,6 +12230,12 @@
               "url": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-util/node_modules/async"
             }
           ]
         }
@@ -9489,6 +12259,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-replace-json"
+        }
       ]
     },
     {
@@ -9510,6 +12286,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9528,6 +12310,12 @@
               "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt/node_modules/brace-expansion"
             }
           ]
         },
@@ -9550,6 +12338,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt/node_modules/findup-sync"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -9568,6 +12362,12 @@
                   "url": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/grunt/node_modules/findup-sync/node_modules/glob"
                 }
               ]
             }
@@ -9591,6 +12391,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt/node_modules/glob"
+            }
           ]
         },
         {
@@ -9610,6 +12416,12 @@
               "url": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.8.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt/node_modules/minimatch"
             }
           ]
         }
@@ -9634,6 +12446,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/handlebars"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9652,6 +12470,12 @@
               "url": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/handlebars/node_modules/wordwrap"
             }
           ]
         }
@@ -9675,6 +12499,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/har-schema"
+        }
       ]
     },
     {
@@ -9694,6 +12524,12 @@
           "url": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/har-validator"
         }
       ]
     },
@@ -9715,6 +12551,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-ansi"
+        }
       ]
     },
     {
@@ -9734,6 +12576,12 @@
           "url": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-bigints"
         }
       ]
     },
@@ -9755,6 +12603,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-flag"
+        }
       ]
     },
     {
@@ -9774,6 +12628,12 @@
           "url": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-property-descriptors"
         }
       ]
     },
@@ -9795,6 +12655,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-symbol-support-x"
+        }
       ]
     },
     {
@@ -9814,6 +12680,12 @@
           "url": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-symbols"
         }
       ]
     },
@@ -9835,6 +12707,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-to-string-tag-x"
+        }
       ]
     },
     {
@@ -9854,6 +12732,12 @@
           "url": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-tostringtag"
         }
       ]
     },
@@ -9875,6 +12759,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-unicode"
+        }
       ]
     },
     {
@@ -9894,6 +12784,12 @@
           "url": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-value"
         }
       ]
     },
@@ -9916,6 +12812,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-values"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9934,6 +12836,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/has-values/node_modules/kind-of"
             }
           ]
         }
@@ -9957,6 +12865,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has"
+        }
       ]
     },
     {
@@ -9976,6 +12890,12 @@
           "url": "https://registry.npmjs.org/hashids/-/hashids-2.2.10.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hashids"
         }
       ]
     },
@@ -9997,6 +12917,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hbs"
+        }
       ]
     },
     {
@@ -10016,6 +12942,12 @@
           "url": "https://registry.npmjs.org/he/-/he-0.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/he"
         }
       ]
     },
@@ -10037,6 +12969,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/heap"
+        }
       ]
     },
     {
@@ -10056,6 +12994,12 @@
           "url": "https://registry.npmjs.org/helmet/-/helmet-4.6.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/helmet"
         }
       ]
     },
@@ -10077,6 +13021,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hoister"
+        }
       ]
     },
     {
@@ -10096,6 +13046,12 @@
           "url": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/homedir-polyfill"
         }
       ]
     },
@@ -10117,6 +13073,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hooker"
+        }
       ]
     },
     {
@@ -10137,6 +13099,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hosted-git-info"
+        }
       ]
     },
     {
@@ -10156,6 +13124,12 @@
           "url": "https://registry.npmjs.org/html-entities/-/html-entities-1.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/html-entities"
         }
       ]
     },
@@ -10178,6 +13152,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/htmlparser2"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -10196,6 +13176,12 @@
               "url": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/htmlparser2/node_modules/isarray"
             }
           ]
         },
@@ -10217,6 +13203,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/htmlparser2/node_modules/readable-stream"
+            }
           ]
         },
         {
@@ -10236,6 +13228,12 @@
               "url": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/htmlparser2/node_modules/string_decoder"
             }
           ]
         }
@@ -10259,6 +13257,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/http-cache-semantics"
+        }
       ]
     },
     {
@@ -10278,6 +13282,12 @@
           "url": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/http-errors"
         }
       ]
     },
@@ -10300,6 +13310,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/http-proxy-agent"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -10318,6 +13334,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/http-proxy-agent/node_modules/debug"
             }
           ]
         },
@@ -10338,6 +13360,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/http-proxy-agent/node_modules/ms"
             }
           ]
         }
@@ -10361,6 +13389,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/http-signature"
+        }
       ]
     },
     {
@@ -10382,6 +13416,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/https-proxy-agent"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -10400,6 +13440,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/https-proxy-agent/node_modules/debug"
             }
           ]
         },
@@ -10420,6 +13466,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/https-proxy-agent/node_modules/ms"
             }
           ]
         }
@@ -10443,6 +13495,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/humanize-ms"
+        }
       ]
     },
     {
@@ -10462,6 +13520,12 @@
           "url": "https://registry.npmjs.org/i18n/-/i18n-0.11.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/i18n"
         }
       ]
     },
@@ -10483,6 +13547,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/iconv-lite"
+        }
       ]
     },
     {
@@ -10502,6 +13572,12 @@
           "url": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ieee754"
         }
       ]
     },
@@ -10524,6 +13600,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ignore-walk"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -10542,6 +13624,12 @@
               "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/ignore-walk/node_modules/brace-expansion"
             }
           ]
         },
@@ -10562,6 +13650,12 @@
               "url": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/ignore-walk/node_modules/minimatch"
             }
           ]
         }
@@ -10585,6 +13679,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/iltorb"
+        }
       ]
     },
     {
@@ -10604,6 +13704,12 @@
           "url": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/imurmurhash"
         }
       ]
     },
@@ -10625,6 +13731,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/indent-string"
+        }
       ]
     },
     {
@@ -10644,6 +13756,12 @@
           "url": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/infer-owner"
         }
       ]
     },
@@ -10665,6 +13783,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/inflection"
+        }
       ]
     },
     {
@@ -10684,6 +13808,12 @@
           "url": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/inflight"
         }
       ]
     },
@@ -10705,6 +13835,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/inherits"
+        }
       ]
     },
     {
@@ -10724,6 +13860,12 @@
           "url": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ini"
         }
       ]
     },
@@ -10745,6 +13887,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/internal-slot"
+        }
       ]
     },
     {
@@ -10764,6 +13912,12 @@
           "url": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/interpret"
         }
       ]
     },
@@ -10785,6 +13939,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/into-stream"
+        }
       ]
     },
     {
@@ -10804,6 +13964,12 @@
           "url": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/invariant"
         }
       ]
     },
@@ -10825,6 +13991,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ip"
+        }
       ]
     },
     {
@@ -10844,6 +14016,12 @@
           "url": "https://registry.npmjs.org/ip6/-/ip6-0.2.10.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ip6"
         }
       ]
     },
@@ -10865,6 +14043,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ipaddr.js"
+        }
       ]
     },
     {
@@ -10884,6 +14068,12 @@
           "url": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-absolute"
         }
       ]
     },
@@ -10905,6 +14095,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-accessor-descriptor"
+        }
       ]
     },
     {
@@ -10924,6 +14120,12 @@
           "url": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-arguments"
         }
       ]
     },
@@ -10945,6 +14147,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-arrayish"
+        }
       ]
     },
     {
@@ -10964,6 +14172,12 @@
           "url": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-bigint"
         }
       ]
     },
@@ -10985,6 +14199,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-binary-path"
+        }
       ]
     },
     {
@@ -11004,6 +14224,12 @@
           "url": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-boolean-object"
         }
       ]
     },
@@ -11025,6 +14251,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-buffer"
+        }
       ]
     },
     {
@@ -11044,6 +14276,12 @@
           "url": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-callable"
         }
       ]
     },
@@ -11065,6 +14303,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-core-module"
+        }
       ]
     },
     {
@@ -11084,6 +14328,12 @@
           "url": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-data-descriptor"
         }
       ]
     },
@@ -11105,6 +14355,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-date-object"
+        }
       ]
     },
     {
@@ -11124,6 +14380,12 @@
           "url": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-descriptor"
         }
       ]
     },
@@ -11145,6 +14407,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-docker"
+        }
       ]
     },
     {
@@ -11164,6 +14432,12 @@
           "url": "https://registry.npmjs.org/is-expression/-/is-expression-4.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-expression"
         }
       ]
     },
@@ -11185,6 +14459,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-extendable"
+        }
       ]
     },
     {
@@ -11204,6 +14484,12 @@
           "url": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-extglob"
         }
       ]
     },
@@ -11225,6 +14511,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-fullwidth-code-point"
+        }
       ]
     },
     {
@@ -11244,6 +14536,12 @@
           "url": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-generator-function"
         }
       ]
     },
@@ -11265,6 +14563,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-glob"
+        }
       ]
     },
     {
@@ -11284,6 +14588,12 @@
           "url": "https://registry.npmjs.org/is-heroku/-/is-heroku-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-heroku"
         }
       ]
     },
@@ -11305,6 +14615,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-lambda"
+        }
       ]
     },
     {
@@ -11324,6 +14640,12 @@
           "url": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-map"
         }
       ]
     },
@@ -11345,6 +14667,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-natural-number"
+        }
       ]
     },
     {
@@ -11364,6 +14692,12 @@
           "url": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-negative-zero"
         }
       ]
     },
@@ -11385,6 +14719,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-number-like"
+        }
       ]
     },
     {
@@ -11404,6 +14744,12 @@
           "url": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-number-object"
         }
       ]
     },
@@ -11426,6 +14772,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-number"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -11444,6 +14796,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/is-number/node_modules/kind-of"
             }
           ]
         }
@@ -11467,6 +14825,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-object"
+        }
       ]
     },
     {
@@ -11486,6 +14850,12 @@
           "url": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-plain-obj"
         }
       ]
     },
@@ -11507,6 +14877,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-plain-object"
+        }
       ]
     },
     {
@@ -11526,6 +14902,12 @@
           "url": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-promise"
         }
       ]
     },
@@ -11547,6 +14929,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-regex"
+        }
       ]
     },
     {
@@ -11566,6 +14954,12 @@
           "url": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-relative"
         }
       ]
     },
@@ -11587,6 +14981,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-retry-allowed"
+        }
       ]
     },
     {
@@ -11606,6 +15006,12 @@
           "url": "https://registry.npmjs.org/is-set/-/is-set-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-set"
         }
       ]
     },
@@ -11627,6 +15033,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-shared-array-buffer"
+        }
       ]
     },
     {
@@ -11646,6 +15058,12 @@
           "url": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-stream"
         }
       ]
     },
@@ -11667,6 +15085,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-string"
+        }
       ]
     },
     {
@@ -11686,6 +15110,12 @@
           "url": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-symbol"
         }
       ]
     },
@@ -11707,6 +15137,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-typed-array"
+        }
       ]
     },
     {
@@ -11726,6 +15162,12 @@
           "url": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-typedarray"
         }
       ]
     },
@@ -11747,6 +15189,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-unc-path"
+        }
       ]
     },
     {
@@ -11766,6 +15214,12 @@
           "url": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-weakmap"
         }
       ]
     },
@@ -11787,6 +15241,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-weakref"
+        }
       ]
     },
     {
@@ -11806,6 +15266,12 @@
           "url": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-weakset"
         }
       ]
     },
@@ -11827,6 +15293,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-windows"
+        }
       ]
     },
     {
@@ -11846,6 +15318,12 @@
           "url": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isarray"
         }
       ]
     },
@@ -11867,6 +15345,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isexe"
+        }
       ]
     },
     {
@@ -11886,6 +15370,12 @@
           "url": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isobject"
         }
       ]
     },
@@ -11907,6 +15397,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isstream"
+        }
       ]
     },
     {
@@ -11926,6 +15422,12 @@
           "url": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isurl"
         }
       ]
     },
@@ -11947,6 +15449,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/js-stringify"
+        }
       ]
     },
     {
@@ -11966,6 +15474,12 @@
           "url": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/js-tokens"
         }
       ]
     },
@@ -11987,6 +15501,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/js-yaml"
+        }
       ]
     },
     {
@@ -12006,6 +15526,12 @@
           "url": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jsbn"
         }
       ]
     },
@@ -12027,6 +15553,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-buffer"
+        }
       ]
     },
     {
@@ -12046,6 +15578,12 @@
           "url": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-parse-better-errors"
         }
       ]
     },
@@ -12067,6 +15605,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-schema-traverse"
+        }
       ]
     },
     {
@@ -12086,6 +15630,12 @@
           "url": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-schema"
         }
       ]
     },
@@ -12107,6 +15657,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-stringify-safe"
+        }
       ]
     },
     {
@@ -12126,6 +15682,12 @@
           "url": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json5"
         }
       ]
     },
@@ -12147,6 +15709,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jsonfile"
+        }
       ]
     },
     {
@@ -12166,6 +15734,12 @@
           "url": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-0.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jsonwebtoken"
         }
       ]
     },
@@ -12187,6 +15761,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jsprim"
+        }
       ]
     },
     {
@@ -12206,6 +15786,12 @@
           "url": "https://registry.npmjs.org/jssha/-/jssha-3.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jssha"
         }
       ]
     },
@@ -12227,6 +15813,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jstransformer"
+        }
       ]
     },
     {
@@ -12246,6 +15838,12 @@
           "url": "https://registry.npmjs.org/juicy-chat-bot/-/juicy-chat-bot-0.6.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/juicy-chat-bot"
         }
       ]
     },
@@ -12267,6 +15865,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jwa"
+        }
       ]
     },
     {
@@ -12286,6 +15890,12 @@
           "url": "https://registry.npmjs.org/jws/-/jws-0.2.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jws"
         }
       ]
     },
@@ -12307,6 +15917,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/keyv"
+        }
       ]
     },
     {
@@ -12326,6 +15942,12 @@
           "url": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/kind-of"
         }
       ]
     },
@@ -12347,6 +15969,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/kuler"
+        }
       ]
     },
     {
@@ -12366,6 +15994,12 @@
           "url": "https://registry.npmjs.org/kuromoji/-/kuromoji-0.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/kuromoji"
         }
       ]
     },
@@ -12387,6 +16021,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lazystream"
+        }
       ]
     },
     {
@@ -12406,6 +16046,12 @@
           "url": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/levn"
         }
       ]
     },
@@ -12428,6 +16074,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/libxmljs2"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12446,6 +16098,12 @@
               "url": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/libxmljs2/node_modules/nan"
             }
           ]
         }
@@ -12470,6 +16128,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/liftup"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12488,6 +16152,12 @@
               "url": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/braces"
             }
           ]
         },
@@ -12509,6 +16179,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/fill-range"
+            }
           ]
         },
         {
@@ -12528,6 +16204,12 @@
               "url": "https://registry.npmjs.org/findup-sync/-/findup-sync-4.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/findup-sync"
             }
           ]
         },
@@ -12549,6 +16231,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/is-glob"
+            }
           ]
         },
         {
@@ -12568,6 +16256,12 @@
               "url": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/is-number"
             }
           ]
         },
@@ -12589,6 +16283,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/micromatch"
+            }
           ]
         },
         {
@@ -12608,6 +16308,12 @@
               "url": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/to-regex-range"
             }
           ]
         }
@@ -12632,6 +16338,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/linebreak"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12650,6 +16362,12 @@
               "url": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/linebreak/node_modules/base64-js"
             }
           ]
         }
@@ -12673,6 +16391,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/listenercount"
+        }
       ]
     },
     {
@@ -12692,6 +16416,12 @@
           "url": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/locate-path"
         }
       ]
     },
@@ -12713,6 +16443,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lodash.camelcase"
+        }
       ]
     },
     {
@@ -12732,6 +16468,12 @@
           "url": "https://registry.npmjs.org/lodash.isfinite/-/lodash.isfinite-3.3.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lodash.isfinite"
         }
       ]
     },
@@ -12753,6 +16495,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lodash.set"
+        }
       ]
     },
     {
@@ -12772,6 +16520,12 @@
           "url": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lodash"
         }
       ]
     },
@@ -12794,6 +16548,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/logform"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12812,6 +16572,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/logform/node_modules/ms"
             }
           ]
         }
@@ -12835,6 +16601,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lolex"
+        }
       ]
     },
     {
@@ -12854,6 +16626,12 @@
           "url": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/loose-envify"
         }
       ]
     },
@@ -12875,6 +16653,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lowercase-keys"
+        }
       ]
     },
     {
@@ -12894,6 +16678,12 @@
           "url": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lru-cache"
         }
       ]
     },
@@ -12916,6 +16706,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-dir"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12934,6 +16730,12 @@
               "url": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-dir/node_modules/semver"
             }
           ]
         }
@@ -12957,6 +16759,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-error"
+        }
       ]
     },
     {
@@ -12976,6 +16784,12 @@
           "url": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-9.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-fetch-happen"
         }
       ],
       "components": [
@@ -12998,6 +16812,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen/node_modules/@tootallnate/once"
+            }
           ]
         },
         {
@@ -13017,6 +16837,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen/node_modules/debug"
             }
           ]
         },
@@ -13038,6 +16864,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen/node_modules/http-cache-semantics"
+            }
           ]
         },
         {
@@ -13058,6 +16890,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen/node_modules/http-proxy-agent"
+            }
           ]
         },
         {
@@ -13077,6 +16915,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen/node_modules/ms"
             }
           ]
         }
@@ -13100,6 +16944,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-iterator"
+        }
       ]
     },
     {
@@ -13119,6 +16969,12 @@
           "url": "https://registry.npmjs.org/make-plural/-/make-plural-6.2.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-plural"
         }
       ]
     },
@@ -13140,6 +16996,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/map-cache"
+        }
       ]
     },
     {
@@ -13159,6 +17021,12 @@
           "url": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/map-visit"
         }
       ]
     },
@@ -13180,6 +17048,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/marsdb"
+        }
       ]
     },
     {
@@ -13199,6 +17073,12 @@
           "url": "https://registry.npmjs.org/math-interval-parser/-/math-interval-parser-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/math-interval-parser"
         }
       ]
     },
@@ -13220,6 +17100,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/media-typer"
+        }
       ]
     },
     {
@@ -13239,6 +17125,12 @@
           "url": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/merge-descriptors"
         }
       ]
     },
@@ -13260,6 +17152,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/messageformat-formatters"
+        }
       ]
     },
     {
@@ -13279,6 +17177,12 @@
           "url": "https://registry.npmjs.org/messageformat-parser/-/messageformat-parser-4.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/messageformat-parser"
         }
       ]
     },
@@ -13301,6 +17205,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/messageformat"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -13319,6 +17229,12 @@
               "url": "https://registry.npmjs.org/make-plural/-/make-plural-4.3.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/messageformat/node_modules/make-plural"
             }
           ]
         }
@@ -13342,6 +17258,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/methods"
+        }
       ]
     },
     {
@@ -13361,6 +17283,12 @@
           "url": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/micromatch"
         }
       ]
     },
@@ -13382,6 +17310,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mime-db"
+        }
       ]
     },
     {
@@ -13401,6 +17335,12 @@
           "url": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mime-types"
         }
       ]
     },
@@ -13422,6 +17362,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mime"
+        }
       ]
     },
     {
@@ -13441,6 +17387,12 @@
           "url": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mimic-response"
         }
       ]
     },
@@ -13462,6 +17414,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minimatch"
+        }
       ]
     },
     {
@@ -13481,6 +17439,12 @@
           "url": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minimist"
         }
       ]
     },
@@ -13502,6 +17466,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-collect"
+        }
       ]
     },
     {
@@ -13521,6 +17491,12 @@
           "url": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-1.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-fetch"
         }
       ]
     },
@@ -13542,6 +17518,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-flush"
+        }
       ]
     },
     {
@@ -13561,6 +17543,12 @@
           "url": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-pipeline"
         }
       ]
     },
@@ -13582,6 +17570,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-sized"
+        }
       ]
     },
     {
@@ -13601,6 +17595,12 @@
           "url": "https://registry.npmjs.org/minipass/-/minipass-3.3.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass"
         }
       ]
     },
@@ -13622,6 +17622,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minizlib"
+        }
       ]
     },
     {
@@ -13641,6 +17647,12 @@
           "url": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mixin-deep"
         }
       ]
     },
@@ -13662,6 +17674,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mkdirp-classic"
+        }
       ]
     },
     {
@@ -13681,6 +17699,12 @@
           "url": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mkdirp"
         }
       ]
     },
@@ -13702,6 +17726,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/moment-timezone"
+        }
       ]
     },
     {
@@ -13721,6 +17751,12 @@
           "url": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/moment"
         }
       ]
     },
@@ -13743,6 +17779,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/morgan"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -13761,6 +17803,12 @@
               "url": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/morgan/node_modules/on-finished"
             }
           ]
         }
@@ -13784,6 +17832,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mout"
+        }
       ]
     },
     {
@@ -13803,6 +17857,12 @@
           "url": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ms"
         }
       ]
     },
@@ -13825,6 +17885,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/multer"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -13843,6 +17909,12 @@
               "url": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/multer/node_modules/mkdirp"
             }
           ]
         }
@@ -13866,6 +17938,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mustache"
+        }
       ]
     },
     {
@@ -13885,6 +17963,12 @@
           "url": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/nan"
         }
       ]
     },
@@ -13906,6 +17990,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/nanomatch"
+        }
       ]
     },
     {
@@ -13925,6 +18015,12 @@
           "url": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/napi-build-utils"
         }
       ]
     },
@@ -13947,6 +18043,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/needle"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -13965,6 +18067,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/needle/node_modules/debug"
             }
           ]
         },
@@ -13985,6 +18093,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/needle/node_modules/ms"
             }
           ]
         }
@@ -14008,6 +18122,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/negotiator"
+        }
       ]
     },
     {
@@ -14027,6 +18147,12 @@
           "url": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/neo-async"
         }
       ]
     },
@@ -14049,6 +18175,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-abi"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14067,6 +18199,12 @@
               "url": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-abi/node_modules/semver"
             }
           ]
         }
@@ -14090,6 +18228,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-addon-api"
+        }
       ]
     },
     {
@@ -14109,6 +18253,12 @@
           "url": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-fetch"
         }
       ]
     },
@@ -14131,6 +18281,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-gyp"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14149,6 +18305,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/ansi-regex"
             }
           ]
         },
@@ -14170,6 +18332,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/are-we-there-yet"
+            }
           ]
         },
         {
@@ -14189,6 +18357,12 @@
               "url": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/gauge"
             }
           ]
         },
@@ -14210,6 +18384,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/is-fullwidth-code-point"
+            }
           ]
         },
         {
@@ -14229,6 +18409,12 @@
               "url": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/nopt"
             }
           ]
         },
@@ -14250,6 +18436,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/npmlog"
+            }
           ]
         },
         {
@@ -14269,6 +18461,12 @@
               "url": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/readable-stream"
             }
           ]
         },
@@ -14290,6 +18488,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/string-width"
+            }
           ]
         },
         {
@@ -14309,6 +18513,12 @@
               "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/strip-ansi"
             }
           ]
         }
@@ -14333,6 +18543,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-pre-gyp"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14351,6 +18567,12 @@
               "url": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/chownr"
             }
           ]
         },
@@ -14372,6 +18594,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/fs-minipass"
+            }
           ]
         },
         {
@@ -14391,6 +18619,12 @@
               "url": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/minipass"
             }
           ]
         },
@@ -14412,6 +18646,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/minizlib"
+            }
           ]
         },
         {
@@ -14431,6 +18671,12 @@
               "url": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/mkdirp"
             }
           ]
         },
@@ -14452,6 +18698,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/nopt"
+            }
           ]
         },
         {
@@ -14471,6 +18723,12 @@
               "url": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/rimraf"
             }
           ]
         },
@@ -14492,6 +18750,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/safe-buffer"
+            }
           ]
         },
         {
@@ -14511,6 +18775,12 @@
               "url": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/semver"
             }
           ]
         },
@@ -14532,6 +18802,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/tar"
+            }
           ]
         },
         {
@@ -14551,6 +18827,12 @@
               "url": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/yallist"
             }
           ]
         }
@@ -14574,6 +18856,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/noop-logger"
+        }
       ]
     },
     {
@@ -14593,6 +18881,12 @@
           "url": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/nopt"
         }
       ]
     },
@@ -14615,6 +18909,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/normalize-package-data"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14633,6 +18933,12 @@
               "url": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/normalize-package-data/node_modules/semver"
             }
           ]
         }
@@ -14656,6 +18962,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/normalize-path"
+        }
       ]
     },
     {
@@ -14675,6 +18987,12 @@
           "url": "https://registry.npmjs.org/normalize-url/-/normalize-url-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/normalize-url"
         }
       ]
     },
@@ -14697,6 +19015,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/notevil"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14715,6 +19039,12 @@
               "url": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/notevil/node_modules/esprima"
             }
           ]
         }
@@ -14738,6 +19068,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/npm-bundled"
+        }
       ]
     },
     {
@@ -14757,6 +19093,12 @@
           "url": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/npm-normalize-package-bin"
         }
       ]
     },
@@ -14778,6 +19120,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/npm-packlist"
+        }
       ]
     },
     {
@@ -14797,6 +19145,12 @@
           "url": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/npmlog"
         }
       ]
     },
@@ -14818,6 +19172,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/number-is-nan"
+        }
       ]
     },
     {
@@ -14838,6 +19198,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/oauth-sign"
+        }
       ]
     },
     {
@@ -14857,6 +19223,12 @@
           "url": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-assign"
         }
       ]
     },
@@ -14879,6 +19251,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-copy"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14897,6 +19275,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy/node_modules/define-property"
             }
           ]
         },
@@ -14918,6 +19302,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy/node_modules/is-accessor-descriptor"
+            }
           ]
         },
         {
@@ -14937,6 +19327,12 @@
               "url": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy/node_modules/is-data-descriptor"
             }
           ]
         },
@@ -14959,6 +19355,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy/node_modules/is-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -14977,6 +19379,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/object-copy/node_modules/is-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -15000,6 +19408,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy/node_modules/kind-of"
+            }
           ]
         }
       ]
@@ -15022,6 +19436,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-inspect"
+        }
       ]
     },
     {
@@ -15041,6 +19461,12 @@
           "url": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-is"
         }
       ]
     },
@@ -15062,6 +19488,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-keys"
+        }
       ]
     },
     {
@@ -15081,6 +19513,12 @@
           "url": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-visit"
         }
       ]
     },
@@ -15102,6 +19540,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object.assign"
+        }
       ]
     },
     {
@@ -15121,6 +19565,12 @@
           "url": "https://registry.npmjs.org/object.defaults/-/object.defaults-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object.defaults"
         }
       ]
     },
@@ -15142,6 +19592,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object.map"
+        }
       ]
     },
     {
@@ -15161,6 +19617,12 @@
           "url": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object.pick"
         }
       ]
     },
@@ -15182,6 +19644,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/on-finished"
+        }
       ]
     },
     {
@@ -15201,6 +19669,12 @@
           "url": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/on-headers"
         }
       ]
     },
@@ -15222,6 +19696,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/once"
+        }
       ]
     },
     {
@@ -15241,6 +19721,12 @@
           "url": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/one-time"
         }
       ]
     },
@@ -15262,6 +19748,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/opentype.js"
+        }
       ]
     },
     {
@@ -15281,6 +19773,12 @@
           "url": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/optionator"
         }
       ]
     },
@@ -15302,6 +19800,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/os-homedir"
+        }
       ]
     },
     {
@@ -15321,6 +19825,12 @@
           "url": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/os-tmpdir"
         }
       ]
     },
@@ -15342,6 +19852,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/osenv"
+        }
       ]
     },
     {
@@ -15361,6 +19877,12 @@
           "url": "https://registry.npmjs.org/otplib/-/otplib-12.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/otplib"
         }
       ]
     },
@@ -15382,6 +19904,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-cancelable"
+        }
       ]
     },
     {
@@ -15401,6 +19929,12 @@
           "url": "https://registry.npmjs.org/p-event/-/p-event-2.3.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-event"
         }
       ]
     },
@@ -15422,6 +19956,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-finally"
+        }
       ]
     },
     {
@@ -15441,6 +19981,12 @@
           "url": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-is-promise"
         }
       ]
     },
@@ -15462,6 +20008,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-limit"
+        }
       ]
     },
     {
@@ -15481,6 +20033,12 @@
           "url": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-locate"
         }
       ]
     },
@@ -15502,6 +20060,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-map"
+        }
       ]
     },
     {
@@ -15521,6 +20085,12 @@
           "url": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-timeout"
         }
       ]
     },
@@ -15542,6 +20112,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-try"
+        }
       ]
     },
     {
@@ -15561,6 +20137,12 @@
           "url": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pako"
         }
       ]
     },
@@ -15582,6 +20164,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/parse-filepath"
+        }
       ]
     },
     {
@@ -15601,6 +20189,12 @@
           "url": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/parse-json"
         }
       ]
     },
@@ -15622,6 +20216,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/parse-passwd"
+        }
       ]
     },
     {
@@ -15641,6 +20241,12 @@
           "url": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/parseurl"
         }
       ]
     },
@@ -15662,6 +20268,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pascalcase"
+        }
       ]
     },
     {
@@ -15681,6 +20293,12 @@
           "url": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-exists"
         }
       ]
     },
@@ -15702,6 +20320,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-is-absolute"
+        }
       ]
     },
     {
@@ -15721,6 +20345,12 @@
           "url": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-parse"
         }
       ]
     },
@@ -15742,6 +20372,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-root-regex"
+        }
       ]
     },
     {
@@ -15761,6 +20397,12 @@
           "url": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-root"
         }
       ]
     },
@@ -15782,6 +20424,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-to-regexp"
+        }
       ]
     },
     {
@@ -15801,6 +20449,12 @@
           "url": "https://registry.npmjs.org/pdfkit/-/pdfkit-0.11.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pdfkit"
         }
       ]
     },
@@ -15822,6 +20476,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/peek-readable"
+        }
       ]
     },
     {
@@ -15841,6 +20501,12 @@
           "url": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pend"
         }
       ]
     },
@@ -15862,6 +20528,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/performance-now"
+        }
       ]
     },
     {
@@ -15881,6 +20553,12 @@
           "url": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.5.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pg-connection-string"
         }
       ]
     },
@@ -15902,6 +20580,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/picomatch"
+        }
       ]
     },
     {
@@ -15921,6 +20605,12 @@
           "url": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pify"
         }
       ]
     },
@@ -15942,6 +20632,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pinkie-promise"
+        }
       ]
     },
     {
@@ -15961,6 +20657,12 @@
           "url": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pinkie"
         }
       ]
     },
@@ -15982,6 +20684,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/png-js"
+        }
       ]
     },
     {
@@ -16001,6 +20709,12 @@
           "url": "https://registry.npmjs.org/portscanner/-/portscanner-2.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/portscanner"
         }
       ]
     },
@@ -16022,6 +20736,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/posix-character-classes"
+        }
       ]
     },
     {
@@ -16041,6 +20761,12 @@
           "url": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.3.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/prebuild-install"
         }
       ]
     },
@@ -16062,6 +20788,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/prelude-ls"
+        }
       ]
     },
     {
@@ -16081,6 +20813,12 @@
           "url": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/prepend-http"
         }
       ]
     },
@@ -16102,6 +20840,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pretty-bytes"
+        }
       ]
     },
     {
@@ -16121,6 +20865,12 @@
           "url": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/process-nextick-args"
         }
       ]
     },
@@ -16142,6 +20892,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/prom-client"
+        }
       ]
     },
     {
@@ -16161,6 +20917,12 @@
           "url": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/promise-inflight"
         }
       ]
     },
@@ -16183,6 +20945,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/promise-retry"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -16201,6 +20969,12 @@
               "url": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/promise-retry/node_modules/err-code"
             }
           ]
         },
@@ -16221,6 +20995,12 @@
               "url": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/promise-retry/node_modules/retry"
             }
           ]
         }
@@ -16244,6 +21024,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/promise"
+        }
       ]
     },
     {
@@ -16263,6 +21049,12 @@
           "url": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/proper-lockfile"
         }
       ]
     },
@@ -16284,6 +21076,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/proxy-addr"
+        }
       ]
     },
     {
@@ -16303,6 +21101,12 @@
           "url": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/psl"
         }
       ]
     },
@@ -16324,6 +21128,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-attrs"
+        }
       ]
     },
     {
@@ -16343,6 +21153,12 @@
           "url": "https://registry.npmjs.org/pug-code-gen/-/pug-code-gen-3.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-code-gen"
         }
       ]
     },
@@ -16364,6 +21180,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-error"
+        }
       ]
     },
     {
@@ -16383,6 +21205,12 @@
           "url": "https://registry.npmjs.org/pug-filters/-/pug-filters-4.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-filters"
         }
       ]
     },
@@ -16404,6 +21232,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-lexer"
+        }
       ]
     },
     {
@@ -16423,6 +21257,12 @@
           "url": "https://registry.npmjs.org/pug-linker/-/pug-linker-4.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-linker"
         }
       ]
     },
@@ -16444,6 +21284,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-load"
+        }
       ]
     },
     {
@@ -16463,6 +21309,12 @@
           "url": "https://registry.npmjs.org/pug-parser/-/pug-parser-6.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-parser"
         }
       ]
     },
@@ -16484,6 +21336,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-runtime"
+        }
       ]
     },
     {
@@ -16503,6 +21361,12 @@
           "url": "https://registry.npmjs.org/pug-strip-comments/-/pug-strip-comments-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-strip-comments"
         }
       ]
     },
@@ -16524,6 +21388,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-walk"
+        }
       ]
     },
     {
@@ -16543,6 +21413,12 @@
           "url": "https://registry.npmjs.org/pug/-/pug-3.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug"
         }
       ]
     },
@@ -16564,6 +21440,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pump"
+        }
       ]
     },
     {
@@ -16583,6 +21465,12 @@
           "url": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/punycode"
         }
       ]
     },
@@ -16604,6 +21492,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/qs"
+        }
       ]
     },
     {
@@ -16623,6 +21517,12 @@
           "url": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/query-string"
         }
       ]
     },
@@ -16644,6 +21544,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/range_check"
+        }
       ]
     },
     {
@@ -16663,6 +21569,12 @@
           "url": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/range-parser"
         }
       ]
     },
@@ -16684,6 +21596,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/raw-body"
+        }
       ]
     },
     {
@@ -16703,6 +21621,12 @@
           "url": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/rc"
         }
       ]
     },
@@ -16725,6 +21649,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/read-pkg"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -16743,6 +21673,12 @@
               "url": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/read-pkg/node_modules/pify"
             }
           ]
         }
@@ -16767,6 +21703,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/readable-stream"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -16785,6 +21727,12 @@
               "url": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/readable-stream/node_modules/isarray"
             }
           ]
         }
@@ -16809,6 +21757,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/readable-web-to-node-stream"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -16827,6 +21781,12 @@
               "url": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/readable-web-to-node-stream/node_modules/readable-stream"
             }
           ]
         }
@@ -16850,6 +21810,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/readdirp"
+        }
       ]
     },
     {
@@ -16869,6 +21835,12 @@
           "url": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/rechoir"
         }
       ]
     },
@@ -16890,6 +21862,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/regex-not"
+        }
       ]
     },
     {
@@ -16909,6 +21887,12 @@
           "url": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/regexp.prototype.flags"
         }
       ]
     },
@@ -16930,6 +21914,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/remove-trailing-separator"
+        }
       ]
     },
     {
@@ -16950,6 +21940,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/repeat-element"
+        }
       ]
     },
     {
@@ -16969,6 +21965,12 @@
           "url": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/repeat-string"
         }
       ]
     },
@@ -16991,6 +21993,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/replace"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17009,6 +22017,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/ansi-regex"
             }
           ]
         },
@@ -17030,6 +22044,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/ansi-styles"
+            }
           ]
         },
         {
@@ -17049,6 +22069,12 @@
               "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/brace-expansion"
             }
           ]
         },
@@ -17070,6 +22096,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/cliui"
+            }
           ]
         },
         {
@@ -17089,6 +22121,12 @@
               "url": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/color-convert"
             }
           ]
         },
@@ -17110,6 +22148,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/color-name"
+            }
           ]
         },
         {
@@ -17129,6 +22173,12 @@
               "url": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/find-up"
             }
           ]
         },
@@ -17150,6 +22200,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/is-fullwidth-code-point"
+            }
           ]
         },
         {
@@ -17169,6 +22225,12 @@
               "url": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/locate-path"
             }
           ]
         },
@@ -17190,6 +22252,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/minimatch"
+            }
           ]
         },
         {
@@ -17209,6 +22277,12 @@
               "url": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/p-locate"
             }
           ]
         },
@@ -17230,6 +22304,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/path-exists"
+            }
           ]
         },
         {
@@ -17249,6 +22329,12 @@
               "url": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/string-width"
             }
           ]
         },
@@ -17270,6 +22356,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/strip-ansi"
+            }
           ]
         },
         {
@@ -17289,6 +22381,12 @@
               "url": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/wrap-ansi"
             }
           ]
         },
@@ -17310,6 +22408,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/yargs-parser"
+            }
           ]
         },
         {
@@ -17329,6 +22433,12 @@
               "url": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/yargs"
             }
           ]
         }
@@ -17353,6 +22463,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/request"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17371,6 +22487,12 @@
               "url": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/request/node_modules/qs"
             }
           ]
         }
@@ -17394,6 +22516,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/require-directory"
+        }
       ]
     },
     {
@@ -17413,6 +22541,12 @@
           "url": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/require-main-filename"
         }
       ]
     },
@@ -17434,6 +22568,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/resolve-dir"
+        }
       ]
     },
     {
@@ -17453,6 +22593,12 @@
           "url": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/resolve-url"
         }
       ]
     },
@@ -17474,6 +22620,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/resolve"
+        }
       ]
     },
     {
@@ -17493,6 +22645,12 @@
           "url": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/responselike"
         }
       ]
     },
@@ -17514,6 +22672,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/restructure"
+        }
       ]
     },
     {
@@ -17533,6 +22697,12 @@
           "url": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ret"
         }
       ]
     },
@@ -17554,6 +22724,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/retry-as-promised"
+        }
       ]
     },
     {
@@ -17574,6 +22750,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/retry"
+        }
       ]
     },
     {
@@ -17593,6 +22775,12 @@
           "url": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/rimraf"
         }
       ]
     },
@@ -17615,6 +22803,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/rxjs"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17633,6 +22827,12 @@
               "url": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/rxjs/node_modules/tslib"
             }
           ]
         }
@@ -17656,6 +22856,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safe-buffer"
+        }
       ]
     },
     {
@@ -17675,6 +22881,12 @@
           "url": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safe-regex-test"
         }
       ]
     },
@@ -17696,6 +22908,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safe-regex"
+        }
       ]
     },
     {
@@ -17715,6 +22933,12 @@
           "url": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safe-stable-stringify"
         }
       ]
     },
@@ -17736,6 +22960,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safer-buffer"
+        }
       ]
     },
     {
@@ -17756,6 +22986,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/samsam"
+        }
       ]
     },
     {
@@ -17775,6 +23011,12 @@
           "url": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sanitize-filename"
         }
       ]
     },
@@ -17797,6 +23039,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sanitize-html"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17815,6 +23063,12 @@
               "url": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sanitize-html/node_modules/lodash"
             }
           ]
         }
@@ -17838,6 +23092,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sax"
+        }
       ]
     },
     {
@@ -17858,6 +23118,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/seek-bzip"
+        }
       ]
     },
     {
@@ -17877,6 +23143,12 @@
           "url": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/semver"
         }
       ]
     },
@@ -17899,6 +23171,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/send"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17917,6 +23195,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/send/node_modules/ms"
             }
           ]
         }
@@ -17940,6 +23224,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sequelize-pool"
+        }
       ]
     },
     {
@@ -17961,6 +23251,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sequelize"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17979,6 +23275,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sequelize/node_modules/debug"
             }
           ]
         },
@@ -18000,6 +23302,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sequelize/node_modules/ms"
+            }
           ]
         },
         {
@@ -18019,6 +23327,12 @@
               "url": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sequelize/node_modules/uuid"
             }
           ]
         }
@@ -18043,6 +23357,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/serve-index"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18061,6 +23381,12 @@
               "url": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index/node_modules/depd"
             }
           ]
         },
@@ -18082,6 +23408,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index/node_modules/http-errors"
+            }
           ]
         },
         {
@@ -18101,6 +23433,12 @@
               "url": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index/node_modules/inherits"
             }
           ]
         },
@@ -18122,6 +23460,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index/node_modules/setprototypeof"
+            }
           ]
         },
         {
@@ -18141,6 +23485,12 @@
               "url": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index/node_modules/statuses"
             }
           ]
         }
@@ -18164,6 +23514,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/serve-static"
+        }
       ]
     },
     {
@@ -18183,6 +23539,12 @@
           "url": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/set-blocking"
         }
       ]
     },
@@ -18205,6 +23567,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/set-value"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18223,6 +23591,12 @@
               "url": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/set-value/node_modules/extend-shallow"
             }
           ]
         },
@@ -18243,6 +23617,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/set-value/node_modules/is-extendable"
             }
           ]
         }
@@ -18266,6 +23646,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/setimmediate"
+        }
       ]
     },
     {
@@ -18285,6 +23671,12 @@
           "url": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/setprototypeof"
         }
       ]
     },
@@ -18306,6 +23698,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/side-channel"
+        }
       ]
     },
     {
@@ -18326,6 +23724,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/signal-exit"
+        }
       ]
     },
     {
@@ -18345,6 +23749,12 @@
           "url": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/simple-concat"
         }
       ]
     },
@@ -18367,6 +23777,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/simple-get"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18385,6 +23801,12 @@
               "url": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/simple-get/node_modules/decompress-response"
             }
           ]
         },
@@ -18405,6 +23827,12 @@
               "url": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/simple-get/node_modules/mimic-response"
             }
           ]
         }
@@ -18429,6 +23857,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/simple-swizzle"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18447,6 +23881,12 @@
               "url": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/simple-swizzle/node_modules/is-arrayish"
             }
           ]
         }
@@ -18470,6 +23910,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sinon"
+        }
       ]
     },
     {
@@ -18489,6 +23935,12 @@
           "url": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/smart-buffer"
         }
       ]
     },
@@ -18511,6 +23963,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/snapdragon-node"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18529,6 +23987,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon-node/node_modules/define-property"
             }
           ]
         }
@@ -18553,6 +24017,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/snapdragon-util"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18571,6 +24041,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon-util/node_modules/kind-of"
             }
           ]
         }
@@ -18595,6 +24071,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/snapdragon"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18613,6 +24095,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/define-property"
             }
           ]
         },
@@ -18633,6 +24121,12 @@
               "url": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/extend-shallow"
             }
           ]
         },
@@ -18655,6 +24149,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/is-accessor-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -18673,6 +24173,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/snapdragon/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -18697,6 +24203,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/is-data-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -18715,6 +24227,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/snapdragon/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -18738,6 +24256,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/is-descriptor"
+            }
           ]
         },
         {
@@ -18757,6 +24281,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/is-extendable"
             }
           ]
         },
@@ -18778,6 +24308,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/kind-of"
+            }
           ]
         },
         {
@@ -18797,6 +24333,12 @@
               "url": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/source-map"
             }
           ]
         }
@@ -18820,6 +24362,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socket.io-adapter"
+        }
       ]
     },
     {
@@ -18841,6 +24389,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socket.io-parser"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18859,6 +24413,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socket.io-parser/node_modules/debug"
             }
           ]
         },
@@ -18879,6 +24439,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socket.io-parser/node_modules/ms"
             }
           ]
         }
@@ -18903,6 +24469,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socket.io"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18921,6 +24493,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socket.io/node_modules/debug"
             }
           ]
         },
@@ -18941,6 +24519,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socket.io/node_modules/ms"
             }
           ]
         }
@@ -18965,6 +24549,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socks-proxy-agent"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18983,6 +24573,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socks-proxy-agent/node_modules/debug"
             }
           ]
         },
@@ -19003,6 +24599,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socks-proxy-agent/node_modules/ms"
             }
           ]
         }
@@ -19027,6 +24629,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socks"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -19045,6 +24653,12 @@
               "url": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socks/node_modules/ip"
             }
           ]
         }
@@ -19069,6 +24683,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sort-keys-length"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -19087,6 +24707,12 @@
               "url": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sort-keys-length/node_modules/sort-keys"
             }
           ]
         }
@@ -19110,6 +24736,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sort-keys"
+        }
       ]
     },
     {
@@ -19129,6 +24761,12 @@
           "url": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/source-map-resolve"
         }
       ]
     },
@@ -19150,6 +24788,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/source-map-support"
+        }
       ]
     },
     {
@@ -19169,6 +24813,12 @@
           "url": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/source-map-url"
         }
       ]
     },
@@ -19190,6 +24840,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/source-map"
+        }
       ]
     },
     {
@@ -19209,6 +24865,12 @@
           "url": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2-1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spawn-command"
         }
       ]
     },
@@ -19230,6 +24892,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spdx-correct"
+        }
       ]
     },
     {
@@ -19249,6 +24917,12 @@
           "url": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spdx-exceptions"
         }
       ]
     },
@@ -19270,6 +24944,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spdx-expression-parse"
+        }
       ]
     },
     {
@@ -19289,6 +24969,12 @@
           "url": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.12.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spdx-license-ids"
         }
       ]
     },
@@ -19310,6 +24996,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/split-string"
+        }
       ]
     },
     {
@@ -19329,6 +25021,12 @@
           "url": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sprintf-js"
         }
       ]
     },
@@ -19350,6 +25048,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sqlite3"
+        }
       ]
     },
     {
@@ -19369,6 +25073,12 @@
           "url": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sshpk"
         }
       ]
     },
@@ -19390,6 +25100,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ssri"
+        }
       ]
     },
     {
@@ -19409,6 +25125,12 @@
           "url": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/stack-trace"
         }
       ]
     },
@@ -19431,6 +25153,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/static-extend"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -19449,6 +25177,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend/node_modules/define-property"
             }
           ]
         },
@@ -19471,6 +25205,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend/node_modules/is-accessor-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -19489,6 +25229,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/static-extend/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -19513,6 +25259,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend/node_modules/is-data-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -19531,6 +25283,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/static-extend/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -19554,6 +25312,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend/node_modules/is-descriptor"
+            }
           ]
         },
         {
@@ -19573,6 +25337,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend/node_modules/kind-of"
             }
           ]
         }
@@ -19596,6 +25366,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/statuses"
+        }
       ]
     },
     {
@@ -19615,6 +25391,12 @@
           "url": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-2.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/stream-buffers"
         }
       ]
     },
@@ -19636,6 +25418,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/streamsearch"
+        }
       ]
     },
     {
@@ -19655,6 +25443,12 @@
           "url": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strict-uri-encode"
         }
       ]
     },
@@ -19676,6 +25470,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string_decoder"
+        }
       ]
     },
     {
@@ -19695,6 +25495,12 @@
           "url": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string-width"
         }
       ]
     },
@@ -19716,6 +25522,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string.fromcodepoint"
+        }
       ]
     },
     {
@@ -19735,6 +25547,12 @@
           "url": "https://registry.npmjs.org/string.prototype.codepointat/-/string.prototype.codepointat-0.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string.prototype.codepointat"
         }
       ]
     },
@@ -19756,6 +25574,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string.prototype.trimend"
+        }
       ]
     },
     {
@@ -19775,6 +25599,12 @@
           "url": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string.prototype.trimstart"
         }
       ]
     },
@@ -19796,6 +25626,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-ansi"
+        }
       ]
     },
     {
@@ -19815,6 +25651,12 @@
           "url": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-bom"
         }
       ]
     },
@@ -19836,6 +25678,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-dirs"
+        }
       ]
     },
     {
@@ -19855,6 +25703,12 @@
           "url": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-json-comments"
         }
       ]
     },
@@ -19876,6 +25730,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-outer"
+        }
       ]
     },
     {
@@ -19895,6 +25755,12 @@
           "url": "https://registry.npmjs.org/strtok3/-/strtok3-6.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strtok3"
         }
       ]
     },
@@ -19916,6 +25782,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/supports-color"
+        }
       ]
     },
     {
@@ -19935,6 +25807,12 @@
           "url": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/supports-preserve-symlinks-flag"
         }
       ]
     },
@@ -19956,6 +25834,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/svg-captcha"
+        }
       ]
     },
     {
@@ -19976,6 +25860,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/swagger-ui-dist"
+        }
       ]
     },
     {
@@ -19995,6 +25885,12 @@
           "url": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-4.5.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/swagger-ui-express"
         }
       ]
     },
@@ -20017,6 +25913,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tar-fs"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -20035,6 +25937,12 @@
               "url": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/tar-fs/node_modules/bl"
             }
           ]
         },
@@ -20056,6 +25964,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/tar-fs/node_modules/chownr"
+            }
           ]
         },
         {
@@ -20076,6 +25990,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/tar-fs/node_modules/readable-stream"
+            }
           ]
         },
         {
@@ -20095,6 +26015,12 @@
               "url": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/tar-fs/node_modules/tar-stream"
             }
           ]
         }
@@ -20118,6 +26044,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tar-stream"
+        }
       ]
     },
     {
@@ -20137,6 +26069,12 @@
           "url": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tar"
         }
       ]
     },
@@ -20158,6 +26096,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tdigest"
+        }
       ]
     },
     {
@@ -20177,6 +26121,12 @@
           "url": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/text-hex"
         }
       ]
     },
@@ -20198,6 +26148,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/thirty-two"
+        }
       ]
     },
     {
@@ -20217,6 +26173,12 @@
           "url": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/through"
         }
       ]
     },
@@ -20238,6 +26200,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/timed-out"
+        }
       ]
     },
     {
@@ -20257,6 +26225,12 @@
           "url": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tiny-inflate"
         }
       ]
     },
@@ -20278,6 +26252,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-buffer"
+        }
       ]
     },
     {
@@ -20297,6 +26277,12 @@
           "url": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-fast-properties"
         }
       ]
     },
@@ -20319,6 +26305,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-object-path"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -20337,6 +26329,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/to-object-path/node_modules/kind-of"
             }
           ]
         }
@@ -20360,6 +26358,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-regex-range"
+        }
       ]
     },
     {
@@ -20379,6 +26383,12 @@
           "url": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-regex"
         }
       ]
     },
@@ -20400,6 +26410,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/toidentifier"
+        }
       ]
     },
     {
@@ -20419,6 +26435,12 @@
           "url": "https://registry.npmjs.org/token-stream/-/token-stream-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/token-stream"
         }
       ]
     },
@@ -20440,6 +26462,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/token-types"
+        }
       ]
     },
     {
@@ -20459,6 +26487,12 @@
           "url": "https://registry.npmjs.org/toposort-class/-/toposort-class-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/toposort-class"
         }
       ]
     },
@@ -20480,6 +26514,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tough-cookie"
+        }
       ]
     },
     {
@@ -20499,6 +26539,12 @@
           "url": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tr46"
         }
       ]
     },
@@ -20520,6 +26566,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/traverse"
+        }
       ]
     },
     {
@@ -20539,6 +26591,12 @@
           "url": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tree-kill"
         }
       ]
     },
@@ -20560,6 +26618,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/trim-repeated"
+        }
       ]
     },
     {
@@ -20580,6 +26644,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/triple-beam"
+        }
       ]
     },
     {
@@ -20599,6 +26669,12 @@
           "url": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/truncate-utf8-bytes"
         }
       ]
     },
@@ -20621,6 +26697,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ts-node-dev"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -20639,6 +26721,12 @@
               "url": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/ts-node-dev/node_modules/rimraf"
             }
           ]
         }
@@ -20662,6 +26750,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ts-node"
+        }
       ]
     },
     {
@@ -20681,6 +26775,12 @@
           "url": "https://registry.npmjs.org/tsconfig/-/tsconfig-7.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tsconfig"
         }
       ]
     },
@@ -20702,6 +26802,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tslib"
+        }
       ]
     },
     {
@@ -20721,6 +26827,12 @@
           "url": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tunnel-agent"
         }
       ]
     },
@@ -20742,6 +26854,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tweetnacl"
+        }
       ]
     },
     {
@@ -20761,6 +26879,12 @@
           "url": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/type-check"
         }
       ]
     },
@@ -20782,6 +26906,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/type-is"
+        }
       ]
     },
     {
@@ -20801,6 +26931,12 @@
           "url": "https://registry.npmjs.org/typecast/-/typecast-0.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/typecast"
         }
       ]
     },
@@ -20822,6 +26958,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/typedarray"
+        }
       ]
     },
     {
@@ -20841,6 +26983,12 @@
           "url": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/typescript"
         }
       ]
     },
@@ -20862,6 +27010,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/uglify-js"
+        }
       ]
     },
     {
@@ -20881,6 +27035,12 @@
           "url": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unbox-primitive"
         }
       ]
     },
@@ -20902,6 +27062,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unbzip2-stream"
+        }
       ]
     },
     {
@@ -20921,6 +27087,12 @@
           "url": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unc-path-regex"
         }
       ]
     },
@@ -20942,6 +27114,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/underscore.string"
+        }
       ]
     },
     {
@@ -20962,6 +27140,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unicode-properties"
+        }
       ]
     },
     {
@@ -20981,6 +27165,12 @@
           "url": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unicode-trie"
         }
       ]
     },
@@ -21003,6 +27193,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/union-value"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21021,6 +27217,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/union-value/node_modules/is-extendable"
             }
           ]
         }
@@ -21044,6 +27246,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unique-filename"
+        }
       ]
     },
     {
@@ -21063,6 +27271,12 @@
           "url": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unique-slug"
         }
       ]
     },
@@ -21084,6 +27298,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unit-compare"
+        }
       ]
     },
     {
@@ -21104,6 +27324,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/universalify"
+        }
       ]
     },
     {
@@ -21123,6 +27349,12 @@
           "url": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unpipe"
         }
       ]
     },
@@ -21145,6 +27377,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unset-value"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21165,6 +27403,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/unset-value/node_modules/has-value"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -21183,6 +27427,12 @@
                   "url": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/unset-value/node_modules/has-value/node_modules/isobject"
                 }
               ]
             }
@@ -21206,6 +27456,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/unset-value/node_modules/has-values"
+            }
           ]
         },
         {
@@ -21225,6 +27481,12 @@
               "url": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/unset-value/node_modules/isarray"
             }
           ]
         }
@@ -21248,6 +27510,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/untildify"
+        }
       ]
     },
     {
@@ -21269,6 +27537,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unzipper"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21287,6 +27561,12 @@
               "url": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/unzipper/node_modules/bluebird"
             }
           ]
         }
@@ -21310,6 +27590,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/uri-js"
+        }
       ]
     },
     {
@@ -21329,6 +27615,12 @@
           "url": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/urix"
         }
       ]
     },
@@ -21350,6 +27642,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/url-parse-lax"
+        }
       ]
     },
     {
@@ -21369,6 +27667,12 @@
           "url": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/url-to-options"
         }
       ]
     },
@@ -21390,6 +27694,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/use"
+        }
       ]
     },
     {
@@ -21409,6 +27719,12 @@
           "url": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/utf8-byte-length"
         }
       ]
     },
@@ -21430,6 +27746,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/util-deprecate"
+        }
       ]
     },
     {
@@ -21449,6 +27771,12 @@
           "url": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/util"
         }
       ]
     },
@@ -21470,6 +27798,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/utils-merge"
+        }
       ]
     },
     {
@@ -21489,6 +27823,12 @@
           "url": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/uuid"
         }
       ]
     },
@@ -21510,6 +27850,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/v8flags"
+        }
       ]
     },
     {
@@ -21529,6 +27875,12 @@
           "url": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/validate-npm-package-license"
         }
       ]
     },
@@ -21550,6 +27902,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/validate"
+        }
       ]
     },
     {
@@ -21570,6 +27928,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/validator"
+        }
       ]
     },
     {
@@ -21589,6 +27953,12 @@
           "url": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/vary"
         }
       ]
     },
@@ -21611,6 +27981,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/verror"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21629,6 +28005,12 @@
               "url": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/verror/node_modules/core-util-is"
             }
           ]
         }
@@ -21653,6 +28035,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/vm2"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21671,6 +28059,12 @@
               "url": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/vm2/node_modules/acorn"
             }
           ]
         }
@@ -21694,6 +28088,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/void-elements"
+        }
       ]
     },
     {
@@ -21713,6 +28113,12 @@
           "url": "https://registry.npmjs.org/walk/-/walk-2.3.15.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/walk"
         }
       ]
     },
@@ -21734,6 +28140,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/walkdir"
+        }
       ]
     },
     {
@@ -21753,6 +28165,12 @@
           "url": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/webidl-conversions"
         }
       ]
     },
@@ -21774,6 +28192,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/whatwg-url"
+        }
       ]
     },
     {
@@ -21793,6 +28217,12 @@
           "url": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-boxed-primitive"
         }
       ]
     },
@@ -21814,6 +28244,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-collection"
+        }
       ]
     },
     {
@@ -21833,6 +28269,12 @@
           "url": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-module"
         }
       ]
     },
@@ -21854,6 +28296,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-pm-runs"
+        }
       ]
     },
     {
@@ -21873,6 +28321,12 @@
           "url": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-typed-array"
         }
       ]
     },
@@ -21894,6 +28348,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which"
+        }
       ]
     },
     {
@@ -21913,6 +28373,12 @@
           "url": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wide-align"
         }
       ]
     },
@@ -21935,6 +28401,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/winston-transport"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21953,6 +28425,12 @@
               "url": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/winston-transport/node_modules/readable-stream"
             }
           ]
         }
@@ -21977,6 +28455,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/winston"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21995,6 +28479,12 @@
               "url": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/winston/node_modules/async"
             }
           ]
         },
@@ -22016,6 +28506,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/winston/node_modules/is-stream"
+            }
           ]
         },
         {
@@ -22035,6 +28531,12 @@
               "url": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/winston/node_modules/readable-stream"
             }
           ]
         }
@@ -22058,6 +28560,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/with"
+        }
       ]
     },
     {
@@ -22077,6 +28585,12 @@
           "url": "https://registry.npmjs.org/wkx/-/wkx-0.5.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wkx"
         }
       ]
     },
@@ -22098,6 +28612,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/word-wrap"
+        }
       ]
     },
     {
@@ -22117,6 +28637,12 @@
           "url": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wordwrap"
         }
       ]
     },
@@ -22139,6 +28665,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wrap-ansi"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -22157,6 +28689,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi/node_modules/ansi-regex"
             }
           ]
         },
@@ -22178,6 +28716,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi/node_modules/emoji-regex"
+            }
           ]
         },
         {
@@ -22197,6 +28741,12 @@
               "url": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi/node_modules/is-fullwidth-code-point"
             }
           ]
         },
@@ -22218,6 +28768,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi/node_modules/string-width"
+            }
           ]
         },
         {
@@ -22237,6 +28793,12 @@
               "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi/node_modules/strip-ansi"
             }
           ]
         }
@@ -22260,6 +28822,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wrappy"
+        }
       ]
     },
     {
@@ -22279,6 +28847,12 @@
           "url": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ws"
         }
       ]
     },
@@ -22300,6 +28874,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/xtend"
+        }
       ]
     },
     {
@@ -22319,6 +28899,12 @@
           "url": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/y18n"
         }
       ]
     },
@@ -22340,6 +28926,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yallist"
+        }
       ]
     },
     {
@@ -22360,6 +28952,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yaml-schema-validator"
+        }
       ]
     },
     {
@@ -22379,6 +28977,12 @@
           "url": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yargs-parser"
         }
       ]
     },
@@ -22401,6 +29005,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yargs"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -22419,6 +29029,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs/node_modules/ansi-regex"
             }
           ]
         },
@@ -22440,6 +29056,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs/node_modules/emoji-regex"
+            }
           ]
         },
         {
@@ -22459,6 +29081,12 @@
               "url": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs/node_modules/is-fullwidth-code-point"
             }
           ]
         },
@@ -22480,6 +29108,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs/node_modules/string-width"
+            }
           ]
         },
         {
@@ -22499,6 +29133,12 @@
               "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs/node_modules/strip-ansi"
             }
           ]
         }
@@ -22522,6 +29162,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yauzl"
+        }
       ]
     },
     {
@@ -22541,6 +29187,12 @@
           "url": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yn"
         }
       ]
     },
@@ -22562,6 +29214,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/z85"
+        }
       ]
     },
     {
@@ -22582,6 +29240,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/zip-stream"
+        }
       ]
     },
     {
@@ -22601,6 +29265,12 @@
           "url": "https://registry.npmjs.org/zlibjs/-/zlibjs-0.3.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/zlibjs"
         }
       ]
     }

--- a/tests/_data/sbom_demo-results/juice-shop_npm7_node18_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/juice-shop_npm7_node18_ubuntu-latest.snap.json
@@ -62,7 +62,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -95,7 +95,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@babel/helper-string-parser"
         }
       ]
@@ -122,7 +122,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@babel/helper-validator-identifier"
         }
       ]
@@ -149,7 +149,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@babel/parser"
         }
       ]
@@ -176,7 +176,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@babel/types"
         }
       ]
@@ -203,7 +203,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@colors/colors"
         }
       ]
@@ -230,7 +230,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@dabh/diagnostics"
         }
       ]
@@ -257,7 +257,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@gar/promisify"
         }
       ]
@@ -284,7 +284,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@mapbox/node-pre-gyp"
         }
       ],
@@ -310,7 +310,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/ansi-regex"
             }
           ]
@@ -336,7 +336,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/are-we-there-yet"
             }
           ]
@@ -362,7 +362,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/detect-libc"
             }
           ]
@@ -388,7 +388,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/gauge"
             }
           ]
@@ -414,7 +414,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -440,7 +440,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/make-dir"
             }
           ],
@@ -466,7 +466,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/@mapbox/node-pre-gyp/node_modules/make-dir/node_modules/semver"
                 }
               ]
@@ -494,7 +494,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/nopt"
             }
           ]
@@ -520,7 +520,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/npmlog"
             }
           ]
@@ -546,7 +546,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/readable-stream"
             }
           ]
@@ -572,7 +572,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/string-width"
             }
           ]
@@ -598,7 +598,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/strip-ansi"
             }
           ]
@@ -627,7 +627,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/core-loader"
         }
       ]
@@ -654,7 +654,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/core"
         }
       ]
@@ -681,7 +681,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/evaluator"
         }
       ]
@@ -708,7 +708,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-all"
         }
       ]
@@ -735,7 +735,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ar"
         }
       ]
@@ -762,7 +762,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-bn"
         }
       ]
@@ -789,7 +789,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ca"
         }
       ]
@@ -816,7 +816,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-cs"
         }
       ]
@@ -843,7 +843,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-da"
         }
       ]
@@ -870,7 +870,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-de"
         }
       ]
@@ -897,7 +897,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-el"
         }
       ]
@@ -924,7 +924,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-en-min"
         }
       ]
@@ -951,7 +951,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-en"
         }
       ]
@@ -978,7 +978,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-es"
         }
       ]
@@ -1005,7 +1005,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-eu"
         }
       ]
@@ -1032,7 +1032,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-fa"
         }
       ]
@@ -1059,7 +1059,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-fi"
         }
       ]
@@ -1086,7 +1086,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-fr"
         }
       ]
@@ -1113,7 +1113,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ga"
         }
       ]
@@ -1140,7 +1140,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-gl"
         }
       ]
@@ -1167,7 +1167,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-hi"
         }
       ]
@@ -1194,7 +1194,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-hu"
         }
       ]
@@ -1221,7 +1221,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-hy"
         }
       ]
@@ -1248,7 +1248,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-id"
         }
       ]
@@ -1275,7 +1275,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-it"
         }
       ]
@@ -1302,7 +1302,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ja"
         }
       ]
@@ -1329,7 +1329,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ko"
         }
       ]
@@ -1356,7 +1356,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-lt"
         }
       ]
@@ -1383,7 +1383,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ms"
         }
       ]
@@ -1410,7 +1410,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ne"
         }
       ]
@@ -1437,7 +1437,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-nl"
         }
       ]
@@ -1464,7 +1464,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-no"
         }
       ]
@@ -1491,7 +1491,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-pl"
         }
       ]
@@ -1518,7 +1518,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-pt"
         }
       ]
@@ -1545,7 +1545,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ro"
         }
       ]
@@ -1572,7 +1572,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ru"
         }
       ]
@@ -1599,7 +1599,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-sl"
         }
       ]
@@ -1626,7 +1626,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-sr"
         }
       ]
@@ -1653,7 +1653,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-sv"
         }
       ]
@@ -1680,7 +1680,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ta"
         }
       ]
@@ -1707,7 +1707,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-th"
         }
       ]
@@ -1734,7 +1734,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-tl"
         }
       ]
@@ -1761,7 +1761,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-tr"
         }
       ]
@@ -1788,7 +1788,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-uk"
         }
       ]
@@ -1815,7 +1815,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-zh"
         }
       ]
@@ -1842,7 +1842,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/language-min"
         }
       ]
@@ -1869,7 +1869,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/language"
         }
       ]
@@ -1896,7 +1896,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/ner"
         }
       ]
@@ -1923,7 +1923,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/neural"
         }
       ]
@@ -1950,7 +1950,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/nlg"
         }
       ]
@@ -1977,7 +1977,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/nlp"
         }
       ]
@@ -2004,7 +2004,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/nlu"
         }
       ]
@@ -2031,7 +2031,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/request"
         }
       ]
@@ -2058,7 +2058,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/sentiment"
         }
       ]
@@ -2085,7 +2085,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/similarity"
         }
       ]
@@ -2112,7 +2112,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/slot"
         }
       ]
@@ -2139,7 +2139,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@npmcli/fs"
         }
       ]
@@ -2166,7 +2166,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@npmcli/move-file"
         }
       ]
@@ -2193,7 +2193,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib/core"
         }
       ]
@@ -2220,7 +2220,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib/plugin-crypto"
         }
       ]
@@ -2247,7 +2247,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib/plugin-thirty-two"
         }
       ]
@@ -2274,7 +2274,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib/preset-default"
         }
       ]
@@ -2301,7 +2301,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib/preset-v11"
         }
       ]
@@ -2328,7 +2328,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@sindresorhus/is"
         }
       ]
@@ -2355,7 +2355,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@swc/helpers"
         }
       ]
@@ -2382,7 +2382,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@tokenizer/token"
         }
       ]
@@ -2409,7 +2409,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@tootallnate/once"
         }
       ]
@@ -2436,7 +2436,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/component-emitter"
         }
       ]
@@ -2463,7 +2463,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/cookie"
         }
       ]
@@ -2490,7 +2490,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/cors"
         }
       ]
@@ -2517,7 +2517,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/debug"
         }
       ]
@@ -2544,7 +2544,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/ms"
         }
       ]
@@ -2571,7 +2571,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/node"
         }
       ]
@@ -2598,7 +2598,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/strip-bom"
         }
       ]
@@ -2625,7 +2625,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/strip-json-comments"
         }
       ]
@@ -2652,7 +2652,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/validator"
         }
       ]
@@ -2678,7 +2678,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/abbrev"
         }
       ]
@@ -2704,7 +2704,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/accepts"
         }
       ]
@@ -2730,7 +2730,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/acorn-walk"
         }
       ]
@@ -2756,7 +2756,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/acorn"
         }
       ]
@@ -2782,7 +2782,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/agent-base"
         }
       ],
@@ -2808,7 +2808,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agent-base/node_modules/debug"
             }
           ]
@@ -2834,7 +2834,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agent-base/node_modules/ms"
             }
           ]
@@ -2862,7 +2862,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/agentkeepalive"
         }
       ],
@@ -2888,7 +2888,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agentkeepalive/node_modules/debug"
             }
           ]
@@ -2914,7 +2914,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agentkeepalive/node_modules/depd"
             }
           ]
@@ -2940,7 +2940,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agentkeepalive/node_modules/ms"
             }
           ]
@@ -2968,7 +2968,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/aggregate-error"
         }
       ]
@@ -2994,7 +2994,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ajv"
         }
       ]
@@ -3020,7 +3020,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ansi-regex"
         }
       ]
@@ -3046,7 +3046,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ansi-styles"
         }
       ]
@@ -3072,7 +3072,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/anymatch"
         }
       ],
@@ -3098,7 +3098,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/anymatch/node_modules/normalize-path"
             }
           ]
@@ -3126,7 +3126,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/append-field"
         }
       ]
@@ -3152,7 +3152,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/aproba"
         }
       ]
@@ -3178,7 +3178,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/archive-type"
         }
       ],
@@ -3204,7 +3204,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/archive-type/node_modules/file-type"
             }
           ]
@@ -3232,7 +3232,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/archiver-utils"
         }
       ]
@@ -3258,7 +3258,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/archiver"
         }
       ]
@@ -3284,7 +3284,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/are-we-there-yet"
         }
       ]
@@ -3310,7 +3310,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/arg"
         }
       ]
@@ -3336,7 +3336,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/argparse"
         }
       ],
@@ -3362,7 +3362,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/argparse/node_modules/sprintf-js"
             }
           ]
@@ -3390,7 +3390,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/arr-diff"
         }
       ]
@@ -3416,7 +3416,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/arr-flatten"
         }
       ]
@@ -3442,7 +3442,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/arr-union"
         }
       ]
@@ -3468,7 +3468,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/array-each"
         }
       ]
@@ -3494,7 +3494,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/array-flatten"
         }
       ]
@@ -3520,7 +3520,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/array-slice"
         }
       ]
@@ -3546,7 +3546,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/array-unique"
         }
       ]
@@ -3572,7 +3572,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/asap"
         }
       ]
@@ -3598,7 +3598,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/asn1"
         }
       ]
@@ -3624,7 +3624,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/assert-never"
         }
       ]
@@ -3650,7 +3650,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/assert-plus"
         }
       ]
@@ -3676,7 +3676,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/assign-symbols"
         }
       ]
@@ -3702,7 +3702,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/async"
         }
       ]
@@ -3728,7 +3728,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/asynckit"
         }
       ]
@@ -3754,7 +3754,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/at-least-node"
         }
       ]
@@ -3780,7 +3780,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/atob"
         }
       ]
@@ -3806,7 +3806,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/available-typed-arrays"
         }
       ]
@@ -3832,7 +3832,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/aws-sign2"
         }
       ]
@@ -3858,7 +3858,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/aws4"
         }
       ]
@@ -3884,7 +3884,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/babel-walk"
         }
       ]
@@ -3910,7 +3910,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/balanced-match"
         }
       ]
@@ -3936,7 +3936,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base"
         }
       ],
@@ -3962,7 +3962,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/base/node_modules/define-property"
             }
           ]
@@ -3990,7 +3990,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base64-arraybuffer"
         }
       ]
@@ -4016,7 +4016,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base64-js"
         }
       ]
@@ -4042,7 +4042,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base64id"
         }
       ]
@@ -4068,7 +4068,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base64url"
         }
       ]
@@ -4094,7 +4094,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/basic-auth"
         }
       ]
@@ -4120,7 +4120,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/batch"
         }
       ]
@@ -4146,7 +4146,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bcrypt-pbkdf"
         }
       ]
@@ -4172,7 +4172,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/big-integer"
         }
       ]
@@ -4198,7 +4198,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/binary-extensions"
         }
       ]
@@ -4224,7 +4224,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/binary"
         }
       ]
@@ -4250,7 +4250,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bindings"
         }
       ]
@@ -4276,7 +4276,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bintrees"
         }
       ]
@@ -4302,7 +4302,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bl"
         }
       ]
@@ -4328,7 +4328,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bluebird"
         }
       ]
@@ -4354,7 +4354,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/body-parser"
         }
       ]
@@ -4380,7 +4380,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bower-config"
         }
       ],
@@ -4406,7 +4406,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bower-config/node_modules/minimist"
             }
           ]
@@ -4434,7 +4434,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/brace-expansion"
         }
       ]
@@ -4460,7 +4460,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/braces"
         }
       ],
@@ -4486,7 +4486,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/braces/node_modules/extend-shallow"
             }
           ]
@@ -4512,7 +4512,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/braces/node_modules/is-extendable"
             }
           ]
@@ -4540,7 +4540,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/brotli"
         }
       ]
@@ -4566,7 +4566,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-alloc-unsafe"
         }
       ]
@@ -4592,7 +4592,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-alloc"
         }
       ]
@@ -4618,7 +4618,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-crc32"
         }
       ]
@@ -4644,7 +4644,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-fill"
         }
       ]
@@ -4670,7 +4670,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-from"
         }
       ]
@@ -4696,7 +4696,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-indexof-polyfill"
         }
       ]
@@ -4722,7 +4722,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer"
         }
       ]
@@ -4748,7 +4748,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffers"
         }
       ]
@@ -4774,7 +4774,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/busboy"
         }
       ],
@@ -4800,7 +4800,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/busboy/node_modules/isarray"
             }
           ]
@@ -4826,7 +4826,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/busboy/node_modules/readable-stream"
             }
           ]
@@ -4852,7 +4852,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/busboy/node_modules/string_decoder"
             }
           ]
@@ -4880,7 +4880,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/byline"
         }
       ]
@@ -4906,7 +4906,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bytes"
         }
       ]
@@ -4932,7 +4932,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cacache"
         }
       ]
@@ -4958,7 +4958,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cache-base"
         }
       ]
@@ -4984,7 +4984,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cacheable-request"
         }
       ],
@@ -5010,7 +5010,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cacheable-request/node_modules/get-stream"
             }
           ]
@@ -5036,7 +5036,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cacheable-request/node_modules/lowercase-keys"
             }
           ]
@@ -5064,7 +5064,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/call-bind"
         }
       ]
@@ -5090,7 +5090,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/camelcase"
         }
       ]
@@ -5116,7 +5116,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/caseless"
         }
       ]
@@ -5142,7 +5142,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/chainsaw"
         }
       ]
@@ -5168,7 +5168,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/chalk"
         }
       ]
@@ -5194,7 +5194,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/character-parser"
         }
       ]
@@ -5220,7 +5220,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/check-dependencies"
         }
       ],
@@ -5246,7 +5246,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/check-dependencies/node_modules/semver"
             }
           ]
@@ -5274,7 +5274,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/check-types"
         }
       ]
@@ -5300,7 +5300,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/chokidar"
         }
       ],
@@ -5326,7 +5326,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar/node_modules/braces"
             }
           ]
@@ -5352,7 +5352,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar/node_modules/fill-range"
             }
           ]
@@ -5378,7 +5378,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar/node_modules/is-glob"
             }
           ]
@@ -5404,7 +5404,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar/node_modules/is-number"
             }
           ]
@@ -5430,7 +5430,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar/node_modules/normalize-path"
             }
           ]
@@ -5456,7 +5456,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar/node_modules/to-regex-range"
             }
           ]
@@ -5484,7 +5484,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/chownr"
         }
       ]
@@ -5510,7 +5510,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/clarinet"
         }
       ]
@@ -5536,7 +5536,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/class-utils"
         }
       ],
@@ -5562,7 +5562,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils/node_modules/define-property"
             }
           ]
@@ -5588,7 +5588,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils/node_modules/is-accessor-descriptor"
             }
           ],
@@ -5614,7 +5614,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/class-utils/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
@@ -5642,7 +5642,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils/node_modules/is-data-descriptor"
             }
           ],
@@ -5668,7 +5668,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/class-utils/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
@@ -5696,7 +5696,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils/node_modules/is-descriptor"
             }
           ]
@@ -5722,7 +5722,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils/node_modules/kind-of"
             }
           ]
@@ -5750,7 +5750,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/clean-stack"
         }
       ]
@@ -5776,7 +5776,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cliui"
         }
       ],
@@ -5802,7 +5802,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui/node_modules/ansi-regex"
             }
           ]
@@ -5828,7 +5828,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui/node_modules/emoji-regex"
             }
           ]
@@ -5854,7 +5854,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -5880,7 +5880,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui/node_modules/string-width"
             }
           ]
@@ -5906,7 +5906,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui/node_modules/strip-ansi"
             }
           ]
@@ -5934,7 +5934,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/clone-response"
         }
       ]
@@ -5960,7 +5960,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/clone"
         }
       ]
@@ -5986,7 +5986,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/code-point-at"
         }
       ]
@@ -6012,7 +6012,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/collection-visit"
         }
       ]
@@ -6038,7 +6038,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color-convert"
         }
       ]
@@ -6064,7 +6064,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color-name"
         }
       ]
@@ -6090,7 +6090,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color-string"
         }
       ]
@@ -6116,7 +6116,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color-support"
         }
       ]
@@ -6142,7 +6142,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color"
         }
       ]
@@ -6168,7 +6168,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/colors"
         }
       ]
@@ -6194,7 +6194,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/colorspace"
         }
       ]
@@ -6220,7 +6220,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/combined-stream"
         }
       ]
@@ -6246,7 +6246,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/commander"
         }
       ]
@@ -6272,7 +6272,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/component-emitter"
         }
       ]
@@ -6298,7 +6298,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/component-type"
         }
       ]
@@ -6324,7 +6324,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/compress-commons"
         }
       ]
@@ -6350,7 +6350,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/compressible"
         }
       ]
@@ -6376,7 +6376,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/compression"
         }
       ],
@@ -6402,7 +6402,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/compression/node_modules/bytes"
             }
           ]
@@ -6430,7 +6430,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/concat-map"
         }
       ]
@@ -6456,7 +6456,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/concat-stream"
         }
       ]
@@ -6482,7 +6482,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/concurrently"
         }
       ],
@@ -6508,7 +6508,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/concurrently/node_modules/supports-color"
             }
           ]
@@ -6536,7 +6536,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/config"
         }
       ]
@@ -6562,7 +6562,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/console-control-strings"
         }
       ]
@@ -6588,7 +6588,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/constantinople"
         }
       ]
@@ -6614,7 +6614,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/content-disposition"
         }
       ],
@@ -6640,7 +6640,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/content-disposition/node_modules/safe-buffer"
             }
           ]
@@ -6668,7 +6668,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/content-type"
         }
       ]
@@ -6694,7 +6694,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cookie-parser"
         }
       ]
@@ -6720,7 +6720,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cookie-signature"
         }
       ]
@@ -6746,7 +6746,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cookie"
         }
       ]
@@ -6772,7 +6772,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/copy-descriptor"
         }
       ]
@@ -6798,7 +6798,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/core-util-is"
         }
       ]
@@ -6824,7 +6824,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cors"
         }
       ]
@@ -6850,7 +6850,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/crc"
         }
       ]
@@ -6876,7 +6876,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/crc32-stream"
         }
       ]
@@ -6902,7 +6902,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/create-require"
         }
       ]
@@ -6928,7 +6928,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/crypto-js"
         }
       ]
@@ -6954,7 +6954,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dashdash"
         }
       ]
@@ -6980,7 +6980,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/date-fns"
         }
       ]
@@ -7006,7 +7006,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dateformat"
         }
       ]
@@ -7032,7 +7032,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/debug"
         }
       ]
@@ -7058,7 +7058,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decamelize"
         }
       ]
@@ -7084,7 +7084,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decode-uri-component"
         }
       ]
@@ -7110,7 +7110,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-response"
         }
       ]
@@ -7136,7 +7136,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-tar"
         }
       ],
@@ -7162,7 +7162,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-tar/node_modules/file-type"
             }
           ]
@@ -7190,7 +7190,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-tarbz2"
         }
       ],
@@ -7216,7 +7216,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-tarbz2/node_modules/file-type"
             }
           ]
@@ -7244,7 +7244,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-targz"
         }
       ],
@@ -7270,7 +7270,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-targz/node_modules/file-type"
             }
           ]
@@ -7298,7 +7298,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-unzip"
         }
       ],
@@ -7324,7 +7324,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-unzip/node_modules/file-type"
             }
           ]
@@ -7350,7 +7350,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-unzip/node_modules/get-stream"
             }
           ]
@@ -7376,7 +7376,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-unzip/node_modules/pify"
             }
           ]
@@ -7404,7 +7404,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress"
         }
       ],
@@ -7430,7 +7430,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress/node_modules/make-dir"
             }
           ],
@@ -7456,7 +7456,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/decompress/node_modules/make-dir/node_modules/pify"
                 }
               ]
@@ -7484,7 +7484,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress/node_modules/pify"
             }
           ]
@@ -7512,7 +7512,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/deep-equal"
         }
       ]
@@ -7538,7 +7538,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/deep-extend"
         }
       ]
@@ -7564,7 +7564,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/deep-is"
         }
       ]
@@ -7590,7 +7590,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/define-properties"
         }
       ]
@@ -7616,7 +7616,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/define-property"
         }
       ]
@@ -7642,7 +7642,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/delayed-stream"
         }
       ]
@@ -7668,7 +7668,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/delegates"
         }
       ]
@@ -7694,7 +7694,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/depd"
         }
       ]
@@ -7720,7 +7720,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/destroy"
         }
       ]
@@ -7746,7 +7746,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/detect-file"
         }
       ]
@@ -7772,7 +7772,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/detect-libc"
         }
       ]
@@ -7798,7 +7798,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dfa"
         }
       ]
@@ -7824,7 +7824,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dicer"
         }
       ],
@@ -7850,7 +7850,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/dicer/node_modules/isarray"
             }
           ]
@@ -7876,7 +7876,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/dicer/node_modules/readable-stream"
             }
           ]
@@ -7902,7 +7902,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/dicer/node_modules/string_decoder"
             }
           ]
@@ -7930,7 +7930,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/diff"
         }
       ]
@@ -7956,7 +7956,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/doctypes"
         }
       ]
@@ -7982,7 +7982,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/domelementtype"
         }
       ]
@@ -8008,7 +8008,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/domhandler"
         }
       ]
@@ -8034,7 +8034,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/domutils"
         }
       ]
@@ -8060,7 +8060,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dottie"
         }
       ]
@@ -8086,7 +8086,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/double-ended-queue"
         }
       ]
@@ -8112,7 +8112,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/doublearray"
         }
       ]
@@ -8138,7 +8138,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/download"
         }
       ],
@@ -8164,7 +8164,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/download/node_modules/file-type"
             }
           ]
@@ -8192,7 +8192,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/duplexer2"
         }
       ]
@@ -8218,7 +8218,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/duplexer3"
         }
       ]
@@ -8244,7 +8244,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dynamic-dedupe"
         }
       ]
@@ -8270,7 +8270,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ecc-jsbn"
         }
       ]
@@ -8296,7 +8296,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ee-first"
         }
       ]
@@ -8322,7 +8322,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/eivindfjeldstad-dot"
         }
       ]
@@ -8348,7 +8348,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/emoji-regex"
         }
       ]
@@ -8374,7 +8374,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/enabled"
         }
       ]
@@ -8400,7 +8400,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/encodeurl"
         }
       ]
@@ -8426,7 +8426,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/encoding"
         }
       ],
@@ -8452,7 +8452,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/encoding/node_modules/iconv-lite"
             }
           ]
@@ -8480,7 +8480,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/end-of-stream"
         }
       ]
@@ -8506,7 +8506,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/engine.io-parser"
         }
       ]
@@ -8532,7 +8532,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/engine.io"
         }
       ],
@@ -8558,7 +8558,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/engine.io/node_modules/debug"
             }
           ]
@@ -8584,7 +8584,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/engine.io/node_modules/ms"
             }
           ]
@@ -8612,7 +8612,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/env-paths"
         }
       ]
@@ -8638,7 +8638,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/err-code"
         }
       ]
@@ -8664,7 +8664,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/error-ex"
         }
       ]
@@ -8690,7 +8690,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/errorhandler"
         }
       ]
@@ -8716,7 +8716,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/es-abstract"
         }
       ]
@@ -8742,7 +8742,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/es-get-iterator"
         }
       ]
@@ -8768,7 +8768,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/es-to-primitive"
         }
       ]
@@ -8794,7 +8794,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/escape-html"
         }
       ]
@@ -8820,7 +8820,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/escape-string-regexp"
         }
       ]
@@ -8846,7 +8846,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/escodegen"
         }
       ]
@@ -8872,7 +8872,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/esprima"
         }
       ]
@@ -8898,7 +8898,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/estraverse"
         }
       ]
@@ -8924,7 +8924,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/esutils"
         }
       ]
@@ -8950,7 +8950,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/etag"
         }
       ]
@@ -8976,7 +8976,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/eventemitter2"
         }
       ]
@@ -9002,7 +9002,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/eventemitter3"
         }
       ]
@@ -9028,7 +9028,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/exif"
         }
       ]
@@ -9054,7 +9054,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/exit"
         }
       ]
@@ -9080,7 +9080,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/expand-brackets"
         }
       ],
@@ -9106,7 +9106,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/define-property"
             }
           ]
@@ -9132,7 +9132,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/extend-shallow"
             }
           ]
@@ -9158,7 +9158,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/is-accessor-descriptor"
             }
           ],
@@ -9184,7 +9184,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/expand-brackets/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
@@ -9212,7 +9212,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/is-data-descriptor"
             }
           ],
@@ -9238,7 +9238,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/expand-brackets/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
@@ -9266,7 +9266,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/is-descriptor"
             }
           ]
@@ -9292,7 +9292,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/is-extendable"
             }
           ]
@@ -9318,7 +9318,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/kind-of"
             }
           ]
@@ -9346,7 +9346,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/expand-template"
         }
       ]
@@ -9372,7 +9372,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/expand-tilde"
         }
       ]
@@ -9398,7 +9398,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-ipfilter"
         }
       ]
@@ -9424,7 +9424,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-jwt"
         }
       ],
@@ -9450,7 +9450,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/express-jwt/node_modules/jsonwebtoken"
             }
           ]
@@ -9476,7 +9476,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/express-jwt/node_modules/moment"
             }
           ]
@@ -9504,7 +9504,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-rate-limit"
         }
       ]
@@ -9530,7 +9530,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-robots-txt"
         }
       ]
@@ -9556,7 +9556,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-security.txt"
         }
       ]
@@ -9582,7 +9582,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express"
         }
       ],
@@ -9608,7 +9608,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/express/node_modules/cookie"
             }
           ]
@@ -9634,7 +9634,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/express/node_modules/safe-buffer"
             }
           ]
@@ -9662,7 +9662,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ext-list"
         }
       ]
@@ -9688,7 +9688,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ext-name"
         }
       ]
@@ -9714,7 +9714,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/extend-shallow"
         }
       ]
@@ -9740,7 +9740,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/extend"
         }
       ]
@@ -9766,7 +9766,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/extglob"
         }
       ],
@@ -9792,7 +9792,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/extglob/node_modules/define-property"
             }
           ]
@@ -9818,7 +9818,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/extglob/node_modules/extend-shallow"
             }
           ]
@@ -9844,7 +9844,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/extglob/node_modules/is-extendable"
             }
           ]
@@ -9872,7 +9872,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/extsprintf"
         }
       ]
@@ -9898,7 +9898,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fast-deep-equal"
         }
       ]
@@ -9924,7 +9924,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fast-json-stable-stringify"
         }
       ]
@@ -9950,7 +9950,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fast-levenshtein"
         }
       ]
@@ -9976,7 +9976,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fast.js"
         }
       ]
@@ -10002,7 +10002,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fd-slicer"
         }
       ]
@@ -10028,7 +10028,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/feature-policy"
         }
       ]
@@ -10054,7 +10054,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fecha"
         }
       ]
@@ -10080,7 +10080,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/file-js"
         }
       ],
@@ -10106,7 +10106,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/file-js/node_modules/brace-expansion"
             }
           ]
@@ -10132,7 +10132,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/file-js/node_modules/minimatch"
             }
           ]
@@ -10160,7 +10160,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/file-stream-rotator"
         }
       ]
@@ -10186,7 +10186,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/file-type"
         }
       ]
@@ -10212,7 +10212,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/file-uri-to-path"
         }
       ]
@@ -10238,7 +10238,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/filehound"
         }
       ]
@@ -10264,7 +10264,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/filename-reserved-regex"
         }
       ]
@@ -10290,7 +10290,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/filenamify"
         }
       ]
@@ -10316,7 +10316,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/filesniffer"
         }
       ]
@@ -10342,7 +10342,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fill-range"
         }
       ],
@@ -10368,7 +10368,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/fill-range/node_modules/extend-shallow"
             }
           ]
@@ -10394,7 +10394,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/fill-range/node_modules/is-extendable"
             }
           ]
@@ -10422,7 +10422,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/finale-rest"
         }
       ]
@@ -10448,7 +10448,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/finalhandler"
         }
       ]
@@ -10474,7 +10474,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/find-up"
         }
       ]
@@ -10500,7 +10500,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/findup-sync"
         }
       ]
@@ -10526,7 +10526,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fined"
         }
       ]
@@ -10552,7 +10552,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/flagged-respawn"
         }
       ]
@@ -10578,7 +10578,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fn.name"
         }
       ]
@@ -10604,7 +10604,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fontkit"
         }
       ]
@@ -10630,7 +10630,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/for-each"
         }
       ]
@@ -10656,7 +10656,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/for-in"
         }
       ]
@@ -10682,7 +10682,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/for-own"
         }
       ]
@@ -10708,7 +10708,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/foreachasync"
         }
       ]
@@ -10734,7 +10734,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/forever-agent"
         }
       ]
@@ -10760,7 +10760,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/form-data"
         }
       ]
@@ -10786,7 +10786,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/formatio"
         }
       ]
@@ -10812,7 +10812,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/forwarded"
         }
       ]
@@ -10838,7 +10838,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fragment-cache"
         }
       ]
@@ -10864,7 +10864,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fresh"
         }
       ]
@@ -10890,7 +10890,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/from2"
         }
       ]
@@ -10916,7 +10916,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fs-constants"
         }
       ]
@@ -10942,7 +10942,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fs-extra"
         }
       ]
@@ -10968,7 +10968,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fs-minipass"
         }
       ]
@@ -10994,7 +10994,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fs.realpath"
         }
       ]
@@ -11020,7 +11020,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fstream"
         }
       ],
@@ -11046,7 +11046,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/fstream/node_modules/mkdirp"
             }
           ]
@@ -11072,7 +11072,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/fstream/node_modules/rimraf"
             }
           ]
@@ -11100,7 +11100,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/function-bind"
         }
       ]
@@ -11126,7 +11126,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/function.prototype.name"
         }
       ]
@@ -11152,7 +11152,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/functions-have-names"
         }
       ]
@@ -11178,7 +11178,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fuzzball"
         }
       ]
@@ -11204,7 +11204,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/gauge"
         }
       ]
@@ -11230,7 +11230,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/geojson-utils"
         }
       ]
@@ -11256,7 +11256,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-caller-file"
         }
       ]
@@ -11282,7 +11282,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-intrinsic"
         }
       ]
@@ -11308,7 +11308,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-stream"
         }
       ]
@@ -11334,7 +11334,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-symbol-description"
         }
       ]
@@ -11360,7 +11360,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-value"
         }
       ]
@@ -11386,7 +11386,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/getobject"
         }
       ]
@@ -11412,7 +11412,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/getpass"
         }
       ]
@@ -11438,7 +11438,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/github-from-package"
         }
       ]
@@ -11464,7 +11464,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/glob-parent"
         }
       ],
@@ -11490,7 +11490,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/glob-parent/node_modules/is-glob"
             }
           ]
@@ -11518,7 +11518,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/glob"
         }
       ],
@@ -11544,7 +11544,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/glob/node_modules/brace-expansion"
             }
           ]
@@ -11570,7 +11570,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/glob/node_modules/minimatch"
             }
           ]
@@ -11598,7 +11598,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/global-modules"
         }
       ]
@@ -11624,7 +11624,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/global-prefix"
         }
       ],
@@ -11650,7 +11650,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/global-prefix/node_modules/which"
             }
           ]
@@ -11678,7 +11678,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/got"
         }
       ],
@@ -11704,7 +11704,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/got/node_modules/get-stream"
             }
           ]
@@ -11730,7 +11730,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/got/node_modules/pify"
             }
           ]
@@ -11758,7 +11758,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/graceful-fs"
         }
       ]
@@ -11784,7 +11784,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-cli"
         }
       ],
@@ -11810,7 +11810,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-cli/node_modules/nopt"
             }
           ]
@@ -11838,7 +11838,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-contrib-compress"
         }
       ],
@@ -11864,7 +11864,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-contrib-compress/node_modules/ansi-styles"
             }
           ]
@@ -11890,7 +11890,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-contrib-compress/node_modules/chalk"
             }
           ]
@@ -11916,7 +11916,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-contrib-compress/node_modules/supports-color"
             }
           ]
@@ -11944,7 +11944,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-known-options"
         }
       ]
@@ -11970,7 +11970,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-legacy-log-utils"
         }
       ],
@@ -11996,7 +11996,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils/node_modules/ansi-styles"
             }
           ]
@@ -12022,7 +12022,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils/node_modules/chalk"
             }
           ]
@@ -12048,7 +12048,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils/node_modules/color-convert"
             }
           ]
@@ -12074,7 +12074,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils/node_modules/color-name"
             }
           ]
@@ -12100,7 +12100,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils/node_modules/has-flag"
             }
           ]
@@ -12126,7 +12126,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils/node_modules/supports-color"
             }
           ]
@@ -12154,7 +12154,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-legacy-log"
         }
       ],
@@ -12180,7 +12180,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log/node_modules/colors"
             }
           ]
@@ -12208,7 +12208,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-legacy-util"
         }
       ],
@@ -12234,7 +12234,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-util/node_modules/async"
             }
           ]
@@ -12262,7 +12262,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-replace-json"
         }
       ]
@@ -12288,7 +12288,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt"
         }
       ],
@@ -12314,7 +12314,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt/node_modules/brace-expansion"
             }
           ]
@@ -12340,7 +12340,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt/node_modules/findup-sync"
             }
           ],
@@ -12366,7 +12366,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/grunt/node_modules/findup-sync/node_modules/glob"
                 }
               ]
@@ -12394,7 +12394,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt/node_modules/glob"
             }
           ]
@@ -12420,7 +12420,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt/node_modules/minimatch"
             }
           ]
@@ -12448,7 +12448,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/handlebars"
         }
       ],
@@ -12474,7 +12474,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/handlebars/node_modules/wordwrap"
             }
           ]
@@ -12502,7 +12502,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/har-schema"
         }
       ]
@@ -12528,7 +12528,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/har-validator"
         }
       ]
@@ -12554,7 +12554,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-ansi"
         }
       ]
@@ -12580,7 +12580,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-bigints"
         }
       ]
@@ -12606,7 +12606,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-flag"
         }
       ]
@@ -12632,7 +12632,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-property-descriptors"
         }
       ]
@@ -12658,7 +12658,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-symbol-support-x"
         }
       ]
@@ -12684,7 +12684,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-symbols"
         }
       ]
@@ -12710,7 +12710,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-to-string-tag-x"
         }
       ]
@@ -12736,7 +12736,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-tostringtag"
         }
       ]
@@ -12762,7 +12762,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-unicode"
         }
       ]
@@ -12788,7 +12788,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-value"
         }
       ]
@@ -12814,7 +12814,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-values"
         }
       ],
@@ -12840,7 +12840,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/has-values/node_modules/kind-of"
             }
           ]
@@ -12868,7 +12868,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has"
         }
       ]
@@ -12894,7 +12894,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hashids"
         }
       ]
@@ -12920,7 +12920,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hbs"
         }
       ]
@@ -12946,7 +12946,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/he"
         }
       ]
@@ -12972,7 +12972,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/heap"
         }
       ]
@@ -12998,7 +12998,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/helmet"
         }
       ]
@@ -13024,7 +13024,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hoister"
         }
       ]
@@ -13050,7 +13050,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/homedir-polyfill"
         }
       ]
@@ -13076,7 +13076,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hooker"
         }
       ]
@@ -13102,7 +13102,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hosted-git-info"
         }
       ]
@@ -13128,7 +13128,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/html-entities"
         }
       ]
@@ -13154,7 +13154,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/htmlparser2"
         }
       ],
@@ -13180,7 +13180,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/htmlparser2/node_modules/isarray"
             }
           ]
@@ -13206,7 +13206,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/htmlparser2/node_modules/readable-stream"
             }
           ]
@@ -13232,7 +13232,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/htmlparser2/node_modules/string_decoder"
             }
           ]
@@ -13260,7 +13260,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/http-cache-semantics"
         }
       ]
@@ -13286,7 +13286,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/http-errors"
         }
       ]
@@ -13312,7 +13312,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/http-proxy-agent"
         }
       ],
@@ -13338,7 +13338,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/http-proxy-agent/node_modules/debug"
             }
           ]
@@ -13364,7 +13364,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/http-proxy-agent/node_modules/ms"
             }
           ]
@@ -13392,7 +13392,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/http-signature"
         }
       ]
@@ -13418,7 +13418,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/https-proxy-agent"
         }
       ],
@@ -13444,7 +13444,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/https-proxy-agent/node_modules/debug"
             }
           ]
@@ -13470,7 +13470,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/https-proxy-agent/node_modules/ms"
             }
           ]
@@ -13498,7 +13498,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/humanize-ms"
         }
       ]
@@ -13524,7 +13524,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/i18n"
         }
       ]
@@ -13550,7 +13550,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/iconv-lite"
         }
       ]
@@ -13576,7 +13576,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ieee754"
         }
       ]
@@ -13602,7 +13602,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ignore-walk"
         }
       ],
@@ -13628,7 +13628,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/ignore-walk/node_modules/brace-expansion"
             }
           ]
@@ -13654,7 +13654,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/ignore-walk/node_modules/minimatch"
             }
           ]
@@ -13682,7 +13682,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/iltorb"
         }
       ]
@@ -13708,7 +13708,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/imurmurhash"
         }
       ]
@@ -13734,7 +13734,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/indent-string"
         }
       ]
@@ -13760,7 +13760,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/infer-owner"
         }
       ]
@@ -13786,7 +13786,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/inflection"
         }
       ]
@@ -13812,7 +13812,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/inflight"
         }
       ]
@@ -13838,7 +13838,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/inherits"
         }
       ]
@@ -13864,7 +13864,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ini"
         }
       ]
@@ -13890,7 +13890,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/internal-slot"
         }
       ]
@@ -13916,7 +13916,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/interpret"
         }
       ]
@@ -13942,7 +13942,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/into-stream"
         }
       ]
@@ -13968,7 +13968,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/invariant"
         }
       ]
@@ -13994,7 +13994,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ip"
         }
       ]
@@ -14020,7 +14020,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ip6"
         }
       ]
@@ -14046,7 +14046,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ipaddr.js"
         }
       ]
@@ -14072,7 +14072,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-absolute"
         }
       ]
@@ -14098,7 +14098,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-accessor-descriptor"
         }
       ]
@@ -14124,7 +14124,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-arguments"
         }
       ]
@@ -14150,7 +14150,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-arrayish"
         }
       ]
@@ -14176,7 +14176,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-bigint"
         }
       ]
@@ -14202,7 +14202,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-binary-path"
         }
       ]
@@ -14228,7 +14228,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-boolean-object"
         }
       ]
@@ -14254,7 +14254,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-buffer"
         }
       ]
@@ -14280,7 +14280,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-callable"
         }
       ]
@@ -14306,7 +14306,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-core-module"
         }
       ]
@@ -14332,7 +14332,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-data-descriptor"
         }
       ]
@@ -14358,7 +14358,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-date-object"
         }
       ]
@@ -14384,7 +14384,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-descriptor"
         }
       ]
@@ -14410,7 +14410,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-docker"
         }
       ]
@@ -14436,7 +14436,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-expression"
         }
       ]
@@ -14462,7 +14462,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-extendable"
         }
       ]
@@ -14488,7 +14488,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-extglob"
         }
       ]
@@ -14514,7 +14514,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-fullwidth-code-point"
         }
       ]
@@ -14540,7 +14540,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-generator-function"
         }
       ]
@@ -14566,7 +14566,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-glob"
         }
       ]
@@ -14592,7 +14592,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-heroku"
         }
       ]
@@ -14618,7 +14618,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-lambda"
         }
       ]
@@ -14644,7 +14644,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-map"
         }
       ]
@@ -14670,7 +14670,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-natural-number"
         }
       ]
@@ -14696,7 +14696,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-negative-zero"
         }
       ]
@@ -14722,7 +14722,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-number-like"
         }
       ]
@@ -14748,7 +14748,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-number-object"
         }
       ]
@@ -14774,7 +14774,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-number"
         }
       ],
@@ -14800,7 +14800,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/is-number/node_modules/kind-of"
             }
           ]
@@ -14828,7 +14828,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-object"
         }
       ]
@@ -14854,7 +14854,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-plain-obj"
         }
       ]
@@ -14880,7 +14880,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-plain-object"
         }
       ]
@@ -14906,7 +14906,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-promise"
         }
       ]
@@ -14932,7 +14932,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-regex"
         }
       ]
@@ -14958,7 +14958,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-relative"
         }
       ]
@@ -14984,7 +14984,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-retry-allowed"
         }
       ]
@@ -15010,7 +15010,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-set"
         }
       ]
@@ -15036,7 +15036,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-shared-array-buffer"
         }
       ]
@@ -15062,7 +15062,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-stream"
         }
       ]
@@ -15088,7 +15088,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-string"
         }
       ]
@@ -15114,7 +15114,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-symbol"
         }
       ]
@@ -15140,7 +15140,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-typed-array"
         }
       ]
@@ -15166,7 +15166,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-typedarray"
         }
       ]
@@ -15192,7 +15192,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-unc-path"
         }
       ]
@@ -15218,7 +15218,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-weakmap"
         }
       ]
@@ -15244,7 +15244,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-weakref"
         }
       ]
@@ -15270,7 +15270,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-weakset"
         }
       ]
@@ -15296,7 +15296,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-windows"
         }
       ]
@@ -15322,7 +15322,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isarray"
         }
       ]
@@ -15348,7 +15348,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isexe"
         }
       ]
@@ -15374,7 +15374,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isobject"
         }
       ]
@@ -15400,7 +15400,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isstream"
         }
       ]
@@ -15426,7 +15426,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isurl"
         }
       ]
@@ -15452,7 +15452,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/js-stringify"
         }
       ]
@@ -15478,7 +15478,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/js-tokens"
         }
       ]
@@ -15504,7 +15504,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/js-yaml"
         }
       ]
@@ -15530,7 +15530,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jsbn"
         }
       ]
@@ -15556,7 +15556,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-buffer"
         }
       ]
@@ -15582,7 +15582,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-parse-better-errors"
         }
       ]
@@ -15608,7 +15608,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-schema-traverse"
         }
       ]
@@ -15634,7 +15634,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-schema"
         }
       ]
@@ -15660,7 +15660,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-stringify-safe"
         }
       ]
@@ -15686,7 +15686,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json5"
         }
       ]
@@ -15712,7 +15712,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jsonfile"
         }
       ]
@@ -15738,7 +15738,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jsonwebtoken"
         }
       ]
@@ -15764,7 +15764,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jsprim"
         }
       ]
@@ -15790,7 +15790,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jssha"
         }
       ]
@@ -15816,7 +15816,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jstransformer"
         }
       ]
@@ -15842,7 +15842,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/juicy-chat-bot"
         }
       ]
@@ -15868,7 +15868,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jwa"
         }
       ]
@@ -15894,7 +15894,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jws"
         }
       ]
@@ -15920,7 +15920,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/keyv"
         }
       ]
@@ -15946,7 +15946,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/kind-of"
         }
       ]
@@ -15972,7 +15972,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/kuler"
         }
       ]
@@ -15998,7 +15998,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/kuromoji"
         }
       ]
@@ -16024,7 +16024,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lazystream"
         }
       ]
@@ -16050,7 +16050,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/levn"
         }
       ]
@@ -16076,7 +16076,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/libxmljs2"
         }
       ],
@@ -16102,7 +16102,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/libxmljs2/node_modules/nan"
             }
           ]
@@ -16130,7 +16130,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/liftup"
         }
       ],
@@ -16156,7 +16156,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/braces"
             }
           ]
@@ -16182,7 +16182,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/fill-range"
             }
           ]
@@ -16208,7 +16208,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/findup-sync"
             }
           ]
@@ -16234,7 +16234,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/is-glob"
             }
           ]
@@ -16260,7 +16260,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/is-number"
             }
           ]
@@ -16286,7 +16286,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/micromatch"
             }
           ]
@@ -16312,7 +16312,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/to-regex-range"
             }
           ]
@@ -16340,7 +16340,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/linebreak"
         }
       ],
@@ -16366,7 +16366,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/linebreak/node_modules/base64-js"
             }
           ]
@@ -16394,7 +16394,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/listenercount"
         }
       ]
@@ -16420,7 +16420,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/locate-path"
         }
       ]
@@ -16446,7 +16446,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lodash.camelcase"
         }
       ]
@@ -16472,7 +16472,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lodash.isfinite"
         }
       ]
@@ -16498,7 +16498,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lodash.set"
         }
       ]
@@ -16524,7 +16524,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lodash"
         }
       ]
@@ -16550,7 +16550,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/logform"
         }
       ],
@@ -16576,7 +16576,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/logform/node_modules/ms"
             }
           ]
@@ -16604,7 +16604,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lolex"
         }
       ]
@@ -16630,7 +16630,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/loose-envify"
         }
       ]
@@ -16656,7 +16656,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lowercase-keys"
         }
       ]
@@ -16682,7 +16682,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lru-cache"
         }
       ]
@@ -16708,7 +16708,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-dir"
         }
       ],
@@ -16734,7 +16734,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-dir/node_modules/semver"
             }
           ]
@@ -16762,7 +16762,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-error"
         }
       ]
@@ -16788,7 +16788,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-fetch-happen"
         }
       ],
@@ -16815,7 +16815,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen/node_modules/@tootallnate/once"
             }
           ]
@@ -16841,7 +16841,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen/node_modules/debug"
             }
           ]
@@ -16867,7 +16867,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen/node_modules/http-cache-semantics"
             }
           ]
@@ -16893,7 +16893,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen/node_modules/http-proxy-agent"
             }
           ]
@@ -16919,7 +16919,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen/node_modules/ms"
             }
           ]
@@ -16947,7 +16947,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-iterator"
         }
       ]
@@ -16973,7 +16973,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-plural"
         }
       ]
@@ -16999,7 +16999,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/map-cache"
         }
       ]
@@ -17025,7 +17025,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/map-visit"
         }
       ]
@@ -17051,7 +17051,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/marsdb"
         }
       ]
@@ -17077,7 +17077,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/math-interval-parser"
         }
       ]
@@ -17103,7 +17103,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/media-typer"
         }
       ]
@@ -17129,7 +17129,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/merge-descriptors"
         }
       ]
@@ -17155,7 +17155,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/messageformat-formatters"
         }
       ]
@@ -17181,7 +17181,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/messageformat-parser"
         }
       ]
@@ -17207,7 +17207,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/messageformat"
         }
       ],
@@ -17233,7 +17233,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/messageformat/node_modules/make-plural"
             }
           ]
@@ -17261,7 +17261,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/methods"
         }
       ]
@@ -17287,7 +17287,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/micromatch"
         }
       ]
@@ -17313,7 +17313,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mime-db"
         }
       ]
@@ -17339,7 +17339,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mime-types"
         }
       ]
@@ -17365,7 +17365,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mime"
         }
       ]
@@ -17391,7 +17391,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mimic-response"
         }
       ]
@@ -17417,7 +17417,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minimatch"
         }
       ]
@@ -17443,7 +17443,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minimist"
         }
       ]
@@ -17469,7 +17469,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-collect"
         }
       ]
@@ -17495,7 +17495,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-fetch"
         }
       ]
@@ -17521,7 +17521,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-flush"
         }
       ]
@@ -17547,7 +17547,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-pipeline"
         }
       ]
@@ -17573,7 +17573,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-sized"
         }
       ]
@@ -17599,7 +17599,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass"
         }
       ]
@@ -17625,7 +17625,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minizlib"
         }
       ]
@@ -17651,7 +17651,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mixin-deep"
         }
       ]
@@ -17677,7 +17677,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mkdirp-classic"
         }
       ]
@@ -17703,7 +17703,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mkdirp"
         }
       ]
@@ -17729,7 +17729,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/moment-timezone"
         }
       ]
@@ -17755,7 +17755,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/moment"
         }
       ]
@@ -17781,7 +17781,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/morgan"
         }
       ],
@@ -17807,7 +17807,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/morgan/node_modules/on-finished"
             }
           ]
@@ -17835,7 +17835,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mout"
         }
       ]
@@ -17861,7 +17861,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ms"
         }
       ]
@@ -17887,7 +17887,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/multer"
         }
       ],
@@ -17913,7 +17913,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/multer/node_modules/mkdirp"
             }
           ]
@@ -17941,7 +17941,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mustache"
         }
       ]
@@ -17967,7 +17967,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/nan"
         }
       ]
@@ -17993,7 +17993,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/nanomatch"
         }
       ]
@@ -18019,7 +18019,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/napi-build-utils"
         }
       ]
@@ -18045,7 +18045,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/needle"
         }
       ],
@@ -18071,7 +18071,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/needle/node_modules/debug"
             }
           ]
@@ -18097,7 +18097,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/needle/node_modules/ms"
             }
           ]
@@ -18125,7 +18125,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/negotiator"
         }
       ]
@@ -18151,7 +18151,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/neo-async"
         }
       ]
@@ -18177,7 +18177,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-abi"
         }
       ],
@@ -18203,7 +18203,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-abi/node_modules/semver"
             }
           ]
@@ -18231,7 +18231,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-addon-api"
         }
       ]
@@ -18257,7 +18257,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-fetch"
         }
       ]
@@ -18283,7 +18283,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-gyp"
         }
       ],
@@ -18309,7 +18309,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/ansi-regex"
             }
           ]
@@ -18335,7 +18335,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/are-we-there-yet"
             }
           ]
@@ -18361,7 +18361,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/gauge"
             }
           ]
@@ -18387,7 +18387,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -18413,7 +18413,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/nopt"
             }
           ]
@@ -18439,7 +18439,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/npmlog"
             }
           ]
@@ -18465,7 +18465,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/readable-stream"
             }
           ]
@@ -18491,7 +18491,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/string-width"
             }
           ]
@@ -18517,7 +18517,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/strip-ansi"
             }
           ]
@@ -18545,7 +18545,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-pre-gyp"
         }
       ],
@@ -18571,7 +18571,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/chownr"
             }
           ]
@@ -18597,7 +18597,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/fs-minipass"
             }
           ]
@@ -18623,7 +18623,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/minipass"
             }
           ]
@@ -18649,7 +18649,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/minizlib"
             }
           ]
@@ -18675,7 +18675,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/mkdirp"
             }
           ]
@@ -18701,7 +18701,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/nopt"
             }
           ]
@@ -18727,7 +18727,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/rimraf"
             }
           ]
@@ -18753,7 +18753,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/safe-buffer"
             }
           ]
@@ -18779,7 +18779,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/semver"
             }
           ]
@@ -18805,7 +18805,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/tar"
             }
           ]
@@ -18831,7 +18831,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/yallist"
             }
           ]
@@ -18859,7 +18859,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/noop-logger"
         }
       ]
@@ -18885,7 +18885,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/nopt"
         }
       ]
@@ -18911,7 +18911,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/normalize-package-data"
         }
       ],
@@ -18937,7 +18937,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/normalize-package-data/node_modules/semver"
             }
           ]
@@ -18965,7 +18965,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/normalize-path"
         }
       ]
@@ -18991,7 +18991,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/normalize-url"
         }
       ]
@@ -19017,7 +19017,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/notevil"
         }
       ],
@@ -19043,7 +19043,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/notevil/node_modules/esprima"
             }
           ]
@@ -19071,7 +19071,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/npm-bundled"
         }
       ]
@@ -19097,7 +19097,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/npm-normalize-package-bin"
         }
       ]
@@ -19123,7 +19123,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/npm-packlist"
         }
       ]
@@ -19149,7 +19149,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/npmlog"
         }
       ]
@@ -19175,7 +19175,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/number-is-nan"
         }
       ]
@@ -19201,7 +19201,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/oauth-sign"
         }
       ]
@@ -19227,7 +19227,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-assign"
         }
       ]
@@ -19253,7 +19253,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-copy"
         }
       ],
@@ -19279,7 +19279,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy/node_modules/define-property"
             }
           ]
@@ -19305,7 +19305,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy/node_modules/is-accessor-descriptor"
             }
           ]
@@ -19331,7 +19331,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy/node_modules/is-data-descriptor"
             }
           ]
@@ -19357,7 +19357,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy/node_modules/is-descriptor"
             }
           ],
@@ -19383,7 +19383,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/object-copy/node_modules/is-descriptor/node_modules/kind-of"
                 }
               ]
@@ -19411,7 +19411,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy/node_modules/kind-of"
             }
           ]
@@ -19439,7 +19439,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-inspect"
         }
       ]
@@ -19465,7 +19465,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-is"
         }
       ]
@@ -19491,7 +19491,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-keys"
         }
       ]
@@ -19517,7 +19517,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-visit"
         }
       ]
@@ -19543,7 +19543,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object.assign"
         }
       ]
@@ -19569,7 +19569,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object.defaults"
         }
       ]
@@ -19595,7 +19595,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object.map"
         }
       ]
@@ -19621,7 +19621,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object.pick"
         }
       ]
@@ -19647,7 +19647,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/on-finished"
         }
       ]
@@ -19673,7 +19673,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/on-headers"
         }
       ]
@@ -19699,7 +19699,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/once"
         }
       ]
@@ -19725,7 +19725,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/one-time"
         }
       ]
@@ -19751,7 +19751,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/opentype.js"
         }
       ]
@@ -19777,7 +19777,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/optionator"
         }
       ]
@@ -19803,7 +19803,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/os-homedir"
         }
       ]
@@ -19829,7 +19829,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/os-tmpdir"
         }
       ]
@@ -19855,7 +19855,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/osenv"
         }
       ]
@@ -19881,7 +19881,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/otplib"
         }
       ]
@@ -19907,7 +19907,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-cancelable"
         }
       ]
@@ -19933,7 +19933,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-event"
         }
       ]
@@ -19959,7 +19959,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-finally"
         }
       ]
@@ -19985,7 +19985,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-is-promise"
         }
       ]
@@ -20011,7 +20011,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-limit"
         }
       ]
@@ -20037,7 +20037,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-locate"
         }
       ]
@@ -20063,7 +20063,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-map"
         }
       ]
@@ -20089,7 +20089,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-timeout"
         }
       ]
@@ -20115,7 +20115,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-try"
         }
       ]
@@ -20141,7 +20141,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pako"
         }
       ]
@@ -20167,7 +20167,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/parse-filepath"
         }
       ]
@@ -20193,7 +20193,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/parse-json"
         }
       ]
@@ -20219,7 +20219,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/parse-passwd"
         }
       ]
@@ -20245,7 +20245,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/parseurl"
         }
       ]
@@ -20271,7 +20271,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pascalcase"
         }
       ]
@@ -20297,7 +20297,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-exists"
         }
       ]
@@ -20323,7 +20323,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-is-absolute"
         }
       ]
@@ -20349,7 +20349,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-parse"
         }
       ]
@@ -20375,7 +20375,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-root-regex"
         }
       ]
@@ -20401,7 +20401,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-root"
         }
       ]
@@ -20427,7 +20427,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-to-regexp"
         }
       ]
@@ -20453,7 +20453,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pdfkit"
         }
       ]
@@ -20479,7 +20479,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/peek-readable"
         }
       ]
@@ -20505,7 +20505,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pend"
         }
       ]
@@ -20531,7 +20531,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/performance-now"
         }
       ]
@@ -20557,7 +20557,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pg-connection-string"
         }
       ]
@@ -20583,7 +20583,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/picomatch"
         }
       ]
@@ -20609,7 +20609,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pify"
         }
       ]
@@ -20635,7 +20635,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pinkie-promise"
         }
       ]
@@ -20661,7 +20661,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pinkie"
         }
       ]
@@ -20687,7 +20687,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/png-js"
         }
       ]
@@ -20713,7 +20713,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/portscanner"
         }
       ]
@@ -20739,7 +20739,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/posix-character-classes"
         }
       ]
@@ -20765,7 +20765,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/prebuild-install"
         }
       ]
@@ -20791,7 +20791,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/prelude-ls"
         }
       ]
@@ -20817,7 +20817,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/prepend-http"
         }
       ]
@@ -20843,7 +20843,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pretty-bytes"
         }
       ]
@@ -20869,7 +20869,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/process-nextick-args"
         }
       ]
@@ -20895,7 +20895,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/prom-client"
         }
       ]
@@ -20921,7 +20921,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/promise-inflight"
         }
       ]
@@ -20947,7 +20947,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/promise-retry"
         }
       ],
@@ -20973,7 +20973,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/promise-retry/node_modules/err-code"
             }
           ]
@@ -20999,7 +20999,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/promise-retry/node_modules/retry"
             }
           ]
@@ -21027,7 +21027,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/promise"
         }
       ]
@@ -21053,7 +21053,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/proper-lockfile"
         }
       ]
@@ -21079,7 +21079,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/proxy-addr"
         }
       ]
@@ -21105,7 +21105,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/psl"
         }
       ]
@@ -21131,7 +21131,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-attrs"
         }
       ]
@@ -21157,7 +21157,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-code-gen"
         }
       ]
@@ -21183,7 +21183,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-error"
         }
       ]
@@ -21209,7 +21209,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-filters"
         }
       ]
@@ -21235,7 +21235,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-lexer"
         }
       ]
@@ -21261,7 +21261,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-linker"
         }
       ]
@@ -21287,7 +21287,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-load"
         }
       ]
@@ -21313,7 +21313,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-parser"
         }
       ]
@@ -21339,7 +21339,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-runtime"
         }
       ]
@@ -21365,7 +21365,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-strip-comments"
         }
       ]
@@ -21391,7 +21391,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-walk"
         }
       ]
@@ -21417,7 +21417,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug"
         }
       ]
@@ -21443,7 +21443,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pump"
         }
       ]
@@ -21469,7 +21469,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/punycode"
         }
       ]
@@ -21495,7 +21495,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/qs"
         }
       ]
@@ -21521,7 +21521,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/query-string"
         }
       ]
@@ -21547,7 +21547,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/range_check"
         }
       ]
@@ -21573,7 +21573,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/range-parser"
         }
       ]
@@ -21599,7 +21599,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/raw-body"
         }
       ]
@@ -21625,7 +21625,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/rc"
         }
       ]
@@ -21651,7 +21651,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/read-pkg"
         }
       ],
@@ -21677,7 +21677,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/read-pkg/node_modules/pify"
             }
           ]
@@ -21705,7 +21705,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/readable-stream"
         }
       ],
@@ -21731,7 +21731,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/readable-stream/node_modules/isarray"
             }
           ]
@@ -21759,7 +21759,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/readable-web-to-node-stream"
         }
       ],
@@ -21785,7 +21785,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/readable-web-to-node-stream/node_modules/readable-stream"
             }
           ]
@@ -21813,7 +21813,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/readdirp"
         }
       ]
@@ -21839,7 +21839,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/rechoir"
         }
       ]
@@ -21865,7 +21865,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/regex-not"
         }
       ]
@@ -21891,7 +21891,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/regexp.prototype.flags"
         }
       ]
@@ -21917,7 +21917,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/remove-trailing-separator"
         }
       ]
@@ -21943,7 +21943,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/repeat-element"
         }
       ]
@@ -21969,7 +21969,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/repeat-string"
         }
       ]
@@ -21995,7 +21995,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/replace"
         }
       ],
@@ -22021,7 +22021,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/ansi-regex"
             }
           ]
@@ -22047,7 +22047,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/ansi-styles"
             }
           ]
@@ -22073,7 +22073,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/brace-expansion"
             }
           ]
@@ -22099,7 +22099,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/cliui"
             }
           ]
@@ -22125,7 +22125,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/color-convert"
             }
           ]
@@ -22151,7 +22151,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/color-name"
             }
           ]
@@ -22177,7 +22177,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/find-up"
             }
           ]
@@ -22203,7 +22203,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -22229,7 +22229,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/locate-path"
             }
           ]
@@ -22255,7 +22255,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/minimatch"
             }
           ]
@@ -22281,7 +22281,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/p-locate"
             }
           ]
@@ -22307,7 +22307,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/path-exists"
             }
           ]
@@ -22333,7 +22333,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/string-width"
             }
           ]
@@ -22359,7 +22359,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/strip-ansi"
             }
           ]
@@ -22385,7 +22385,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/wrap-ansi"
             }
           ]
@@ -22411,7 +22411,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/yargs-parser"
             }
           ]
@@ -22437,7 +22437,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/yargs"
             }
           ]
@@ -22465,7 +22465,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/request"
         }
       ],
@@ -22491,7 +22491,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/request/node_modules/qs"
             }
           ]
@@ -22519,7 +22519,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/require-directory"
         }
       ]
@@ -22545,7 +22545,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/require-main-filename"
         }
       ]
@@ -22571,7 +22571,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/resolve-dir"
         }
       ]
@@ -22597,7 +22597,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/resolve-url"
         }
       ]
@@ -22623,7 +22623,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/resolve"
         }
       ]
@@ -22649,7 +22649,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/responselike"
         }
       ]
@@ -22675,7 +22675,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/restructure"
         }
       ]
@@ -22701,7 +22701,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ret"
         }
       ]
@@ -22727,7 +22727,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/retry-as-promised"
         }
       ]
@@ -22753,7 +22753,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/retry"
         }
       ]
@@ -22779,7 +22779,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/rimraf"
         }
       ]
@@ -22805,7 +22805,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/rxjs"
         }
       ],
@@ -22831,7 +22831,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/rxjs/node_modules/tslib"
             }
           ]
@@ -22859,7 +22859,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safe-buffer"
         }
       ]
@@ -22885,7 +22885,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safe-regex-test"
         }
       ]
@@ -22911,7 +22911,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safe-regex"
         }
       ]
@@ -22937,7 +22937,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safe-stable-stringify"
         }
       ]
@@ -22963,7 +22963,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safer-buffer"
         }
       ]
@@ -22989,7 +22989,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/samsam"
         }
       ]
@@ -23015,7 +23015,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sanitize-filename"
         }
       ]
@@ -23041,7 +23041,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sanitize-html"
         }
       ],
@@ -23067,7 +23067,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sanitize-html/node_modules/lodash"
             }
           ]
@@ -23095,7 +23095,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sax"
         }
       ]
@@ -23121,7 +23121,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/seek-bzip"
         }
       ]
@@ -23147,7 +23147,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/semver"
         }
       ]
@@ -23173,7 +23173,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/send"
         }
       ],
@@ -23199,7 +23199,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/send/node_modules/ms"
             }
           ]
@@ -23227,7 +23227,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sequelize-pool"
         }
       ]
@@ -23253,7 +23253,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sequelize"
         }
       ],
@@ -23279,7 +23279,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sequelize/node_modules/debug"
             }
           ]
@@ -23305,7 +23305,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sequelize/node_modules/ms"
             }
           ]
@@ -23331,7 +23331,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sequelize/node_modules/uuid"
             }
           ]
@@ -23359,7 +23359,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/serve-index"
         }
       ],
@@ -23385,7 +23385,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index/node_modules/depd"
             }
           ]
@@ -23411,7 +23411,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index/node_modules/http-errors"
             }
           ]
@@ -23437,7 +23437,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index/node_modules/inherits"
             }
           ]
@@ -23463,7 +23463,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index/node_modules/setprototypeof"
             }
           ]
@@ -23489,7 +23489,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index/node_modules/statuses"
             }
           ]
@@ -23517,7 +23517,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/serve-static"
         }
       ]
@@ -23543,7 +23543,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/set-blocking"
         }
       ]
@@ -23569,7 +23569,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/set-value"
         }
       ],
@@ -23595,7 +23595,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/set-value/node_modules/extend-shallow"
             }
           ]
@@ -23621,7 +23621,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/set-value/node_modules/is-extendable"
             }
           ]
@@ -23649,7 +23649,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/setimmediate"
         }
       ]
@@ -23675,7 +23675,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/setprototypeof"
         }
       ]
@@ -23701,7 +23701,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/side-channel"
         }
       ]
@@ -23727,7 +23727,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/signal-exit"
         }
       ]
@@ -23753,7 +23753,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/simple-concat"
         }
       ]
@@ -23779,7 +23779,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/simple-get"
         }
       ],
@@ -23805,7 +23805,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/simple-get/node_modules/decompress-response"
             }
           ]
@@ -23831,7 +23831,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/simple-get/node_modules/mimic-response"
             }
           ]
@@ -23859,7 +23859,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/simple-swizzle"
         }
       ],
@@ -23885,7 +23885,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/simple-swizzle/node_modules/is-arrayish"
             }
           ]
@@ -23913,7 +23913,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sinon"
         }
       ]
@@ -23939,7 +23939,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/smart-buffer"
         }
       ]
@@ -23965,7 +23965,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/snapdragon-node"
         }
       ],
@@ -23991,7 +23991,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon-node/node_modules/define-property"
             }
           ]
@@ -24019,7 +24019,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/snapdragon-util"
         }
       ],
@@ -24045,7 +24045,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon-util/node_modules/kind-of"
             }
           ]
@@ -24073,7 +24073,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/snapdragon"
         }
       ],
@@ -24099,7 +24099,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/define-property"
             }
           ]
@@ -24125,7 +24125,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/extend-shallow"
             }
           ]
@@ -24151,7 +24151,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/is-accessor-descriptor"
             }
           ],
@@ -24177,7 +24177,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/snapdragon/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
@@ -24205,7 +24205,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/is-data-descriptor"
             }
           ],
@@ -24231,7 +24231,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/snapdragon/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
@@ -24259,7 +24259,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/is-descriptor"
             }
           ]
@@ -24285,7 +24285,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/is-extendable"
             }
           ]
@@ -24311,7 +24311,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/kind-of"
             }
           ]
@@ -24337,7 +24337,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/source-map"
             }
           ]
@@ -24365,7 +24365,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socket.io-adapter"
         }
       ]
@@ -24391,7 +24391,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socket.io-parser"
         }
       ],
@@ -24417,7 +24417,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socket.io-parser/node_modules/debug"
             }
           ]
@@ -24443,7 +24443,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socket.io-parser/node_modules/ms"
             }
           ]
@@ -24471,7 +24471,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socket.io"
         }
       ],
@@ -24497,7 +24497,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socket.io/node_modules/debug"
             }
           ]
@@ -24523,7 +24523,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socket.io/node_modules/ms"
             }
           ]
@@ -24551,7 +24551,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socks-proxy-agent"
         }
       ],
@@ -24577,7 +24577,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socks-proxy-agent/node_modules/debug"
             }
           ]
@@ -24603,7 +24603,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socks-proxy-agent/node_modules/ms"
             }
           ]
@@ -24631,7 +24631,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socks"
         }
       ],
@@ -24657,7 +24657,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socks/node_modules/ip"
             }
           ]
@@ -24685,7 +24685,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sort-keys-length"
         }
       ],
@@ -24711,7 +24711,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sort-keys-length/node_modules/sort-keys"
             }
           ]
@@ -24739,7 +24739,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sort-keys"
         }
       ]
@@ -24765,7 +24765,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/source-map-resolve"
         }
       ]
@@ -24791,7 +24791,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/source-map-support"
         }
       ]
@@ -24817,7 +24817,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/source-map-url"
         }
       ]
@@ -24843,7 +24843,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/source-map"
         }
       ]
@@ -24869,7 +24869,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spawn-command"
         }
       ]
@@ -24895,7 +24895,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spdx-correct"
         }
       ]
@@ -24921,7 +24921,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spdx-exceptions"
         }
       ]
@@ -24947,7 +24947,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spdx-expression-parse"
         }
       ]
@@ -24973,7 +24973,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spdx-license-ids"
         }
       ]
@@ -24999,7 +24999,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/split-string"
         }
       ]
@@ -25025,7 +25025,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sprintf-js"
         }
       ]
@@ -25051,7 +25051,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sqlite3"
         }
       ]
@@ -25077,7 +25077,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sshpk"
         }
       ]
@@ -25103,7 +25103,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ssri"
         }
       ]
@@ -25129,7 +25129,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/stack-trace"
         }
       ]
@@ -25155,7 +25155,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/static-extend"
         }
       ],
@@ -25181,7 +25181,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend/node_modules/define-property"
             }
           ]
@@ -25207,7 +25207,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend/node_modules/is-accessor-descriptor"
             }
           ],
@@ -25233,7 +25233,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/static-extend/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
@@ -25261,7 +25261,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend/node_modules/is-data-descriptor"
             }
           ],
@@ -25287,7 +25287,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/static-extend/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
@@ -25315,7 +25315,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend/node_modules/is-descriptor"
             }
           ]
@@ -25341,7 +25341,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend/node_modules/kind-of"
             }
           ]
@@ -25369,7 +25369,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/statuses"
         }
       ]
@@ -25395,7 +25395,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/stream-buffers"
         }
       ]
@@ -25421,7 +25421,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/streamsearch"
         }
       ]
@@ -25447,7 +25447,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strict-uri-encode"
         }
       ]
@@ -25473,7 +25473,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string_decoder"
         }
       ]
@@ -25499,7 +25499,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string-width"
         }
       ]
@@ -25525,7 +25525,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string.fromcodepoint"
         }
       ]
@@ -25551,7 +25551,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string.prototype.codepointat"
         }
       ]
@@ -25577,7 +25577,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string.prototype.trimend"
         }
       ]
@@ -25603,7 +25603,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string.prototype.trimstart"
         }
       ]
@@ -25629,7 +25629,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-ansi"
         }
       ]
@@ -25655,7 +25655,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-bom"
         }
       ]
@@ -25681,7 +25681,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-dirs"
         }
       ]
@@ -25707,7 +25707,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-json-comments"
         }
       ]
@@ -25733,7 +25733,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-outer"
         }
       ]
@@ -25759,7 +25759,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strtok3"
         }
       ]
@@ -25785,7 +25785,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/supports-color"
         }
       ]
@@ -25811,7 +25811,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/supports-preserve-symlinks-flag"
         }
       ]
@@ -25837,7 +25837,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/svg-captcha"
         }
       ]
@@ -25863,7 +25863,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/swagger-ui-dist"
         }
       ]
@@ -25889,7 +25889,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/swagger-ui-express"
         }
       ]
@@ -25915,7 +25915,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tar-fs"
         }
       ],
@@ -25941,7 +25941,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/tar-fs/node_modules/bl"
             }
           ]
@@ -25967,7 +25967,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/tar-fs/node_modules/chownr"
             }
           ]
@@ -25993,7 +25993,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/tar-fs/node_modules/readable-stream"
             }
           ]
@@ -26019,7 +26019,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/tar-fs/node_modules/tar-stream"
             }
           ]
@@ -26047,7 +26047,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tar-stream"
         }
       ]
@@ -26073,7 +26073,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tar"
         }
       ]
@@ -26099,7 +26099,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tdigest"
         }
       ]
@@ -26125,7 +26125,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/text-hex"
         }
       ]
@@ -26151,7 +26151,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/thirty-two"
         }
       ]
@@ -26177,7 +26177,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/through"
         }
       ]
@@ -26203,7 +26203,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/timed-out"
         }
       ]
@@ -26229,7 +26229,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tiny-inflate"
         }
       ]
@@ -26255,7 +26255,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-buffer"
         }
       ]
@@ -26281,7 +26281,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-fast-properties"
         }
       ]
@@ -26307,7 +26307,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-object-path"
         }
       ],
@@ -26333,7 +26333,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/to-object-path/node_modules/kind-of"
             }
           ]
@@ -26361,7 +26361,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-regex-range"
         }
       ]
@@ -26387,7 +26387,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-regex"
         }
       ]
@@ -26413,7 +26413,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/toidentifier"
         }
       ]
@@ -26439,7 +26439,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/token-stream"
         }
       ]
@@ -26465,7 +26465,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/token-types"
         }
       ]
@@ -26491,7 +26491,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/toposort-class"
         }
       ]
@@ -26517,7 +26517,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tough-cookie"
         }
       ]
@@ -26543,7 +26543,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tr46"
         }
       ]
@@ -26569,7 +26569,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/traverse"
         }
       ]
@@ -26595,7 +26595,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tree-kill"
         }
       ]
@@ -26621,7 +26621,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/trim-repeated"
         }
       ]
@@ -26647,7 +26647,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/triple-beam"
         }
       ]
@@ -26673,7 +26673,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/truncate-utf8-bytes"
         }
       ]
@@ -26699,7 +26699,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ts-node-dev"
         }
       ],
@@ -26725,7 +26725,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/ts-node-dev/node_modules/rimraf"
             }
           ]
@@ -26753,7 +26753,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ts-node"
         }
       ]
@@ -26779,7 +26779,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tsconfig"
         }
       ]
@@ -26805,7 +26805,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tslib"
         }
       ]
@@ -26831,7 +26831,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tunnel-agent"
         }
       ]
@@ -26857,7 +26857,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tweetnacl"
         }
       ]
@@ -26883,7 +26883,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/type-check"
         }
       ]
@@ -26909,7 +26909,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/type-is"
         }
       ]
@@ -26935,7 +26935,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/typecast"
         }
       ]
@@ -26961,7 +26961,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/typedarray"
         }
       ]
@@ -26987,7 +26987,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/typescript"
         }
       ]
@@ -27013,7 +27013,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/uglify-js"
         }
       ]
@@ -27039,7 +27039,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unbox-primitive"
         }
       ]
@@ -27065,7 +27065,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unbzip2-stream"
         }
       ]
@@ -27091,7 +27091,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unc-path-regex"
         }
       ]
@@ -27117,7 +27117,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/underscore.string"
         }
       ]
@@ -27143,7 +27143,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unicode-properties"
         }
       ]
@@ -27169,7 +27169,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unicode-trie"
         }
       ]
@@ -27195,7 +27195,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/union-value"
         }
       ],
@@ -27221,7 +27221,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/union-value/node_modules/is-extendable"
             }
           ]
@@ -27249,7 +27249,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unique-filename"
         }
       ]
@@ -27275,7 +27275,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unique-slug"
         }
       ]
@@ -27301,7 +27301,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unit-compare"
         }
       ]
@@ -27327,7 +27327,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/universalify"
         }
       ]
@@ -27353,7 +27353,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unpipe"
         }
       ]
@@ -27379,7 +27379,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unset-value"
         }
       ],
@@ -27405,7 +27405,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/unset-value/node_modules/has-value"
             }
           ],
@@ -27431,7 +27431,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/unset-value/node_modules/has-value/node_modules/isobject"
                 }
               ]
@@ -27459,7 +27459,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/unset-value/node_modules/has-values"
             }
           ]
@@ -27485,7 +27485,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/unset-value/node_modules/isarray"
             }
           ]
@@ -27513,7 +27513,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/untildify"
         }
       ]
@@ -27539,7 +27539,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unzipper"
         }
       ],
@@ -27565,7 +27565,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/unzipper/node_modules/bluebird"
             }
           ]
@@ -27593,7 +27593,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/uri-js"
         }
       ]
@@ -27619,7 +27619,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/urix"
         }
       ]
@@ -27645,7 +27645,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/url-parse-lax"
         }
       ]
@@ -27671,7 +27671,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/url-to-options"
         }
       ]
@@ -27697,7 +27697,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/use"
         }
       ]
@@ -27723,7 +27723,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/utf8-byte-length"
         }
       ]
@@ -27749,7 +27749,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/util-deprecate"
         }
       ]
@@ -27775,7 +27775,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/util"
         }
       ]
@@ -27801,7 +27801,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/utils-merge"
         }
       ]
@@ -27827,7 +27827,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/uuid"
         }
       ]
@@ -27853,7 +27853,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/v8flags"
         }
       ]
@@ -27879,7 +27879,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/validate-npm-package-license"
         }
       ]
@@ -27905,7 +27905,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/validate"
         }
       ]
@@ -27931,7 +27931,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/validator"
         }
       ]
@@ -27957,7 +27957,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/vary"
         }
       ]
@@ -27983,7 +27983,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/verror"
         }
       ],
@@ -28009,7 +28009,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/verror/node_modules/core-util-is"
             }
           ]
@@ -28037,7 +28037,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/vm2"
         }
       ],
@@ -28063,7 +28063,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/vm2/node_modules/acorn"
             }
           ]
@@ -28091,7 +28091,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/void-elements"
         }
       ]
@@ -28117,7 +28117,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/walk"
         }
       ]
@@ -28143,7 +28143,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/walkdir"
         }
       ]
@@ -28169,7 +28169,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/webidl-conversions"
         }
       ]
@@ -28195,7 +28195,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/whatwg-url"
         }
       ]
@@ -28221,7 +28221,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-boxed-primitive"
         }
       ]
@@ -28247,7 +28247,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-collection"
         }
       ]
@@ -28273,7 +28273,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-module"
         }
       ]
@@ -28299,7 +28299,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-pm-runs"
         }
       ]
@@ -28325,7 +28325,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-typed-array"
         }
       ]
@@ -28351,7 +28351,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which"
         }
       ]
@@ -28377,7 +28377,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wide-align"
         }
       ]
@@ -28403,7 +28403,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/winston-transport"
         }
       ],
@@ -28429,7 +28429,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/winston-transport/node_modules/readable-stream"
             }
           ]
@@ -28457,7 +28457,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/winston"
         }
       ],
@@ -28483,7 +28483,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/winston/node_modules/async"
             }
           ]
@@ -28509,7 +28509,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/winston/node_modules/is-stream"
             }
           ]
@@ -28535,7 +28535,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/winston/node_modules/readable-stream"
             }
           ]
@@ -28563,7 +28563,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/with"
         }
       ]
@@ -28589,7 +28589,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wkx"
         }
       ]
@@ -28615,7 +28615,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/word-wrap"
         }
       ]
@@ -28641,7 +28641,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wordwrap"
         }
       ]
@@ -28667,7 +28667,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wrap-ansi"
         }
       ],
@@ -28693,7 +28693,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi/node_modules/ansi-regex"
             }
           ]
@@ -28719,7 +28719,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi/node_modules/emoji-regex"
             }
           ]
@@ -28745,7 +28745,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -28771,7 +28771,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi/node_modules/string-width"
             }
           ]
@@ -28797,7 +28797,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi/node_modules/strip-ansi"
             }
           ]
@@ -28825,7 +28825,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wrappy"
         }
       ]
@@ -28851,7 +28851,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ws"
         }
       ]
@@ -28877,7 +28877,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/xtend"
         }
       ]
@@ -28903,7 +28903,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/y18n"
         }
       ]
@@ -28929,7 +28929,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yallist"
         }
       ]
@@ -28955,7 +28955,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yaml-schema-validator"
         }
       ]
@@ -28981,7 +28981,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yargs-parser"
         }
       ]
@@ -29007,7 +29007,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yargs"
         }
       ],
@@ -29033,7 +29033,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs/node_modules/ansi-regex"
             }
           ]
@@ -29059,7 +29059,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs/node_modules/emoji-regex"
             }
           ]
@@ -29085,7 +29085,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -29111,7 +29111,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs/node_modules/string-width"
             }
           ]
@@ -29137,7 +29137,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs/node_modules/strip-ansi"
             }
           ]
@@ -29165,7 +29165,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yauzl"
         }
       ]
@@ -29191,7 +29191,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yn"
         }
       ]
@@ -29217,7 +29217,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/z85"
         }
       ]
@@ -29243,7 +29243,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/zip-stream"
         }
       ]
@@ -29269,7 +29269,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/zlibjs"
         }
       ]

--- a/tests/_data/sbom_demo-results/juice-shop_npm7_node18_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/juice-shop_npm7_node18_windows-latest.snap.json
@@ -62,6 +62,10 @@
       ],
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -88,6 +92,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@babel\\helper-string-parser"
+        }
       ]
     },
     {
@@ -108,6 +118,12 @@
           "url": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@babel\\helper-validator-identifier"
         }
       ]
     },
@@ -130,6 +146,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@babel\\parser"
+        }
       ]
     },
     {
@@ -150,6 +172,12 @@
           "url": "https://registry.npmjs.org/@babel/types/-/types-7.20.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@babel\\types"
         }
       ]
     },
@@ -172,6 +200,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@colors\\colors"
+        }
       ]
     },
     {
@@ -193,6 +227,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@dabh\\diagnostics"
+        }
       ]
     },
     {
@@ -213,6 +253,12 @@
           "url": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@gar\\promisify"
         }
       ]
     },
@@ -236,6 +282,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@mapbox\\node-pre-gyp"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -254,6 +306,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\ansi-regex"
             }
           ]
         },
@@ -275,6 +333,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\are-we-there-yet"
+            }
           ]
         },
         {
@@ -294,6 +358,12 @@
               "url": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\detect-libc"
             }
           ]
         },
@@ -315,6 +385,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\gauge"
+            }
           ]
         },
         {
@@ -334,6 +410,12 @@
               "url": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\is-fullwidth-code-point"
             }
           ]
         },
@@ -356,6 +438,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\make-dir"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -374,6 +462,12 @@
                   "url": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\make-dir\\node_modules\\semver"
                 }
               ]
             }
@@ -397,6 +491,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\nopt"
+            }
           ]
         },
         {
@@ -416,6 +516,12 @@
               "url": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\npmlog"
             }
           ]
         },
@@ -437,6 +543,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\readable-stream"
+            }
           ]
         },
         {
@@ -457,6 +569,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\string-width"
+            }
           ]
         },
         {
@@ -476,6 +594,12 @@
               "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\strip-ansi"
             }
           ]
         }
@@ -500,6 +624,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\core-loader"
+        }
       ]
     },
     {
@@ -520,6 +650,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/core/-/core-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\core"
         }
       ]
     },
@@ -542,6 +678,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\evaluator"
+        }
       ]
     },
     {
@@ -562,6 +704,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-all/-/lang-all-4.24.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-all"
         }
       ]
     },
@@ -584,6 +732,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-ar"
+        }
       ]
     },
     {
@@ -604,6 +758,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-bn/-/lang-bn-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-bn"
         }
       ]
     },
@@ -626,6 +786,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-ca"
+        }
       ]
     },
     {
@@ -646,6 +812,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-cs/-/lang-cs-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-cs"
         }
       ]
     },
@@ -668,6 +840,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-da"
+        }
       ]
     },
     {
@@ -688,6 +866,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-de/-/lang-de-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-de"
         }
       ]
     },
@@ -710,6 +894,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-el"
+        }
       ]
     },
     {
@@ -730,6 +920,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-en-min/-/lang-en-min-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-en-min"
         }
       ]
     },
@@ -752,6 +948,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-en"
+        }
       ]
     },
     {
@@ -772,6 +974,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-es/-/lang-es-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-es"
         }
       ]
     },
@@ -794,6 +1002,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-eu"
+        }
       ]
     },
     {
@@ -814,6 +1028,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-fa/-/lang-fa-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-fa"
         }
       ]
     },
@@ -836,6 +1056,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-fi"
+        }
       ]
     },
     {
@@ -856,6 +1082,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-fr/-/lang-fr-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-fr"
         }
       ]
     },
@@ -878,6 +1110,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-ga"
+        }
       ]
     },
     {
@@ -898,6 +1136,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-gl/-/lang-gl-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-gl"
         }
       ]
     },
@@ -920,6 +1164,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-hi"
+        }
       ]
     },
     {
@@ -940,6 +1190,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-hu/-/lang-hu-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-hu"
         }
       ]
     },
@@ -962,6 +1218,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-hy"
+        }
       ]
     },
     {
@@ -982,6 +1244,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-id/-/lang-id-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-id"
         }
       ]
     },
@@ -1004,6 +1272,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-it"
+        }
       ]
     },
     {
@@ -1024,6 +1298,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-ja/-/lang-ja-4.24.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-ja"
         }
       ]
     },
@@ -1046,6 +1326,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-ko"
+        }
       ]
     },
     {
@@ -1066,6 +1352,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-lt/-/lang-lt-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-lt"
         }
       ]
     },
@@ -1088,6 +1380,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-ms"
+        }
       ]
     },
     {
@@ -1108,6 +1406,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-ne/-/lang-ne-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-ne"
         }
       ]
     },
@@ -1130,6 +1434,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-nl"
+        }
       ]
     },
     {
@@ -1150,6 +1460,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-no/-/lang-no-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-no"
         }
       ]
     },
@@ -1172,6 +1488,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-pl"
+        }
       ]
     },
     {
@@ -1192,6 +1514,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-pt/-/lang-pt-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-pt"
         }
       ]
     },
@@ -1214,6 +1542,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-ro"
+        }
       ]
     },
     {
@@ -1234,6 +1568,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-ru/-/lang-ru-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-ru"
         }
       ]
     },
@@ -1256,6 +1596,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-sl"
+        }
       ]
     },
     {
@@ -1276,6 +1622,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-sr/-/lang-sr-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-sr"
         }
       ]
     },
@@ -1298,6 +1650,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-sv"
+        }
       ]
     },
     {
@@ -1318,6 +1676,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-ta/-/lang-ta-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-ta"
         }
       ]
     },
@@ -1340,6 +1704,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-th"
+        }
       ]
     },
     {
@@ -1360,6 +1730,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-tl/-/lang-tl-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-tl"
         }
       ]
     },
@@ -1382,6 +1758,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-tr"
+        }
       ]
     },
     {
@@ -1402,6 +1784,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-uk/-/lang-uk-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-uk"
         }
       ]
     },
@@ -1424,6 +1812,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-zh"
+        }
       ]
     },
     {
@@ -1444,6 +1838,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/language-min/-/language-min-4.22.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\language-min"
         }
       ]
     },
@@ -1466,6 +1866,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\language"
+        }
       ]
     },
     {
@@ -1486,6 +1892,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/ner/-/ner-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\ner"
         }
       ]
     },
@@ -1508,6 +1920,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\neural"
+        }
       ]
     },
     {
@@ -1528,6 +1946,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/nlg/-/nlg-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\nlg"
         }
       ]
     },
@@ -1550,6 +1974,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\nlp"
+        }
       ]
     },
     {
@@ -1570,6 +2000,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/nlu/-/nlu-4.23.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\nlu"
         }
       ]
     },
@@ -1592,6 +2028,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\request"
+        }
       ]
     },
     {
@@ -1612,6 +2054,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/sentiment/-/sentiment-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\sentiment"
         }
       ]
     },
@@ -1634,6 +2082,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\similarity"
+        }
       ]
     },
     {
@@ -1654,6 +2108,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/slot/-/slot-4.22.17.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\slot"
         }
       ]
     },
@@ -1676,6 +2136,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@npmcli\\fs"
+        }
       ]
     },
     {
@@ -1696,6 +2162,12 @@
           "url": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@npmcli\\move-file"
         }
       ]
     },
@@ -1718,6 +2190,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib\\core"
+        }
       ]
     },
     {
@@ -1738,6 +2216,12 @@
           "url": "https://registry.npmjs.org/@otplib/plugin-crypto/-/plugin-crypto-12.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib\\plugin-crypto"
         }
       ]
     },
@@ -1760,6 +2244,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib\\plugin-thirty-two"
+        }
       ]
     },
     {
@@ -1780,6 +2270,12 @@
           "url": "https://registry.npmjs.org/@otplib/preset-default/-/preset-default-12.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib\\preset-default"
         }
       ]
     },
@@ -1802,6 +2298,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib\\preset-v11"
+        }
       ]
     },
     {
@@ -1822,6 +2324,12 @@
           "url": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@sindresorhus\\is"
         }
       ]
     },
@@ -1844,6 +2352,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@swc\\helpers"
+        }
       ]
     },
     {
@@ -1864,6 +2378,12 @@
           "url": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@tokenizer\\token"
         }
       ]
     },
@@ -1886,6 +2406,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@tootallnate\\once"
+        }
       ]
     },
     {
@@ -1906,6 +2432,12 @@
           "url": "https://registry.npmjs.org/@types/component-emitter/-/component-emitter-1.2.11.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types\\component-emitter"
         }
       ]
     },
@@ -1928,6 +2460,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types\\cookie"
+        }
       ]
     },
     {
@@ -1948,6 +2486,12 @@
           "url": "https://registry.npmjs.org/@types/cors/-/cors-2.8.12.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types\\cors"
         }
       ]
     },
@@ -1970,6 +2514,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types\\debug"
+        }
       ]
     },
     {
@@ -1990,6 +2540,12 @@
           "url": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types\\ms"
         }
       ]
     },
@@ -2012,6 +2568,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types\\node"
+        }
       ]
     },
     {
@@ -2032,6 +2594,12 @@
           "url": "https://registry.npmjs.org/@types/strip-bom/-/strip-bom-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types\\strip-bom"
         }
       ]
     },
@@ -2054,6 +2622,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types\\strip-json-comments"
+        }
       ]
     },
     {
@@ -2075,6 +2649,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types\\validator"
+        }
       ]
     },
     {
@@ -2094,6 +2674,12 @@
           "url": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/abbrev"
         }
       ]
     },
@@ -2115,6 +2701,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/accepts"
+        }
       ]
     },
     {
@@ -2135,6 +2727,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/acorn-walk"
+        }
       ]
     },
     {
@@ -2154,6 +2752,12 @@
           "url": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/acorn"
         }
       ]
     },
@@ -2176,6 +2780,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/agent-base"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -2194,6 +2804,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agent-base\\node_modules\\debug"
             }
           ]
         },
@@ -2214,6 +2830,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agent-base\\node_modules\\ms"
             }
           ]
         }
@@ -2238,6 +2860,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/agentkeepalive"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -2256,6 +2884,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agentkeepalive\\node_modules\\debug"
             }
           ]
         },
@@ -2277,6 +2911,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agentkeepalive\\node_modules\\depd"
+            }
           ]
         },
         {
@@ -2296,6 +2936,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agentkeepalive\\node_modules\\ms"
             }
           ]
         }
@@ -2319,6 +2965,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/aggregate-error"
+        }
       ]
     },
     {
@@ -2338,6 +2990,12 @@
           "url": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ajv"
         }
       ]
     },
@@ -2359,6 +3017,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ansi-regex"
+        }
       ]
     },
     {
@@ -2378,6 +3042,12 @@
           "url": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ansi-styles"
         }
       ]
     },
@@ -2400,6 +3070,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/anymatch"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -2418,6 +3094,12 @@
               "url": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/anymatch\\node_modules\\normalize-path"
             }
           ]
         }
@@ -2441,6 +3123,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/append-field"
+        }
       ]
     },
     {
@@ -2460,6 +3148,12 @@
           "url": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/aproba"
         }
       ]
     },
@@ -2482,6 +3176,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/archive-type"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -2500,6 +3200,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-4.4.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/archive-type\\node_modules\\file-type"
             }
           ]
         }
@@ -2523,6 +3229,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/archiver-utils"
+        }
       ]
     },
     {
@@ -2542,6 +3254,12 @@
           "url": "https://registry.npmjs.org/archiver/-/archiver-1.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/archiver"
         }
       ]
     },
@@ -2563,6 +3281,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/are-we-there-yet"
+        }
       ]
     },
     {
@@ -2582,6 +3306,12 @@
           "url": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/arg"
         }
       ]
     },
@@ -2604,6 +3334,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/argparse"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -2622,6 +3358,12 @@
               "url": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/argparse\\node_modules\\sprintf-js"
             }
           ]
         }
@@ -2645,6 +3387,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/arr-diff"
+        }
       ]
     },
     {
@@ -2664,6 +3412,12 @@
           "url": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/arr-flatten"
         }
       ]
     },
@@ -2685,6 +3439,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/arr-union"
+        }
       ]
     },
     {
@@ -2704,6 +3464,12 @@
           "url": "https://registry.npmjs.org/array-each/-/array-each-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/array-each"
         }
       ]
     },
@@ -2725,6 +3491,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/array-flatten"
+        }
       ]
     },
     {
@@ -2744,6 +3516,12 @@
           "url": "https://registry.npmjs.org/array-slice/-/array-slice-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/array-slice"
         }
       ]
     },
@@ -2765,6 +3543,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/array-unique"
+        }
       ]
     },
     {
@@ -2784,6 +3568,12 @@
           "url": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/asap"
         }
       ]
     },
@@ -2805,6 +3595,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/asn1"
+        }
       ]
     },
     {
@@ -2824,6 +3620,12 @@
           "url": "https://registry.npmjs.org/assert-never/-/assert-never-1.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/assert-never"
         }
       ]
     },
@@ -2845,6 +3647,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/assert-plus"
+        }
       ]
     },
     {
@@ -2864,6 +3672,12 @@
           "url": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/assign-symbols"
         }
       ]
     },
@@ -2885,6 +3699,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/async"
+        }
       ]
     },
     {
@@ -2904,6 +3724,12 @@
           "url": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/asynckit"
         }
       ]
     },
@@ -2925,6 +3751,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/at-least-node"
+        }
       ]
     },
     {
@@ -2944,6 +3776,12 @@
           "url": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/atob"
         }
       ]
     },
@@ -2965,6 +3803,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/available-typed-arrays"
+        }
       ]
     },
     {
@@ -2984,6 +3828,12 @@
           "url": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/aws-sign2"
         }
       ]
     },
@@ -3005,6 +3855,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/aws4"
+        }
       ]
     },
     {
@@ -3025,6 +3881,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/babel-walk"
+        }
       ]
     },
     {
@@ -3044,6 +3906,12 @@
           "url": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/balanced-match"
         }
       ]
     },
@@ -3066,6 +3934,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -3084,6 +3958,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/base\\node_modules\\define-property"
             }
           ]
         }
@@ -3107,6 +3987,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base64-arraybuffer"
+        }
       ]
     },
     {
@@ -3126,6 +4012,12 @@
           "url": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base64-js"
         }
       ]
     },
@@ -3147,6 +4039,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base64id"
+        }
       ]
     },
     {
@@ -3166,6 +4064,12 @@
           "url": "https://registry.npmjs.org/base64url/-/base64url-0.0.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base64url"
         }
       ]
     },
@@ -3187,6 +4091,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/basic-auth"
+        }
       ]
     },
     {
@@ -3206,6 +4116,12 @@
           "url": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/batch"
         }
       ]
     },
@@ -3227,6 +4143,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bcrypt-pbkdf"
+        }
       ]
     },
     {
@@ -3246,6 +4168,12 @@
           "url": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/big-integer"
         }
       ]
     },
@@ -3267,6 +4195,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/binary-extensions"
+        }
       ]
     },
     {
@@ -3286,6 +4220,12 @@
           "url": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/binary"
         }
       ]
     },
@@ -3307,6 +4247,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bindings"
+        }
       ]
     },
     {
@@ -3326,6 +4272,12 @@
           "url": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bintrees"
         }
       ]
     },
@@ -3347,6 +4299,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bl"
+        }
       ]
     },
     {
@@ -3367,6 +4325,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bluebird"
+        }
       ]
     },
     {
@@ -3386,6 +4350,12 @@
           "url": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/body-parser"
         }
       ]
     },
@@ -3408,6 +4378,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bower-config"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -3426,6 +4402,12 @@
               "url": "https://registry.npmjs.org/minimist/-/minimist-0.2.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bower-config\\node_modules\\minimist"
             }
           ]
         }
@@ -3449,6 +4431,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/brace-expansion"
+        }
       ]
     },
     {
@@ -3470,6 +4458,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/braces"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -3488,6 +4482,12 @@
               "url": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/braces\\node_modules\\extend-shallow"
             }
           ]
         },
@@ -3508,6 +4508,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/braces\\node_modules\\is-extendable"
             }
           ]
         }
@@ -3531,6 +4537,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/brotli"
+        }
       ]
     },
     {
@@ -3550,6 +4562,12 @@
           "url": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-alloc-unsafe"
         }
       ]
     },
@@ -3571,6 +4589,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-alloc"
+        }
       ]
     },
     {
@@ -3590,6 +4614,12 @@
           "url": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-crc32"
         }
       ]
     },
@@ -3611,6 +4641,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-fill"
+        }
       ]
     },
     {
@@ -3630,6 +4666,12 @@
           "url": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-from"
         }
       ]
     },
@@ -3651,6 +4693,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-indexof-polyfill"
+        }
       ]
     },
     {
@@ -3671,6 +4719,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer"
+        }
       ]
     },
     {
@@ -3690,6 +4744,12 @@
           "url": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffers"
         }
       ]
     },
@@ -3712,6 +4772,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/busboy"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -3730,6 +4796,12 @@
               "url": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/busboy\\node_modules\\isarray"
             }
           ]
         },
@@ -3751,6 +4823,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/busboy\\node_modules\\readable-stream"
+            }
           ]
         },
         {
@@ -3770,6 +4848,12 @@
               "url": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/busboy\\node_modules\\string_decoder"
             }
           ]
         }
@@ -3793,6 +4877,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/byline"
+        }
       ]
     },
     {
@@ -3812,6 +4902,12 @@
           "url": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bytes"
         }
       ]
     },
@@ -3833,6 +4929,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cacache"
+        }
       ]
     },
     {
@@ -3852,6 +4954,12 @@
           "url": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cache-base"
         }
       ]
     },
@@ -3874,6 +4982,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cacheable-request"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -3892,6 +5006,12 @@
               "url": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cacheable-request\\node_modules\\get-stream"
             }
           ]
         },
@@ -3912,6 +5032,12 @@
               "url": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cacheable-request\\node_modules\\lowercase-keys"
             }
           ]
         }
@@ -3935,6 +5061,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/call-bind"
+        }
       ]
     },
     {
@@ -3954,6 +5086,12 @@
           "url": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/camelcase"
         }
       ]
     },
@@ -3975,6 +5113,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/caseless"
+        }
       ]
     },
     {
@@ -3994,6 +5138,12 @@
           "url": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/chainsaw"
         }
       ]
     },
@@ -4015,6 +5165,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/chalk"
+        }
       ]
     },
     {
@@ -4034,6 +5190,12 @@
           "url": "https://registry.npmjs.org/character-parser/-/character-parser-2.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/character-parser"
         }
       ]
     },
@@ -4056,6 +5218,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/check-dependencies"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4074,6 +5242,12 @@
               "url": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/check-dependencies\\node_modules\\semver"
             }
           ]
         }
@@ -4097,6 +5271,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/check-types"
+        }
       ]
     },
     {
@@ -4118,6 +5298,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/chokidar"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4136,6 +5322,12 @@
               "url": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar\\node_modules\\braces"
             }
           ]
         },
@@ -4157,6 +5349,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar\\node_modules\\fill-range"
+            }
           ]
         },
         {
@@ -4176,6 +5374,12 @@
               "url": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar\\node_modules\\is-glob"
             }
           ]
         },
@@ -4197,6 +5401,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar\\node_modules\\is-number"
+            }
           ]
         },
         {
@@ -4217,6 +5427,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar\\node_modules\\normalize-path"
+            }
           ]
         },
         {
@@ -4236,6 +5452,12 @@
               "url": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar\\node_modules\\to-regex-range"
             }
           ]
         }
@@ -4259,6 +5481,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/chownr"
+        }
       ]
     },
     {
@@ -4278,6 +5506,12 @@
           "url": "https://registry.npmjs.org/clarinet/-/clarinet-0.12.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/clarinet"
         }
       ]
     },
@@ -4300,6 +5534,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/class-utils"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4318,6 +5558,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils\\node_modules\\define-property"
             }
           ]
         },
@@ -4340,6 +5586,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils\\node_modules\\is-accessor-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -4358,6 +5610,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/class-utils\\node_modules\\is-accessor-descriptor\\node_modules\\kind-of"
                 }
               ]
             }
@@ -4382,6 +5640,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils\\node_modules\\is-data-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -4400,6 +5664,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/class-utils\\node_modules\\is-data-descriptor\\node_modules\\kind-of"
                 }
               ]
             }
@@ -4423,6 +5693,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils\\node_modules\\is-descriptor"
+            }
           ]
         },
         {
@@ -4442,6 +5718,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils\\node_modules\\kind-of"
             }
           ]
         }
@@ -4465,6 +5747,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/clean-stack"
+        }
       ]
     },
     {
@@ -4486,6 +5774,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cliui"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4504,6 +5798,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui\\node_modules\\ansi-regex"
             }
           ]
         },
@@ -4525,6 +5825,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui\\node_modules\\emoji-regex"
+            }
           ]
         },
         {
@@ -4544,6 +5850,12 @@
               "url": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui\\node_modules\\is-fullwidth-code-point"
             }
           ]
         },
@@ -4565,6 +5877,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui\\node_modules\\string-width"
+            }
           ]
         },
         {
@@ -4584,6 +5902,12 @@
               "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui\\node_modules\\strip-ansi"
             }
           ]
         }
@@ -4607,6 +5931,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/clone-response"
+        }
       ]
     },
     {
@@ -4626,6 +5956,12 @@
           "url": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/clone"
         }
       ]
     },
@@ -4647,6 +5983,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/code-point-at"
+        }
       ]
     },
     {
@@ -4666,6 +6008,12 @@
           "url": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/collection-visit"
         }
       ]
     },
@@ -4687,6 +6035,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color-convert"
+        }
       ]
     },
     {
@@ -4706,6 +6060,12 @@
           "url": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color-name"
         }
       ]
     },
@@ -4727,6 +6087,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color-string"
+        }
       ]
     },
     {
@@ -4746,6 +6112,12 @@
           "url": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color-support"
         }
       ]
     },
@@ -4767,6 +6139,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color"
+        }
       ]
     },
     {
@@ -4786,6 +6164,12 @@
           "url": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/colors"
         }
       ]
     },
@@ -4807,6 +6191,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/colorspace"
+        }
       ]
     },
     {
@@ -4826,6 +6216,12 @@
           "url": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/combined-stream"
         }
       ]
     },
@@ -4847,6 +6243,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/commander"
+        }
       ]
     },
     {
@@ -4866,6 +6268,12 @@
           "url": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/component-emitter"
         }
       ]
     },
@@ -4887,6 +6295,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/component-type"
+        }
       ]
     },
     {
@@ -4907,6 +6321,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/compress-commons"
+        }
       ]
     },
     {
@@ -4926,6 +6346,12 @@
           "url": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/compressible"
         }
       ]
     },
@@ -4948,6 +6374,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/compression"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4966,6 +6398,12 @@
               "url": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/compression\\node_modules\\bytes"
             }
           ]
         }
@@ -4989,6 +6427,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/concat-map"
+        }
       ]
     },
     {
@@ -5008,6 +6452,12 @@
           "url": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/concat-stream"
         }
       ]
     },
@@ -5030,6 +6480,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/concurrently"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5048,6 +6504,12 @@
               "url": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/concurrently\\node_modules\\supports-color"
             }
           ]
         }
@@ -5071,6 +6533,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/config"
+        }
       ]
     },
     {
@@ -5091,6 +6559,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/console-control-strings"
+        }
       ]
     },
     {
@@ -5110,6 +6584,12 @@
           "url": "https://registry.npmjs.org/constantinople/-/constantinople-4.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/constantinople"
         }
       ]
     },
@@ -5132,6 +6612,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/content-disposition"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5150,6 +6636,12 @@
               "url": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/content-disposition\\node_modules\\safe-buffer"
             }
           ]
         }
@@ -5173,6 +6665,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/content-type"
+        }
       ]
     },
     {
@@ -5192,6 +6690,12 @@
           "url": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cookie-parser"
         }
       ]
     },
@@ -5213,6 +6717,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cookie-signature"
+        }
       ]
     },
     {
@@ -5232,6 +6742,12 @@
           "url": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cookie"
         }
       ]
     },
@@ -5253,6 +6769,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/copy-descriptor"
+        }
       ]
     },
     {
@@ -5272,6 +6794,12 @@
           "url": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/core-util-is"
         }
       ]
     },
@@ -5293,6 +6821,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cors"
+        }
       ]
     },
     {
@@ -5312,6 +6846,12 @@
           "url": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/crc"
         }
       ]
     },
@@ -5333,6 +6873,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/crc32-stream"
+        }
       ]
     },
     {
@@ -5352,6 +6898,12 @@
           "url": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/create-require"
         }
       ]
     },
@@ -5373,6 +6925,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/crypto-js"
+        }
       ]
     },
     {
@@ -5392,6 +6950,12 @@
           "url": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dashdash"
         }
       ]
     },
@@ -5413,6 +6977,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/date-fns"
+        }
       ]
     },
     {
@@ -5432,6 +7002,12 @@
           "url": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dateformat"
         }
       ]
     },
@@ -5453,6 +7029,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/debug"
+        }
       ]
     },
     {
@@ -5472,6 +7054,12 @@
           "url": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decamelize"
         }
       ]
     },
@@ -5493,6 +7081,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decode-uri-component"
+        }
       ]
     },
     {
@@ -5512,6 +7106,12 @@
           "url": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-response"
         }
       ]
     },
@@ -5534,6 +7134,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-tar"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5552,6 +7158,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-tar\\node_modules\\file-type"
             }
           ]
         }
@@ -5576,6 +7188,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-tarbz2"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5594,6 +7212,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-6.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-tarbz2\\node_modules\\file-type"
             }
           ]
         }
@@ -5618,6 +7242,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-targz"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5636,6 +7266,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-targz\\node_modules\\file-type"
             }
           ]
         }
@@ -5660,6 +7296,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-unzip"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5678,6 +7320,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-unzip\\node_modules\\file-type"
             }
           ]
         },
@@ -5699,6 +7347,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-unzip\\node_modules\\get-stream"
+            }
           ]
         },
         {
@@ -5718,6 +7372,12 @@
               "url": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-unzip\\node_modules\\pify"
             }
           ]
         }
@@ -5742,6 +7402,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5762,6 +7428,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress\\node_modules\\make-dir"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -5780,6 +7452,12 @@
                   "url": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/decompress\\node_modules\\make-dir\\node_modules\\pify"
                 }
               ]
             }
@@ -5803,6 +7481,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress\\node_modules\\pify"
+            }
           ]
         }
       ]
@@ -5825,6 +7509,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/deep-equal"
+        }
       ]
     },
     {
@@ -5844,6 +7534,12 @@
           "url": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/deep-extend"
         }
       ]
     },
@@ -5865,6 +7561,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/deep-is"
+        }
       ]
     },
     {
@@ -5884,6 +7586,12 @@
           "url": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/define-properties"
         }
       ]
     },
@@ -5905,6 +7613,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/define-property"
+        }
       ]
     },
     {
@@ -5924,6 +7638,12 @@
           "url": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/delayed-stream"
         }
       ]
     },
@@ -5945,6 +7665,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/delegates"
+        }
       ]
     },
     {
@@ -5964,6 +7690,12 @@
           "url": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/depd"
         }
       ]
     },
@@ -5985,6 +7717,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/destroy"
+        }
       ]
     },
     {
@@ -6004,6 +7742,12 @@
           "url": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/detect-file"
         }
       ]
     },
@@ -6025,6 +7769,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/detect-libc"
+        }
       ]
     },
     {
@@ -6044,6 +7794,12 @@
           "url": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dfa"
         }
       ]
     },
@@ -6066,6 +7822,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dicer"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -6084,6 +7846,12 @@
               "url": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/dicer\\node_modules\\isarray"
             }
           ]
         },
@@ -6105,6 +7873,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/dicer\\node_modules\\readable-stream"
+            }
           ]
         },
         {
@@ -6124,6 +7898,12 @@
               "url": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/dicer\\node_modules\\string_decoder"
             }
           ]
         }
@@ -6147,6 +7927,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/diff"
+        }
       ]
     },
     {
@@ -6166,6 +7952,12 @@
           "url": "https://registry.npmjs.org/doctypes/-/doctypes-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/doctypes"
         }
       ]
     },
@@ -6187,6 +7979,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/domelementtype"
+        }
       ]
     },
     {
@@ -6206,6 +8004,12 @@
           "url": "https://registry.npmjs.org/domhandler/-/domhandler-2.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/domhandler"
         }
       ]
     },
@@ -6227,6 +8031,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/domutils"
+        }
       ]
     },
     {
@@ -6246,6 +8056,12 @@
           "url": "https://registry.npmjs.org/dottie/-/dottie-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dottie"
         }
       ]
     },
@@ -6267,6 +8083,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/double-ended-queue"
+        }
       ]
     },
     {
@@ -6286,6 +8108,12 @@
           "url": "https://registry.npmjs.org/doublearray/-/doublearray-0.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/doublearray"
         }
       ]
     },
@@ -6308,6 +8136,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/download"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -6326,6 +8160,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-11.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/download\\node_modules\\file-type"
             }
           ]
         }
@@ -6349,6 +8189,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/duplexer2"
+        }
       ]
     },
     {
@@ -6368,6 +8214,12 @@
           "url": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/duplexer3"
         }
       ]
     },
@@ -6389,6 +8241,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dynamic-dedupe"
+        }
       ]
     },
     {
@@ -6408,6 +8266,12 @@
           "url": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ecc-jsbn"
         }
       ]
     },
@@ -6429,6 +8293,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ee-first"
+        }
       ]
     },
     {
@@ -6448,6 +8318,12 @@
           "url": "https://registry.npmjs.org/eivindfjeldstad-dot/-/eivindfjeldstad-dot-0.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/eivindfjeldstad-dot"
         }
       ]
     },
@@ -6469,6 +8345,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/emoji-regex"
+        }
       ]
     },
     {
@@ -6489,6 +8371,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/enabled"
+        }
       ]
     },
     {
@@ -6508,6 +8396,12 @@
           "url": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/encodeurl"
         }
       ]
     },
@@ -6530,6 +8424,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/encoding"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -6548,6 +8448,12 @@
               "url": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/encoding\\node_modules\\iconv-lite"
             }
           ]
         }
@@ -6571,6 +8477,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/end-of-stream"
+        }
       ]
     },
     {
@@ -6590,6 +8502,12 @@
           "url": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-4.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/engine.io-parser"
         }
       ]
     },
@@ -6612,6 +8530,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/engine.io"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -6630,6 +8554,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/engine.io\\node_modules\\debug"
             }
           ]
         },
@@ -6650,6 +8580,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/engine.io\\node_modules\\ms"
             }
           ]
         }
@@ -6673,6 +8609,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/env-paths"
+        }
       ]
     },
     {
@@ -6692,6 +8634,12 @@
           "url": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/err-code"
         }
       ]
     },
@@ -6713,6 +8661,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/error-ex"
+        }
       ]
     },
     {
@@ -6732,6 +8686,12 @@
           "url": "https://registry.npmjs.org/errorhandler/-/errorhandler-1.5.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/errorhandler"
         }
       ]
     },
@@ -6753,6 +8713,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/es-abstract"
+        }
       ]
     },
     {
@@ -6772,6 +8738,12 @@
           "url": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/es-get-iterator"
         }
       ]
     },
@@ -6793,6 +8765,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/es-to-primitive"
+        }
       ]
     },
     {
@@ -6812,6 +8790,12 @@
           "url": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/escape-html"
         }
       ]
     },
@@ -6833,6 +8817,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/escape-string-regexp"
+        }
       ]
     },
     {
@@ -6852,6 +8842,12 @@
           "url": "https://registry.npmjs.org/escodegen/-/escodegen-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/escodegen"
         }
       ]
     },
@@ -6873,6 +8869,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/esprima"
+        }
       ]
     },
     {
@@ -6892,6 +8894,12 @@
           "url": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/estraverse"
         }
       ]
     },
@@ -6913,6 +8921,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/esutils"
+        }
       ]
     },
     {
@@ -6932,6 +8946,12 @@
           "url": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/etag"
         }
       ]
     },
@@ -6953,6 +8973,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/eventemitter2"
+        }
       ]
     },
     {
@@ -6972,6 +8998,12 @@
           "url": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/eventemitter3"
         }
       ]
     },
@@ -6993,6 +9025,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/exif"
+        }
       ]
     },
     {
@@ -7012,6 +9050,12 @@
           "url": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/exit"
         }
       ]
     },
@@ -7034,6 +9078,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/expand-brackets"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7052,6 +9102,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets\\node_modules\\define-property"
             }
           ]
         },
@@ -7072,6 +9128,12 @@
               "url": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets\\node_modules\\extend-shallow"
             }
           ]
         },
@@ -7094,6 +9156,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets\\node_modules\\is-accessor-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -7112,6 +9180,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/expand-brackets\\node_modules\\is-accessor-descriptor\\node_modules\\kind-of"
                 }
               ]
             }
@@ -7136,6 +9210,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets\\node_modules\\is-data-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -7154,6 +9234,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/expand-brackets\\node_modules\\is-data-descriptor\\node_modules\\kind-of"
                 }
               ]
             }
@@ -7177,6 +9263,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets\\node_modules\\is-descriptor"
+            }
           ]
         },
         {
@@ -7197,6 +9289,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets\\node_modules\\is-extendable"
+            }
           ]
         },
         {
@@ -7216,6 +9314,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets\\node_modules\\kind-of"
             }
           ]
         }
@@ -7239,6 +9343,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/expand-template"
+        }
       ]
     },
     {
@@ -7259,6 +9369,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/expand-tilde"
+        }
       ]
     },
     {
@@ -7278,6 +9394,12 @@
           "url": "https://registry.npmjs.org/express-ipfilter/-/express-ipfilter-1.3.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-ipfilter"
         }
       ]
     },
@@ -7300,6 +9422,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-jwt"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7318,6 +9446,12 @@
               "url": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-0.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/express-jwt\\node_modules\\jsonwebtoken"
             }
           ]
         },
@@ -7338,6 +9472,12 @@
               "url": "https://registry.npmjs.org/moment/-/moment-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/express-jwt\\node_modules\\moment"
             }
           ]
         }
@@ -7361,6 +9501,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-rate-limit"
+        }
       ]
     },
     {
@@ -7381,6 +9527,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-robots-txt"
+        }
       ]
     },
     {
@@ -7400,6 +9552,12 @@
           "url": "https://registry.npmjs.org/express-security.txt/-/express-security.txt-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-security.txt"
         }
       ]
     },
@@ -7422,6 +9580,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7440,6 +9604,12 @@
               "url": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/express\\node_modules\\cookie"
             }
           ]
         },
@@ -7460,6 +9630,12 @@
               "url": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/express\\node_modules\\safe-buffer"
             }
           ]
         }
@@ -7483,6 +9659,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ext-list"
+        }
       ]
     },
     {
@@ -7502,6 +9684,12 @@
           "url": "https://registry.npmjs.org/ext-name/-/ext-name-5.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ext-name"
         }
       ]
     },
@@ -7523,6 +9711,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/extend-shallow"
+        }
       ]
     },
     {
@@ -7542,6 +9736,12 @@
           "url": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/extend"
         }
       ]
     },
@@ -7564,6 +9764,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/extglob"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7582,6 +9788,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/extglob\\node_modules\\define-property"
             }
           ]
         },
@@ -7603,6 +9815,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/extglob\\node_modules\\extend-shallow"
+            }
           ]
         },
         {
@@ -7622,6 +9840,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/extglob\\node_modules\\is-extendable"
             }
           ]
         }
@@ -7645,6 +9869,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/extsprintf"
+        }
       ]
     },
     {
@@ -7664,6 +9894,12 @@
           "url": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fast-deep-equal"
         }
       ]
     },
@@ -7685,6 +9921,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fast-json-stable-stringify"
+        }
       ]
     },
     {
@@ -7704,6 +9946,12 @@
           "url": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fast-levenshtein"
         }
       ]
     },
@@ -7725,6 +9973,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fast.js"
+        }
       ]
     },
     {
@@ -7744,6 +9998,12 @@
           "url": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fd-slicer"
         }
       ]
     },
@@ -7765,6 +10025,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/feature-policy"
+        }
       ]
     },
     {
@@ -7784,6 +10050,12 @@
           "url": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fecha"
         }
       ]
     },
@@ -7806,6 +10078,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/file-js"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7824,6 +10102,12 @@
               "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/file-js\\node_modules\\brace-expansion"
             }
           ]
         },
@@ -7844,6 +10128,12 @@
               "url": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/file-js\\node_modules\\minimatch"
             }
           ]
         }
@@ -7867,6 +10157,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/file-stream-rotator"
+        }
       ]
     },
     {
@@ -7886,6 +10182,12 @@
           "url": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/file-type"
         }
       ]
     },
@@ -7907,6 +10209,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/file-uri-to-path"
+        }
       ]
     },
     {
@@ -7926,6 +10234,12 @@
           "url": "https://registry.npmjs.org/filehound/-/filehound-1.17.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/filehound"
         }
       ]
     },
@@ -7947,6 +10261,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/filename-reserved-regex"
+        }
       ]
     },
     {
@@ -7967,6 +10287,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/filenamify"
+        }
       ]
     },
     {
@@ -7986,6 +10312,12 @@
           "url": "https://registry.npmjs.org/filesniffer/-/filesniffer-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/filesniffer"
         }
       ]
     },
@@ -8008,6 +10340,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fill-range"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -8026,6 +10364,12 @@
               "url": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/fill-range\\node_modules\\extend-shallow"
             }
           ]
         },
@@ -8046,6 +10390,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/fill-range\\node_modules\\is-extendable"
             }
           ]
         }
@@ -8069,6 +10419,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/finale-rest"
+        }
       ]
     },
     {
@@ -8088,6 +10444,12 @@
           "url": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/finalhandler"
         }
       ]
     },
@@ -8109,6 +10471,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/find-up"
+        }
       ]
     },
     {
@@ -8128,6 +10496,12 @@
           "url": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/findup-sync"
         }
       ]
     },
@@ -8149,6 +10523,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fined"
+        }
       ]
     },
     {
@@ -8168,6 +10548,12 @@
           "url": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/flagged-respawn"
         }
       ]
     },
@@ -8189,6 +10575,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fn.name"
+        }
       ]
     },
     {
@@ -8208,6 +10600,12 @@
           "url": "https://registry.npmjs.org/fontkit/-/fontkit-1.9.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fontkit"
         }
       ]
     },
@@ -8229,6 +10627,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/for-each"
+        }
       ]
     },
     {
@@ -8248,6 +10652,12 @@
           "url": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/for-in"
         }
       ]
     },
@@ -8269,6 +10679,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/for-own"
+        }
       ]
     },
     {
@@ -8288,6 +10704,12 @@
           "url": "https://registry.npmjs.org/foreachasync/-/foreachasync-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/foreachasync"
         }
       ]
     },
@@ -8309,6 +10731,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/forever-agent"
+        }
       ]
     },
     {
@@ -8328,6 +10756,12 @@
           "url": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/form-data"
         }
       ]
     },
@@ -8349,6 +10783,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/formatio"
+        }
       ]
     },
     {
@@ -8368,6 +10808,12 @@
           "url": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/forwarded"
         }
       ]
     },
@@ -8389,6 +10835,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fragment-cache"
+        }
       ]
     },
     {
@@ -8408,6 +10860,12 @@
           "url": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fresh"
         }
       ]
     },
@@ -8429,6 +10887,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/from2"
+        }
       ]
     },
     {
@@ -8448,6 +10912,12 @@
           "url": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fs-constants"
         }
       ]
     },
@@ -8469,6 +10939,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fs-extra"
+        }
       ]
     },
     {
@@ -8489,6 +10965,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fs-minipass"
+        }
       ]
     },
     {
@@ -8508,6 +10990,12 @@
           "url": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fs.realpath"
         }
       ]
     },
@@ -8530,6 +11018,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fstream"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -8548,6 +11042,12 @@
               "url": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/fstream\\node_modules\\mkdirp"
             }
           ]
         },
@@ -8568,6 +11068,12 @@
               "url": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/fstream\\node_modules\\rimraf"
             }
           ]
         }
@@ -8591,6 +11097,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/function-bind"
+        }
       ]
     },
     {
@@ -8610,6 +11122,12 @@
           "url": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/function.prototype.name"
         }
       ]
     },
@@ -8631,6 +11149,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/functions-have-names"
+        }
       ]
     },
     {
@@ -8650,6 +11174,12 @@
           "url": "https://registry.npmjs.org/fuzzball/-/fuzzball-1.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fuzzball"
         }
       ]
     },
@@ -8671,6 +11201,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/gauge"
+        }
       ]
     },
     {
@@ -8690,6 +11226,12 @@
           "url": "https://registry.npmjs.org/geojson-utils/-/geojson-utils-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/geojson-utils"
         }
       ]
     },
@@ -8711,6 +11253,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-caller-file"
+        }
       ]
     },
     {
@@ -8730,6 +11278,12 @@
           "url": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-intrinsic"
         }
       ]
     },
@@ -8751,6 +11305,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-stream"
+        }
       ]
     },
     {
@@ -8770,6 +11330,12 @@
           "url": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-symbol-description"
         }
       ]
     },
@@ -8791,6 +11357,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-value"
+        }
       ]
     },
     {
@@ -8810,6 +11382,12 @@
           "url": "https://registry.npmjs.org/getobject/-/getobject-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/getobject"
         }
       ]
     },
@@ -8831,6 +11409,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/getpass"
+        }
       ]
     },
     {
@@ -8850,6 +11434,12 @@
           "url": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/github-from-package"
         }
       ]
     },
@@ -8872,6 +11462,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/glob-parent"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -8890,6 +11486,12 @@
               "url": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/glob-parent\\node_modules\\is-glob"
             }
           ]
         }
@@ -8914,6 +11516,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/glob"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -8932,6 +11540,12 @@
               "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/glob\\node_modules\\brace-expansion"
             }
           ]
         },
@@ -8952,6 +11566,12 @@
               "url": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/glob\\node_modules\\minimatch"
             }
           ]
         }
@@ -8975,6 +11595,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/global-modules"
+        }
       ]
     },
     {
@@ -8996,6 +11622,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/global-prefix"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9014,6 +11646,12 @@
               "url": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/global-prefix\\node_modules\\which"
             }
           ]
         }
@@ -9038,6 +11676,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/got"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9056,6 +11700,12 @@
               "url": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/got\\node_modules\\get-stream"
             }
           ]
         },
@@ -9076,6 +11726,12 @@
               "url": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/got\\node_modules\\pify"
             }
           ]
         }
@@ -9099,6 +11755,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/graceful-fs"
+        }
       ]
     },
     {
@@ -9120,6 +11782,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-cli"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9138,6 +11806,12 @@
               "url": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-cli\\node_modules\\nopt"
             }
           ]
         }
@@ -9162,6 +11836,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-contrib-compress"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9180,6 +11860,12 @@
               "url": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-contrib-compress\\node_modules\\ansi-styles"
             }
           ]
         },
@@ -9201,6 +11887,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-contrib-compress\\node_modules\\chalk"
+            }
           ]
         },
         {
@@ -9220,6 +11912,12 @@
               "url": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-contrib-compress\\node_modules\\supports-color"
             }
           ]
         }
@@ -9243,6 +11941,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-known-options"
+        }
       ]
     },
     {
@@ -9264,6 +11968,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-legacy-log-utils"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9282,6 +11992,12 @@
               "url": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils\\node_modules\\ansi-styles"
             }
           ]
         },
@@ -9303,6 +12019,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils\\node_modules\\chalk"
+            }
           ]
         },
         {
@@ -9322,6 +12044,12 @@
               "url": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils\\node_modules\\color-convert"
             }
           ]
         },
@@ -9343,6 +12071,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils\\node_modules\\color-name"
+            }
           ]
         },
         {
@@ -9363,6 +12097,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils\\node_modules\\has-flag"
+            }
           ]
         },
         {
@@ -9382,6 +12122,12 @@
               "url": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils\\node_modules\\supports-color"
             }
           ]
         }
@@ -9406,6 +12152,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-legacy-log"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9424,6 +12176,12 @@
               "url": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log\\node_modules\\colors"
             }
           ]
         }
@@ -9448,6 +12206,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-legacy-util"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9466,6 +12230,12 @@
               "url": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-util\\node_modules\\async"
             }
           ]
         }
@@ -9489,6 +12259,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-replace-json"
+        }
       ]
     },
     {
@@ -9510,6 +12286,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9528,6 +12310,12 @@
               "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt\\node_modules\\brace-expansion"
             }
           ]
         },
@@ -9550,6 +12338,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt\\node_modules\\findup-sync"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -9568,6 +12362,12 @@
                   "url": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/grunt\\node_modules\\findup-sync\\node_modules\\glob"
                 }
               ]
             }
@@ -9591,6 +12391,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt\\node_modules\\glob"
+            }
           ]
         },
         {
@@ -9610,6 +12416,12 @@
               "url": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.8.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt\\node_modules\\minimatch"
             }
           ]
         }
@@ -9634,6 +12446,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/handlebars"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9652,6 +12470,12 @@
               "url": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/handlebars\\node_modules\\wordwrap"
             }
           ]
         }
@@ -9675,6 +12499,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/har-schema"
+        }
       ]
     },
     {
@@ -9694,6 +12524,12 @@
           "url": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/har-validator"
         }
       ]
     },
@@ -9715,6 +12551,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-ansi"
+        }
       ]
     },
     {
@@ -9734,6 +12576,12 @@
           "url": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-bigints"
         }
       ]
     },
@@ -9755,6 +12603,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-flag"
+        }
       ]
     },
     {
@@ -9774,6 +12628,12 @@
           "url": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-property-descriptors"
         }
       ]
     },
@@ -9795,6 +12655,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-symbol-support-x"
+        }
       ]
     },
     {
@@ -9814,6 +12680,12 @@
           "url": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-symbols"
         }
       ]
     },
@@ -9835,6 +12707,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-to-string-tag-x"
+        }
       ]
     },
     {
@@ -9854,6 +12732,12 @@
           "url": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-tostringtag"
         }
       ]
     },
@@ -9875,6 +12759,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-unicode"
+        }
       ]
     },
     {
@@ -9894,6 +12784,12 @@
           "url": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-value"
         }
       ]
     },
@@ -9916,6 +12812,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-values"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9934,6 +12836,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/has-values\\node_modules\\kind-of"
             }
           ]
         }
@@ -9957,6 +12865,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has"
+        }
       ]
     },
     {
@@ -9976,6 +12890,12 @@
           "url": "https://registry.npmjs.org/hashids/-/hashids-2.2.10.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hashids"
         }
       ]
     },
@@ -9997,6 +12917,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hbs"
+        }
       ]
     },
     {
@@ -10016,6 +12942,12 @@
           "url": "https://registry.npmjs.org/he/-/he-0.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/he"
         }
       ]
     },
@@ -10037,6 +12969,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/heap"
+        }
       ]
     },
     {
@@ -10056,6 +12994,12 @@
           "url": "https://registry.npmjs.org/helmet/-/helmet-4.6.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/helmet"
         }
       ]
     },
@@ -10077,6 +13021,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hoister"
+        }
       ]
     },
     {
@@ -10096,6 +13046,12 @@
           "url": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/homedir-polyfill"
         }
       ]
     },
@@ -10117,6 +13073,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hooker"
+        }
       ]
     },
     {
@@ -10137,6 +13099,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hosted-git-info"
+        }
       ]
     },
     {
@@ -10156,6 +13124,12 @@
           "url": "https://registry.npmjs.org/html-entities/-/html-entities-1.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/html-entities"
         }
       ]
     },
@@ -10178,6 +13152,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/htmlparser2"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -10196,6 +13176,12 @@
               "url": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/htmlparser2\\node_modules\\isarray"
             }
           ]
         },
@@ -10217,6 +13203,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/htmlparser2\\node_modules\\readable-stream"
+            }
           ]
         },
         {
@@ -10236,6 +13228,12 @@
               "url": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/htmlparser2\\node_modules\\string_decoder"
             }
           ]
         }
@@ -10259,6 +13257,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/http-cache-semantics"
+        }
       ]
     },
     {
@@ -10278,6 +13282,12 @@
           "url": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/http-errors"
         }
       ]
     },
@@ -10300,6 +13310,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/http-proxy-agent"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -10318,6 +13334,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/http-proxy-agent\\node_modules\\debug"
             }
           ]
         },
@@ -10338,6 +13360,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/http-proxy-agent\\node_modules\\ms"
             }
           ]
         }
@@ -10361,6 +13389,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/http-signature"
+        }
       ]
     },
     {
@@ -10382,6 +13416,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/https-proxy-agent"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -10400,6 +13440,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/https-proxy-agent\\node_modules\\debug"
             }
           ]
         },
@@ -10420,6 +13466,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/https-proxy-agent\\node_modules\\ms"
             }
           ]
         }
@@ -10443,6 +13495,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/humanize-ms"
+        }
       ]
     },
     {
@@ -10462,6 +13520,12 @@
           "url": "https://registry.npmjs.org/i18n/-/i18n-0.11.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/i18n"
         }
       ]
     },
@@ -10483,6 +13547,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/iconv-lite"
+        }
       ]
     },
     {
@@ -10502,6 +13572,12 @@
           "url": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ieee754"
         }
       ]
     },
@@ -10524,6 +13600,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ignore-walk"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -10542,6 +13624,12 @@
               "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/ignore-walk\\node_modules\\brace-expansion"
             }
           ]
         },
@@ -10562,6 +13650,12 @@
               "url": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/ignore-walk\\node_modules\\minimatch"
             }
           ]
         }
@@ -10585,6 +13679,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/iltorb"
+        }
       ]
     },
     {
@@ -10604,6 +13704,12 @@
           "url": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/imurmurhash"
         }
       ]
     },
@@ -10625,6 +13731,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/indent-string"
+        }
       ]
     },
     {
@@ -10644,6 +13756,12 @@
           "url": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/infer-owner"
         }
       ]
     },
@@ -10665,6 +13783,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/inflection"
+        }
       ]
     },
     {
@@ -10684,6 +13808,12 @@
           "url": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/inflight"
         }
       ]
     },
@@ -10705,6 +13835,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/inherits"
+        }
       ]
     },
     {
@@ -10724,6 +13860,12 @@
           "url": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ini"
         }
       ]
     },
@@ -10745,6 +13887,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/internal-slot"
+        }
       ]
     },
     {
@@ -10764,6 +13912,12 @@
           "url": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/interpret"
         }
       ]
     },
@@ -10785,6 +13939,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/into-stream"
+        }
       ]
     },
     {
@@ -10804,6 +13964,12 @@
           "url": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/invariant"
         }
       ]
     },
@@ -10825,6 +13991,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ip"
+        }
       ]
     },
     {
@@ -10844,6 +14016,12 @@
           "url": "https://registry.npmjs.org/ip6/-/ip6-0.2.10.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ip6"
         }
       ]
     },
@@ -10865,6 +14043,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ipaddr.js"
+        }
       ]
     },
     {
@@ -10884,6 +14068,12 @@
           "url": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-absolute"
         }
       ]
     },
@@ -10905,6 +14095,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-accessor-descriptor"
+        }
       ]
     },
     {
@@ -10924,6 +14120,12 @@
           "url": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-arguments"
         }
       ]
     },
@@ -10945,6 +14147,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-arrayish"
+        }
       ]
     },
     {
@@ -10964,6 +14172,12 @@
           "url": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-bigint"
         }
       ]
     },
@@ -10985,6 +14199,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-binary-path"
+        }
       ]
     },
     {
@@ -11004,6 +14224,12 @@
           "url": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-boolean-object"
         }
       ]
     },
@@ -11025,6 +14251,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-buffer"
+        }
       ]
     },
     {
@@ -11044,6 +14276,12 @@
           "url": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-callable"
         }
       ]
     },
@@ -11065,6 +14303,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-core-module"
+        }
       ]
     },
     {
@@ -11084,6 +14328,12 @@
           "url": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-data-descriptor"
         }
       ]
     },
@@ -11105,6 +14355,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-date-object"
+        }
       ]
     },
     {
@@ -11124,6 +14380,12 @@
           "url": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-descriptor"
         }
       ]
     },
@@ -11145,6 +14407,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-docker"
+        }
       ]
     },
     {
@@ -11164,6 +14432,12 @@
           "url": "https://registry.npmjs.org/is-expression/-/is-expression-4.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-expression"
         }
       ]
     },
@@ -11185,6 +14459,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-extendable"
+        }
       ]
     },
     {
@@ -11204,6 +14484,12 @@
           "url": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-extglob"
         }
       ]
     },
@@ -11225,6 +14511,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-fullwidth-code-point"
+        }
       ]
     },
     {
@@ -11244,6 +14536,12 @@
           "url": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-generator-function"
         }
       ]
     },
@@ -11265,6 +14563,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-glob"
+        }
       ]
     },
     {
@@ -11284,6 +14588,12 @@
           "url": "https://registry.npmjs.org/is-heroku/-/is-heroku-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-heroku"
         }
       ]
     },
@@ -11305,6 +14615,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-lambda"
+        }
       ]
     },
     {
@@ -11324,6 +14640,12 @@
           "url": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-map"
         }
       ]
     },
@@ -11345,6 +14667,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-natural-number"
+        }
       ]
     },
     {
@@ -11364,6 +14692,12 @@
           "url": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-negative-zero"
         }
       ]
     },
@@ -11385,6 +14719,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-number-like"
+        }
       ]
     },
     {
@@ -11404,6 +14744,12 @@
           "url": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-number-object"
         }
       ]
     },
@@ -11426,6 +14772,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-number"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -11444,6 +14796,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/is-number\\node_modules\\kind-of"
             }
           ]
         }
@@ -11467,6 +14825,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-object"
+        }
       ]
     },
     {
@@ -11486,6 +14850,12 @@
           "url": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-plain-obj"
         }
       ]
     },
@@ -11507,6 +14877,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-plain-object"
+        }
       ]
     },
     {
@@ -11526,6 +14902,12 @@
           "url": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-promise"
         }
       ]
     },
@@ -11547,6 +14929,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-regex"
+        }
       ]
     },
     {
@@ -11566,6 +14954,12 @@
           "url": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-relative"
         }
       ]
     },
@@ -11587,6 +14981,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-retry-allowed"
+        }
       ]
     },
     {
@@ -11606,6 +15006,12 @@
           "url": "https://registry.npmjs.org/is-set/-/is-set-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-set"
         }
       ]
     },
@@ -11627,6 +15033,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-shared-array-buffer"
+        }
       ]
     },
     {
@@ -11646,6 +15058,12 @@
           "url": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-stream"
         }
       ]
     },
@@ -11667,6 +15085,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-string"
+        }
       ]
     },
     {
@@ -11686,6 +15110,12 @@
           "url": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-symbol"
         }
       ]
     },
@@ -11707,6 +15137,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-typed-array"
+        }
       ]
     },
     {
@@ -11726,6 +15162,12 @@
           "url": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-typedarray"
         }
       ]
     },
@@ -11747,6 +15189,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-unc-path"
+        }
       ]
     },
     {
@@ -11766,6 +15214,12 @@
           "url": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-weakmap"
         }
       ]
     },
@@ -11787,6 +15241,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-weakref"
+        }
       ]
     },
     {
@@ -11806,6 +15266,12 @@
           "url": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-weakset"
         }
       ]
     },
@@ -11827,6 +15293,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-windows"
+        }
       ]
     },
     {
@@ -11846,6 +15318,12 @@
           "url": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isarray"
         }
       ]
     },
@@ -11867,6 +15345,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isexe"
+        }
       ]
     },
     {
@@ -11886,6 +15370,12 @@
           "url": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isobject"
         }
       ]
     },
@@ -11907,6 +15397,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isstream"
+        }
       ]
     },
     {
@@ -11926,6 +15422,12 @@
           "url": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isurl"
         }
       ]
     },
@@ -11947,6 +15449,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/js-stringify"
+        }
       ]
     },
     {
@@ -11966,6 +15474,12 @@
           "url": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/js-tokens"
         }
       ]
     },
@@ -11987,6 +15501,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/js-yaml"
+        }
       ]
     },
     {
@@ -12006,6 +15526,12 @@
           "url": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jsbn"
         }
       ]
     },
@@ -12027,6 +15553,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-buffer"
+        }
       ]
     },
     {
@@ -12046,6 +15578,12 @@
           "url": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-parse-better-errors"
         }
       ]
     },
@@ -12067,6 +15605,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-schema-traverse"
+        }
       ]
     },
     {
@@ -12086,6 +15630,12 @@
           "url": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-schema"
         }
       ]
     },
@@ -12107,6 +15657,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-stringify-safe"
+        }
       ]
     },
     {
@@ -12126,6 +15682,12 @@
           "url": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json5"
         }
       ]
     },
@@ -12147,6 +15709,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jsonfile"
+        }
       ]
     },
     {
@@ -12166,6 +15734,12 @@
           "url": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-0.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jsonwebtoken"
         }
       ]
     },
@@ -12187,6 +15761,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jsprim"
+        }
       ]
     },
     {
@@ -12206,6 +15786,12 @@
           "url": "https://registry.npmjs.org/jssha/-/jssha-3.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jssha"
         }
       ]
     },
@@ -12227,6 +15813,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jstransformer"
+        }
       ]
     },
     {
@@ -12246,6 +15838,12 @@
           "url": "https://registry.npmjs.org/juicy-chat-bot/-/juicy-chat-bot-0.6.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/juicy-chat-bot"
         }
       ]
     },
@@ -12267,6 +15865,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jwa"
+        }
       ]
     },
     {
@@ -12286,6 +15890,12 @@
           "url": "https://registry.npmjs.org/jws/-/jws-0.2.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jws"
         }
       ]
     },
@@ -12307,6 +15917,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/keyv"
+        }
       ]
     },
     {
@@ -12326,6 +15942,12 @@
           "url": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/kind-of"
         }
       ]
     },
@@ -12347,6 +15969,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/kuler"
+        }
       ]
     },
     {
@@ -12366,6 +15994,12 @@
           "url": "https://registry.npmjs.org/kuromoji/-/kuromoji-0.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/kuromoji"
         }
       ]
     },
@@ -12387,6 +16021,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lazystream"
+        }
       ]
     },
     {
@@ -12406,6 +16046,12 @@
           "url": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/levn"
         }
       ]
     },
@@ -12428,6 +16074,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/libxmljs2"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12446,6 +16098,12 @@
               "url": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/libxmljs2\\node_modules\\nan"
             }
           ]
         }
@@ -12470,6 +16128,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/liftup"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12488,6 +16152,12 @@
               "url": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup\\node_modules\\braces"
             }
           ]
         },
@@ -12509,6 +16179,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup\\node_modules\\fill-range"
+            }
           ]
         },
         {
@@ -12528,6 +16204,12 @@
               "url": "https://registry.npmjs.org/findup-sync/-/findup-sync-4.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup\\node_modules\\findup-sync"
             }
           ]
         },
@@ -12549,6 +16231,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup\\node_modules\\is-glob"
+            }
           ]
         },
         {
@@ -12568,6 +16256,12 @@
               "url": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup\\node_modules\\is-number"
             }
           ]
         },
@@ -12589,6 +16283,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup\\node_modules\\micromatch"
+            }
           ]
         },
         {
@@ -12608,6 +16308,12 @@
               "url": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup\\node_modules\\to-regex-range"
             }
           ]
         }
@@ -12632,6 +16338,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/linebreak"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12650,6 +16362,12 @@
               "url": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/linebreak\\node_modules\\base64-js"
             }
           ]
         }
@@ -12673,6 +16391,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/listenercount"
+        }
       ]
     },
     {
@@ -12692,6 +16416,12 @@
           "url": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/locate-path"
         }
       ]
     },
@@ -12713,6 +16443,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lodash.camelcase"
+        }
       ]
     },
     {
@@ -12732,6 +16468,12 @@
           "url": "https://registry.npmjs.org/lodash.isfinite/-/lodash.isfinite-3.3.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lodash.isfinite"
         }
       ]
     },
@@ -12753,6 +16495,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lodash.set"
+        }
       ]
     },
     {
@@ -12772,6 +16520,12 @@
           "url": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lodash"
         }
       ]
     },
@@ -12794,6 +16548,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/logform"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12812,6 +16572,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/logform\\node_modules\\ms"
             }
           ]
         }
@@ -12835,6 +16601,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lolex"
+        }
       ]
     },
     {
@@ -12854,6 +16626,12 @@
           "url": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/loose-envify"
         }
       ]
     },
@@ -12875,6 +16653,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lowercase-keys"
+        }
       ]
     },
     {
@@ -12894,6 +16678,12 @@
           "url": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lru-cache"
         }
       ]
     },
@@ -12916,6 +16706,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-dir"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12934,6 +16730,12 @@
               "url": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-dir\\node_modules\\semver"
             }
           ]
         }
@@ -12957,6 +16759,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-error"
+        }
       ]
     },
     {
@@ -12976,6 +16784,12 @@
           "url": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-9.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-fetch-happen"
         }
       ],
       "components": [
@@ -12998,6 +16812,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen\\node_modules\\@tootallnate\\once"
+            }
           ]
         },
         {
@@ -13017,6 +16837,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen\\node_modules\\debug"
             }
           ]
         },
@@ -13038,6 +16864,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen\\node_modules\\http-cache-semantics"
+            }
           ]
         },
         {
@@ -13058,6 +16890,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen\\node_modules\\http-proxy-agent"
+            }
           ]
         },
         {
@@ -13077,6 +16915,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen\\node_modules\\ms"
             }
           ]
         }
@@ -13100,6 +16944,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-iterator"
+        }
       ]
     },
     {
@@ -13119,6 +16969,12 @@
           "url": "https://registry.npmjs.org/make-plural/-/make-plural-6.2.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-plural"
         }
       ]
     },
@@ -13140,6 +16996,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/map-cache"
+        }
       ]
     },
     {
@@ -13159,6 +17021,12 @@
           "url": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/map-visit"
         }
       ]
     },
@@ -13180,6 +17048,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/marsdb"
+        }
       ]
     },
     {
@@ -13199,6 +17073,12 @@
           "url": "https://registry.npmjs.org/math-interval-parser/-/math-interval-parser-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/math-interval-parser"
         }
       ]
     },
@@ -13220,6 +17100,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/media-typer"
+        }
       ]
     },
     {
@@ -13239,6 +17125,12 @@
           "url": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/merge-descriptors"
         }
       ]
     },
@@ -13260,6 +17152,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/messageformat-formatters"
+        }
       ]
     },
     {
@@ -13279,6 +17177,12 @@
           "url": "https://registry.npmjs.org/messageformat-parser/-/messageformat-parser-4.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/messageformat-parser"
         }
       ]
     },
@@ -13301,6 +17205,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/messageformat"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -13319,6 +17229,12 @@
               "url": "https://registry.npmjs.org/make-plural/-/make-plural-4.3.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/messageformat\\node_modules\\make-plural"
             }
           ]
         }
@@ -13342,6 +17258,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/methods"
+        }
       ]
     },
     {
@@ -13361,6 +17283,12 @@
           "url": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/micromatch"
         }
       ]
     },
@@ -13382,6 +17310,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mime-db"
+        }
       ]
     },
     {
@@ -13401,6 +17335,12 @@
           "url": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mime-types"
         }
       ]
     },
@@ -13422,6 +17362,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mime"
+        }
       ]
     },
     {
@@ -13441,6 +17387,12 @@
           "url": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mimic-response"
         }
       ]
     },
@@ -13462,6 +17414,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minimatch"
+        }
       ]
     },
     {
@@ -13481,6 +17439,12 @@
           "url": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minimist"
         }
       ]
     },
@@ -13502,6 +17466,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-collect"
+        }
       ]
     },
     {
@@ -13521,6 +17491,12 @@
           "url": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-1.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-fetch"
         }
       ]
     },
@@ -13542,6 +17518,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-flush"
+        }
       ]
     },
     {
@@ -13561,6 +17543,12 @@
           "url": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-pipeline"
         }
       ]
     },
@@ -13582,6 +17570,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-sized"
+        }
       ]
     },
     {
@@ -13601,6 +17595,12 @@
           "url": "https://registry.npmjs.org/minipass/-/minipass-3.3.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass"
         }
       ]
     },
@@ -13622,6 +17622,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minizlib"
+        }
       ]
     },
     {
@@ -13641,6 +17647,12 @@
           "url": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mixin-deep"
         }
       ]
     },
@@ -13662,6 +17674,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mkdirp-classic"
+        }
       ]
     },
     {
@@ -13681,6 +17699,12 @@
           "url": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mkdirp"
         }
       ]
     },
@@ -13702,6 +17726,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/moment-timezone"
+        }
       ]
     },
     {
@@ -13721,6 +17751,12 @@
           "url": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/moment"
         }
       ]
     },
@@ -13743,6 +17779,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/morgan"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -13761,6 +17803,12 @@
               "url": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/morgan\\node_modules\\on-finished"
             }
           ]
         }
@@ -13784,6 +17832,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mout"
+        }
       ]
     },
     {
@@ -13803,6 +17857,12 @@
           "url": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ms"
         }
       ]
     },
@@ -13825,6 +17885,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/multer"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -13843,6 +17909,12 @@
               "url": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/multer\\node_modules\\mkdirp"
             }
           ]
         }
@@ -13866,6 +17938,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mustache"
+        }
       ]
     },
     {
@@ -13885,6 +17963,12 @@
           "url": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/nan"
         }
       ]
     },
@@ -13906,6 +17990,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/nanomatch"
+        }
       ]
     },
     {
@@ -13925,6 +18015,12 @@
           "url": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/napi-build-utils"
         }
       ]
     },
@@ -13947,6 +18043,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/needle"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -13965,6 +18067,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/needle\\node_modules\\debug"
             }
           ]
         },
@@ -13985,6 +18093,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/needle\\node_modules\\ms"
             }
           ]
         }
@@ -14008,6 +18122,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/negotiator"
+        }
       ]
     },
     {
@@ -14027,6 +18147,12 @@
           "url": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/neo-async"
         }
       ]
     },
@@ -14049,6 +18175,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-abi"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14067,6 +18199,12 @@
               "url": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-abi\\node_modules\\semver"
             }
           ]
         }
@@ -14090,6 +18228,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-addon-api"
+        }
       ]
     },
     {
@@ -14109,6 +18253,12 @@
           "url": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-fetch"
         }
       ]
     },
@@ -14131,6 +18281,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-gyp"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14149,6 +18305,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp\\node_modules\\ansi-regex"
             }
           ]
         },
@@ -14170,6 +18332,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp\\node_modules\\are-we-there-yet"
+            }
           ]
         },
         {
@@ -14189,6 +18357,12 @@
               "url": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp\\node_modules\\gauge"
             }
           ]
         },
@@ -14210,6 +18384,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp\\node_modules\\is-fullwidth-code-point"
+            }
           ]
         },
         {
@@ -14229,6 +18409,12 @@
               "url": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp\\node_modules\\nopt"
             }
           ]
         },
@@ -14250,6 +18436,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp\\node_modules\\npmlog"
+            }
           ]
         },
         {
@@ -14269,6 +18461,12 @@
               "url": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp\\node_modules\\readable-stream"
             }
           ]
         },
@@ -14290,6 +18488,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp\\node_modules\\string-width"
+            }
           ]
         },
         {
@@ -14309,6 +18513,12 @@
               "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp\\node_modules\\strip-ansi"
             }
           ]
         }
@@ -14333,6 +18543,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-pre-gyp"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14351,6 +18567,12 @@
               "url": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp\\node_modules\\chownr"
             }
           ]
         },
@@ -14372,6 +18594,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp\\node_modules\\fs-minipass"
+            }
           ]
         },
         {
@@ -14391,6 +18619,12 @@
               "url": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp\\node_modules\\minipass"
             }
           ]
         },
@@ -14412,6 +18646,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp\\node_modules\\minizlib"
+            }
           ]
         },
         {
@@ -14431,6 +18671,12 @@
               "url": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp\\node_modules\\mkdirp"
             }
           ]
         },
@@ -14452,6 +18698,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp\\node_modules\\nopt"
+            }
           ]
         },
         {
@@ -14471,6 +18723,12 @@
               "url": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp\\node_modules\\rimraf"
             }
           ]
         },
@@ -14492,6 +18750,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp\\node_modules\\safe-buffer"
+            }
           ]
         },
         {
@@ -14511,6 +18775,12 @@
               "url": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp\\node_modules\\semver"
             }
           ]
         },
@@ -14532,6 +18802,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp\\node_modules\\tar"
+            }
           ]
         },
         {
@@ -14551,6 +18827,12 @@
               "url": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp\\node_modules\\yallist"
             }
           ]
         }
@@ -14574,6 +18856,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/noop-logger"
+        }
       ]
     },
     {
@@ -14593,6 +18881,12 @@
           "url": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/nopt"
         }
       ]
     },
@@ -14615,6 +18909,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/normalize-package-data"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14633,6 +18933,12 @@
               "url": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/normalize-package-data\\node_modules\\semver"
             }
           ]
         }
@@ -14656,6 +18962,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/normalize-path"
+        }
       ]
     },
     {
@@ -14675,6 +18987,12 @@
           "url": "https://registry.npmjs.org/normalize-url/-/normalize-url-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/normalize-url"
         }
       ]
     },
@@ -14697,6 +19015,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/notevil"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14715,6 +19039,12 @@
               "url": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/notevil\\node_modules\\esprima"
             }
           ]
         }
@@ -14738,6 +19068,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/npm-bundled"
+        }
       ]
     },
     {
@@ -14757,6 +19093,12 @@
           "url": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/npm-normalize-package-bin"
         }
       ]
     },
@@ -14778,6 +19120,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/npm-packlist"
+        }
       ]
     },
     {
@@ -14797,6 +19145,12 @@
           "url": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/npmlog"
         }
       ]
     },
@@ -14818,6 +19172,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/number-is-nan"
+        }
       ]
     },
     {
@@ -14838,6 +19198,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/oauth-sign"
+        }
       ]
     },
     {
@@ -14857,6 +19223,12 @@
           "url": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-assign"
         }
       ]
     },
@@ -14879,6 +19251,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-copy"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14897,6 +19275,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy\\node_modules\\define-property"
             }
           ]
         },
@@ -14918,6 +19302,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy\\node_modules\\is-accessor-descriptor"
+            }
           ]
         },
         {
@@ -14937,6 +19327,12 @@
               "url": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy\\node_modules\\is-data-descriptor"
             }
           ]
         },
@@ -14959,6 +19355,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy\\node_modules\\is-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -14977,6 +19379,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/object-copy\\node_modules\\is-descriptor\\node_modules\\kind-of"
                 }
               ]
             }
@@ -15000,6 +19408,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy\\node_modules\\kind-of"
+            }
           ]
         }
       ]
@@ -15022,6 +19436,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-inspect"
+        }
       ]
     },
     {
@@ -15041,6 +19461,12 @@
           "url": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-is"
         }
       ]
     },
@@ -15062,6 +19488,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-keys"
+        }
       ]
     },
     {
@@ -15081,6 +19513,12 @@
           "url": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-visit"
         }
       ]
     },
@@ -15102,6 +19540,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object.assign"
+        }
       ]
     },
     {
@@ -15121,6 +19565,12 @@
           "url": "https://registry.npmjs.org/object.defaults/-/object.defaults-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object.defaults"
         }
       ]
     },
@@ -15142,6 +19592,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object.map"
+        }
       ]
     },
     {
@@ -15161,6 +19617,12 @@
           "url": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object.pick"
         }
       ]
     },
@@ -15182,6 +19644,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/on-finished"
+        }
       ]
     },
     {
@@ -15201,6 +19669,12 @@
           "url": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/on-headers"
         }
       ]
     },
@@ -15222,6 +19696,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/once"
+        }
       ]
     },
     {
@@ -15241,6 +19721,12 @@
           "url": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/one-time"
         }
       ]
     },
@@ -15262,6 +19748,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/opentype.js"
+        }
       ]
     },
     {
@@ -15281,6 +19773,12 @@
           "url": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/optionator"
         }
       ]
     },
@@ -15302,6 +19800,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/os-homedir"
+        }
       ]
     },
     {
@@ -15321,6 +19825,12 @@
           "url": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/os-tmpdir"
         }
       ]
     },
@@ -15342,6 +19852,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/osenv"
+        }
       ]
     },
     {
@@ -15361,6 +19877,12 @@
           "url": "https://registry.npmjs.org/otplib/-/otplib-12.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/otplib"
         }
       ]
     },
@@ -15382,6 +19904,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-cancelable"
+        }
       ]
     },
     {
@@ -15401,6 +19929,12 @@
           "url": "https://registry.npmjs.org/p-event/-/p-event-2.3.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-event"
         }
       ]
     },
@@ -15422,6 +19956,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-finally"
+        }
       ]
     },
     {
@@ -15441,6 +19981,12 @@
           "url": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-is-promise"
         }
       ]
     },
@@ -15462,6 +20008,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-limit"
+        }
       ]
     },
     {
@@ -15481,6 +20033,12 @@
           "url": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-locate"
         }
       ]
     },
@@ -15502,6 +20060,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-map"
+        }
       ]
     },
     {
@@ -15521,6 +20085,12 @@
           "url": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-timeout"
         }
       ]
     },
@@ -15542,6 +20112,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-try"
+        }
       ]
     },
     {
@@ -15561,6 +20137,12 @@
           "url": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pako"
         }
       ]
     },
@@ -15582,6 +20164,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/parse-filepath"
+        }
       ]
     },
     {
@@ -15601,6 +20189,12 @@
           "url": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/parse-json"
         }
       ]
     },
@@ -15622,6 +20216,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/parse-passwd"
+        }
       ]
     },
     {
@@ -15641,6 +20241,12 @@
           "url": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/parseurl"
         }
       ]
     },
@@ -15662,6 +20268,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pascalcase"
+        }
       ]
     },
     {
@@ -15681,6 +20293,12 @@
           "url": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-exists"
         }
       ]
     },
@@ -15702,6 +20320,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-is-absolute"
+        }
       ]
     },
     {
@@ -15721,6 +20345,12 @@
           "url": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-parse"
         }
       ]
     },
@@ -15742,6 +20372,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-root-regex"
+        }
       ]
     },
     {
@@ -15761,6 +20397,12 @@
           "url": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-root"
         }
       ]
     },
@@ -15782,6 +20424,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-to-regexp"
+        }
       ]
     },
     {
@@ -15801,6 +20449,12 @@
           "url": "https://registry.npmjs.org/pdfkit/-/pdfkit-0.11.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pdfkit"
         }
       ]
     },
@@ -15822,6 +20476,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/peek-readable"
+        }
       ]
     },
     {
@@ -15841,6 +20501,12 @@
           "url": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pend"
         }
       ]
     },
@@ -15862,6 +20528,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/performance-now"
+        }
       ]
     },
     {
@@ -15881,6 +20553,12 @@
           "url": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.5.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pg-connection-string"
         }
       ]
     },
@@ -15902,6 +20580,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/picomatch"
+        }
       ]
     },
     {
@@ -15921,6 +20605,12 @@
           "url": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pify"
         }
       ]
     },
@@ -15942,6 +20632,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pinkie-promise"
+        }
       ]
     },
     {
@@ -15961,6 +20657,12 @@
           "url": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pinkie"
         }
       ]
     },
@@ -15982,6 +20684,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/png-js"
+        }
       ]
     },
     {
@@ -16001,6 +20709,12 @@
           "url": "https://registry.npmjs.org/portscanner/-/portscanner-2.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/portscanner"
         }
       ]
     },
@@ -16022,6 +20736,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/posix-character-classes"
+        }
       ]
     },
     {
@@ -16041,6 +20761,12 @@
           "url": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.3.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/prebuild-install"
         }
       ]
     },
@@ -16062,6 +20788,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/prelude-ls"
+        }
       ]
     },
     {
@@ -16081,6 +20813,12 @@
           "url": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/prepend-http"
         }
       ]
     },
@@ -16102,6 +20840,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pretty-bytes"
+        }
       ]
     },
     {
@@ -16121,6 +20865,12 @@
           "url": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/process-nextick-args"
         }
       ]
     },
@@ -16142,6 +20892,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/prom-client"
+        }
       ]
     },
     {
@@ -16161,6 +20917,12 @@
           "url": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/promise-inflight"
         }
       ]
     },
@@ -16183,6 +20945,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/promise-retry"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -16201,6 +20969,12 @@
               "url": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/promise-retry\\node_modules\\err-code"
             }
           ]
         },
@@ -16221,6 +20995,12 @@
               "url": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/promise-retry\\node_modules\\retry"
             }
           ]
         }
@@ -16244,6 +21024,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/promise"
+        }
       ]
     },
     {
@@ -16263,6 +21049,12 @@
           "url": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/proper-lockfile"
         }
       ]
     },
@@ -16284,6 +21076,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/proxy-addr"
+        }
       ]
     },
     {
@@ -16303,6 +21101,12 @@
           "url": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/psl"
         }
       ]
     },
@@ -16324,6 +21128,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-attrs"
+        }
       ]
     },
     {
@@ -16343,6 +21153,12 @@
           "url": "https://registry.npmjs.org/pug-code-gen/-/pug-code-gen-3.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-code-gen"
         }
       ]
     },
@@ -16364,6 +21180,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-error"
+        }
       ]
     },
     {
@@ -16383,6 +21205,12 @@
           "url": "https://registry.npmjs.org/pug-filters/-/pug-filters-4.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-filters"
         }
       ]
     },
@@ -16404,6 +21232,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-lexer"
+        }
       ]
     },
     {
@@ -16423,6 +21257,12 @@
           "url": "https://registry.npmjs.org/pug-linker/-/pug-linker-4.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-linker"
         }
       ]
     },
@@ -16444,6 +21284,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-load"
+        }
       ]
     },
     {
@@ -16463,6 +21309,12 @@
           "url": "https://registry.npmjs.org/pug-parser/-/pug-parser-6.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-parser"
         }
       ]
     },
@@ -16484,6 +21336,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-runtime"
+        }
       ]
     },
     {
@@ -16503,6 +21361,12 @@
           "url": "https://registry.npmjs.org/pug-strip-comments/-/pug-strip-comments-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-strip-comments"
         }
       ]
     },
@@ -16524,6 +21388,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-walk"
+        }
       ]
     },
     {
@@ -16543,6 +21413,12 @@
           "url": "https://registry.npmjs.org/pug/-/pug-3.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug"
         }
       ]
     },
@@ -16564,6 +21440,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pump"
+        }
       ]
     },
     {
@@ -16583,6 +21465,12 @@
           "url": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/punycode"
         }
       ]
     },
@@ -16604,6 +21492,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/qs"
+        }
       ]
     },
     {
@@ -16623,6 +21517,12 @@
           "url": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/query-string"
         }
       ]
     },
@@ -16644,6 +21544,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/range_check"
+        }
       ]
     },
     {
@@ -16663,6 +21569,12 @@
           "url": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/range-parser"
         }
       ]
     },
@@ -16684,6 +21596,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/raw-body"
+        }
       ]
     },
     {
@@ -16703,6 +21621,12 @@
           "url": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/rc"
         }
       ]
     },
@@ -16725,6 +21649,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/read-pkg"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -16743,6 +21673,12 @@
               "url": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/read-pkg\\node_modules\\pify"
             }
           ]
         }
@@ -16767,6 +21703,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/readable-stream"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -16785,6 +21727,12 @@
               "url": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/readable-stream\\node_modules\\isarray"
             }
           ]
         }
@@ -16809,6 +21757,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/readable-web-to-node-stream"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -16827,6 +21781,12 @@
               "url": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/readable-web-to-node-stream\\node_modules\\readable-stream"
             }
           ]
         }
@@ -16850,6 +21810,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/readdirp"
+        }
       ]
     },
     {
@@ -16869,6 +21835,12 @@
           "url": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/rechoir"
         }
       ]
     },
@@ -16890,6 +21862,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/regex-not"
+        }
       ]
     },
     {
@@ -16909,6 +21887,12 @@
           "url": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/regexp.prototype.flags"
         }
       ]
     },
@@ -16930,6 +21914,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/remove-trailing-separator"
+        }
       ]
     },
     {
@@ -16950,6 +21940,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/repeat-element"
+        }
       ]
     },
     {
@@ -16969,6 +21965,12 @@
           "url": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/repeat-string"
         }
       ]
     },
@@ -16991,6 +21993,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/replace"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17009,6 +22017,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\ansi-regex"
             }
           ]
         },
@@ -17030,6 +22044,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\ansi-styles"
+            }
           ]
         },
         {
@@ -17049,6 +22069,12 @@
               "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\brace-expansion"
             }
           ]
         },
@@ -17070,6 +22096,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\cliui"
+            }
           ]
         },
         {
@@ -17089,6 +22121,12 @@
               "url": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\color-convert"
             }
           ]
         },
@@ -17110,6 +22148,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\color-name"
+            }
           ]
         },
         {
@@ -17129,6 +22173,12 @@
               "url": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\find-up"
             }
           ]
         },
@@ -17150,6 +22200,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\is-fullwidth-code-point"
+            }
           ]
         },
         {
@@ -17169,6 +22225,12 @@
               "url": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\locate-path"
             }
           ]
         },
@@ -17190,6 +22252,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\minimatch"
+            }
           ]
         },
         {
@@ -17209,6 +22277,12 @@
               "url": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\p-locate"
             }
           ]
         },
@@ -17230,6 +22304,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\path-exists"
+            }
           ]
         },
         {
@@ -17249,6 +22329,12 @@
               "url": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\string-width"
             }
           ]
         },
@@ -17270,6 +22356,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\strip-ansi"
+            }
           ]
         },
         {
@@ -17289,6 +22381,12 @@
               "url": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\wrap-ansi"
             }
           ]
         },
@@ -17310,6 +22408,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\yargs-parser"
+            }
           ]
         },
         {
@@ -17329,6 +22433,12 @@
               "url": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\yargs"
             }
           ]
         }
@@ -17353,6 +22463,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/request"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17371,6 +22487,12 @@
               "url": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/request\\node_modules\\qs"
             }
           ]
         }
@@ -17394,6 +22516,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/require-directory"
+        }
       ]
     },
     {
@@ -17413,6 +22541,12 @@
           "url": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/require-main-filename"
         }
       ]
     },
@@ -17434,6 +22568,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/resolve-dir"
+        }
       ]
     },
     {
@@ -17453,6 +22593,12 @@
           "url": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/resolve-url"
         }
       ]
     },
@@ -17474,6 +22620,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/resolve"
+        }
       ]
     },
     {
@@ -17493,6 +22645,12 @@
           "url": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/responselike"
         }
       ]
     },
@@ -17514,6 +22672,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/restructure"
+        }
       ]
     },
     {
@@ -17533,6 +22697,12 @@
           "url": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ret"
         }
       ]
     },
@@ -17554,6 +22724,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/retry-as-promised"
+        }
       ]
     },
     {
@@ -17574,6 +22750,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/retry"
+        }
       ]
     },
     {
@@ -17593,6 +22775,12 @@
           "url": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/rimraf"
         }
       ]
     },
@@ -17615,6 +22803,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/rxjs"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17633,6 +22827,12 @@
               "url": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/rxjs\\node_modules\\tslib"
             }
           ]
         }
@@ -17656,6 +22856,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safe-buffer"
+        }
       ]
     },
     {
@@ -17675,6 +22881,12 @@
           "url": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safe-regex-test"
         }
       ]
     },
@@ -17696,6 +22908,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safe-regex"
+        }
       ]
     },
     {
@@ -17715,6 +22933,12 @@
           "url": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safe-stable-stringify"
         }
       ]
     },
@@ -17736,6 +22960,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safer-buffer"
+        }
       ]
     },
     {
@@ -17756,6 +22986,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/samsam"
+        }
       ]
     },
     {
@@ -17775,6 +23011,12 @@
           "url": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sanitize-filename"
         }
       ]
     },
@@ -17797,6 +23039,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sanitize-html"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17815,6 +23063,12 @@
               "url": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sanitize-html\\node_modules\\lodash"
             }
           ]
         }
@@ -17838,6 +23092,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sax"
+        }
       ]
     },
     {
@@ -17858,6 +23118,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/seek-bzip"
+        }
       ]
     },
     {
@@ -17877,6 +23143,12 @@
           "url": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/semver"
         }
       ]
     },
@@ -17899,6 +23171,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/send"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17917,6 +23195,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/send\\node_modules\\ms"
             }
           ]
         }
@@ -17940,6 +23224,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sequelize-pool"
+        }
       ]
     },
     {
@@ -17961,6 +23251,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sequelize"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17979,6 +23275,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sequelize\\node_modules\\debug"
             }
           ]
         },
@@ -18000,6 +23302,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sequelize\\node_modules\\ms"
+            }
           ]
         },
         {
@@ -18019,6 +23327,12 @@
               "url": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sequelize\\node_modules\\uuid"
             }
           ]
         }
@@ -18043,6 +23357,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/serve-index"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18061,6 +23381,12 @@
               "url": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index\\node_modules\\depd"
             }
           ]
         },
@@ -18082,6 +23408,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index\\node_modules\\http-errors"
+            }
           ]
         },
         {
@@ -18101,6 +23433,12 @@
               "url": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index\\node_modules\\inherits"
             }
           ]
         },
@@ -18122,6 +23460,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index\\node_modules\\setprototypeof"
+            }
           ]
         },
         {
@@ -18141,6 +23485,12 @@
               "url": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index\\node_modules\\statuses"
             }
           ]
         }
@@ -18164,6 +23514,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/serve-static"
+        }
       ]
     },
     {
@@ -18183,6 +23539,12 @@
           "url": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/set-blocking"
         }
       ]
     },
@@ -18205,6 +23567,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/set-value"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18223,6 +23591,12 @@
               "url": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/set-value\\node_modules\\extend-shallow"
             }
           ]
         },
@@ -18243,6 +23617,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/set-value\\node_modules\\is-extendable"
             }
           ]
         }
@@ -18266,6 +23646,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/setimmediate"
+        }
       ]
     },
     {
@@ -18285,6 +23671,12 @@
           "url": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/setprototypeof"
         }
       ]
     },
@@ -18306,6 +23698,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/side-channel"
+        }
       ]
     },
     {
@@ -18326,6 +23724,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/signal-exit"
+        }
       ]
     },
     {
@@ -18345,6 +23749,12 @@
           "url": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/simple-concat"
         }
       ]
     },
@@ -18367,6 +23777,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/simple-get"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18385,6 +23801,12 @@
               "url": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/simple-get\\node_modules\\decompress-response"
             }
           ]
         },
@@ -18405,6 +23827,12 @@
               "url": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/simple-get\\node_modules\\mimic-response"
             }
           ]
         }
@@ -18429,6 +23857,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/simple-swizzle"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18447,6 +23881,12 @@
               "url": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/simple-swizzle\\node_modules\\is-arrayish"
             }
           ]
         }
@@ -18470,6 +23910,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sinon"
+        }
       ]
     },
     {
@@ -18489,6 +23935,12 @@
           "url": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/smart-buffer"
         }
       ]
     },
@@ -18511,6 +23963,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/snapdragon-node"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18529,6 +23987,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon-node\\node_modules\\define-property"
             }
           ]
         }
@@ -18553,6 +24017,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/snapdragon-util"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18571,6 +24041,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon-util\\node_modules\\kind-of"
             }
           ]
         }
@@ -18595,6 +24071,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/snapdragon"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18613,6 +24095,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon\\node_modules\\define-property"
             }
           ]
         },
@@ -18633,6 +24121,12 @@
               "url": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon\\node_modules\\extend-shallow"
             }
           ]
         },
@@ -18655,6 +24149,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon\\node_modules\\is-accessor-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -18673,6 +24173,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/snapdragon\\node_modules\\is-accessor-descriptor\\node_modules\\kind-of"
                 }
               ]
             }
@@ -18697,6 +24203,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon\\node_modules\\is-data-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -18715,6 +24227,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/snapdragon\\node_modules\\is-data-descriptor\\node_modules\\kind-of"
                 }
               ]
             }
@@ -18738,6 +24256,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon\\node_modules\\is-descriptor"
+            }
           ]
         },
         {
@@ -18757,6 +24281,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon\\node_modules\\is-extendable"
             }
           ]
         },
@@ -18778,6 +24308,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon\\node_modules\\kind-of"
+            }
           ]
         },
         {
@@ -18797,6 +24333,12 @@
               "url": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon\\node_modules\\source-map"
             }
           ]
         }
@@ -18820,6 +24362,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socket.io-adapter"
+        }
       ]
     },
     {
@@ -18841,6 +24389,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socket.io-parser"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18859,6 +24413,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socket.io-parser\\node_modules\\debug"
             }
           ]
         },
@@ -18879,6 +24439,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socket.io-parser\\node_modules\\ms"
             }
           ]
         }
@@ -18903,6 +24469,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socket.io"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18921,6 +24493,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socket.io\\node_modules\\debug"
             }
           ]
         },
@@ -18941,6 +24519,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socket.io\\node_modules\\ms"
             }
           ]
         }
@@ -18965,6 +24549,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socks-proxy-agent"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18983,6 +24573,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socks-proxy-agent\\node_modules\\debug"
             }
           ]
         },
@@ -19003,6 +24599,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socks-proxy-agent\\node_modules\\ms"
             }
           ]
         }
@@ -19027,6 +24629,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socks"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -19045,6 +24653,12 @@
               "url": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socks\\node_modules\\ip"
             }
           ]
         }
@@ -19069,6 +24683,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sort-keys-length"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -19087,6 +24707,12 @@
               "url": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sort-keys-length\\node_modules\\sort-keys"
             }
           ]
         }
@@ -19110,6 +24736,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sort-keys"
+        }
       ]
     },
     {
@@ -19129,6 +24761,12 @@
           "url": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/source-map-resolve"
         }
       ]
     },
@@ -19150,6 +24788,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/source-map-support"
+        }
       ]
     },
     {
@@ -19169,6 +24813,12 @@
           "url": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/source-map-url"
         }
       ]
     },
@@ -19190,6 +24840,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/source-map"
+        }
       ]
     },
     {
@@ -19209,6 +24865,12 @@
           "url": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2-1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spawn-command"
         }
       ]
     },
@@ -19230,6 +24892,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spdx-correct"
+        }
       ]
     },
     {
@@ -19249,6 +24917,12 @@
           "url": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spdx-exceptions"
         }
       ]
     },
@@ -19270,6 +24944,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spdx-expression-parse"
+        }
       ]
     },
     {
@@ -19289,6 +24969,12 @@
           "url": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.12.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spdx-license-ids"
         }
       ]
     },
@@ -19310,6 +24996,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/split-string"
+        }
       ]
     },
     {
@@ -19329,6 +25021,12 @@
           "url": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sprintf-js"
         }
       ]
     },
@@ -19350,6 +25048,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sqlite3"
+        }
       ]
     },
     {
@@ -19369,6 +25073,12 @@
           "url": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sshpk"
         }
       ]
     },
@@ -19390,6 +25100,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ssri"
+        }
       ]
     },
     {
@@ -19409,6 +25125,12 @@
           "url": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/stack-trace"
         }
       ]
     },
@@ -19431,6 +25153,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/static-extend"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -19449,6 +25177,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend\\node_modules\\define-property"
             }
           ]
         },
@@ -19471,6 +25205,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend\\node_modules\\is-accessor-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -19489,6 +25229,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/static-extend\\node_modules\\is-accessor-descriptor\\node_modules\\kind-of"
                 }
               ]
             }
@@ -19513,6 +25259,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend\\node_modules\\is-data-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -19531,6 +25283,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/static-extend\\node_modules\\is-data-descriptor\\node_modules\\kind-of"
                 }
               ]
             }
@@ -19554,6 +25312,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend\\node_modules\\is-descriptor"
+            }
           ]
         },
         {
@@ -19573,6 +25337,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend\\node_modules\\kind-of"
             }
           ]
         }
@@ -19596,6 +25366,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/statuses"
+        }
       ]
     },
     {
@@ -19615,6 +25391,12 @@
           "url": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-2.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/stream-buffers"
         }
       ]
     },
@@ -19636,6 +25418,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/streamsearch"
+        }
       ]
     },
     {
@@ -19655,6 +25443,12 @@
           "url": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strict-uri-encode"
         }
       ]
     },
@@ -19676,6 +25470,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string_decoder"
+        }
       ]
     },
     {
@@ -19695,6 +25495,12 @@
           "url": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string-width"
         }
       ]
     },
@@ -19716,6 +25522,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string.fromcodepoint"
+        }
       ]
     },
     {
@@ -19735,6 +25547,12 @@
           "url": "https://registry.npmjs.org/string.prototype.codepointat/-/string.prototype.codepointat-0.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string.prototype.codepointat"
         }
       ]
     },
@@ -19756,6 +25574,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string.prototype.trimend"
+        }
       ]
     },
     {
@@ -19775,6 +25599,12 @@
           "url": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string.prototype.trimstart"
         }
       ]
     },
@@ -19796,6 +25626,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-ansi"
+        }
       ]
     },
     {
@@ -19815,6 +25651,12 @@
           "url": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-bom"
         }
       ]
     },
@@ -19836,6 +25678,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-dirs"
+        }
       ]
     },
     {
@@ -19855,6 +25703,12 @@
           "url": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-json-comments"
         }
       ]
     },
@@ -19876,6 +25730,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-outer"
+        }
       ]
     },
     {
@@ -19895,6 +25755,12 @@
           "url": "https://registry.npmjs.org/strtok3/-/strtok3-6.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strtok3"
         }
       ]
     },
@@ -19916,6 +25782,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/supports-color"
+        }
       ]
     },
     {
@@ -19935,6 +25807,12 @@
           "url": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/supports-preserve-symlinks-flag"
         }
       ]
     },
@@ -19956,6 +25834,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/svg-captcha"
+        }
       ]
     },
     {
@@ -19976,6 +25860,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/swagger-ui-dist"
+        }
       ]
     },
     {
@@ -19995,6 +25885,12 @@
           "url": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-4.5.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/swagger-ui-express"
         }
       ]
     },
@@ -20017,6 +25913,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tar-fs"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -20035,6 +25937,12 @@
               "url": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/tar-fs\\node_modules\\bl"
             }
           ]
         },
@@ -20056,6 +25964,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/tar-fs\\node_modules\\chownr"
+            }
           ]
         },
         {
@@ -20076,6 +25990,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/tar-fs\\node_modules\\readable-stream"
+            }
           ]
         },
         {
@@ -20095,6 +26015,12 @@
               "url": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/tar-fs\\node_modules\\tar-stream"
             }
           ]
         }
@@ -20118,6 +26044,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tar-stream"
+        }
       ]
     },
     {
@@ -20137,6 +26069,12 @@
           "url": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tar"
         }
       ]
     },
@@ -20158,6 +26096,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tdigest"
+        }
       ]
     },
     {
@@ -20177,6 +26121,12 @@
           "url": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/text-hex"
         }
       ]
     },
@@ -20198,6 +26148,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/thirty-two"
+        }
       ]
     },
     {
@@ -20217,6 +26173,12 @@
           "url": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/through"
         }
       ]
     },
@@ -20238,6 +26200,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/timed-out"
+        }
       ]
     },
     {
@@ -20257,6 +26225,12 @@
           "url": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tiny-inflate"
         }
       ]
     },
@@ -20278,6 +26252,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-buffer"
+        }
       ]
     },
     {
@@ -20297,6 +26277,12 @@
           "url": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-fast-properties"
         }
       ]
     },
@@ -20319,6 +26305,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-object-path"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -20337,6 +26329,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/to-object-path\\node_modules\\kind-of"
             }
           ]
         }
@@ -20360,6 +26358,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-regex-range"
+        }
       ]
     },
     {
@@ -20379,6 +26383,12 @@
           "url": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-regex"
         }
       ]
     },
@@ -20400,6 +26410,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/toidentifier"
+        }
       ]
     },
     {
@@ -20419,6 +26435,12 @@
           "url": "https://registry.npmjs.org/token-stream/-/token-stream-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/token-stream"
         }
       ]
     },
@@ -20440,6 +26462,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/token-types"
+        }
       ]
     },
     {
@@ -20459,6 +26487,12 @@
           "url": "https://registry.npmjs.org/toposort-class/-/toposort-class-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/toposort-class"
         }
       ]
     },
@@ -20480,6 +26514,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tough-cookie"
+        }
       ]
     },
     {
@@ -20499,6 +26539,12 @@
           "url": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tr46"
         }
       ]
     },
@@ -20520,6 +26566,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/traverse"
+        }
       ]
     },
     {
@@ -20539,6 +26591,12 @@
           "url": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tree-kill"
         }
       ]
     },
@@ -20560,6 +26618,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/trim-repeated"
+        }
       ]
     },
     {
@@ -20580,6 +26644,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/triple-beam"
+        }
       ]
     },
     {
@@ -20599,6 +26669,12 @@
           "url": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/truncate-utf8-bytes"
         }
       ]
     },
@@ -20621,6 +26697,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ts-node-dev"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -20639,6 +26721,12 @@
               "url": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/ts-node-dev\\node_modules\\rimraf"
             }
           ]
         }
@@ -20662,6 +26750,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ts-node"
+        }
       ]
     },
     {
@@ -20681,6 +26775,12 @@
           "url": "https://registry.npmjs.org/tsconfig/-/tsconfig-7.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tsconfig"
         }
       ]
     },
@@ -20702,6 +26802,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tslib"
+        }
       ]
     },
     {
@@ -20721,6 +26827,12 @@
           "url": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tunnel-agent"
         }
       ]
     },
@@ -20742,6 +26854,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tweetnacl"
+        }
       ]
     },
     {
@@ -20761,6 +26879,12 @@
           "url": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/type-check"
         }
       ]
     },
@@ -20782,6 +26906,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/type-is"
+        }
       ]
     },
     {
@@ -20801,6 +26931,12 @@
           "url": "https://registry.npmjs.org/typecast/-/typecast-0.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/typecast"
         }
       ]
     },
@@ -20822,6 +26958,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/typedarray"
+        }
       ]
     },
     {
@@ -20841,6 +26983,12 @@
           "url": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/typescript"
         }
       ]
     },
@@ -20862,6 +27010,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/uglify-js"
+        }
       ]
     },
     {
@@ -20881,6 +27035,12 @@
           "url": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unbox-primitive"
         }
       ]
     },
@@ -20902,6 +27062,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unbzip2-stream"
+        }
       ]
     },
     {
@@ -20921,6 +27087,12 @@
           "url": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unc-path-regex"
         }
       ]
     },
@@ -20942,6 +27114,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/underscore.string"
+        }
       ]
     },
     {
@@ -20962,6 +27140,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unicode-properties"
+        }
       ]
     },
     {
@@ -20981,6 +27165,12 @@
           "url": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unicode-trie"
         }
       ]
     },
@@ -21003,6 +27193,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/union-value"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21021,6 +27217,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/union-value\\node_modules\\is-extendable"
             }
           ]
         }
@@ -21044,6 +27246,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unique-filename"
+        }
       ]
     },
     {
@@ -21063,6 +27271,12 @@
           "url": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unique-slug"
         }
       ]
     },
@@ -21084,6 +27298,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unit-compare"
+        }
       ]
     },
     {
@@ -21104,6 +27324,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/universalify"
+        }
       ]
     },
     {
@@ -21123,6 +27349,12 @@
           "url": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unpipe"
         }
       ]
     },
@@ -21145,6 +27377,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unset-value"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21165,6 +27403,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/unset-value\\node_modules\\has-value"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -21183,6 +27427,12 @@
                   "url": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/unset-value\\node_modules\\has-value\\node_modules\\isobject"
                 }
               ]
             }
@@ -21206,6 +27456,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/unset-value\\node_modules\\has-values"
+            }
           ]
         },
         {
@@ -21225,6 +27481,12 @@
               "url": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/unset-value\\node_modules\\isarray"
             }
           ]
         }
@@ -21248,6 +27510,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/untildify"
+        }
       ]
     },
     {
@@ -21269,6 +27537,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unzipper"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21287,6 +27561,12 @@
               "url": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/unzipper\\node_modules\\bluebird"
             }
           ]
         }
@@ -21310,6 +27590,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/uri-js"
+        }
       ]
     },
     {
@@ -21329,6 +27615,12 @@
           "url": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/urix"
         }
       ]
     },
@@ -21350,6 +27642,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/url-parse-lax"
+        }
       ]
     },
     {
@@ -21369,6 +27667,12 @@
           "url": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/url-to-options"
         }
       ]
     },
@@ -21390,6 +27694,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/use"
+        }
       ]
     },
     {
@@ -21409,6 +27719,12 @@
           "url": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/utf8-byte-length"
         }
       ]
     },
@@ -21430,6 +27746,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/util-deprecate"
+        }
       ]
     },
     {
@@ -21449,6 +27771,12 @@
           "url": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/util"
         }
       ]
     },
@@ -21470,6 +27798,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/utils-merge"
+        }
       ]
     },
     {
@@ -21489,6 +27823,12 @@
           "url": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/uuid"
         }
       ]
     },
@@ -21510,6 +27850,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/v8flags"
+        }
       ]
     },
     {
@@ -21529,6 +27875,12 @@
           "url": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/validate-npm-package-license"
         }
       ]
     },
@@ -21550,6 +27902,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/validate"
+        }
       ]
     },
     {
@@ -21570,6 +27928,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/validator"
+        }
       ]
     },
     {
@@ -21589,6 +27953,12 @@
           "url": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/vary"
         }
       ]
     },
@@ -21611,6 +27981,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/verror"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21629,6 +28005,12 @@
               "url": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/verror\\node_modules\\core-util-is"
             }
           ]
         }
@@ -21653,6 +28035,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/vm2"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21671,6 +28059,12 @@
               "url": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/vm2\\node_modules\\acorn"
             }
           ]
         }
@@ -21694,6 +28088,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/void-elements"
+        }
       ]
     },
     {
@@ -21713,6 +28113,12 @@
           "url": "https://registry.npmjs.org/walk/-/walk-2.3.15.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/walk"
         }
       ]
     },
@@ -21734,6 +28140,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/walkdir"
+        }
       ]
     },
     {
@@ -21753,6 +28165,12 @@
           "url": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/webidl-conversions"
         }
       ]
     },
@@ -21774,6 +28192,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/whatwg-url"
+        }
       ]
     },
     {
@@ -21793,6 +28217,12 @@
           "url": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-boxed-primitive"
         }
       ]
     },
@@ -21814,6 +28244,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-collection"
+        }
       ]
     },
     {
@@ -21833,6 +28269,12 @@
           "url": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-module"
         }
       ]
     },
@@ -21854,6 +28296,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-pm-runs"
+        }
       ]
     },
     {
@@ -21873,6 +28321,12 @@
           "url": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-typed-array"
         }
       ]
     },
@@ -21894,6 +28348,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which"
+        }
       ]
     },
     {
@@ -21913,6 +28373,12 @@
           "url": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wide-align"
         }
       ]
     },
@@ -21935,6 +28401,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/winston-transport"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21953,6 +28425,12 @@
               "url": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/winston-transport\\node_modules\\readable-stream"
             }
           ]
         }
@@ -21977,6 +28455,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/winston"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21995,6 +28479,12 @@
               "url": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/winston\\node_modules\\async"
             }
           ]
         },
@@ -22016,6 +28506,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/winston\\node_modules\\is-stream"
+            }
           ]
         },
         {
@@ -22035,6 +28531,12 @@
               "url": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/winston\\node_modules\\readable-stream"
             }
           ]
         }
@@ -22058,6 +28560,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/with"
+        }
       ]
     },
     {
@@ -22077,6 +28585,12 @@
           "url": "https://registry.npmjs.org/wkx/-/wkx-0.5.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wkx"
         }
       ]
     },
@@ -22098,6 +28612,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/word-wrap"
+        }
       ]
     },
     {
@@ -22117,6 +28637,12 @@
           "url": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wordwrap"
         }
       ]
     },
@@ -22139,6 +28665,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wrap-ansi"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -22157,6 +28689,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi\\node_modules\\ansi-regex"
             }
           ]
         },
@@ -22178,6 +28716,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi\\node_modules\\emoji-regex"
+            }
           ]
         },
         {
@@ -22197,6 +28741,12 @@
               "url": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi\\node_modules\\is-fullwidth-code-point"
             }
           ]
         },
@@ -22218,6 +28768,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi\\node_modules\\string-width"
+            }
           ]
         },
         {
@@ -22237,6 +28793,12 @@
               "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi\\node_modules\\strip-ansi"
             }
           ]
         }
@@ -22260,6 +28822,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wrappy"
+        }
       ]
     },
     {
@@ -22279,6 +28847,12 @@
           "url": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ws"
         }
       ]
     },
@@ -22300,6 +28874,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/xtend"
+        }
       ]
     },
     {
@@ -22319,6 +28899,12 @@
           "url": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/y18n"
         }
       ]
     },
@@ -22340,6 +28926,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yallist"
+        }
       ]
     },
     {
@@ -22360,6 +28952,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yaml-schema-validator"
+        }
       ]
     },
     {
@@ -22379,6 +28977,12 @@
           "url": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yargs-parser"
         }
       ]
     },
@@ -22401,6 +29005,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yargs"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -22419,6 +29029,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs\\node_modules\\ansi-regex"
             }
           ]
         },
@@ -22440,6 +29056,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs\\node_modules\\emoji-regex"
+            }
           ]
         },
         {
@@ -22459,6 +29081,12 @@
               "url": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs\\node_modules\\is-fullwidth-code-point"
             }
           ]
         },
@@ -22480,6 +29108,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs\\node_modules\\string-width"
+            }
           ]
         },
         {
@@ -22499,6 +29133,12 @@
               "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs\\node_modules\\strip-ansi"
             }
           ]
         }
@@ -22522,6 +29162,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yauzl"
+        }
       ]
     },
     {
@@ -22541,6 +29187,12 @@
           "url": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yn"
         }
       ]
     },
@@ -22562,6 +29214,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/z85"
+        }
       ]
     },
     {
@@ -22582,6 +29240,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/zip-stream"
+        }
       ]
     },
     {
@@ -22601,6 +29265,12 @@
           "url": "https://registry.npmjs.org/zlibjs/-/zlibjs-0.3.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/zlibjs"
         }
       ]
     }

--- a/tests/_data/sbom_demo-results/juice-shop_npm7_node18_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/juice-shop_npm7_node18_windows-latest.snap.json
@@ -62,7 +62,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -95,7 +95,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@babel\\helper-string-parser"
         }
       ]
@@ -122,7 +122,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@babel\\helper-validator-identifier"
         }
       ]
@@ -149,7 +149,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@babel\\parser"
         }
       ]
@@ -176,7 +176,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@babel\\types"
         }
       ]
@@ -203,7 +203,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@colors\\colors"
         }
       ]
@@ -230,7 +230,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@dabh\\diagnostics"
         }
       ]
@@ -257,7 +257,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@gar\\promisify"
         }
       ]
@@ -284,7 +284,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@mapbox\\node-pre-gyp"
         }
       ],
@@ -310,7 +310,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\ansi-regex"
             }
           ]
@@ -336,7 +336,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\are-we-there-yet"
             }
           ]
@@ -362,7 +362,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\detect-libc"
             }
           ]
@@ -388,7 +388,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\gauge"
             }
           ]
@@ -414,7 +414,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\is-fullwidth-code-point"
             }
           ]
@@ -440,7 +440,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\make-dir"
             }
           ],
@@ -466,7 +466,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\make-dir\\node_modules\\semver"
                 }
               ]
@@ -494,7 +494,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\nopt"
             }
           ]
@@ -520,7 +520,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\npmlog"
             }
           ]
@@ -546,7 +546,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\readable-stream"
             }
           ]
@@ -572,7 +572,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\string-width"
             }
           ]
@@ -598,7 +598,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\strip-ansi"
             }
           ]
@@ -627,7 +627,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\core-loader"
         }
       ]
@@ -654,7 +654,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\core"
         }
       ]
@@ -681,7 +681,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\evaluator"
         }
       ]
@@ -708,7 +708,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-all"
         }
       ]
@@ -735,7 +735,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-ar"
         }
       ]
@@ -762,7 +762,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-bn"
         }
       ]
@@ -789,7 +789,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-ca"
         }
       ]
@@ -816,7 +816,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-cs"
         }
       ]
@@ -843,7 +843,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-da"
         }
       ]
@@ -870,7 +870,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-de"
         }
       ]
@@ -897,7 +897,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-el"
         }
       ]
@@ -924,7 +924,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-en-min"
         }
       ]
@@ -951,7 +951,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-en"
         }
       ]
@@ -978,7 +978,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-es"
         }
       ]
@@ -1005,7 +1005,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-eu"
         }
       ]
@@ -1032,7 +1032,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-fa"
         }
       ]
@@ -1059,7 +1059,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-fi"
         }
       ]
@@ -1086,7 +1086,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-fr"
         }
       ]
@@ -1113,7 +1113,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-ga"
         }
       ]
@@ -1140,7 +1140,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-gl"
         }
       ]
@@ -1167,7 +1167,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-hi"
         }
       ]
@@ -1194,7 +1194,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-hu"
         }
       ]
@@ -1221,7 +1221,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-hy"
         }
       ]
@@ -1248,7 +1248,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-id"
         }
       ]
@@ -1275,7 +1275,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-it"
         }
       ]
@@ -1302,7 +1302,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-ja"
         }
       ]
@@ -1329,7 +1329,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-ko"
         }
       ]
@@ -1356,7 +1356,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-lt"
         }
       ]
@@ -1383,7 +1383,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-ms"
         }
       ]
@@ -1410,7 +1410,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-ne"
         }
       ]
@@ -1437,7 +1437,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-nl"
         }
       ]
@@ -1464,7 +1464,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-no"
         }
       ]
@@ -1491,7 +1491,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-pl"
         }
       ]
@@ -1518,7 +1518,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-pt"
         }
       ]
@@ -1545,7 +1545,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-ro"
         }
       ]
@@ -1572,7 +1572,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-ru"
         }
       ]
@@ -1599,7 +1599,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-sl"
         }
       ]
@@ -1626,7 +1626,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-sr"
         }
       ]
@@ -1653,7 +1653,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-sv"
         }
       ]
@@ -1680,7 +1680,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-ta"
         }
       ]
@@ -1707,7 +1707,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-th"
         }
       ]
@@ -1734,7 +1734,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-tl"
         }
       ]
@@ -1761,7 +1761,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-tr"
         }
       ]
@@ -1788,7 +1788,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-uk"
         }
       ]
@@ -1815,7 +1815,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-zh"
         }
       ]
@@ -1842,7 +1842,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\language-min"
         }
       ]
@@ -1869,7 +1869,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\language"
         }
       ]
@@ -1896,7 +1896,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\ner"
         }
       ]
@@ -1923,7 +1923,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\neural"
         }
       ]
@@ -1950,7 +1950,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\nlg"
         }
       ]
@@ -1977,7 +1977,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\nlp"
         }
       ]
@@ -2004,7 +2004,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\nlu"
         }
       ]
@@ -2031,7 +2031,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\request"
         }
       ]
@@ -2058,7 +2058,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\sentiment"
         }
       ]
@@ -2085,7 +2085,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\similarity"
         }
       ]
@@ -2112,7 +2112,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\slot"
         }
       ]
@@ -2139,7 +2139,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@npmcli\\fs"
         }
       ]
@@ -2166,7 +2166,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@npmcli\\move-file"
         }
       ]
@@ -2193,7 +2193,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib\\core"
         }
       ]
@@ -2220,7 +2220,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib\\plugin-crypto"
         }
       ]
@@ -2247,7 +2247,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib\\plugin-thirty-two"
         }
       ]
@@ -2274,7 +2274,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib\\preset-default"
         }
       ]
@@ -2301,7 +2301,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib\\preset-v11"
         }
       ]
@@ -2328,7 +2328,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@sindresorhus\\is"
         }
       ]
@@ -2355,7 +2355,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@swc\\helpers"
         }
       ]
@@ -2382,7 +2382,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@tokenizer\\token"
         }
       ]
@@ -2409,7 +2409,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@tootallnate\\once"
         }
       ]
@@ -2436,7 +2436,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types\\component-emitter"
         }
       ]
@@ -2463,7 +2463,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types\\cookie"
         }
       ]
@@ -2490,7 +2490,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types\\cors"
         }
       ]
@@ -2517,7 +2517,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types\\debug"
         }
       ]
@@ -2544,7 +2544,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types\\ms"
         }
       ]
@@ -2571,7 +2571,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types\\node"
         }
       ]
@@ -2598,7 +2598,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types\\strip-bom"
         }
       ]
@@ -2625,7 +2625,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types\\strip-json-comments"
         }
       ]
@@ -2652,7 +2652,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types\\validator"
         }
       ]
@@ -2678,7 +2678,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/abbrev"
         }
       ]
@@ -2704,7 +2704,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/accepts"
         }
       ]
@@ -2730,7 +2730,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/acorn-walk"
         }
       ]
@@ -2756,7 +2756,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/acorn"
         }
       ]
@@ -2782,7 +2782,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/agent-base"
         }
       ],
@@ -2808,7 +2808,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agent-base\\node_modules\\debug"
             }
           ]
@@ -2834,7 +2834,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agent-base\\node_modules\\ms"
             }
           ]
@@ -2862,7 +2862,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/agentkeepalive"
         }
       ],
@@ -2888,7 +2888,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agentkeepalive\\node_modules\\debug"
             }
           ]
@@ -2914,7 +2914,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agentkeepalive\\node_modules\\depd"
             }
           ]
@@ -2940,7 +2940,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agentkeepalive\\node_modules\\ms"
             }
           ]
@@ -2968,7 +2968,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/aggregate-error"
         }
       ]
@@ -2994,7 +2994,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ajv"
         }
       ]
@@ -3020,7 +3020,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ansi-regex"
         }
       ]
@@ -3046,7 +3046,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ansi-styles"
         }
       ]
@@ -3072,7 +3072,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/anymatch"
         }
       ],
@@ -3098,7 +3098,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/anymatch\\node_modules\\normalize-path"
             }
           ]
@@ -3126,7 +3126,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/append-field"
         }
       ]
@@ -3152,7 +3152,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/aproba"
         }
       ]
@@ -3178,7 +3178,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/archive-type"
         }
       ],
@@ -3204,7 +3204,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/archive-type\\node_modules\\file-type"
             }
           ]
@@ -3232,7 +3232,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/archiver-utils"
         }
       ]
@@ -3258,7 +3258,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/archiver"
         }
       ]
@@ -3284,7 +3284,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/are-we-there-yet"
         }
       ]
@@ -3310,7 +3310,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/arg"
         }
       ]
@@ -3336,7 +3336,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/argparse"
         }
       ],
@@ -3362,7 +3362,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/argparse\\node_modules\\sprintf-js"
             }
           ]
@@ -3390,7 +3390,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/arr-diff"
         }
       ]
@@ -3416,7 +3416,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/arr-flatten"
         }
       ]
@@ -3442,7 +3442,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/arr-union"
         }
       ]
@@ -3468,7 +3468,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/array-each"
         }
       ]
@@ -3494,7 +3494,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/array-flatten"
         }
       ]
@@ -3520,7 +3520,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/array-slice"
         }
       ]
@@ -3546,7 +3546,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/array-unique"
         }
       ]
@@ -3572,7 +3572,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/asap"
         }
       ]
@@ -3598,7 +3598,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/asn1"
         }
       ]
@@ -3624,7 +3624,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/assert-never"
         }
       ]
@@ -3650,7 +3650,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/assert-plus"
         }
       ]
@@ -3676,7 +3676,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/assign-symbols"
         }
       ]
@@ -3702,7 +3702,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/async"
         }
       ]
@@ -3728,7 +3728,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/asynckit"
         }
       ]
@@ -3754,7 +3754,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/at-least-node"
         }
       ]
@@ -3780,7 +3780,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/atob"
         }
       ]
@@ -3806,7 +3806,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/available-typed-arrays"
         }
       ]
@@ -3832,7 +3832,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/aws-sign2"
         }
       ]
@@ -3858,7 +3858,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/aws4"
         }
       ]
@@ -3884,7 +3884,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/babel-walk"
         }
       ]
@@ -3910,7 +3910,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/balanced-match"
         }
       ]
@@ -3936,7 +3936,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base"
         }
       ],
@@ -3962,7 +3962,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/base\\node_modules\\define-property"
             }
           ]
@@ -3990,7 +3990,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base64-arraybuffer"
         }
       ]
@@ -4016,7 +4016,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base64-js"
         }
       ]
@@ -4042,7 +4042,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base64id"
         }
       ]
@@ -4068,7 +4068,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base64url"
         }
       ]
@@ -4094,7 +4094,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/basic-auth"
         }
       ]
@@ -4120,7 +4120,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/batch"
         }
       ]
@@ -4146,7 +4146,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bcrypt-pbkdf"
         }
       ]
@@ -4172,7 +4172,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/big-integer"
         }
       ]
@@ -4198,7 +4198,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/binary-extensions"
         }
       ]
@@ -4224,7 +4224,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/binary"
         }
       ]
@@ -4250,7 +4250,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bindings"
         }
       ]
@@ -4276,7 +4276,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bintrees"
         }
       ]
@@ -4302,7 +4302,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bl"
         }
       ]
@@ -4328,7 +4328,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bluebird"
         }
       ]
@@ -4354,7 +4354,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/body-parser"
         }
       ]
@@ -4380,7 +4380,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bower-config"
         }
       ],
@@ -4406,7 +4406,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bower-config\\node_modules\\minimist"
             }
           ]
@@ -4434,7 +4434,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/brace-expansion"
         }
       ]
@@ -4460,7 +4460,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/braces"
         }
       ],
@@ -4486,7 +4486,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/braces\\node_modules\\extend-shallow"
             }
           ]
@@ -4512,7 +4512,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/braces\\node_modules\\is-extendable"
             }
           ]
@@ -4540,7 +4540,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/brotli"
         }
       ]
@@ -4566,7 +4566,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-alloc-unsafe"
         }
       ]
@@ -4592,7 +4592,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-alloc"
         }
       ]
@@ -4618,7 +4618,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-crc32"
         }
       ]
@@ -4644,7 +4644,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-fill"
         }
       ]
@@ -4670,7 +4670,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-from"
         }
       ]
@@ -4696,7 +4696,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-indexof-polyfill"
         }
       ]
@@ -4722,7 +4722,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer"
         }
       ]
@@ -4748,7 +4748,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffers"
         }
       ]
@@ -4774,7 +4774,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/busboy"
         }
       ],
@@ -4800,7 +4800,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/busboy\\node_modules\\isarray"
             }
           ]
@@ -4826,7 +4826,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/busboy\\node_modules\\readable-stream"
             }
           ]
@@ -4852,7 +4852,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/busboy\\node_modules\\string_decoder"
             }
           ]
@@ -4880,7 +4880,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/byline"
         }
       ]
@@ -4906,7 +4906,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bytes"
         }
       ]
@@ -4932,7 +4932,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cacache"
         }
       ]
@@ -4958,7 +4958,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cache-base"
         }
       ]
@@ -4984,7 +4984,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cacheable-request"
         }
       ],
@@ -5010,7 +5010,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cacheable-request\\node_modules\\get-stream"
             }
           ]
@@ -5036,7 +5036,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cacheable-request\\node_modules\\lowercase-keys"
             }
           ]
@@ -5064,7 +5064,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/call-bind"
         }
       ]
@@ -5090,7 +5090,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/camelcase"
         }
       ]
@@ -5116,7 +5116,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/caseless"
         }
       ]
@@ -5142,7 +5142,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/chainsaw"
         }
       ]
@@ -5168,7 +5168,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/chalk"
         }
       ]
@@ -5194,7 +5194,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/character-parser"
         }
       ]
@@ -5220,7 +5220,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/check-dependencies"
         }
       ],
@@ -5246,7 +5246,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/check-dependencies\\node_modules\\semver"
             }
           ]
@@ -5274,7 +5274,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/check-types"
         }
       ]
@@ -5300,7 +5300,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/chokidar"
         }
       ],
@@ -5326,7 +5326,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar\\node_modules\\braces"
             }
           ]
@@ -5352,7 +5352,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar\\node_modules\\fill-range"
             }
           ]
@@ -5378,7 +5378,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar\\node_modules\\is-glob"
             }
           ]
@@ -5404,7 +5404,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar\\node_modules\\is-number"
             }
           ]
@@ -5430,7 +5430,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar\\node_modules\\normalize-path"
             }
           ]
@@ -5456,7 +5456,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar\\node_modules\\to-regex-range"
             }
           ]
@@ -5484,7 +5484,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/chownr"
         }
       ]
@@ -5510,7 +5510,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/clarinet"
         }
       ]
@@ -5536,7 +5536,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/class-utils"
         }
       ],
@@ -5562,7 +5562,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils\\node_modules\\define-property"
             }
           ]
@@ -5588,7 +5588,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils\\node_modules\\is-accessor-descriptor"
             }
           ],
@@ -5614,7 +5614,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/class-utils\\node_modules\\is-accessor-descriptor\\node_modules\\kind-of"
                 }
               ]
@@ -5642,7 +5642,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils\\node_modules\\is-data-descriptor"
             }
           ],
@@ -5668,7 +5668,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/class-utils\\node_modules\\is-data-descriptor\\node_modules\\kind-of"
                 }
               ]
@@ -5696,7 +5696,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils\\node_modules\\is-descriptor"
             }
           ]
@@ -5722,7 +5722,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils\\node_modules\\kind-of"
             }
           ]
@@ -5750,7 +5750,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/clean-stack"
         }
       ]
@@ -5776,7 +5776,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cliui"
         }
       ],
@@ -5802,7 +5802,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui\\node_modules\\ansi-regex"
             }
           ]
@@ -5828,7 +5828,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui\\node_modules\\emoji-regex"
             }
           ]
@@ -5854,7 +5854,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui\\node_modules\\is-fullwidth-code-point"
             }
           ]
@@ -5880,7 +5880,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui\\node_modules\\string-width"
             }
           ]
@@ -5906,7 +5906,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui\\node_modules\\strip-ansi"
             }
           ]
@@ -5934,7 +5934,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/clone-response"
         }
       ]
@@ -5960,7 +5960,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/clone"
         }
       ]
@@ -5986,7 +5986,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/code-point-at"
         }
       ]
@@ -6012,7 +6012,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/collection-visit"
         }
       ]
@@ -6038,7 +6038,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color-convert"
         }
       ]
@@ -6064,7 +6064,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color-name"
         }
       ]
@@ -6090,7 +6090,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color-string"
         }
       ]
@@ -6116,7 +6116,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color-support"
         }
       ]
@@ -6142,7 +6142,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color"
         }
       ]
@@ -6168,7 +6168,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/colors"
         }
       ]
@@ -6194,7 +6194,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/colorspace"
         }
       ]
@@ -6220,7 +6220,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/combined-stream"
         }
       ]
@@ -6246,7 +6246,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/commander"
         }
       ]
@@ -6272,7 +6272,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/component-emitter"
         }
       ]
@@ -6298,7 +6298,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/component-type"
         }
       ]
@@ -6324,7 +6324,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/compress-commons"
         }
       ]
@@ -6350,7 +6350,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/compressible"
         }
       ]
@@ -6376,7 +6376,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/compression"
         }
       ],
@@ -6402,7 +6402,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/compression\\node_modules\\bytes"
             }
           ]
@@ -6430,7 +6430,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/concat-map"
         }
       ]
@@ -6456,7 +6456,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/concat-stream"
         }
       ]
@@ -6482,7 +6482,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/concurrently"
         }
       ],
@@ -6508,7 +6508,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/concurrently\\node_modules\\supports-color"
             }
           ]
@@ -6536,7 +6536,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/config"
         }
       ]
@@ -6562,7 +6562,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/console-control-strings"
         }
       ]
@@ -6588,7 +6588,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/constantinople"
         }
       ]
@@ -6614,7 +6614,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/content-disposition"
         }
       ],
@@ -6640,7 +6640,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/content-disposition\\node_modules\\safe-buffer"
             }
           ]
@@ -6668,7 +6668,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/content-type"
         }
       ]
@@ -6694,7 +6694,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cookie-parser"
         }
       ]
@@ -6720,7 +6720,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cookie-signature"
         }
       ]
@@ -6746,7 +6746,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cookie"
         }
       ]
@@ -6772,7 +6772,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/copy-descriptor"
         }
       ]
@@ -6798,7 +6798,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/core-util-is"
         }
       ]
@@ -6824,7 +6824,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cors"
         }
       ]
@@ -6850,7 +6850,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/crc"
         }
       ]
@@ -6876,7 +6876,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/crc32-stream"
         }
       ]
@@ -6902,7 +6902,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/create-require"
         }
       ]
@@ -6928,7 +6928,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/crypto-js"
         }
       ]
@@ -6954,7 +6954,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dashdash"
         }
       ]
@@ -6980,7 +6980,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/date-fns"
         }
       ]
@@ -7006,7 +7006,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dateformat"
         }
       ]
@@ -7032,7 +7032,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/debug"
         }
       ]
@@ -7058,7 +7058,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decamelize"
         }
       ]
@@ -7084,7 +7084,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decode-uri-component"
         }
       ]
@@ -7110,7 +7110,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-response"
         }
       ]
@@ -7136,7 +7136,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-tar"
         }
       ],
@@ -7162,7 +7162,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-tar\\node_modules\\file-type"
             }
           ]
@@ -7190,7 +7190,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-tarbz2"
         }
       ],
@@ -7216,7 +7216,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-tarbz2\\node_modules\\file-type"
             }
           ]
@@ -7244,7 +7244,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-targz"
         }
       ],
@@ -7270,7 +7270,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-targz\\node_modules\\file-type"
             }
           ]
@@ -7298,7 +7298,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-unzip"
         }
       ],
@@ -7324,7 +7324,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-unzip\\node_modules\\file-type"
             }
           ]
@@ -7350,7 +7350,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-unzip\\node_modules\\get-stream"
             }
           ]
@@ -7376,7 +7376,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-unzip\\node_modules\\pify"
             }
           ]
@@ -7404,7 +7404,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress"
         }
       ],
@@ -7430,7 +7430,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress\\node_modules\\make-dir"
             }
           ],
@@ -7456,7 +7456,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/decompress\\node_modules\\make-dir\\node_modules\\pify"
                 }
               ]
@@ -7484,7 +7484,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress\\node_modules\\pify"
             }
           ]
@@ -7512,7 +7512,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/deep-equal"
         }
       ]
@@ -7538,7 +7538,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/deep-extend"
         }
       ]
@@ -7564,7 +7564,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/deep-is"
         }
       ]
@@ -7590,7 +7590,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/define-properties"
         }
       ]
@@ -7616,7 +7616,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/define-property"
         }
       ]
@@ -7642,7 +7642,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/delayed-stream"
         }
       ]
@@ -7668,7 +7668,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/delegates"
         }
       ]
@@ -7694,7 +7694,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/depd"
         }
       ]
@@ -7720,7 +7720,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/destroy"
         }
       ]
@@ -7746,7 +7746,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/detect-file"
         }
       ]
@@ -7772,7 +7772,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/detect-libc"
         }
       ]
@@ -7798,7 +7798,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dfa"
         }
       ]
@@ -7824,7 +7824,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dicer"
         }
       ],
@@ -7850,7 +7850,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/dicer\\node_modules\\isarray"
             }
           ]
@@ -7876,7 +7876,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/dicer\\node_modules\\readable-stream"
             }
           ]
@@ -7902,7 +7902,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/dicer\\node_modules\\string_decoder"
             }
           ]
@@ -7930,7 +7930,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/diff"
         }
       ]
@@ -7956,7 +7956,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/doctypes"
         }
       ]
@@ -7982,7 +7982,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/domelementtype"
         }
       ]
@@ -8008,7 +8008,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/domhandler"
         }
       ]
@@ -8034,7 +8034,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/domutils"
         }
       ]
@@ -8060,7 +8060,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dottie"
         }
       ]
@@ -8086,7 +8086,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/double-ended-queue"
         }
       ]
@@ -8112,7 +8112,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/doublearray"
         }
       ]
@@ -8138,7 +8138,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/download"
         }
       ],
@@ -8164,7 +8164,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/download\\node_modules\\file-type"
             }
           ]
@@ -8192,7 +8192,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/duplexer2"
         }
       ]
@@ -8218,7 +8218,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/duplexer3"
         }
       ]
@@ -8244,7 +8244,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dynamic-dedupe"
         }
       ]
@@ -8270,7 +8270,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ecc-jsbn"
         }
       ]
@@ -8296,7 +8296,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ee-first"
         }
       ]
@@ -8322,7 +8322,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/eivindfjeldstad-dot"
         }
       ]
@@ -8348,7 +8348,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/emoji-regex"
         }
       ]
@@ -8374,7 +8374,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/enabled"
         }
       ]
@@ -8400,7 +8400,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/encodeurl"
         }
       ]
@@ -8426,7 +8426,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/encoding"
         }
       ],
@@ -8452,7 +8452,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/encoding\\node_modules\\iconv-lite"
             }
           ]
@@ -8480,7 +8480,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/end-of-stream"
         }
       ]
@@ -8506,7 +8506,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/engine.io-parser"
         }
       ]
@@ -8532,7 +8532,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/engine.io"
         }
       ],
@@ -8558,7 +8558,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/engine.io\\node_modules\\debug"
             }
           ]
@@ -8584,7 +8584,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/engine.io\\node_modules\\ms"
             }
           ]
@@ -8612,7 +8612,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/env-paths"
         }
       ]
@@ -8638,7 +8638,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/err-code"
         }
       ]
@@ -8664,7 +8664,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/error-ex"
         }
       ]
@@ -8690,7 +8690,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/errorhandler"
         }
       ]
@@ -8716,7 +8716,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/es-abstract"
         }
       ]
@@ -8742,7 +8742,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/es-get-iterator"
         }
       ]
@@ -8768,7 +8768,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/es-to-primitive"
         }
       ]
@@ -8794,7 +8794,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/escape-html"
         }
       ]
@@ -8820,7 +8820,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/escape-string-regexp"
         }
       ]
@@ -8846,7 +8846,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/escodegen"
         }
       ]
@@ -8872,7 +8872,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/esprima"
         }
       ]
@@ -8898,7 +8898,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/estraverse"
         }
       ]
@@ -8924,7 +8924,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/esutils"
         }
       ]
@@ -8950,7 +8950,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/etag"
         }
       ]
@@ -8976,7 +8976,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/eventemitter2"
         }
       ]
@@ -9002,7 +9002,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/eventemitter3"
         }
       ]
@@ -9028,7 +9028,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/exif"
         }
       ]
@@ -9054,7 +9054,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/exit"
         }
       ]
@@ -9080,7 +9080,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/expand-brackets"
         }
       ],
@@ -9106,7 +9106,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets\\node_modules\\define-property"
             }
           ]
@@ -9132,7 +9132,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets\\node_modules\\extend-shallow"
             }
           ]
@@ -9158,7 +9158,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets\\node_modules\\is-accessor-descriptor"
             }
           ],
@@ -9184,7 +9184,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/expand-brackets\\node_modules\\is-accessor-descriptor\\node_modules\\kind-of"
                 }
               ]
@@ -9212,7 +9212,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets\\node_modules\\is-data-descriptor"
             }
           ],
@@ -9238,7 +9238,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/expand-brackets\\node_modules\\is-data-descriptor\\node_modules\\kind-of"
                 }
               ]
@@ -9266,7 +9266,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets\\node_modules\\is-descriptor"
             }
           ]
@@ -9292,7 +9292,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets\\node_modules\\is-extendable"
             }
           ]
@@ -9318,7 +9318,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets\\node_modules\\kind-of"
             }
           ]
@@ -9346,7 +9346,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/expand-template"
         }
       ]
@@ -9372,7 +9372,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/expand-tilde"
         }
       ]
@@ -9398,7 +9398,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-ipfilter"
         }
       ]
@@ -9424,7 +9424,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-jwt"
         }
       ],
@@ -9450,7 +9450,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/express-jwt\\node_modules\\jsonwebtoken"
             }
           ]
@@ -9476,7 +9476,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/express-jwt\\node_modules\\moment"
             }
           ]
@@ -9504,7 +9504,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-rate-limit"
         }
       ]
@@ -9530,7 +9530,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-robots-txt"
         }
       ]
@@ -9556,7 +9556,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-security.txt"
         }
       ]
@@ -9582,7 +9582,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express"
         }
       ],
@@ -9608,7 +9608,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/express\\node_modules\\cookie"
             }
           ]
@@ -9634,7 +9634,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/express\\node_modules\\safe-buffer"
             }
           ]
@@ -9662,7 +9662,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ext-list"
         }
       ]
@@ -9688,7 +9688,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ext-name"
         }
       ]
@@ -9714,7 +9714,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/extend-shallow"
         }
       ]
@@ -9740,7 +9740,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/extend"
         }
       ]
@@ -9766,7 +9766,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/extglob"
         }
       ],
@@ -9792,7 +9792,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/extglob\\node_modules\\define-property"
             }
           ]
@@ -9818,7 +9818,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/extglob\\node_modules\\extend-shallow"
             }
           ]
@@ -9844,7 +9844,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/extglob\\node_modules\\is-extendable"
             }
           ]
@@ -9872,7 +9872,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/extsprintf"
         }
       ]
@@ -9898,7 +9898,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fast-deep-equal"
         }
       ]
@@ -9924,7 +9924,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fast-json-stable-stringify"
         }
       ]
@@ -9950,7 +9950,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fast-levenshtein"
         }
       ]
@@ -9976,7 +9976,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fast.js"
         }
       ]
@@ -10002,7 +10002,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fd-slicer"
         }
       ]
@@ -10028,7 +10028,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/feature-policy"
         }
       ]
@@ -10054,7 +10054,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fecha"
         }
       ]
@@ -10080,7 +10080,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/file-js"
         }
       ],
@@ -10106,7 +10106,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/file-js\\node_modules\\brace-expansion"
             }
           ]
@@ -10132,7 +10132,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/file-js\\node_modules\\minimatch"
             }
           ]
@@ -10160,7 +10160,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/file-stream-rotator"
         }
       ]
@@ -10186,7 +10186,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/file-type"
         }
       ]
@@ -10212,7 +10212,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/file-uri-to-path"
         }
       ]
@@ -10238,7 +10238,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/filehound"
         }
       ]
@@ -10264,7 +10264,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/filename-reserved-regex"
         }
       ]
@@ -10290,7 +10290,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/filenamify"
         }
       ]
@@ -10316,7 +10316,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/filesniffer"
         }
       ]
@@ -10342,7 +10342,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fill-range"
         }
       ],
@@ -10368,7 +10368,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/fill-range\\node_modules\\extend-shallow"
             }
           ]
@@ -10394,7 +10394,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/fill-range\\node_modules\\is-extendable"
             }
           ]
@@ -10422,7 +10422,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/finale-rest"
         }
       ]
@@ -10448,7 +10448,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/finalhandler"
         }
       ]
@@ -10474,7 +10474,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/find-up"
         }
       ]
@@ -10500,7 +10500,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/findup-sync"
         }
       ]
@@ -10526,7 +10526,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fined"
         }
       ]
@@ -10552,7 +10552,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/flagged-respawn"
         }
       ]
@@ -10578,7 +10578,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fn.name"
         }
       ]
@@ -10604,7 +10604,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fontkit"
         }
       ]
@@ -10630,7 +10630,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/for-each"
         }
       ]
@@ -10656,7 +10656,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/for-in"
         }
       ]
@@ -10682,7 +10682,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/for-own"
         }
       ]
@@ -10708,7 +10708,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/foreachasync"
         }
       ]
@@ -10734,7 +10734,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/forever-agent"
         }
       ]
@@ -10760,7 +10760,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/form-data"
         }
       ]
@@ -10786,7 +10786,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/formatio"
         }
       ]
@@ -10812,7 +10812,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/forwarded"
         }
       ]
@@ -10838,7 +10838,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fragment-cache"
         }
       ]
@@ -10864,7 +10864,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fresh"
         }
       ]
@@ -10890,7 +10890,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/from2"
         }
       ]
@@ -10916,7 +10916,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fs-constants"
         }
       ]
@@ -10942,7 +10942,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fs-extra"
         }
       ]
@@ -10968,7 +10968,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fs-minipass"
         }
       ]
@@ -10994,7 +10994,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fs.realpath"
         }
       ]
@@ -11020,7 +11020,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fstream"
         }
       ],
@@ -11046,7 +11046,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/fstream\\node_modules\\mkdirp"
             }
           ]
@@ -11072,7 +11072,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/fstream\\node_modules\\rimraf"
             }
           ]
@@ -11100,7 +11100,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/function-bind"
         }
       ]
@@ -11126,7 +11126,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/function.prototype.name"
         }
       ]
@@ -11152,7 +11152,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/functions-have-names"
         }
       ]
@@ -11178,7 +11178,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fuzzball"
         }
       ]
@@ -11204,7 +11204,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/gauge"
         }
       ]
@@ -11230,7 +11230,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/geojson-utils"
         }
       ]
@@ -11256,7 +11256,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-caller-file"
         }
       ]
@@ -11282,7 +11282,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-intrinsic"
         }
       ]
@@ -11308,7 +11308,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-stream"
         }
       ]
@@ -11334,7 +11334,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-symbol-description"
         }
       ]
@@ -11360,7 +11360,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-value"
         }
       ]
@@ -11386,7 +11386,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/getobject"
         }
       ]
@@ -11412,7 +11412,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/getpass"
         }
       ]
@@ -11438,7 +11438,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/github-from-package"
         }
       ]
@@ -11464,7 +11464,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/glob-parent"
         }
       ],
@@ -11490,7 +11490,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/glob-parent\\node_modules\\is-glob"
             }
           ]
@@ -11518,7 +11518,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/glob"
         }
       ],
@@ -11544,7 +11544,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/glob\\node_modules\\brace-expansion"
             }
           ]
@@ -11570,7 +11570,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/glob\\node_modules\\minimatch"
             }
           ]
@@ -11598,7 +11598,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/global-modules"
         }
       ]
@@ -11624,7 +11624,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/global-prefix"
         }
       ],
@@ -11650,7 +11650,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/global-prefix\\node_modules\\which"
             }
           ]
@@ -11678,7 +11678,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/got"
         }
       ],
@@ -11704,7 +11704,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/got\\node_modules\\get-stream"
             }
           ]
@@ -11730,7 +11730,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/got\\node_modules\\pify"
             }
           ]
@@ -11758,7 +11758,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/graceful-fs"
         }
       ]
@@ -11784,7 +11784,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-cli"
         }
       ],
@@ -11810,7 +11810,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-cli\\node_modules\\nopt"
             }
           ]
@@ -11838,7 +11838,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-contrib-compress"
         }
       ],
@@ -11864,7 +11864,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-contrib-compress\\node_modules\\ansi-styles"
             }
           ]
@@ -11890,7 +11890,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-contrib-compress\\node_modules\\chalk"
             }
           ]
@@ -11916,7 +11916,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-contrib-compress\\node_modules\\supports-color"
             }
           ]
@@ -11944,7 +11944,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-known-options"
         }
       ]
@@ -11970,7 +11970,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-legacy-log-utils"
         }
       ],
@@ -11996,7 +11996,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils\\node_modules\\ansi-styles"
             }
           ]
@@ -12022,7 +12022,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils\\node_modules\\chalk"
             }
           ]
@@ -12048,7 +12048,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils\\node_modules\\color-convert"
             }
           ]
@@ -12074,7 +12074,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils\\node_modules\\color-name"
             }
           ]
@@ -12100,7 +12100,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils\\node_modules\\has-flag"
             }
           ]
@@ -12126,7 +12126,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils\\node_modules\\supports-color"
             }
           ]
@@ -12154,7 +12154,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-legacy-log"
         }
       ],
@@ -12180,7 +12180,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log\\node_modules\\colors"
             }
           ]
@@ -12208,7 +12208,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-legacy-util"
         }
       ],
@@ -12234,7 +12234,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-util\\node_modules\\async"
             }
           ]
@@ -12262,7 +12262,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-replace-json"
         }
       ]
@@ -12288,7 +12288,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt"
         }
       ],
@@ -12314,7 +12314,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt\\node_modules\\brace-expansion"
             }
           ]
@@ -12340,7 +12340,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt\\node_modules\\findup-sync"
             }
           ],
@@ -12366,7 +12366,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/grunt\\node_modules\\findup-sync\\node_modules\\glob"
                 }
               ]
@@ -12394,7 +12394,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt\\node_modules\\glob"
             }
           ]
@@ -12420,7 +12420,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt\\node_modules\\minimatch"
             }
           ]
@@ -12448,7 +12448,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/handlebars"
         }
       ],
@@ -12474,7 +12474,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/handlebars\\node_modules\\wordwrap"
             }
           ]
@@ -12502,7 +12502,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/har-schema"
         }
       ]
@@ -12528,7 +12528,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/har-validator"
         }
       ]
@@ -12554,7 +12554,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-ansi"
         }
       ]
@@ -12580,7 +12580,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-bigints"
         }
       ]
@@ -12606,7 +12606,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-flag"
         }
       ]
@@ -12632,7 +12632,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-property-descriptors"
         }
       ]
@@ -12658,7 +12658,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-symbol-support-x"
         }
       ]
@@ -12684,7 +12684,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-symbols"
         }
       ]
@@ -12710,7 +12710,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-to-string-tag-x"
         }
       ]
@@ -12736,7 +12736,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-tostringtag"
         }
       ]
@@ -12762,7 +12762,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-unicode"
         }
       ]
@@ -12788,7 +12788,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-value"
         }
       ]
@@ -12814,7 +12814,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-values"
         }
       ],
@@ -12840,7 +12840,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/has-values\\node_modules\\kind-of"
             }
           ]
@@ -12868,7 +12868,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has"
         }
       ]
@@ -12894,7 +12894,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hashids"
         }
       ]
@@ -12920,7 +12920,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hbs"
         }
       ]
@@ -12946,7 +12946,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/he"
         }
       ]
@@ -12972,7 +12972,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/heap"
         }
       ]
@@ -12998,7 +12998,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/helmet"
         }
       ]
@@ -13024,7 +13024,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hoister"
         }
       ]
@@ -13050,7 +13050,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/homedir-polyfill"
         }
       ]
@@ -13076,7 +13076,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hooker"
         }
       ]
@@ -13102,7 +13102,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hosted-git-info"
         }
       ]
@@ -13128,7 +13128,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/html-entities"
         }
       ]
@@ -13154,7 +13154,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/htmlparser2"
         }
       ],
@@ -13180,7 +13180,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/htmlparser2\\node_modules\\isarray"
             }
           ]
@@ -13206,7 +13206,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/htmlparser2\\node_modules\\readable-stream"
             }
           ]
@@ -13232,7 +13232,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/htmlparser2\\node_modules\\string_decoder"
             }
           ]
@@ -13260,7 +13260,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/http-cache-semantics"
         }
       ]
@@ -13286,7 +13286,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/http-errors"
         }
       ]
@@ -13312,7 +13312,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/http-proxy-agent"
         }
       ],
@@ -13338,7 +13338,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/http-proxy-agent\\node_modules\\debug"
             }
           ]
@@ -13364,7 +13364,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/http-proxy-agent\\node_modules\\ms"
             }
           ]
@@ -13392,7 +13392,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/http-signature"
         }
       ]
@@ -13418,7 +13418,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/https-proxy-agent"
         }
       ],
@@ -13444,7 +13444,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/https-proxy-agent\\node_modules\\debug"
             }
           ]
@@ -13470,7 +13470,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/https-proxy-agent\\node_modules\\ms"
             }
           ]
@@ -13498,7 +13498,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/humanize-ms"
         }
       ]
@@ -13524,7 +13524,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/i18n"
         }
       ]
@@ -13550,7 +13550,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/iconv-lite"
         }
       ]
@@ -13576,7 +13576,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ieee754"
         }
       ]
@@ -13602,7 +13602,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ignore-walk"
         }
       ],
@@ -13628,7 +13628,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/ignore-walk\\node_modules\\brace-expansion"
             }
           ]
@@ -13654,7 +13654,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/ignore-walk\\node_modules\\minimatch"
             }
           ]
@@ -13682,7 +13682,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/iltorb"
         }
       ]
@@ -13708,7 +13708,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/imurmurhash"
         }
       ]
@@ -13734,7 +13734,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/indent-string"
         }
       ]
@@ -13760,7 +13760,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/infer-owner"
         }
       ]
@@ -13786,7 +13786,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/inflection"
         }
       ]
@@ -13812,7 +13812,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/inflight"
         }
       ]
@@ -13838,7 +13838,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/inherits"
         }
       ]
@@ -13864,7 +13864,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ini"
         }
       ]
@@ -13890,7 +13890,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/internal-slot"
         }
       ]
@@ -13916,7 +13916,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/interpret"
         }
       ]
@@ -13942,7 +13942,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/into-stream"
         }
       ]
@@ -13968,7 +13968,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/invariant"
         }
       ]
@@ -13994,7 +13994,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ip"
         }
       ]
@@ -14020,7 +14020,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ip6"
         }
       ]
@@ -14046,7 +14046,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ipaddr.js"
         }
       ]
@@ -14072,7 +14072,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-absolute"
         }
       ]
@@ -14098,7 +14098,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-accessor-descriptor"
         }
       ]
@@ -14124,7 +14124,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-arguments"
         }
       ]
@@ -14150,7 +14150,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-arrayish"
         }
       ]
@@ -14176,7 +14176,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-bigint"
         }
       ]
@@ -14202,7 +14202,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-binary-path"
         }
       ]
@@ -14228,7 +14228,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-boolean-object"
         }
       ]
@@ -14254,7 +14254,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-buffer"
         }
       ]
@@ -14280,7 +14280,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-callable"
         }
       ]
@@ -14306,7 +14306,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-core-module"
         }
       ]
@@ -14332,7 +14332,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-data-descriptor"
         }
       ]
@@ -14358,7 +14358,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-date-object"
         }
       ]
@@ -14384,7 +14384,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-descriptor"
         }
       ]
@@ -14410,7 +14410,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-docker"
         }
       ]
@@ -14436,7 +14436,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-expression"
         }
       ]
@@ -14462,7 +14462,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-extendable"
         }
       ]
@@ -14488,7 +14488,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-extglob"
         }
       ]
@@ -14514,7 +14514,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-fullwidth-code-point"
         }
       ]
@@ -14540,7 +14540,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-generator-function"
         }
       ]
@@ -14566,7 +14566,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-glob"
         }
       ]
@@ -14592,7 +14592,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-heroku"
         }
       ]
@@ -14618,7 +14618,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-lambda"
         }
       ]
@@ -14644,7 +14644,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-map"
         }
       ]
@@ -14670,7 +14670,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-natural-number"
         }
       ]
@@ -14696,7 +14696,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-negative-zero"
         }
       ]
@@ -14722,7 +14722,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-number-like"
         }
       ]
@@ -14748,7 +14748,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-number-object"
         }
       ]
@@ -14774,7 +14774,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-number"
         }
       ],
@@ -14800,7 +14800,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/is-number\\node_modules\\kind-of"
             }
           ]
@@ -14828,7 +14828,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-object"
         }
       ]
@@ -14854,7 +14854,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-plain-obj"
         }
       ]
@@ -14880,7 +14880,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-plain-object"
         }
       ]
@@ -14906,7 +14906,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-promise"
         }
       ]
@@ -14932,7 +14932,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-regex"
         }
       ]
@@ -14958,7 +14958,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-relative"
         }
       ]
@@ -14984,7 +14984,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-retry-allowed"
         }
       ]
@@ -15010,7 +15010,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-set"
         }
       ]
@@ -15036,7 +15036,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-shared-array-buffer"
         }
       ]
@@ -15062,7 +15062,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-stream"
         }
       ]
@@ -15088,7 +15088,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-string"
         }
       ]
@@ -15114,7 +15114,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-symbol"
         }
       ]
@@ -15140,7 +15140,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-typed-array"
         }
       ]
@@ -15166,7 +15166,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-typedarray"
         }
       ]
@@ -15192,7 +15192,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-unc-path"
         }
       ]
@@ -15218,7 +15218,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-weakmap"
         }
       ]
@@ -15244,7 +15244,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-weakref"
         }
       ]
@@ -15270,7 +15270,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-weakset"
         }
       ]
@@ -15296,7 +15296,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-windows"
         }
       ]
@@ -15322,7 +15322,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isarray"
         }
       ]
@@ -15348,7 +15348,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isexe"
         }
       ]
@@ -15374,7 +15374,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isobject"
         }
       ]
@@ -15400,7 +15400,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isstream"
         }
       ]
@@ -15426,7 +15426,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isurl"
         }
       ]
@@ -15452,7 +15452,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/js-stringify"
         }
       ]
@@ -15478,7 +15478,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/js-tokens"
         }
       ]
@@ -15504,7 +15504,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/js-yaml"
         }
       ]
@@ -15530,7 +15530,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jsbn"
         }
       ]
@@ -15556,7 +15556,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-buffer"
         }
       ]
@@ -15582,7 +15582,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-parse-better-errors"
         }
       ]
@@ -15608,7 +15608,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-schema-traverse"
         }
       ]
@@ -15634,7 +15634,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-schema"
         }
       ]
@@ -15660,7 +15660,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-stringify-safe"
         }
       ]
@@ -15686,7 +15686,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json5"
         }
       ]
@@ -15712,7 +15712,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jsonfile"
         }
       ]
@@ -15738,7 +15738,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jsonwebtoken"
         }
       ]
@@ -15764,7 +15764,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jsprim"
         }
       ]
@@ -15790,7 +15790,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jssha"
         }
       ]
@@ -15816,7 +15816,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jstransformer"
         }
       ]
@@ -15842,7 +15842,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/juicy-chat-bot"
         }
       ]
@@ -15868,7 +15868,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jwa"
         }
       ]
@@ -15894,7 +15894,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jws"
         }
       ]
@@ -15920,7 +15920,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/keyv"
         }
       ]
@@ -15946,7 +15946,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/kind-of"
         }
       ]
@@ -15972,7 +15972,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/kuler"
         }
       ]
@@ -15998,7 +15998,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/kuromoji"
         }
       ]
@@ -16024,7 +16024,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lazystream"
         }
       ]
@@ -16050,7 +16050,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/levn"
         }
       ]
@@ -16076,7 +16076,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/libxmljs2"
         }
       ],
@@ -16102,7 +16102,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/libxmljs2\\node_modules\\nan"
             }
           ]
@@ -16130,7 +16130,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/liftup"
         }
       ],
@@ -16156,7 +16156,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup\\node_modules\\braces"
             }
           ]
@@ -16182,7 +16182,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup\\node_modules\\fill-range"
             }
           ]
@@ -16208,7 +16208,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup\\node_modules\\findup-sync"
             }
           ]
@@ -16234,7 +16234,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup\\node_modules\\is-glob"
             }
           ]
@@ -16260,7 +16260,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup\\node_modules\\is-number"
             }
           ]
@@ -16286,7 +16286,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup\\node_modules\\micromatch"
             }
           ]
@@ -16312,7 +16312,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup\\node_modules\\to-regex-range"
             }
           ]
@@ -16340,7 +16340,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/linebreak"
         }
       ],
@@ -16366,7 +16366,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/linebreak\\node_modules\\base64-js"
             }
           ]
@@ -16394,7 +16394,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/listenercount"
         }
       ]
@@ -16420,7 +16420,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/locate-path"
         }
       ]
@@ -16446,7 +16446,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lodash.camelcase"
         }
       ]
@@ -16472,7 +16472,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lodash.isfinite"
         }
       ]
@@ -16498,7 +16498,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lodash.set"
         }
       ]
@@ -16524,7 +16524,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lodash"
         }
       ]
@@ -16550,7 +16550,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/logform"
         }
       ],
@@ -16576,7 +16576,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/logform\\node_modules\\ms"
             }
           ]
@@ -16604,7 +16604,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lolex"
         }
       ]
@@ -16630,7 +16630,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/loose-envify"
         }
       ]
@@ -16656,7 +16656,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lowercase-keys"
         }
       ]
@@ -16682,7 +16682,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lru-cache"
         }
       ]
@@ -16708,7 +16708,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-dir"
         }
       ],
@@ -16734,7 +16734,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-dir\\node_modules\\semver"
             }
           ]
@@ -16762,7 +16762,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-error"
         }
       ]
@@ -16788,7 +16788,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-fetch-happen"
         }
       ],
@@ -16815,7 +16815,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen\\node_modules\\@tootallnate\\once"
             }
           ]
@@ -16841,7 +16841,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen\\node_modules\\debug"
             }
           ]
@@ -16867,7 +16867,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen\\node_modules\\http-cache-semantics"
             }
           ]
@@ -16893,7 +16893,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen\\node_modules\\http-proxy-agent"
             }
           ]
@@ -16919,7 +16919,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen\\node_modules\\ms"
             }
           ]
@@ -16947,7 +16947,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-iterator"
         }
       ]
@@ -16973,7 +16973,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-plural"
         }
       ]
@@ -16999,7 +16999,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/map-cache"
         }
       ]
@@ -17025,7 +17025,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/map-visit"
         }
       ]
@@ -17051,7 +17051,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/marsdb"
         }
       ]
@@ -17077,7 +17077,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/math-interval-parser"
         }
       ]
@@ -17103,7 +17103,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/media-typer"
         }
       ]
@@ -17129,7 +17129,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/merge-descriptors"
         }
       ]
@@ -17155,7 +17155,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/messageformat-formatters"
         }
       ]
@@ -17181,7 +17181,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/messageformat-parser"
         }
       ]
@@ -17207,7 +17207,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/messageformat"
         }
       ],
@@ -17233,7 +17233,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/messageformat\\node_modules\\make-plural"
             }
           ]
@@ -17261,7 +17261,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/methods"
         }
       ]
@@ -17287,7 +17287,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/micromatch"
         }
       ]
@@ -17313,7 +17313,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mime-db"
         }
       ]
@@ -17339,7 +17339,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mime-types"
         }
       ]
@@ -17365,7 +17365,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mime"
         }
       ]
@@ -17391,7 +17391,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mimic-response"
         }
       ]
@@ -17417,7 +17417,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minimatch"
         }
       ]
@@ -17443,7 +17443,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minimist"
         }
       ]
@@ -17469,7 +17469,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-collect"
         }
       ]
@@ -17495,7 +17495,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-fetch"
         }
       ]
@@ -17521,7 +17521,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-flush"
         }
       ]
@@ -17547,7 +17547,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-pipeline"
         }
       ]
@@ -17573,7 +17573,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-sized"
         }
       ]
@@ -17599,7 +17599,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass"
         }
       ]
@@ -17625,7 +17625,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minizlib"
         }
       ]
@@ -17651,7 +17651,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mixin-deep"
         }
       ]
@@ -17677,7 +17677,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mkdirp-classic"
         }
       ]
@@ -17703,7 +17703,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mkdirp"
         }
       ]
@@ -17729,7 +17729,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/moment-timezone"
         }
       ]
@@ -17755,7 +17755,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/moment"
         }
       ]
@@ -17781,7 +17781,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/morgan"
         }
       ],
@@ -17807,7 +17807,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/morgan\\node_modules\\on-finished"
             }
           ]
@@ -17835,7 +17835,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mout"
         }
       ]
@@ -17861,7 +17861,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ms"
         }
       ]
@@ -17887,7 +17887,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/multer"
         }
       ],
@@ -17913,7 +17913,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/multer\\node_modules\\mkdirp"
             }
           ]
@@ -17941,7 +17941,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mustache"
         }
       ]
@@ -17967,7 +17967,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/nan"
         }
       ]
@@ -17993,7 +17993,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/nanomatch"
         }
       ]
@@ -18019,7 +18019,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/napi-build-utils"
         }
       ]
@@ -18045,7 +18045,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/needle"
         }
       ],
@@ -18071,7 +18071,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/needle\\node_modules\\debug"
             }
           ]
@@ -18097,7 +18097,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/needle\\node_modules\\ms"
             }
           ]
@@ -18125,7 +18125,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/negotiator"
         }
       ]
@@ -18151,7 +18151,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/neo-async"
         }
       ]
@@ -18177,7 +18177,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-abi"
         }
       ],
@@ -18203,7 +18203,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-abi\\node_modules\\semver"
             }
           ]
@@ -18231,7 +18231,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-addon-api"
         }
       ]
@@ -18257,7 +18257,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-fetch"
         }
       ]
@@ -18283,7 +18283,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-gyp"
         }
       ],
@@ -18309,7 +18309,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp\\node_modules\\ansi-regex"
             }
           ]
@@ -18335,7 +18335,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp\\node_modules\\are-we-there-yet"
             }
           ]
@@ -18361,7 +18361,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp\\node_modules\\gauge"
             }
           ]
@@ -18387,7 +18387,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp\\node_modules\\is-fullwidth-code-point"
             }
           ]
@@ -18413,7 +18413,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp\\node_modules\\nopt"
             }
           ]
@@ -18439,7 +18439,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp\\node_modules\\npmlog"
             }
           ]
@@ -18465,7 +18465,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp\\node_modules\\readable-stream"
             }
           ]
@@ -18491,7 +18491,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp\\node_modules\\string-width"
             }
           ]
@@ -18517,7 +18517,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp\\node_modules\\strip-ansi"
             }
           ]
@@ -18545,7 +18545,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-pre-gyp"
         }
       ],
@@ -18571,7 +18571,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp\\node_modules\\chownr"
             }
           ]
@@ -18597,7 +18597,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp\\node_modules\\fs-minipass"
             }
           ]
@@ -18623,7 +18623,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp\\node_modules\\minipass"
             }
           ]
@@ -18649,7 +18649,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp\\node_modules\\minizlib"
             }
           ]
@@ -18675,7 +18675,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp\\node_modules\\mkdirp"
             }
           ]
@@ -18701,7 +18701,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp\\node_modules\\nopt"
             }
           ]
@@ -18727,7 +18727,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp\\node_modules\\rimraf"
             }
           ]
@@ -18753,7 +18753,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp\\node_modules\\safe-buffer"
             }
           ]
@@ -18779,7 +18779,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp\\node_modules\\semver"
             }
           ]
@@ -18805,7 +18805,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp\\node_modules\\tar"
             }
           ]
@@ -18831,7 +18831,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp\\node_modules\\yallist"
             }
           ]
@@ -18859,7 +18859,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/noop-logger"
         }
       ]
@@ -18885,7 +18885,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/nopt"
         }
       ]
@@ -18911,7 +18911,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/normalize-package-data"
         }
       ],
@@ -18937,7 +18937,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/normalize-package-data\\node_modules\\semver"
             }
           ]
@@ -18965,7 +18965,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/normalize-path"
         }
       ]
@@ -18991,7 +18991,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/normalize-url"
         }
       ]
@@ -19017,7 +19017,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/notevil"
         }
       ],
@@ -19043,7 +19043,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/notevil\\node_modules\\esprima"
             }
           ]
@@ -19071,7 +19071,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/npm-bundled"
         }
       ]
@@ -19097,7 +19097,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/npm-normalize-package-bin"
         }
       ]
@@ -19123,7 +19123,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/npm-packlist"
         }
       ]
@@ -19149,7 +19149,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/npmlog"
         }
       ]
@@ -19175,7 +19175,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/number-is-nan"
         }
       ]
@@ -19201,7 +19201,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/oauth-sign"
         }
       ]
@@ -19227,7 +19227,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-assign"
         }
       ]
@@ -19253,7 +19253,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-copy"
         }
       ],
@@ -19279,7 +19279,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy\\node_modules\\define-property"
             }
           ]
@@ -19305,7 +19305,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy\\node_modules\\is-accessor-descriptor"
             }
           ]
@@ -19331,7 +19331,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy\\node_modules\\is-data-descriptor"
             }
           ]
@@ -19357,7 +19357,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy\\node_modules\\is-descriptor"
             }
           ],
@@ -19383,7 +19383,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/object-copy\\node_modules\\is-descriptor\\node_modules\\kind-of"
                 }
               ]
@@ -19411,7 +19411,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy\\node_modules\\kind-of"
             }
           ]
@@ -19439,7 +19439,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-inspect"
         }
       ]
@@ -19465,7 +19465,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-is"
         }
       ]
@@ -19491,7 +19491,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-keys"
         }
       ]
@@ -19517,7 +19517,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-visit"
         }
       ]
@@ -19543,7 +19543,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object.assign"
         }
       ]
@@ -19569,7 +19569,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object.defaults"
         }
       ]
@@ -19595,7 +19595,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object.map"
         }
       ]
@@ -19621,7 +19621,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object.pick"
         }
       ]
@@ -19647,7 +19647,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/on-finished"
         }
       ]
@@ -19673,7 +19673,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/on-headers"
         }
       ]
@@ -19699,7 +19699,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/once"
         }
       ]
@@ -19725,7 +19725,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/one-time"
         }
       ]
@@ -19751,7 +19751,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/opentype.js"
         }
       ]
@@ -19777,7 +19777,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/optionator"
         }
       ]
@@ -19803,7 +19803,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/os-homedir"
         }
       ]
@@ -19829,7 +19829,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/os-tmpdir"
         }
       ]
@@ -19855,7 +19855,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/osenv"
         }
       ]
@@ -19881,7 +19881,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/otplib"
         }
       ]
@@ -19907,7 +19907,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-cancelable"
         }
       ]
@@ -19933,7 +19933,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-event"
         }
       ]
@@ -19959,7 +19959,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-finally"
         }
       ]
@@ -19985,7 +19985,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-is-promise"
         }
       ]
@@ -20011,7 +20011,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-limit"
         }
       ]
@@ -20037,7 +20037,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-locate"
         }
       ]
@@ -20063,7 +20063,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-map"
         }
       ]
@@ -20089,7 +20089,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-timeout"
         }
       ]
@@ -20115,7 +20115,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-try"
         }
       ]
@@ -20141,7 +20141,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pako"
         }
       ]
@@ -20167,7 +20167,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/parse-filepath"
         }
       ]
@@ -20193,7 +20193,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/parse-json"
         }
       ]
@@ -20219,7 +20219,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/parse-passwd"
         }
       ]
@@ -20245,7 +20245,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/parseurl"
         }
       ]
@@ -20271,7 +20271,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pascalcase"
         }
       ]
@@ -20297,7 +20297,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-exists"
         }
       ]
@@ -20323,7 +20323,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-is-absolute"
         }
       ]
@@ -20349,7 +20349,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-parse"
         }
       ]
@@ -20375,7 +20375,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-root-regex"
         }
       ]
@@ -20401,7 +20401,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-root"
         }
       ]
@@ -20427,7 +20427,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-to-regexp"
         }
       ]
@@ -20453,7 +20453,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pdfkit"
         }
       ]
@@ -20479,7 +20479,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/peek-readable"
         }
       ]
@@ -20505,7 +20505,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pend"
         }
       ]
@@ -20531,7 +20531,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/performance-now"
         }
       ]
@@ -20557,7 +20557,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pg-connection-string"
         }
       ]
@@ -20583,7 +20583,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/picomatch"
         }
       ]
@@ -20609,7 +20609,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pify"
         }
       ]
@@ -20635,7 +20635,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pinkie-promise"
         }
       ]
@@ -20661,7 +20661,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pinkie"
         }
       ]
@@ -20687,7 +20687,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/png-js"
         }
       ]
@@ -20713,7 +20713,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/portscanner"
         }
       ]
@@ -20739,7 +20739,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/posix-character-classes"
         }
       ]
@@ -20765,7 +20765,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/prebuild-install"
         }
       ]
@@ -20791,7 +20791,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/prelude-ls"
         }
       ]
@@ -20817,7 +20817,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/prepend-http"
         }
       ]
@@ -20843,7 +20843,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pretty-bytes"
         }
       ]
@@ -20869,7 +20869,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/process-nextick-args"
         }
       ]
@@ -20895,7 +20895,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/prom-client"
         }
       ]
@@ -20921,7 +20921,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/promise-inflight"
         }
       ]
@@ -20947,7 +20947,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/promise-retry"
         }
       ],
@@ -20973,7 +20973,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/promise-retry\\node_modules\\err-code"
             }
           ]
@@ -20999,7 +20999,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/promise-retry\\node_modules\\retry"
             }
           ]
@@ -21027,7 +21027,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/promise"
         }
       ]
@@ -21053,7 +21053,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/proper-lockfile"
         }
       ]
@@ -21079,7 +21079,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/proxy-addr"
         }
       ]
@@ -21105,7 +21105,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/psl"
         }
       ]
@@ -21131,7 +21131,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-attrs"
         }
       ]
@@ -21157,7 +21157,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-code-gen"
         }
       ]
@@ -21183,7 +21183,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-error"
         }
       ]
@@ -21209,7 +21209,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-filters"
         }
       ]
@@ -21235,7 +21235,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-lexer"
         }
       ]
@@ -21261,7 +21261,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-linker"
         }
       ]
@@ -21287,7 +21287,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-load"
         }
       ]
@@ -21313,7 +21313,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-parser"
         }
       ]
@@ -21339,7 +21339,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-runtime"
         }
       ]
@@ -21365,7 +21365,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-strip-comments"
         }
       ]
@@ -21391,7 +21391,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-walk"
         }
       ]
@@ -21417,7 +21417,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug"
         }
       ]
@@ -21443,7 +21443,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pump"
         }
       ]
@@ -21469,7 +21469,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/punycode"
         }
       ]
@@ -21495,7 +21495,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/qs"
         }
       ]
@@ -21521,7 +21521,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/query-string"
         }
       ]
@@ -21547,7 +21547,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/range_check"
         }
       ]
@@ -21573,7 +21573,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/range-parser"
         }
       ]
@@ -21599,7 +21599,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/raw-body"
         }
       ]
@@ -21625,7 +21625,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/rc"
         }
       ]
@@ -21651,7 +21651,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/read-pkg"
         }
       ],
@@ -21677,7 +21677,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/read-pkg\\node_modules\\pify"
             }
           ]
@@ -21705,7 +21705,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/readable-stream"
         }
       ],
@@ -21731,7 +21731,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/readable-stream\\node_modules\\isarray"
             }
           ]
@@ -21759,7 +21759,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/readable-web-to-node-stream"
         }
       ],
@@ -21785,7 +21785,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/readable-web-to-node-stream\\node_modules\\readable-stream"
             }
           ]
@@ -21813,7 +21813,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/readdirp"
         }
       ]
@@ -21839,7 +21839,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/rechoir"
         }
       ]
@@ -21865,7 +21865,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/regex-not"
         }
       ]
@@ -21891,7 +21891,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/regexp.prototype.flags"
         }
       ]
@@ -21917,7 +21917,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/remove-trailing-separator"
         }
       ]
@@ -21943,7 +21943,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/repeat-element"
         }
       ]
@@ -21969,7 +21969,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/repeat-string"
         }
       ]
@@ -21995,7 +21995,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/replace"
         }
       ],
@@ -22021,7 +22021,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\ansi-regex"
             }
           ]
@@ -22047,7 +22047,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\ansi-styles"
             }
           ]
@@ -22073,7 +22073,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\brace-expansion"
             }
           ]
@@ -22099,7 +22099,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\cliui"
             }
           ]
@@ -22125,7 +22125,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\color-convert"
             }
           ]
@@ -22151,7 +22151,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\color-name"
             }
           ]
@@ -22177,7 +22177,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\find-up"
             }
           ]
@@ -22203,7 +22203,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\is-fullwidth-code-point"
             }
           ]
@@ -22229,7 +22229,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\locate-path"
             }
           ]
@@ -22255,7 +22255,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\minimatch"
             }
           ]
@@ -22281,7 +22281,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\p-locate"
             }
           ]
@@ -22307,7 +22307,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\path-exists"
             }
           ]
@@ -22333,7 +22333,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\string-width"
             }
           ]
@@ -22359,7 +22359,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\strip-ansi"
             }
           ]
@@ -22385,7 +22385,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\wrap-ansi"
             }
           ]
@@ -22411,7 +22411,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\yargs-parser"
             }
           ]
@@ -22437,7 +22437,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\yargs"
             }
           ]
@@ -22465,7 +22465,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/request"
         }
       ],
@@ -22491,7 +22491,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/request\\node_modules\\qs"
             }
           ]
@@ -22519,7 +22519,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/require-directory"
         }
       ]
@@ -22545,7 +22545,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/require-main-filename"
         }
       ]
@@ -22571,7 +22571,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/resolve-dir"
         }
       ]
@@ -22597,7 +22597,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/resolve-url"
         }
       ]
@@ -22623,7 +22623,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/resolve"
         }
       ]
@@ -22649,7 +22649,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/responselike"
         }
       ]
@@ -22675,7 +22675,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/restructure"
         }
       ]
@@ -22701,7 +22701,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ret"
         }
       ]
@@ -22727,7 +22727,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/retry-as-promised"
         }
       ]
@@ -22753,7 +22753,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/retry"
         }
       ]
@@ -22779,7 +22779,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/rimraf"
         }
       ]
@@ -22805,7 +22805,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/rxjs"
         }
       ],
@@ -22831,7 +22831,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/rxjs\\node_modules\\tslib"
             }
           ]
@@ -22859,7 +22859,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safe-buffer"
         }
       ]
@@ -22885,7 +22885,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safe-regex-test"
         }
       ]
@@ -22911,7 +22911,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safe-regex"
         }
       ]
@@ -22937,7 +22937,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safe-stable-stringify"
         }
       ]
@@ -22963,7 +22963,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safer-buffer"
         }
       ]
@@ -22989,7 +22989,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/samsam"
         }
       ]
@@ -23015,7 +23015,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sanitize-filename"
         }
       ]
@@ -23041,7 +23041,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sanitize-html"
         }
       ],
@@ -23067,7 +23067,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sanitize-html\\node_modules\\lodash"
             }
           ]
@@ -23095,7 +23095,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sax"
         }
       ]
@@ -23121,7 +23121,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/seek-bzip"
         }
       ]
@@ -23147,7 +23147,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/semver"
         }
       ]
@@ -23173,7 +23173,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/send"
         }
       ],
@@ -23199,7 +23199,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/send\\node_modules\\ms"
             }
           ]
@@ -23227,7 +23227,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sequelize-pool"
         }
       ]
@@ -23253,7 +23253,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sequelize"
         }
       ],
@@ -23279,7 +23279,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sequelize\\node_modules\\debug"
             }
           ]
@@ -23305,7 +23305,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sequelize\\node_modules\\ms"
             }
           ]
@@ -23331,7 +23331,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sequelize\\node_modules\\uuid"
             }
           ]
@@ -23359,7 +23359,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/serve-index"
         }
       ],
@@ -23385,7 +23385,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index\\node_modules\\depd"
             }
           ]
@@ -23411,7 +23411,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index\\node_modules\\http-errors"
             }
           ]
@@ -23437,7 +23437,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index\\node_modules\\inherits"
             }
           ]
@@ -23463,7 +23463,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index\\node_modules\\setprototypeof"
             }
           ]
@@ -23489,7 +23489,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index\\node_modules\\statuses"
             }
           ]
@@ -23517,7 +23517,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/serve-static"
         }
       ]
@@ -23543,7 +23543,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/set-blocking"
         }
       ]
@@ -23569,7 +23569,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/set-value"
         }
       ],
@@ -23595,7 +23595,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/set-value\\node_modules\\extend-shallow"
             }
           ]
@@ -23621,7 +23621,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/set-value\\node_modules\\is-extendable"
             }
           ]
@@ -23649,7 +23649,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/setimmediate"
         }
       ]
@@ -23675,7 +23675,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/setprototypeof"
         }
       ]
@@ -23701,7 +23701,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/side-channel"
         }
       ]
@@ -23727,7 +23727,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/signal-exit"
         }
       ]
@@ -23753,7 +23753,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/simple-concat"
         }
       ]
@@ -23779,7 +23779,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/simple-get"
         }
       ],
@@ -23805,7 +23805,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/simple-get\\node_modules\\decompress-response"
             }
           ]
@@ -23831,7 +23831,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/simple-get\\node_modules\\mimic-response"
             }
           ]
@@ -23859,7 +23859,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/simple-swizzle"
         }
       ],
@@ -23885,7 +23885,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/simple-swizzle\\node_modules\\is-arrayish"
             }
           ]
@@ -23913,7 +23913,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sinon"
         }
       ]
@@ -23939,7 +23939,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/smart-buffer"
         }
       ]
@@ -23965,7 +23965,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/snapdragon-node"
         }
       ],
@@ -23991,7 +23991,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon-node\\node_modules\\define-property"
             }
           ]
@@ -24019,7 +24019,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/snapdragon-util"
         }
       ],
@@ -24045,7 +24045,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon-util\\node_modules\\kind-of"
             }
           ]
@@ -24073,7 +24073,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/snapdragon"
         }
       ],
@@ -24099,7 +24099,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon\\node_modules\\define-property"
             }
           ]
@@ -24125,7 +24125,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon\\node_modules\\extend-shallow"
             }
           ]
@@ -24151,7 +24151,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon\\node_modules\\is-accessor-descriptor"
             }
           ],
@@ -24177,7 +24177,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/snapdragon\\node_modules\\is-accessor-descriptor\\node_modules\\kind-of"
                 }
               ]
@@ -24205,7 +24205,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon\\node_modules\\is-data-descriptor"
             }
           ],
@@ -24231,7 +24231,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/snapdragon\\node_modules\\is-data-descriptor\\node_modules\\kind-of"
                 }
               ]
@@ -24259,7 +24259,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon\\node_modules\\is-descriptor"
             }
           ]
@@ -24285,7 +24285,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon\\node_modules\\is-extendable"
             }
           ]
@@ -24311,7 +24311,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon\\node_modules\\kind-of"
             }
           ]
@@ -24337,7 +24337,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon\\node_modules\\source-map"
             }
           ]
@@ -24365,7 +24365,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socket.io-adapter"
         }
       ]
@@ -24391,7 +24391,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socket.io-parser"
         }
       ],
@@ -24417,7 +24417,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socket.io-parser\\node_modules\\debug"
             }
           ]
@@ -24443,7 +24443,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socket.io-parser\\node_modules\\ms"
             }
           ]
@@ -24471,7 +24471,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socket.io"
         }
       ],
@@ -24497,7 +24497,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socket.io\\node_modules\\debug"
             }
           ]
@@ -24523,7 +24523,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socket.io\\node_modules\\ms"
             }
           ]
@@ -24551,7 +24551,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socks-proxy-agent"
         }
       ],
@@ -24577,7 +24577,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socks-proxy-agent\\node_modules\\debug"
             }
           ]
@@ -24603,7 +24603,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socks-proxy-agent\\node_modules\\ms"
             }
           ]
@@ -24631,7 +24631,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socks"
         }
       ],
@@ -24657,7 +24657,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socks\\node_modules\\ip"
             }
           ]
@@ -24685,7 +24685,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sort-keys-length"
         }
       ],
@@ -24711,7 +24711,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sort-keys-length\\node_modules\\sort-keys"
             }
           ]
@@ -24739,7 +24739,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sort-keys"
         }
       ]
@@ -24765,7 +24765,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/source-map-resolve"
         }
       ]
@@ -24791,7 +24791,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/source-map-support"
         }
       ]
@@ -24817,7 +24817,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/source-map-url"
         }
       ]
@@ -24843,7 +24843,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/source-map"
         }
       ]
@@ -24869,7 +24869,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spawn-command"
         }
       ]
@@ -24895,7 +24895,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spdx-correct"
         }
       ]
@@ -24921,7 +24921,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spdx-exceptions"
         }
       ]
@@ -24947,7 +24947,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spdx-expression-parse"
         }
       ]
@@ -24973,7 +24973,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spdx-license-ids"
         }
       ]
@@ -24999,7 +24999,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/split-string"
         }
       ]
@@ -25025,7 +25025,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sprintf-js"
         }
       ]
@@ -25051,7 +25051,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sqlite3"
         }
       ]
@@ -25077,7 +25077,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sshpk"
         }
       ]
@@ -25103,7 +25103,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ssri"
         }
       ]
@@ -25129,7 +25129,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/stack-trace"
         }
       ]
@@ -25155,7 +25155,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/static-extend"
         }
       ],
@@ -25181,7 +25181,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend\\node_modules\\define-property"
             }
           ]
@@ -25207,7 +25207,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend\\node_modules\\is-accessor-descriptor"
             }
           ],
@@ -25233,7 +25233,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/static-extend\\node_modules\\is-accessor-descriptor\\node_modules\\kind-of"
                 }
               ]
@@ -25261,7 +25261,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend\\node_modules\\is-data-descriptor"
             }
           ],
@@ -25287,7 +25287,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/static-extend\\node_modules\\is-data-descriptor\\node_modules\\kind-of"
                 }
               ]
@@ -25315,7 +25315,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend\\node_modules\\is-descriptor"
             }
           ]
@@ -25341,7 +25341,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend\\node_modules\\kind-of"
             }
           ]
@@ -25369,7 +25369,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/statuses"
         }
       ]
@@ -25395,7 +25395,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/stream-buffers"
         }
       ]
@@ -25421,7 +25421,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/streamsearch"
         }
       ]
@@ -25447,7 +25447,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strict-uri-encode"
         }
       ]
@@ -25473,7 +25473,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string_decoder"
         }
       ]
@@ -25499,7 +25499,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string-width"
         }
       ]
@@ -25525,7 +25525,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string.fromcodepoint"
         }
       ]
@@ -25551,7 +25551,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string.prototype.codepointat"
         }
       ]
@@ -25577,7 +25577,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string.prototype.trimend"
         }
       ]
@@ -25603,7 +25603,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string.prototype.trimstart"
         }
       ]
@@ -25629,7 +25629,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-ansi"
         }
       ]
@@ -25655,7 +25655,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-bom"
         }
       ]
@@ -25681,7 +25681,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-dirs"
         }
       ]
@@ -25707,7 +25707,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-json-comments"
         }
       ]
@@ -25733,7 +25733,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-outer"
         }
       ]
@@ -25759,7 +25759,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strtok3"
         }
       ]
@@ -25785,7 +25785,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/supports-color"
         }
       ]
@@ -25811,7 +25811,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/supports-preserve-symlinks-flag"
         }
       ]
@@ -25837,7 +25837,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/svg-captcha"
         }
       ]
@@ -25863,7 +25863,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/swagger-ui-dist"
         }
       ]
@@ -25889,7 +25889,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/swagger-ui-express"
         }
       ]
@@ -25915,7 +25915,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tar-fs"
         }
       ],
@@ -25941,7 +25941,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/tar-fs\\node_modules\\bl"
             }
           ]
@@ -25967,7 +25967,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/tar-fs\\node_modules\\chownr"
             }
           ]
@@ -25993,7 +25993,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/tar-fs\\node_modules\\readable-stream"
             }
           ]
@@ -26019,7 +26019,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/tar-fs\\node_modules\\tar-stream"
             }
           ]
@@ -26047,7 +26047,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tar-stream"
         }
       ]
@@ -26073,7 +26073,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tar"
         }
       ]
@@ -26099,7 +26099,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tdigest"
         }
       ]
@@ -26125,7 +26125,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/text-hex"
         }
       ]
@@ -26151,7 +26151,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/thirty-two"
         }
       ]
@@ -26177,7 +26177,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/through"
         }
       ]
@@ -26203,7 +26203,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/timed-out"
         }
       ]
@@ -26229,7 +26229,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tiny-inflate"
         }
       ]
@@ -26255,7 +26255,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-buffer"
         }
       ]
@@ -26281,7 +26281,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-fast-properties"
         }
       ]
@@ -26307,7 +26307,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-object-path"
         }
       ],
@@ -26333,7 +26333,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/to-object-path\\node_modules\\kind-of"
             }
           ]
@@ -26361,7 +26361,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-regex-range"
         }
       ]
@@ -26387,7 +26387,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-regex"
         }
       ]
@@ -26413,7 +26413,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/toidentifier"
         }
       ]
@@ -26439,7 +26439,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/token-stream"
         }
       ]
@@ -26465,7 +26465,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/token-types"
         }
       ]
@@ -26491,7 +26491,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/toposort-class"
         }
       ]
@@ -26517,7 +26517,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tough-cookie"
         }
       ]
@@ -26543,7 +26543,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tr46"
         }
       ]
@@ -26569,7 +26569,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/traverse"
         }
       ]
@@ -26595,7 +26595,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tree-kill"
         }
       ]
@@ -26621,7 +26621,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/trim-repeated"
         }
       ]
@@ -26647,7 +26647,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/triple-beam"
         }
       ]
@@ -26673,7 +26673,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/truncate-utf8-bytes"
         }
       ]
@@ -26699,7 +26699,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ts-node-dev"
         }
       ],
@@ -26725,7 +26725,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/ts-node-dev\\node_modules\\rimraf"
             }
           ]
@@ -26753,7 +26753,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ts-node"
         }
       ]
@@ -26779,7 +26779,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tsconfig"
         }
       ]
@@ -26805,7 +26805,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tslib"
         }
       ]
@@ -26831,7 +26831,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tunnel-agent"
         }
       ]
@@ -26857,7 +26857,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tweetnacl"
         }
       ]
@@ -26883,7 +26883,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/type-check"
         }
       ]
@@ -26909,7 +26909,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/type-is"
         }
       ]
@@ -26935,7 +26935,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/typecast"
         }
       ]
@@ -26961,7 +26961,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/typedarray"
         }
       ]
@@ -26987,7 +26987,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/typescript"
         }
       ]
@@ -27013,7 +27013,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/uglify-js"
         }
       ]
@@ -27039,7 +27039,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unbox-primitive"
         }
       ]
@@ -27065,7 +27065,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unbzip2-stream"
         }
       ]
@@ -27091,7 +27091,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unc-path-regex"
         }
       ]
@@ -27117,7 +27117,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/underscore.string"
         }
       ]
@@ -27143,7 +27143,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unicode-properties"
         }
       ]
@@ -27169,7 +27169,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unicode-trie"
         }
       ]
@@ -27195,7 +27195,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/union-value"
         }
       ],
@@ -27221,7 +27221,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/union-value\\node_modules\\is-extendable"
             }
           ]
@@ -27249,7 +27249,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unique-filename"
         }
       ]
@@ -27275,7 +27275,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unique-slug"
         }
       ]
@@ -27301,7 +27301,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unit-compare"
         }
       ]
@@ -27327,7 +27327,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/universalify"
         }
       ]
@@ -27353,7 +27353,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unpipe"
         }
       ]
@@ -27379,7 +27379,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unset-value"
         }
       ],
@@ -27405,7 +27405,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/unset-value\\node_modules\\has-value"
             }
           ],
@@ -27431,7 +27431,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/unset-value\\node_modules\\has-value\\node_modules\\isobject"
                 }
               ]
@@ -27459,7 +27459,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/unset-value\\node_modules\\has-values"
             }
           ]
@@ -27485,7 +27485,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/unset-value\\node_modules\\isarray"
             }
           ]
@@ -27513,7 +27513,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/untildify"
         }
       ]
@@ -27539,7 +27539,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unzipper"
         }
       ],
@@ -27565,7 +27565,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/unzipper\\node_modules\\bluebird"
             }
           ]
@@ -27593,7 +27593,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/uri-js"
         }
       ]
@@ -27619,7 +27619,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/urix"
         }
       ]
@@ -27645,7 +27645,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/url-parse-lax"
         }
       ]
@@ -27671,7 +27671,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/url-to-options"
         }
       ]
@@ -27697,7 +27697,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/use"
         }
       ]
@@ -27723,7 +27723,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/utf8-byte-length"
         }
       ]
@@ -27749,7 +27749,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/util-deprecate"
         }
       ]
@@ -27775,7 +27775,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/util"
         }
       ]
@@ -27801,7 +27801,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/utils-merge"
         }
       ]
@@ -27827,7 +27827,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/uuid"
         }
       ]
@@ -27853,7 +27853,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/v8flags"
         }
       ]
@@ -27879,7 +27879,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/validate-npm-package-license"
         }
       ]
@@ -27905,7 +27905,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/validate"
         }
       ]
@@ -27931,7 +27931,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/validator"
         }
       ]
@@ -27957,7 +27957,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/vary"
         }
       ]
@@ -27983,7 +27983,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/verror"
         }
       ],
@@ -28009,7 +28009,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/verror\\node_modules\\core-util-is"
             }
           ]
@@ -28037,7 +28037,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/vm2"
         }
       ],
@@ -28063,7 +28063,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/vm2\\node_modules\\acorn"
             }
           ]
@@ -28091,7 +28091,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/void-elements"
         }
       ]
@@ -28117,7 +28117,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/walk"
         }
       ]
@@ -28143,7 +28143,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/walkdir"
         }
       ]
@@ -28169,7 +28169,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/webidl-conversions"
         }
       ]
@@ -28195,7 +28195,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/whatwg-url"
         }
       ]
@@ -28221,7 +28221,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-boxed-primitive"
         }
       ]
@@ -28247,7 +28247,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-collection"
         }
       ]
@@ -28273,7 +28273,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-module"
         }
       ]
@@ -28299,7 +28299,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-pm-runs"
         }
       ]
@@ -28325,7 +28325,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-typed-array"
         }
       ]
@@ -28351,7 +28351,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which"
         }
       ]
@@ -28377,7 +28377,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wide-align"
         }
       ]
@@ -28403,7 +28403,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/winston-transport"
         }
       ],
@@ -28429,7 +28429,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/winston-transport\\node_modules\\readable-stream"
             }
           ]
@@ -28457,7 +28457,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/winston"
         }
       ],
@@ -28483,7 +28483,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/winston\\node_modules\\async"
             }
           ]
@@ -28509,7 +28509,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/winston\\node_modules\\is-stream"
             }
           ]
@@ -28535,7 +28535,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/winston\\node_modules\\readable-stream"
             }
           ]
@@ -28563,7 +28563,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/with"
         }
       ]
@@ -28589,7 +28589,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wkx"
         }
       ]
@@ -28615,7 +28615,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/word-wrap"
         }
       ]
@@ -28641,7 +28641,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wordwrap"
         }
       ]
@@ -28667,7 +28667,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wrap-ansi"
         }
       ],
@@ -28693,7 +28693,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi\\node_modules\\ansi-regex"
             }
           ]
@@ -28719,7 +28719,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi\\node_modules\\emoji-regex"
             }
           ]
@@ -28745,7 +28745,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi\\node_modules\\is-fullwidth-code-point"
             }
           ]
@@ -28771,7 +28771,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi\\node_modules\\string-width"
             }
           ]
@@ -28797,7 +28797,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi\\node_modules\\strip-ansi"
             }
           ]
@@ -28825,7 +28825,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wrappy"
         }
       ]
@@ -28851,7 +28851,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ws"
         }
       ]
@@ -28877,7 +28877,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/xtend"
         }
       ]
@@ -28903,7 +28903,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/y18n"
         }
       ]
@@ -28929,7 +28929,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yallist"
         }
       ]
@@ -28955,7 +28955,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yaml-schema-validator"
         }
       ]
@@ -28981,7 +28981,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yargs-parser"
         }
       ]
@@ -29007,7 +29007,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yargs"
         }
       ],
@@ -29033,7 +29033,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs\\node_modules\\ansi-regex"
             }
           ]
@@ -29059,7 +29059,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs\\node_modules\\emoji-regex"
             }
           ]
@@ -29085,7 +29085,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs\\node_modules\\is-fullwidth-code-point"
             }
           ]
@@ -29111,7 +29111,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs\\node_modules\\string-width"
             }
           ]
@@ -29137,7 +29137,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs\\node_modules\\strip-ansi"
             }
           ]
@@ -29165,7 +29165,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yauzl"
         }
       ]
@@ -29191,7 +29191,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yn"
         }
       ]
@@ -29217,7 +29217,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/z85"
         }
       ]
@@ -29243,7 +29243,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/zip-stream"
         }
       ]
@@ -29269,7 +29269,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/zlibjs"
         }
       ]

--- a/tests/_data/sbom_demo-results/juice-shop_npm8_node16_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/juice-shop_npm8_node16_macos-latest.snap.json
@@ -62,7 +62,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -95,7 +95,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@babel/helper-string-parser"
         }
       ]
@@ -122,7 +122,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@babel/helper-validator-identifier"
         }
       ]
@@ -149,7 +149,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@babel/parser"
         }
       ]
@@ -176,7 +176,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@babel/types"
         }
       ]
@@ -203,7 +203,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@colors/colors"
         }
       ]
@@ -230,7 +230,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@dabh/diagnostics"
         }
       ]
@@ -257,7 +257,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@gar/promisify"
         }
       ]
@@ -284,7 +284,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@mapbox/node-pre-gyp"
         }
       ],
@@ -310,7 +310,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/ansi-regex"
             }
           ]
@@ -336,7 +336,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/are-we-there-yet"
             }
           ]
@@ -362,7 +362,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/detect-libc"
             }
           ]
@@ -388,7 +388,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/gauge"
             }
           ]
@@ -414,7 +414,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -440,7 +440,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/make-dir"
             }
           ],
@@ -466,7 +466,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/@mapbox/node-pre-gyp/node_modules/make-dir/node_modules/semver"
                 }
               ]
@@ -494,7 +494,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/nopt"
             }
           ]
@@ -520,7 +520,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/npmlog"
             }
           ]
@@ -546,7 +546,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/readable-stream"
             }
           ]
@@ -572,7 +572,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/string-width"
             }
           ]
@@ -598,7 +598,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/strip-ansi"
             }
           ]
@@ -627,7 +627,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/core-loader"
         }
       ]
@@ -654,7 +654,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/core"
         }
       ]
@@ -681,7 +681,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/evaluator"
         }
       ]
@@ -708,7 +708,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-all"
         }
       ]
@@ -735,7 +735,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ar"
         }
       ]
@@ -762,7 +762,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-bn"
         }
       ]
@@ -789,7 +789,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ca"
         }
       ]
@@ -816,7 +816,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-cs"
         }
       ]
@@ -843,7 +843,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-da"
         }
       ]
@@ -870,7 +870,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-de"
         }
       ]
@@ -897,7 +897,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-el"
         }
       ]
@@ -924,7 +924,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-en-min"
         }
       ]
@@ -951,7 +951,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-en"
         }
       ]
@@ -978,7 +978,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-es"
         }
       ]
@@ -1005,7 +1005,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-eu"
         }
       ]
@@ -1032,7 +1032,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-fa"
         }
       ]
@@ -1059,7 +1059,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-fi"
         }
       ]
@@ -1086,7 +1086,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-fr"
         }
       ]
@@ -1113,7 +1113,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ga"
         }
       ]
@@ -1140,7 +1140,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-gl"
         }
       ]
@@ -1167,7 +1167,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-hi"
         }
       ]
@@ -1194,7 +1194,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-hu"
         }
       ]
@@ -1221,7 +1221,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-hy"
         }
       ]
@@ -1248,7 +1248,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-id"
         }
       ]
@@ -1275,7 +1275,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-it"
         }
       ]
@@ -1302,7 +1302,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ja"
         }
       ]
@@ -1329,7 +1329,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ko"
         }
       ]
@@ -1356,7 +1356,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-lt"
         }
       ]
@@ -1383,7 +1383,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ms"
         }
       ]
@@ -1410,7 +1410,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ne"
         }
       ]
@@ -1437,7 +1437,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-nl"
         }
       ]
@@ -1464,7 +1464,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-no"
         }
       ]
@@ -1491,7 +1491,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-pl"
         }
       ]
@@ -1518,7 +1518,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-pt"
         }
       ]
@@ -1545,7 +1545,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ro"
         }
       ]
@@ -1572,7 +1572,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ru"
         }
       ]
@@ -1599,7 +1599,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-sl"
         }
       ]
@@ -1626,7 +1626,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-sr"
         }
       ]
@@ -1653,7 +1653,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-sv"
         }
       ]
@@ -1680,7 +1680,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ta"
         }
       ]
@@ -1707,7 +1707,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-th"
         }
       ]
@@ -1734,7 +1734,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-tl"
         }
       ]
@@ -1761,7 +1761,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-tr"
         }
       ]
@@ -1788,7 +1788,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-uk"
         }
       ]
@@ -1815,7 +1815,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-zh"
         }
       ]
@@ -1842,7 +1842,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/language-min"
         }
       ]
@@ -1869,7 +1869,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/language"
         }
       ]
@@ -1896,7 +1896,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/ner"
         }
       ]
@@ -1923,7 +1923,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/neural"
         }
       ]
@@ -1950,7 +1950,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/nlg"
         }
       ]
@@ -1977,7 +1977,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/nlp"
         }
       ]
@@ -2004,7 +2004,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/nlu"
         }
       ]
@@ -2031,7 +2031,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/request"
         }
       ]
@@ -2058,7 +2058,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/sentiment"
         }
       ]
@@ -2085,7 +2085,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/similarity"
         }
       ]
@@ -2112,7 +2112,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/slot"
         }
       ]
@@ -2139,7 +2139,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@npmcli/fs"
         }
       ]
@@ -2166,7 +2166,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@npmcli/move-file"
         }
       ]
@@ -2193,7 +2193,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib/core"
         }
       ]
@@ -2220,7 +2220,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib/plugin-crypto"
         }
       ]
@@ -2247,7 +2247,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib/plugin-thirty-two"
         }
       ]
@@ -2274,7 +2274,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib/preset-default"
         }
       ]
@@ -2301,7 +2301,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib/preset-v11"
         }
       ]
@@ -2328,7 +2328,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@sindresorhus/is"
         }
       ]
@@ -2355,7 +2355,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@swc/helpers"
         }
       ]
@@ -2382,7 +2382,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@tokenizer/token"
         }
       ]
@@ -2409,7 +2409,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@tootallnate/once"
         }
       ]
@@ -2436,7 +2436,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/component-emitter"
         }
       ]
@@ -2463,7 +2463,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/cookie"
         }
       ]
@@ -2490,7 +2490,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/cors"
         }
       ]
@@ -2517,7 +2517,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/debug"
         }
       ]
@@ -2544,7 +2544,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/ms"
         }
       ]
@@ -2571,7 +2571,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/node"
         }
       ]
@@ -2598,7 +2598,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/strip-bom"
         }
       ]
@@ -2625,7 +2625,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/strip-json-comments"
         }
       ]
@@ -2652,7 +2652,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/validator"
         }
       ]
@@ -2678,7 +2678,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/abbrev"
         }
       ]
@@ -2704,7 +2704,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/accepts"
         }
       ]
@@ -2730,7 +2730,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/acorn-walk"
         }
       ]
@@ -2756,7 +2756,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/acorn"
         }
       ]
@@ -2782,7 +2782,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/agent-base"
         }
       ],
@@ -2808,7 +2808,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agent-base/node_modules/debug"
             }
           ]
@@ -2834,7 +2834,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agent-base/node_modules/ms"
             }
           ]
@@ -2862,7 +2862,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/agentkeepalive"
         }
       ],
@@ -2888,7 +2888,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agentkeepalive/node_modules/debug"
             }
           ]
@@ -2914,7 +2914,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agentkeepalive/node_modules/depd"
             }
           ]
@@ -2940,7 +2940,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agentkeepalive/node_modules/ms"
             }
           ]
@@ -2968,7 +2968,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/aggregate-error"
         }
       ]
@@ -2994,7 +2994,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ajv"
         }
       ]
@@ -3020,7 +3020,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ansi-regex"
         }
       ]
@@ -3046,7 +3046,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ansi-styles"
         }
       ]
@@ -3072,7 +3072,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/anymatch"
         }
       ],
@@ -3098,7 +3098,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/anymatch/node_modules/normalize-path"
             }
           ]
@@ -3126,7 +3126,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/append-field"
         }
       ]
@@ -3152,7 +3152,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/aproba"
         }
       ]
@@ -3178,7 +3178,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/archive-type"
         }
       ],
@@ -3204,7 +3204,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/archive-type/node_modules/file-type"
             }
           ]
@@ -3232,7 +3232,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/archiver-utils"
         }
       ]
@@ -3258,7 +3258,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/archiver"
         }
       ]
@@ -3284,7 +3284,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/are-we-there-yet"
         }
       ]
@@ -3310,7 +3310,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/arg"
         }
       ]
@@ -3336,7 +3336,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/argparse"
         }
       ],
@@ -3362,7 +3362,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/argparse/node_modules/sprintf-js"
             }
           ]
@@ -3390,7 +3390,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/arr-diff"
         }
       ]
@@ -3416,7 +3416,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/arr-flatten"
         }
       ]
@@ -3442,7 +3442,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/arr-union"
         }
       ]
@@ -3468,7 +3468,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/array-each"
         }
       ]
@@ -3494,7 +3494,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/array-flatten"
         }
       ]
@@ -3520,7 +3520,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/array-slice"
         }
       ]
@@ -3546,7 +3546,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/array-unique"
         }
       ]
@@ -3572,7 +3572,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/asap"
         }
       ]
@@ -3598,7 +3598,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/asn1"
         }
       ]
@@ -3624,7 +3624,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/assert-never"
         }
       ]
@@ -3650,7 +3650,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/assert-plus"
         }
       ]
@@ -3676,7 +3676,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/assign-symbols"
         }
       ]
@@ -3702,7 +3702,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/async"
         }
       ]
@@ -3728,7 +3728,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/asynckit"
         }
       ]
@@ -3754,7 +3754,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/at-least-node"
         }
       ]
@@ -3780,7 +3780,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/atob"
         }
       ]
@@ -3806,7 +3806,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/available-typed-arrays"
         }
       ]
@@ -3832,7 +3832,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/aws-sign2"
         }
       ]
@@ -3858,7 +3858,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/aws4"
         }
       ]
@@ -3884,7 +3884,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/babel-walk"
         }
       ]
@@ -3910,7 +3910,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/balanced-match"
         }
       ]
@@ -3936,7 +3936,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base"
         }
       ],
@@ -3962,7 +3962,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/base/node_modules/define-property"
             }
           ]
@@ -3990,7 +3990,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base64-arraybuffer"
         }
       ]
@@ -4016,7 +4016,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base64-js"
         }
       ]
@@ -4042,7 +4042,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base64id"
         }
       ]
@@ -4068,7 +4068,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base64url"
         }
       ]
@@ -4094,7 +4094,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/basic-auth"
         }
       ]
@@ -4120,7 +4120,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/batch"
         }
       ]
@@ -4146,7 +4146,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bcrypt-pbkdf"
         }
       ]
@@ -4172,7 +4172,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/big-integer"
         }
       ]
@@ -4198,7 +4198,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/binary-extensions"
         }
       ]
@@ -4224,7 +4224,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/binary"
         }
       ]
@@ -4250,7 +4250,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bindings"
         }
       ]
@@ -4276,7 +4276,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bintrees"
         }
       ]
@@ -4302,7 +4302,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bl"
         }
       ]
@@ -4328,7 +4328,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bluebird"
         }
       ]
@@ -4354,7 +4354,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/body-parser"
         }
       ]
@@ -4380,7 +4380,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bower-config"
         }
       ],
@@ -4406,7 +4406,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bower-config/node_modules/minimist"
             }
           ]
@@ -4434,7 +4434,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/brace-expansion"
         }
       ]
@@ -4460,7 +4460,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/braces"
         }
       ],
@@ -4486,7 +4486,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/braces/node_modules/extend-shallow"
             }
           ]
@@ -4512,7 +4512,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/braces/node_modules/is-extendable"
             }
           ]
@@ -4540,7 +4540,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/brotli"
         }
       ]
@@ -4566,7 +4566,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-alloc-unsafe"
         }
       ]
@@ -4592,7 +4592,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-alloc"
         }
       ]
@@ -4618,7 +4618,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-crc32"
         }
       ]
@@ -4644,7 +4644,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-fill"
         }
       ]
@@ -4670,7 +4670,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-from"
         }
       ]
@@ -4696,7 +4696,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-indexof-polyfill"
         }
       ]
@@ -4722,7 +4722,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer"
         }
       ]
@@ -4748,7 +4748,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffers"
         }
       ]
@@ -4774,7 +4774,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/busboy"
         }
       ],
@@ -4800,7 +4800,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/busboy/node_modules/isarray"
             }
           ]
@@ -4826,7 +4826,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/busboy/node_modules/readable-stream"
             }
           ]
@@ -4852,7 +4852,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/busboy/node_modules/string_decoder"
             }
           ]
@@ -4880,7 +4880,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/byline"
         }
       ]
@@ -4906,7 +4906,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bytes"
         }
       ]
@@ -4932,7 +4932,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cacache"
         }
       ]
@@ -4958,7 +4958,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cache-base"
         }
       ]
@@ -4984,7 +4984,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cacheable-request"
         }
       ],
@@ -5010,7 +5010,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cacheable-request/node_modules/get-stream"
             }
           ]
@@ -5036,7 +5036,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cacheable-request/node_modules/lowercase-keys"
             }
           ]
@@ -5064,7 +5064,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/call-bind"
         }
       ]
@@ -5090,7 +5090,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/camelcase"
         }
       ]
@@ -5116,7 +5116,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/caseless"
         }
       ]
@@ -5142,7 +5142,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/chainsaw"
         }
       ]
@@ -5168,7 +5168,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/chalk"
         }
       ]
@@ -5194,7 +5194,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/character-parser"
         }
       ]
@@ -5220,7 +5220,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/check-dependencies"
         }
       ],
@@ -5246,7 +5246,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/check-dependencies/node_modules/semver"
             }
           ]
@@ -5274,7 +5274,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/check-types"
         }
       ]
@@ -5300,7 +5300,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/chokidar"
         }
       ],
@@ -5326,7 +5326,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar/node_modules/braces"
             }
           ]
@@ -5352,7 +5352,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar/node_modules/fill-range"
             }
           ]
@@ -5378,7 +5378,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar/node_modules/is-glob"
             }
           ]
@@ -5404,7 +5404,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar/node_modules/is-number"
             }
           ]
@@ -5430,7 +5430,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar/node_modules/normalize-path"
             }
           ]
@@ -5456,7 +5456,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar/node_modules/to-regex-range"
             }
           ]
@@ -5484,7 +5484,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/chownr"
         }
       ]
@@ -5510,7 +5510,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/clarinet"
         }
       ]
@@ -5536,7 +5536,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/class-utils"
         }
       ],
@@ -5562,7 +5562,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils/node_modules/define-property"
             }
           ]
@@ -5588,7 +5588,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils/node_modules/is-accessor-descriptor"
             }
           ],
@@ -5614,7 +5614,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/class-utils/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
@@ -5642,7 +5642,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils/node_modules/is-data-descriptor"
             }
           ],
@@ -5668,7 +5668,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/class-utils/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
@@ -5696,7 +5696,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils/node_modules/is-descriptor"
             }
           ]
@@ -5722,7 +5722,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils/node_modules/kind-of"
             }
           ]
@@ -5750,7 +5750,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/clean-stack"
         }
       ]
@@ -5776,7 +5776,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cliui"
         }
       ],
@@ -5802,7 +5802,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui/node_modules/ansi-regex"
             }
           ]
@@ -5828,7 +5828,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui/node_modules/emoji-regex"
             }
           ]
@@ -5854,7 +5854,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -5880,7 +5880,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui/node_modules/string-width"
             }
           ]
@@ -5906,7 +5906,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui/node_modules/strip-ansi"
             }
           ]
@@ -5934,7 +5934,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/clone-response"
         }
       ]
@@ -5960,7 +5960,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/clone"
         }
       ]
@@ -5986,7 +5986,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/code-point-at"
         }
       ]
@@ -6012,7 +6012,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/collection-visit"
         }
       ]
@@ -6038,7 +6038,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color-convert"
         }
       ]
@@ -6064,7 +6064,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color-name"
         }
       ]
@@ -6090,7 +6090,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color-string"
         }
       ]
@@ -6116,7 +6116,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color-support"
         }
       ]
@@ -6142,7 +6142,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color"
         }
       ]
@@ -6168,7 +6168,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/colors"
         }
       ]
@@ -6194,7 +6194,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/colorspace"
         }
       ]
@@ -6220,7 +6220,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/combined-stream"
         }
       ]
@@ -6246,7 +6246,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/commander"
         }
       ]
@@ -6272,7 +6272,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/component-emitter"
         }
       ]
@@ -6298,7 +6298,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/component-type"
         }
       ]
@@ -6324,7 +6324,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/compress-commons"
         }
       ]
@@ -6350,7 +6350,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/compressible"
         }
       ]
@@ -6376,7 +6376,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/compression"
         }
       ],
@@ -6402,7 +6402,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/compression/node_modules/bytes"
             }
           ]
@@ -6430,7 +6430,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/concat-map"
         }
       ]
@@ -6456,7 +6456,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/concat-stream"
         }
       ]
@@ -6482,7 +6482,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/concurrently"
         }
       ],
@@ -6508,7 +6508,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/concurrently/node_modules/supports-color"
             }
           ]
@@ -6536,7 +6536,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/config"
         }
       ]
@@ -6562,7 +6562,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/console-control-strings"
         }
       ]
@@ -6588,7 +6588,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/constantinople"
         }
       ]
@@ -6614,7 +6614,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/content-disposition"
         }
       ],
@@ -6640,7 +6640,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/content-disposition/node_modules/safe-buffer"
             }
           ]
@@ -6668,7 +6668,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/content-type"
         }
       ]
@@ -6694,7 +6694,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cookie-parser"
         }
       ]
@@ -6720,7 +6720,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cookie-signature"
         }
       ]
@@ -6746,7 +6746,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cookie"
         }
       ]
@@ -6772,7 +6772,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/copy-descriptor"
         }
       ]
@@ -6798,7 +6798,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/core-util-is"
         }
       ]
@@ -6824,7 +6824,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cors"
         }
       ]
@@ -6850,7 +6850,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/crc"
         }
       ]
@@ -6876,7 +6876,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/crc32-stream"
         }
       ]
@@ -6902,7 +6902,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/create-require"
         }
       ]
@@ -6928,7 +6928,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/crypto-js"
         }
       ]
@@ -6954,7 +6954,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dashdash"
         }
       ]
@@ -6980,7 +6980,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/date-fns"
         }
       ]
@@ -7006,7 +7006,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dateformat"
         }
       ]
@@ -7032,7 +7032,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/debug"
         }
       ]
@@ -7058,7 +7058,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decamelize"
         }
       ]
@@ -7084,7 +7084,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decode-uri-component"
         }
       ]
@@ -7110,7 +7110,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-response"
         }
       ]
@@ -7136,7 +7136,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-tar"
         }
       ],
@@ -7162,7 +7162,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-tar/node_modules/file-type"
             }
           ]
@@ -7190,7 +7190,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-tarbz2"
         }
       ],
@@ -7216,7 +7216,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-tarbz2/node_modules/file-type"
             }
           ]
@@ -7244,7 +7244,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-targz"
         }
       ],
@@ -7270,7 +7270,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-targz/node_modules/file-type"
             }
           ]
@@ -7298,7 +7298,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-unzip"
         }
       ],
@@ -7324,7 +7324,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-unzip/node_modules/file-type"
             }
           ]
@@ -7350,7 +7350,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-unzip/node_modules/get-stream"
             }
           ]
@@ -7376,7 +7376,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-unzip/node_modules/pify"
             }
           ]
@@ -7404,7 +7404,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress"
         }
       ],
@@ -7430,7 +7430,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress/node_modules/make-dir"
             }
           ],
@@ -7456,7 +7456,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/decompress/node_modules/make-dir/node_modules/pify"
                 }
               ]
@@ -7484,7 +7484,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress/node_modules/pify"
             }
           ]
@@ -7512,7 +7512,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/deep-equal"
         }
       ]
@@ -7538,7 +7538,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/deep-extend"
         }
       ]
@@ -7564,7 +7564,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/deep-is"
         }
       ]
@@ -7590,7 +7590,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/define-properties"
         }
       ]
@@ -7616,7 +7616,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/define-property"
         }
       ]
@@ -7642,7 +7642,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/delayed-stream"
         }
       ]
@@ -7668,7 +7668,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/delegates"
         }
       ]
@@ -7694,7 +7694,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/depd"
         }
       ]
@@ -7720,7 +7720,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/destroy"
         }
       ]
@@ -7746,7 +7746,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/detect-file"
         }
       ]
@@ -7772,7 +7772,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/detect-libc"
         }
       ]
@@ -7798,7 +7798,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dfa"
         }
       ]
@@ -7824,7 +7824,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dicer"
         }
       ],
@@ -7850,7 +7850,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/dicer/node_modules/isarray"
             }
           ]
@@ -7876,7 +7876,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/dicer/node_modules/readable-stream"
             }
           ]
@@ -7902,7 +7902,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/dicer/node_modules/string_decoder"
             }
           ]
@@ -7930,7 +7930,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/diff"
         }
       ]
@@ -7956,7 +7956,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/doctypes"
         }
       ]
@@ -7982,7 +7982,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/domelementtype"
         }
       ]
@@ -8008,7 +8008,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/domhandler"
         }
       ]
@@ -8034,7 +8034,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/domutils"
         }
       ]
@@ -8060,7 +8060,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dottie"
         }
       ]
@@ -8086,7 +8086,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/double-ended-queue"
         }
       ]
@@ -8112,7 +8112,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/doublearray"
         }
       ]
@@ -8138,7 +8138,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/download"
         }
       ],
@@ -8164,7 +8164,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/download/node_modules/file-type"
             }
           ]
@@ -8192,7 +8192,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/duplexer2"
         }
       ]
@@ -8218,7 +8218,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/duplexer3"
         }
       ]
@@ -8244,7 +8244,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dynamic-dedupe"
         }
       ]
@@ -8270,7 +8270,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ecc-jsbn"
         }
       ]
@@ -8296,7 +8296,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ee-first"
         }
       ]
@@ -8322,7 +8322,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/eivindfjeldstad-dot"
         }
       ]
@@ -8348,7 +8348,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/emoji-regex"
         }
       ]
@@ -8374,7 +8374,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/enabled"
         }
       ]
@@ -8400,7 +8400,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/encodeurl"
         }
       ]
@@ -8426,7 +8426,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/encoding"
         }
       ],
@@ -8452,7 +8452,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/encoding/node_modules/iconv-lite"
             }
           ]
@@ -8480,7 +8480,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/end-of-stream"
         }
       ]
@@ -8506,7 +8506,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/engine.io-parser"
         }
       ]
@@ -8532,7 +8532,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/engine.io"
         }
       ],
@@ -8558,7 +8558,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/engine.io/node_modules/debug"
             }
           ]
@@ -8584,7 +8584,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/engine.io/node_modules/ms"
             }
           ]
@@ -8612,7 +8612,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/env-paths"
         }
       ]
@@ -8638,7 +8638,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/err-code"
         }
       ]
@@ -8664,7 +8664,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/error-ex"
         }
       ]
@@ -8690,7 +8690,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/errorhandler"
         }
       ]
@@ -8716,7 +8716,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/es-abstract"
         }
       ]
@@ -8742,7 +8742,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/es-get-iterator"
         }
       ]
@@ -8768,7 +8768,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/es-to-primitive"
         }
       ]
@@ -8794,7 +8794,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/escape-html"
         }
       ]
@@ -8820,7 +8820,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/escape-string-regexp"
         }
       ]
@@ -8846,7 +8846,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/escodegen"
         }
       ]
@@ -8872,7 +8872,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/esprima"
         }
       ]
@@ -8898,7 +8898,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/estraverse"
         }
       ]
@@ -8924,7 +8924,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/esutils"
         }
       ]
@@ -8950,7 +8950,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/etag"
         }
       ]
@@ -8976,7 +8976,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/eventemitter2"
         }
       ]
@@ -9002,7 +9002,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/eventemitter3"
         }
       ]
@@ -9028,7 +9028,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/exif"
         }
       ]
@@ -9054,7 +9054,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/exit"
         }
       ]
@@ -9080,7 +9080,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/expand-brackets"
         }
       ],
@@ -9106,7 +9106,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/define-property"
             }
           ]
@@ -9132,7 +9132,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/extend-shallow"
             }
           ]
@@ -9158,7 +9158,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/is-accessor-descriptor"
             }
           ],
@@ -9184,7 +9184,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/expand-brackets/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
@@ -9212,7 +9212,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/is-data-descriptor"
             }
           ],
@@ -9238,7 +9238,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/expand-brackets/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
@@ -9266,7 +9266,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/is-descriptor"
             }
           ]
@@ -9292,7 +9292,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/is-extendable"
             }
           ]
@@ -9318,7 +9318,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/kind-of"
             }
           ]
@@ -9346,7 +9346,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/expand-template"
         }
       ]
@@ -9372,7 +9372,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/expand-tilde"
         }
       ]
@@ -9398,7 +9398,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-ipfilter"
         }
       ]
@@ -9424,7 +9424,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-jwt"
         }
       ],
@@ -9450,7 +9450,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/express-jwt/node_modules/jsonwebtoken"
             }
           ]
@@ -9476,7 +9476,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/express-jwt/node_modules/moment"
             }
           ]
@@ -9504,7 +9504,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-rate-limit"
         }
       ]
@@ -9530,7 +9530,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-robots-txt"
         }
       ]
@@ -9556,7 +9556,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-security.txt"
         }
       ]
@@ -9582,7 +9582,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express"
         }
       ],
@@ -9608,7 +9608,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/express/node_modules/cookie"
             }
           ]
@@ -9634,7 +9634,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/express/node_modules/safe-buffer"
             }
           ]
@@ -9662,7 +9662,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ext-list"
         }
       ]
@@ -9688,7 +9688,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ext-name"
         }
       ]
@@ -9714,7 +9714,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/extend-shallow"
         }
       ]
@@ -9740,7 +9740,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/extend"
         }
       ]
@@ -9766,7 +9766,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/extglob"
         }
       ],
@@ -9792,7 +9792,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/extglob/node_modules/define-property"
             }
           ]
@@ -9818,7 +9818,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/extglob/node_modules/extend-shallow"
             }
           ]
@@ -9844,7 +9844,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/extglob/node_modules/is-extendable"
             }
           ]
@@ -9872,7 +9872,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/extsprintf"
         }
       ]
@@ -9898,7 +9898,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fast-deep-equal"
         }
       ]
@@ -9924,7 +9924,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fast-json-stable-stringify"
         }
       ]
@@ -9950,7 +9950,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fast-levenshtein"
         }
       ]
@@ -9976,7 +9976,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fast.js"
         }
       ]
@@ -10002,7 +10002,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fd-slicer"
         }
       ]
@@ -10028,7 +10028,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/feature-policy"
         }
       ]
@@ -10054,7 +10054,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fecha"
         }
       ]
@@ -10080,7 +10080,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/file-js"
         }
       ],
@@ -10106,7 +10106,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/file-js/node_modules/brace-expansion"
             }
           ]
@@ -10132,7 +10132,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/file-js/node_modules/minimatch"
             }
           ]
@@ -10160,7 +10160,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/file-stream-rotator"
         }
       ]
@@ -10186,7 +10186,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/file-type"
         }
       ]
@@ -10212,7 +10212,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/file-uri-to-path"
         }
       ]
@@ -10238,7 +10238,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/filehound"
         }
       ]
@@ -10264,7 +10264,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/filename-reserved-regex"
         }
       ]
@@ -10290,7 +10290,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/filenamify"
         }
       ]
@@ -10316,7 +10316,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/filesniffer"
         }
       ]
@@ -10342,7 +10342,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fill-range"
         }
       ],
@@ -10368,7 +10368,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/fill-range/node_modules/extend-shallow"
             }
           ]
@@ -10394,7 +10394,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/fill-range/node_modules/is-extendable"
             }
           ]
@@ -10422,7 +10422,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/finale-rest"
         }
       ]
@@ -10448,7 +10448,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/finalhandler"
         }
       ]
@@ -10474,7 +10474,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/find-up"
         }
       ]
@@ -10500,7 +10500,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/findup-sync"
         }
       ]
@@ -10526,7 +10526,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fined"
         }
       ]
@@ -10552,7 +10552,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/flagged-respawn"
         }
       ]
@@ -10578,7 +10578,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fn.name"
         }
       ]
@@ -10604,7 +10604,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fontkit"
         }
       ]
@@ -10630,7 +10630,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/for-each"
         }
       ]
@@ -10656,7 +10656,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/for-in"
         }
       ]
@@ -10682,7 +10682,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/for-own"
         }
       ]
@@ -10708,7 +10708,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/foreachasync"
         }
       ]
@@ -10734,7 +10734,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/forever-agent"
         }
       ]
@@ -10760,7 +10760,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/form-data"
         }
       ]
@@ -10786,7 +10786,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/formatio"
         }
       ]
@@ -10812,7 +10812,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/forwarded"
         }
       ]
@@ -10838,7 +10838,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fragment-cache"
         }
       ]
@@ -10864,7 +10864,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fresh"
         }
       ]
@@ -10890,7 +10890,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/from2"
         }
       ]
@@ -10916,7 +10916,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fs-constants"
         }
       ]
@@ -10942,7 +10942,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fs-extra"
         }
       ]
@@ -10968,7 +10968,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fs-minipass"
         }
       ]
@@ -10994,7 +10994,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fs.realpath"
         }
       ]
@@ -11020,7 +11020,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fsevents"
         }
       ]
@@ -11046,7 +11046,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fstream"
         }
       ],
@@ -11072,7 +11072,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/fstream/node_modules/mkdirp"
             }
           ]
@@ -11098,7 +11098,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/fstream/node_modules/rimraf"
             }
           ]
@@ -11126,7 +11126,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/function-bind"
         }
       ]
@@ -11152,7 +11152,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/function.prototype.name"
         }
       ]
@@ -11178,7 +11178,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/functions-have-names"
         }
       ]
@@ -11204,7 +11204,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fuzzball"
         }
       ]
@@ -11230,7 +11230,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/gauge"
         }
       ]
@@ -11256,7 +11256,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/geojson-utils"
         }
       ]
@@ -11282,7 +11282,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-caller-file"
         }
       ]
@@ -11308,7 +11308,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-intrinsic"
         }
       ]
@@ -11334,7 +11334,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-stream"
         }
       ]
@@ -11360,7 +11360,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-symbol-description"
         }
       ]
@@ -11386,7 +11386,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-value"
         }
       ]
@@ -11412,7 +11412,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/getobject"
         }
       ]
@@ -11438,7 +11438,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/getpass"
         }
       ]
@@ -11464,7 +11464,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/github-from-package"
         }
       ]
@@ -11490,7 +11490,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/glob-parent"
         }
       ],
@@ -11516,7 +11516,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/glob-parent/node_modules/is-glob"
             }
           ]
@@ -11544,7 +11544,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/glob"
         }
       ],
@@ -11570,7 +11570,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/glob/node_modules/brace-expansion"
             }
           ]
@@ -11596,7 +11596,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/glob/node_modules/minimatch"
             }
           ]
@@ -11624,7 +11624,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/global-modules"
         }
       ]
@@ -11650,7 +11650,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/global-prefix"
         }
       ],
@@ -11676,7 +11676,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/global-prefix/node_modules/which"
             }
           ]
@@ -11704,7 +11704,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/got"
         }
       ],
@@ -11730,7 +11730,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/got/node_modules/get-stream"
             }
           ]
@@ -11756,7 +11756,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/got/node_modules/pify"
             }
           ]
@@ -11784,7 +11784,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/graceful-fs"
         }
       ]
@@ -11810,7 +11810,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-cli"
         }
       ],
@@ -11836,7 +11836,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-cli/node_modules/nopt"
             }
           ]
@@ -11864,7 +11864,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-contrib-compress"
         }
       ],
@@ -11890,7 +11890,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-contrib-compress/node_modules/ansi-styles"
             }
           ]
@@ -11916,7 +11916,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-contrib-compress/node_modules/chalk"
             }
           ]
@@ -11942,7 +11942,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-contrib-compress/node_modules/supports-color"
             }
           ]
@@ -11970,7 +11970,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-known-options"
         }
       ]
@@ -11996,7 +11996,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-legacy-log-utils"
         }
       ],
@@ -12022,7 +12022,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils/node_modules/ansi-styles"
             }
           ]
@@ -12048,7 +12048,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils/node_modules/chalk"
             }
           ]
@@ -12074,7 +12074,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils/node_modules/color-convert"
             }
           ]
@@ -12100,7 +12100,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils/node_modules/color-name"
             }
           ]
@@ -12126,7 +12126,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils/node_modules/has-flag"
             }
           ]
@@ -12152,7 +12152,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils/node_modules/supports-color"
             }
           ]
@@ -12180,7 +12180,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-legacy-log"
         }
       ],
@@ -12206,7 +12206,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log/node_modules/colors"
             }
           ]
@@ -12234,7 +12234,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-legacy-util"
         }
       ],
@@ -12260,7 +12260,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-util/node_modules/async"
             }
           ]
@@ -12288,7 +12288,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-replace-json"
         }
       ]
@@ -12314,7 +12314,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt"
         }
       ],
@@ -12340,7 +12340,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt/node_modules/brace-expansion"
             }
           ]
@@ -12366,7 +12366,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt/node_modules/findup-sync"
             }
           ],
@@ -12392,7 +12392,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/grunt/node_modules/findup-sync/node_modules/glob"
                 }
               ]
@@ -12420,7 +12420,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt/node_modules/glob"
             }
           ]
@@ -12446,7 +12446,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt/node_modules/minimatch"
             }
           ]
@@ -12474,7 +12474,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/handlebars"
         }
       ],
@@ -12500,7 +12500,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/handlebars/node_modules/wordwrap"
             }
           ]
@@ -12528,7 +12528,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/har-schema"
         }
       ]
@@ -12554,7 +12554,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/har-validator"
         }
       ]
@@ -12580,7 +12580,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-ansi"
         }
       ]
@@ -12606,7 +12606,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-bigints"
         }
       ]
@@ -12632,7 +12632,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-flag"
         }
       ]
@@ -12658,7 +12658,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-property-descriptors"
         }
       ]
@@ -12684,7 +12684,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-symbol-support-x"
         }
       ]
@@ -12710,7 +12710,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-symbols"
         }
       ]
@@ -12736,7 +12736,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-to-string-tag-x"
         }
       ]
@@ -12762,7 +12762,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-tostringtag"
         }
       ]
@@ -12788,7 +12788,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-unicode"
         }
       ]
@@ -12814,7 +12814,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-value"
         }
       ]
@@ -12840,7 +12840,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-values"
         }
       ],
@@ -12866,7 +12866,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/has-values/node_modules/kind-of"
             }
           ]
@@ -12894,7 +12894,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has"
         }
       ]
@@ -12920,7 +12920,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hashids"
         }
       ]
@@ -12946,7 +12946,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hbs"
         }
       ]
@@ -12972,7 +12972,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/he"
         }
       ]
@@ -12998,7 +12998,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/heap"
         }
       ]
@@ -13024,7 +13024,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/helmet"
         }
       ]
@@ -13050,7 +13050,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hoister"
         }
       ]
@@ -13076,7 +13076,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/homedir-polyfill"
         }
       ]
@@ -13102,7 +13102,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hooker"
         }
       ]
@@ -13128,7 +13128,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hosted-git-info"
         }
       ]
@@ -13154,7 +13154,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/html-entities"
         }
       ]
@@ -13180,7 +13180,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/htmlparser2"
         }
       ],
@@ -13206,7 +13206,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/htmlparser2/node_modules/isarray"
             }
           ]
@@ -13232,7 +13232,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/htmlparser2/node_modules/readable-stream"
             }
           ]
@@ -13258,7 +13258,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/htmlparser2/node_modules/string_decoder"
             }
           ]
@@ -13286,7 +13286,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/http-cache-semantics"
         }
       ]
@@ -13312,7 +13312,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/http-errors"
         }
       ]
@@ -13338,7 +13338,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/http-proxy-agent"
         }
       ],
@@ -13364,7 +13364,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/http-proxy-agent/node_modules/debug"
             }
           ]
@@ -13390,7 +13390,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/http-proxy-agent/node_modules/ms"
             }
           ]
@@ -13418,7 +13418,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/http-signature"
         }
       ]
@@ -13444,7 +13444,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/https-proxy-agent"
         }
       ],
@@ -13470,7 +13470,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/https-proxy-agent/node_modules/debug"
             }
           ]
@@ -13496,7 +13496,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/https-proxy-agent/node_modules/ms"
             }
           ]
@@ -13524,7 +13524,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/humanize-ms"
         }
       ]
@@ -13550,7 +13550,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/i18n"
         }
       ]
@@ -13576,7 +13576,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/iconv-lite"
         }
       ]
@@ -13602,7 +13602,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ieee754"
         }
       ]
@@ -13628,7 +13628,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ignore-walk"
         }
       ],
@@ -13654,7 +13654,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/ignore-walk/node_modules/brace-expansion"
             }
           ]
@@ -13680,7 +13680,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/ignore-walk/node_modules/minimatch"
             }
           ]
@@ -13708,7 +13708,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/iltorb"
         }
       ]
@@ -13734,7 +13734,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/imurmurhash"
         }
       ]
@@ -13760,7 +13760,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/indent-string"
         }
       ]
@@ -13786,7 +13786,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/infer-owner"
         }
       ]
@@ -13812,7 +13812,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/inflection"
         }
       ]
@@ -13838,7 +13838,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/inflight"
         }
       ]
@@ -13864,7 +13864,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/inherits"
         }
       ]
@@ -13890,7 +13890,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ini"
         }
       ]
@@ -13916,7 +13916,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/internal-slot"
         }
       ]
@@ -13942,7 +13942,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/interpret"
         }
       ]
@@ -13968,7 +13968,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/into-stream"
         }
       ]
@@ -13994,7 +13994,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/invariant"
         }
       ]
@@ -14020,7 +14020,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ip"
         }
       ]
@@ -14046,7 +14046,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ip6"
         }
       ]
@@ -14072,7 +14072,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ipaddr.js"
         }
       ]
@@ -14098,7 +14098,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-absolute"
         }
       ]
@@ -14124,7 +14124,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-accessor-descriptor"
         }
       ]
@@ -14150,7 +14150,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-arguments"
         }
       ]
@@ -14176,7 +14176,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-arrayish"
         }
       ]
@@ -14202,7 +14202,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-bigint"
         }
       ]
@@ -14228,7 +14228,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-binary-path"
         }
       ]
@@ -14254,7 +14254,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-boolean-object"
         }
       ]
@@ -14280,7 +14280,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-buffer"
         }
       ]
@@ -14306,7 +14306,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-callable"
         }
       ]
@@ -14332,7 +14332,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-core-module"
         }
       ]
@@ -14358,7 +14358,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-data-descriptor"
         }
       ]
@@ -14384,7 +14384,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-date-object"
         }
       ]
@@ -14410,7 +14410,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-descriptor"
         }
       ]
@@ -14436,7 +14436,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-docker"
         }
       ]
@@ -14462,7 +14462,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-expression"
         }
       ]
@@ -14488,7 +14488,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-extendable"
         }
       ]
@@ -14514,7 +14514,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-extglob"
         }
       ]
@@ -14540,7 +14540,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-fullwidth-code-point"
         }
       ]
@@ -14566,7 +14566,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-generator-function"
         }
       ]
@@ -14592,7 +14592,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-glob"
         }
       ]
@@ -14618,7 +14618,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-heroku"
         }
       ]
@@ -14644,7 +14644,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-lambda"
         }
       ]
@@ -14670,7 +14670,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-map"
         }
       ]
@@ -14696,7 +14696,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-natural-number"
         }
       ]
@@ -14722,7 +14722,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-negative-zero"
         }
       ]
@@ -14748,7 +14748,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-number-like"
         }
       ]
@@ -14774,7 +14774,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-number-object"
         }
       ]
@@ -14800,7 +14800,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-number"
         }
       ],
@@ -14826,7 +14826,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/is-number/node_modules/kind-of"
             }
           ]
@@ -14854,7 +14854,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-object"
         }
       ]
@@ -14880,7 +14880,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-plain-obj"
         }
       ]
@@ -14906,7 +14906,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-plain-object"
         }
       ]
@@ -14932,7 +14932,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-promise"
         }
       ]
@@ -14958,7 +14958,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-regex"
         }
       ]
@@ -14984,7 +14984,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-relative"
         }
       ]
@@ -15010,7 +15010,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-retry-allowed"
         }
       ]
@@ -15036,7 +15036,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-set"
         }
       ]
@@ -15062,7 +15062,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-shared-array-buffer"
         }
       ]
@@ -15088,7 +15088,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-stream"
         }
       ]
@@ -15114,7 +15114,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-string"
         }
       ]
@@ -15140,7 +15140,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-symbol"
         }
       ]
@@ -15166,7 +15166,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-typed-array"
         }
       ]
@@ -15192,7 +15192,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-typedarray"
         }
       ]
@@ -15218,7 +15218,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-unc-path"
         }
       ]
@@ -15244,7 +15244,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-weakmap"
         }
       ]
@@ -15270,7 +15270,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-weakref"
         }
       ]
@@ -15296,7 +15296,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-weakset"
         }
       ]
@@ -15322,7 +15322,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-windows"
         }
       ]
@@ -15348,7 +15348,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isarray"
         }
       ]
@@ -15374,7 +15374,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isexe"
         }
       ]
@@ -15400,7 +15400,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isobject"
         }
       ]
@@ -15426,7 +15426,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isstream"
         }
       ]
@@ -15452,7 +15452,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isurl"
         }
       ]
@@ -15478,7 +15478,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/js-stringify"
         }
       ]
@@ -15504,7 +15504,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/js-tokens"
         }
       ]
@@ -15530,7 +15530,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/js-yaml"
         }
       ]
@@ -15556,7 +15556,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jsbn"
         }
       ]
@@ -15582,7 +15582,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-buffer"
         }
       ]
@@ -15608,7 +15608,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-parse-better-errors"
         }
       ]
@@ -15634,7 +15634,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-schema-traverse"
         }
       ]
@@ -15660,7 +15660,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-schema"
         }
       ]
@@ -15686,7 +15686,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-stringify-safe"
         }
       ]
@@ -15712,7 +15712,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json5"
         }
       ]
@@ -15738,7 +15738,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jsonfile"
         }
       ]
@@ -15764,7 +15764,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jsonwebtoken"
         }
       ]
@@ -15790,7 +15790,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jsprim"
         }
       ]
@@ -15816,7 +15816,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jssha"
         }
       ]
@@ -15842,7 +15842,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jstransformer"
         }
       ]
@@ -15868,7 +15868,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/juicy-chat-bot"
         }
       ]
@@ -15894,7 +15894,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jwa"
         }
       ]
@@ -15920,7 +15920,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jws"
         }
       ]
@@ -15946,7 +15946,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/keyv"
         }
       ]
@@ -15972,7 +15972,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/kind-of"
         }
       ]
@@ -15998,7 +15998,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/kuler"
         }
       ]
@@ -16024,7 +16024,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/kuromoji"
         }
       ]
@@ -16050,7 +16050,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lazystream"
         }
       ]
@@ -16076,7 +16076,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/levn"
         }
       ]
@@ -16102,7 +16102,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/libxmljs2"
         }
       ],
@@ -16128,7 +16128,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/libxmljs2/node_modules/nan"
             }
           ]
@@ -16156,7 +16156,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/liftup"
         }
       ],
@@ -16182,7 +16182,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/braces"
             }
           ]
@@ -16208,7 +16208,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/fill-range"
             }
           ]
@@ -16234,7 +16234,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/findup-sync"
             }
           ]
@@ -16260,7 +16260,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/is-glob"
             }
           ]
@@ -16286,7 +16286,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/is-number"
             }
           ]
@@ -16312,7 +16312,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/micromatch"
             }
           ]
@@ -16338,7 +16338,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/to-regex-range"
             }
           ]
@@ -16366,7 +16366,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/linebreak"
         }
       ],
@@ -16392,7 +16392,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/linebreak/node_modules/base64-js"
             }
           ]
@@ -16420,7 +16420,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/listenercount"
         }
       ]
@@ -16446,7 +16446,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/locate-path"
         }
       ]
@@ -16472,7 +16472,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lodash.camelcase"
         }
       ]
@@ -16498,7 +16498,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lodash.isfinite"
         }
       ]
@@ -16524,7 +16524,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lodash.set"
         }
       ]
@@ -16550,7 +16550,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lodash"
         }
       ]
@@ -16576,7 +16576,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/logform"
         }
       ],
@@ -16602,7 +16602,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/logform/node_modules/ms"
             }
           ]
@@ -16630,7 +16630,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lolex"
         }
       ]
@@ -16656,7 +16656,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/loose-envify"
         }
       ]
@@ -16682,7 +16682,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lowercase-keys"
         }
       ]
@@ -16708,7 +16708,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lru-cache"
         }
       ]
@@ -16734,7 +16734,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-dir"
         }
       ],
@@ -16760,7 +16760,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-dir/node_modules/semver"
             }
           ]
@@ -16788,7 +16788,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-error"
         }
       ]
@@ -16814,7 +16814,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-fetch-happen"
         }
       ],
@@ -16841,7 +16841,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen/node_modules/@tootallnate/once"
             }
           ]
@@ -16867,7 +16867,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen/node_modules/debug"
             }
           ]
@@ -16893,7 +16893,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen/node_modules/http-cache-semantics"
             }
           ]
@@ -16919,7 +16919,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen/node_modules/http-proxy-agent"
             }
           ]
@@ -16945,7 +16945,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen/node_modules/ms"
             }
           ]
@@ -16973,7 +16973,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-iterator"
         }
       ]
@@ -16999,7 +16999,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-plural"
         }
       ]
@@ -17025,7 +17025,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/map-cache"
         }
       ]
@@ -17051,7 +17051,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/map-visit"
         }
       ]
@@ -17077,7 +17077,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/marsdb"
         }
       ]
@@ -17103,7 +17103,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/math-interval-parser"
         }
       ]
@@ -17129,7 +17129,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/media-typer"
         }
       ]
@@ -17155,7 +17155,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/merge-descriptors"
         }
       ]
@@ -17181,7 +17181,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/messageformat-formatters"
         }
       ]
@@ -17207,7 +17207,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/messageformat-parser"
         }
       ]
@@ -17233,7 +17233,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/messageformat"
         }
       ],
@@ -17259,7 +17259,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/messageformat/node_modules/make-plural"
             }
           ]
@@ -17287,7 +17287,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/methods"
         }
       ]
@@ -17313,7 +17313,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/micromatch"
         }
       ]
@@ -17339,7 +17339,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mime-db"
         }
       ]
@@ -17365,7 +17365,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mime-types"
         }
       ]
@@ -17391,7 +17391,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mime"
         }
       ]
@@ -17417,7 +17417,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mimic-response"
         }
       ]
@@ -17443,7 +17443,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minimatch"
         }
       ]
@@ -17469,7 +17469,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minimist"
         }
       ]
@@ -17495,7 +17495,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-collect"
         }
       ]
@@ -17521,7 +17521,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-fetch"
         }
       ]
@@ -17547,7 +17547,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-flush"
         }
       ]
@@ -17573,7 +17573,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-pipeline"
         }
       ]
@@ -17599,7 +17599,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-sized"
         }
       ]
@@ -17625,7 +17625,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass"
         }
       ]
@@ -17651,7 +17651,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minizlib"
         }
       ]
@@ -17677,7 +17677,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mixin-deep"
         }
       ]
@@ -17703,7 +17703,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mkdirp-classic"
         }
       ]
@@ -17729,7 +17729,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mkdirp"
         }
       ]
@@ -17755,7 +17755,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/moment-timezone"
         }
       ]
@@ -17781,7 +17781,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/moment"
         }
       ]
@@ -17807,7 +17807,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/morgan"
         }
       ],
@@ -17833,7 +17833,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/morgan/node_modules/on-finished"
             }
           ]
@@ -17861,7 +17861,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mout"
         }
       ]
@@ -17887,7 +17887,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ms"
         }
       ]
@@ -17913,7 +17913,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/multer"
         }
       ],
@@ -17939,7 +17939,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/multer/node_modules/mkdirp"
             }
           ]
@@ -17967,7 +17967,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mustache"
         }
       ]
@@ -17993,7 +17993,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/nan"
         }
       ]
@@ -18019,7 +18019,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/nanomatch"
         }
       ]
@@ -18045,7 +18045,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/napi-build-utils"
         }
       ]
@@ -18071,7 +18071,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/needle"
         }
       ],
@@ -18097,7 +18097,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/needle/node_modules/debug"
             }
           ]
@@ -18123,7 +18123,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/needle/node_modules/ms"
             }
           ]
@@ -18151,7 +18151,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/negotiator"
         }
       ]
@@ -18177,7 +18177,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/neo-async"
         }
       ]
@@ -18203,7 +18203,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-abi"
         }
       ],
@@ -18229,7 +18229,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-abi/node_modules/semver"
             }
           ]
@@ -18257,7 +18257,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-addon-api"
         }
       ]
@@ -18283,7 +18283,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-fetch"
         }
       ]
@@ -18309,7 +18309,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-gyp"
         }
       ],
@@ -18335,7 +18335,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/ansi-regex"
             }
           ]
@@ -18361,7 +18361,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/are-we-there-yet"
             }
           ]
@@ -18387,7 +18387,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/gauge"
             }
           ]
@@ -18413,7 +18413,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -18439,7 +18439,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/nopt"
             }
           ]
@@ -18465,7 +18465,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/npmlog"
             }
           ]
@@ -18491,7 +18491,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/readable-stream"
             }
           ]
@@ -18517,7 +18517,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/string-width"
             }
           ]
@@ -18543,7 +18543,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/strip-ansi"
             }
           ]
@@ -18571,7 +18571,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-pre-gyp"
         }
       ],
@@ -18597,7 +18597,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/chownr"
             }
           ]
@@ -18623,7 +18623,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/fs-minipass"
             }
           ]
@@ -18649,7 +18649,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/minipass"
             }
           ]
@@ -18675,7 +18675,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/minizlib"
             }
           ]
@@ -18701,7 +18701,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/mkdirp"
             }
           ]
@@ -18727,7 +18727,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/nopt"
             }
           ]
@@ -18753,7 +18753,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/rimraf"
             }
           ]
@@ -18779,7 +18779,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/safe-buffer"
             }
           ]
@@ -18805,7 +18805,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/semver"
             }
           ]
@@ -18831,7 +18831,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/tar"
             }
           ]
@@ -18857,7 +18857,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/yallist"
             }
           ]
@@ -18885,7 +18885,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/noop-logger"
         }
       ]
@@ -18911,7 +18911,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/nopt"
         }
       ]
@@ -18937,7 +18937,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/normalize-package-data"
         }
       ],
@@ -18963,7 +18963,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/normalize-package-data/node_modules/semver"
             }
           ]
@@ -18991,7 +18991,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/normalize-path"
         }
       ]
@@ -19017,7 +19017,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/normalize-url"
         }
       ]
@@ -19043,7 +19043,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/notevil"
         }
       ],
@@ -19069,7 +19069,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/notevil/node_modules/esprima"
             }
           ]
@@ -19097,7 +19097,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/npm-bundled"
         }
       ]
@@ -19123,7 +19123,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/npm-normalize-package-bin"
         }
       ]
@@ -19149,7 +19149,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/npm-packlist"
         }
       ]
@@ -19175,7 +19175,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/npmlog"
         }
       ]
@@ -19201,7 +19201,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/number-is-nan"
         }
       ]
@@ -19227,7 +19227,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/oauth-sign"
         }
       ]
@@ -19253,7 +19253,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-assign"
         }
       ]
@@ -19279,7 +19279,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-copy"
         }
       ],
@@ -19305,7 +19305,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy/node_modules/define-property"
             }
           ]
@@ -19331,7 +19331,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy/node_modules/is-accessor-descriptor"
             }
           ]
@@ -19357,7 +19357,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy/node_modules/is-data-descriptor"
             }
           ]
@@ -19383,7 +19383,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy/node_modules/is-descriptor"
             }
           ],
@@ -19409,7 +19409,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/object-copy/node_modules/is-descriptor/node_modules/kind-of"
                 }
               ]
@@ -19437,7 +19437,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy/node_modules/kind-of"
             }
           ]
@@ -19465,7 +19465,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-inspect"
         }
       ]
@@ -19491,7 +19491,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-is"
         }
       ]
@@ -19517,7 +19517,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-keys"
         }
       ]
@@ -19543,7 +19543,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-visit"
         }
       ]
@@ -19569,7 +19569,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object.assign"
         }
       ]
@@ -19595,7 +19595,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object.defaults"
         }
       ]
@@ -19621,7 +19621,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object.map"
         }
       ]
@@ -19647,7 +19647,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object.pick"
         }
       ]
@@ -19673,7 +19673,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/on-finished"
         }
       ]
@@ -19699,7 +19699,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/on-headers"
         }
       ]
@@ -19725,7 +19725,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/once"
         }
       ]
@@ -19751,7 +19751,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/one-time"
         }
       ]
@@ -19777,7 +19777,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/opentype.js"
         }
       ]
@@ -19803,7 +19803,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/optionator"
         }
       ]
@@ -19829,7 +19829,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/os-homedir"
         }
       ]
@@ -19855,7 +19855,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/os-tmpdir"
         }
       ]
@@ -19881,7 +19881,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/osenv"
         }
       ]
@@ -19907,7 +19907,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/otplib"
         }
       ]
@@ -19933,7 +19933,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-cancelable"
         }
       ]
@@ -19959,7 +19959,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-event"
         }
       ]
@@ -19985,7 +19985,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-finally"
         }
       ]
@@ -20011,7 +20011,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-is-promise"
         }
       ]
@@ -20037,7 +20037,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-limit"
         }
       ]
@@ -20063,7 +20063,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-locate"
         }
       ]
@@ -20089,7 +20089,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-map"
         }
       ]
@@ -20115,7 +20115,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-timeout"
         }
       ]
@@ -20141,7 +20141,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-try"
         }
       ]
@@ -20167,7 +20167,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pako"
         }
       ]
@@ -20193,7 +20193,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/parse-filepath"
         }
       ]
@@ -20219,7 +20219,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/parse-json"
         }
       ]
@@ -20245,7 +20245,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/parse-passwd"
         }
       ]
@@ -20271,7 +20271,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/parseurl"
         }
       ]
@@ -20297,7 +20297,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pascalcase"
         }
       ]
@@ -20323,7 +20323,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-exists"
         }
       ]
@@ -20349,7 +20349,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-is-absolute"
         }
       ]
@@ -20375,7 +20375,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-parse"
         }
       ]
@@ -20401,7 +20401,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-root-regex"
         }
       ]
@@ -20427,7 +20427,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-root"
         }
       ]
@@ -20453,7 +20453,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-to-regexp"
         }
       ]
@@ -20479,7 +20479,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pdfkit"
         }
       ]
@@ -20505,7 +20505,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/peek-readable"
         }
       ]
@@ -20531,7 +20531,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pend"
         }
       ]
@@ -20557,7 +20557,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/performance-now"
         }
       ]
@@ -20583,7 +20583,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pg-connection-string"
         }
       ]
@@ -20609,7 +20609,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/picomatch"
         }
       ]
@@ -20635,7 +20635,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pify"
         }
       ]
@@ -20661,7 +20661,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pinkie-promise"
         }
       ]
@@ -20687,7 +20687,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pinkie"
         }
       ]
@@ -20713,7 +20713,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/png-js"
         }
       ]
@@ -20739,7 +20739,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/portscanner"
         }
       ]
@@ -20765,7 +20765,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/posix-character-classes"
         }
       ]
@@ -20791,7 +20791,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/prebuild-install"
         }
       ]
@@ -20817,7 +20817,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/prelude-ls"
         }
       ]
@@ -20843,7 +20843,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/prepend-http"
         }
       ]
@@ -20869,7 +20869,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pretty-bytes"
         }
       ]
@@ -20895,7 +20895,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/process-nextick-args"
         }
       ]
@@ -20921,7 +20921,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/prom-client"
         }
       ]
@@ -20947,7 +20947,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/promise-inflight"
         }
       ]
@@ -20973,7 +20973,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/promise-retry"
         }
       ],
@@ -20999,7 +20999,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/promise-retry/node_modules/err-code"
             }
           ]
@@ -21025,7 +21025,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/promise-retry/node_modules/retry"
             }
           ]
@@ -21053,7 +21053,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/promise"
         }
       ]
@@ -21079,7 +21079,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/proper-lockfile"
         }
       ]
@@ -21105,7 +21105,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/proxy-addr"
         }
       ]
@@ -21131,7 +21131,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/psl"
         }
       ]
@@ -21157,7 +21157,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-attrs"
         }
       ]
@@ -21183,7 +21183,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-code-gen"
         }
       ]
@@ -21209,7 +21209,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-error"
         }
       ]
@@ -21235,7 +21235,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-filters"
         }
       ]
@@ -21261,7 +21261,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-lexer"
         }
       ]
@@ -21287,7 +21287,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-linker"
         }
       ]
@@ -21313,7 +21313,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-load"
         }
       ]
@@ -21339,7 +21339,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-parser"
         }
       ]
@@ -21365,7 +21365,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-runtime"
         }
       ]
@@ -21391,7 +21391,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-strip-comments"
         }
       ]
@@ -21417,7 +21417,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-walk"
         }
       ]
@@ -21443,7 +21443,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug"
         }
       ]
@@ -21469,7 +21469,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pump"
         }
       ]
@@ -21495,7 +21495,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/punycode"
         }
       ]
@@ -21521,7 +21521,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/qs"
         }
       ]
@@ -21547,7 +21547,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/query-string"
         }
       ]
@@ -21573,7 +21573,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/range_check"
         }
       ]
@@ -21599,7 +21599,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/range-parser"
         }
       ]
@@ -21625,7 +21625,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/raw-body"
         }
       ]
@@ -21651,7 +21651,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/rc"
         }
       ]
@@ -21677,7 +21677,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/read-pkg"
         }
       ],
@@ -21703,7 +21703,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/read-pkg/node_modules/pify"
             }
           ]
@@ -21731,7 +21731,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/readable-stream"
         }
       ],
@@ -21757,7 +21757,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/readable-stream/node_modules/isarray"
             }
           ]
@@ -21785,7 +21785,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/readable-web-to-node-stream"
         }
       ],
@@ -21811,7 +21811,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/readable-web-to-node-stream/node_modules/readable-stream"
             }
           ]
@@ -21839,7 +21839,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/readdirp"
         }
       ]
@@ -21865,7 +21865,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/rechoir"
         }
       ]
@@ -21891,7 +21891,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/regex-not"
         }
       ]
@@ -21917,7 +21917,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/regexp.prototype.flags"
         }
       ]
@@ -21943,7 +21943,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/remove-trailing-separator"
         }
       ]
@@ -21969,7 +21969,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/repeat-element"
         }
       ]
@@ -21995,7 +21995,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/repeat-string"
         }
       ]
@@ -22021,7 +22021,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/replace"
         }
       ],
@@ -22047,7 +22047,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/ansi-regex"
             }
           ]
@@ -22073,7 +22073,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/ansi-styles"
             }
           ]
@@ -22099,7 +22099,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/brace-expansion"
             }
           ]
@@ -22125,7 +22125,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/cliui"
             }
           ]
@@ -22151,7 +22151,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/color-convert"
             }
           ]
@@ -22177,7 +22177,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/color-name"
             }
           ]
@@ -22203,7 +22203,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/find-up"
             }
           ]
@@ -22229,7 +22229,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -22255,7 +22255,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/locate-path"
             }
           ]
@@ -22281,7 +22281,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/minimatch"
             }
           ]
@@ -22307,7 +22307,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/p-locate"
             }
           ]
@@ -22333,7 +22333,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/path-exists"
             }
           ]
@@ -22359,7 +22359,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/string-width"
             }
           ]
@@ -22385,7 +22385,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/strip-ansi"
             }
           ]
@@ -22411,7 +22411,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/wrap-ansi"
             }
           ]
@@ -22437,7 +22437,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/yargs-parser"
             }
           ]
@@ -22463,7 +22463,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/yargs"
             }
           ]
@@ -22491,7 +22491,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/request"
         }
       ],
@@ -22517,7 +22517,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/request/node_modules/qs"
             }
           ]
@@ -22545,7 +22545,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/require-directory"
         }
       ]
@@ -22571,7 +22571,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/require-main-filename"
         }
       ]
@@ -22597,7 +22597,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/resolve-dir"
         }
       ]
@@ -22623,7 +22623,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/resolve-url"
         }
       ]
@@ -22649,7 +22649,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/resolve"
         }
       ]
@@ -22675,7 +22675,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/responselike"
         }
       ]
@@ -22701,7 +22701,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/restructure"
         }
       ]
@@ -22727,7 +22727,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ret"
         }
       ]
@@ -22753,7 +22753,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/retry-as-promised"
         }
       ]
@@ -22779,7 +22779,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/retry"
         }
       ]
@@ -22805,7 +22805,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/rimraf"
         }
       ]
@@ -22831,7 +22831,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/rxjs"
         }
       ],
@@ -22857,7 +22857,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/rxjs/node_modules/tslib"
             }
           ]
@@ -22885,7 +22885,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safe-buffer"
         }
       ]
@@ -22911,7 +22911,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safe-regex-test"
         }
       ]
@@ -22937,7 +22937,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safe-regex"
         }
       ]
@@ -22963,7 +22963,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safe-stable-stringify"
         }
       ]
@@ -22989,7 +22989,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safer-buffer"
         }
       ]
@@ -23015,7 +23015,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/samsam"
         }
       ]
@@ -23041,7 +23041,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sanitize-filename"
         }
       ]
@@ -23067,7 +23067,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sanitize-html"
         }
       ],
@@ -23093,7 +23093,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sanitize-html/node_modules/lodash"
             }
           ]
@@ -23121,7 +23121,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sax"
         }
       ]
@@ -23147,7 +23147,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/seek-bzip"
         }
       ]
@@ -23173,7 +23173,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/semver"
         }
       ]
@@ -23199,7 +23199,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/send"
         }
       ],
@@ -23225,7 +23225,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/send/node_modules/ms"
             }
           ]
@@ -23253,7 +23253,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sequelize-pool"
         }
       ]
@@ -23279,7 +23279,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sequelize"
         }
       ],
@@ -23305,7 +23305,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sequelize/node_modules/debug"
             }
           ]
@@ -23331,7 +23331,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sequelize/node_modules/ms"
             }
           ]
@@ -23357,7 +23357,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sequelize/node_modules/uuid"
             }
           ]
@@ -23385,7 +23385,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/serve-index"
         }
       ],
@@ -23411,7 +23411,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index/node_modules/depd"
             }
           ]
@@ -23437,7 +23437,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index/node_modules/http-errors"
             }
           ]
@@ -23463,7 +23463,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index/node_modules/inherits"
             }
           ]
@@ -23489,7 +23489,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index/node_modules/setprototypeof"
             }
           ]
@@ -23515,7 +23515,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index/node_modules/statuses"
             }
           ]
@@ -23543,7 +23543,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/serve-static"
         }
       ]
@@ -23569,7 +23569,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/set-blocking"
         }
       ]
@@ -23595,7 +23595,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/set-value"
         }
       ],
@@ -23621,7 +23621,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/set-value/node_modules/extend-shallow"
             }
           ]
@@ -23647,7 +23647,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/set-value/node_modules/is-extendable"
             }
           ]
@@ -23675,7 +23675,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/setimmediate"
         }
       ]
@@ -23701,7 +23701,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/setprototypeof"
         }
       ]
@@ -23727,7 +23727,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/side-channel"
         }
       ]
@@ -23753,7 +23753,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/signal-exit"
         }
       ]
@@ -23779,7 +23779,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/simple-concat"
         }
       ]
@@ -23805,7 +23805,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/simple-get"
         }
       ],
@@ -23831,7 +23831,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/simple-get/node_modules/decompress-response"
             }
           ]
@@ -23857,7 +23857,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/simple-get/node_modules/mimic-response"
             }
           ]
@@ -23885,7 +23885,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/simple-swizzle"
         }
       ],
@@ -23911,7 +23911,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/simple-swizzle/node_modules/is-arrayish"
             }
           ]
@@ -23939,7 +23939,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sinon"
         }
       ]
@@ -23965,7 +23965,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/smart-buffer"
         }
       ]
@@ -23991,7 +23991,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/snapdragon-node"
         }
       ],
@@ -24017,7 +24017,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon-node/node_modules/define-property"
             }
           ]
@@ -24045,7 +24045,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/snapdragon-util"
         }
       ],
@@ -24071,7 +24071,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon-util/node_modules/kind-of"
             }
           ]
@@ -24099,7 +24099,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/snapdragon"
         }
       ],
@@ -24125,7 +24125,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/define-property"
             }
           ]
@@ -24151,7 +24151,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/extend-shallow"
             }
           ]
@@ -24177,7 +24177,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/is-accessor-descriptor"
             }
           ],
@@ -24203,7 +24203,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/snapdragon/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
@@ -24231,7 +24231,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/is-data-descriptor"
             }
           ],
@@ -24257,7 +24257,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/snapdragon/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
@@ -24285,7 +24285,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/is-descriptor"
             }
           ]
@@ -24311,7 +24311,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/is-extendable"
             }
           ]
@@ -24337,7 +24337,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/kind-of"
             }
           ]
@@ -24363,7 +24363,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/source-map"
             }
           ]
@@ -24391,7 +24391,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socket.io-adapter"
         }
       ]
@@ -24417,7 +24417,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socket.io-parser"
         }
       ],
@@ -24443,7 +24443,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socket.io-parser/node_modules/debug"
             }
           ]
@@ -24469,7 +24469,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socket.io-parser/node_modules/ms"
             }
           ]
@@ -24497,7 +24497,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socket.io"
         }
       ],
@@ -24523,7 +24523,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socket.io/node_modules/debug"
             }
           ]
@@ -24549,7 +24549,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socket.io/node_modules/ms"
             }
           ]
@@ -24577,7 +24577,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socks-proxy-agent"
         }
       ],
@@ -24603,7 +24603,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socks-proxy-agent/node_modules/debug"
             }
           ]
@@ -24629,7 +24629,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socks-proxy-agent/node_modules/ms"
             }
           ]
@@ -24657,7 +24657,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socks"
         }
       ],
@@ -24683,7 +24683,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socks/node_modules/ip"
             }
           ]
@@ -24711,7 +24711,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sort-keys-length"
         }
       ],
@@ -24737,7 +24737,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sort-keys-length/node_modules/sort-keys"
             }
           ]
@@ -24765,7 +24765,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sort-keys"
         }
       ]
@@ -24791,7 +24791,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/source-map-resolve"
         }
       ]
@@ -24817,7 +24817,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/source-map-support"
         }
       ]
@@ -24843,7 +24843,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/source-map-url"
         }
       ]
@@ -24869,7 +24869,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/source-map"
         }
       ]
@@ -24895,7 +24895,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spawn-command"
         }
       ]
@@ -24921,7 +24921,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spdx-correct"
         }
       ]
@@ -24947,7 +24947,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spdx-exceptions"
         }
       ]
@@ -24973,7 +24973,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spdx-expression-parse"
         }
       ]
@@ -24999,7 +24999,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spdx-license-ids"
         }
       ]
@@ -25025,7 +25025,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/split-string"
         }
       ]
@@ -25051,7 +25051,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sprintf-js"
         }
       ]
@@ -25077,7 +25077,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sqlite3"
         }
       ]
@@ -25103,7 +25103,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sshpk"
         }
       ]
@@ -25129,7 +25129,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ssri"
         }
       ]
@@ -25155,7 +25155,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/stack-trace"
         }
       ]
@@ -25181,7 +25181,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/static-extend"
         }
       ],
@@ -25207,7 +25207,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend/node_modules/define-property"
             }
           ]
@@ -25233,7 +25233,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend/node_modules/is-accessor-descriptor"
             }
           ],
@@ -25259,7 +25259,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/static-extend/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
@@ -25287,7 +25287,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend/node_modules/is-data-descriptor"
             }
           ],
@@ -25313,7 +25313,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/static-extend/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
@@ -25341,7 +25341,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend/node_modules/is-descriptor"
             }
           ]
@@ -25367,7 +25367,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend/node_modules/kind-of"
             }
           ]
@@ -25395,7 +25395,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/statuses"
         }
       ]
@@ -25421,7 +25421,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/stream-buffers"
         }
       ]
@@ -25447,7 +25447,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/streamsearch"
         }
       ]
@@ -25473,7 +25473,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strict-uri-encode"
         }
       ]
@@ -25499,7 +25499,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string_decoder"
         }
       ]
@@ -25525,7 +25525,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string-width"
         }
       ]
@@ -25551,7 +25551,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string.fromcodepoint"
         }
       ]
@@ -25577,7 +25577,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string.prototype.codepointat"
         }
       ]
@@ -25603,7 +25603,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string.prototype.trimend"
         }
       ]
@@ -25629,7 +25629,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string.prototype.trimstart"
         }
       ]
@@ -25655,7 +25655,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-ansi"
         }
       ]
@@ -25681,7 +25681,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-bom"
         }
       ]
@@ -25707,7 +25707,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-dirs"
         }
       ]
@@ -25733,7 +25733,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-json-comments"
         }
       ]
@@ -25759,7 +25759,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-outer"
         }
       ]
@@ -25785,7 +25785,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strtok3"
         }
       ]
@@ -25811,7 +25811,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/supports-color"
         }
       ]
@@ -25837,7 +25837,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/supports-preserve-symlinks-flag"
         }
       ]
@@ -25863,7 +25863,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/svg-captcha"
         }
       ]
@@ -25889,7 +25889,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/swagger-ui-dist"
         }
       ]
@@ -25915,7 +25915,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/swagger-ui-express"
         }
       ]
@@ -25941,7 +25941,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tar-fs"
         }
       ],
@@ -25967,7 +25967,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/tar-fs/node_modules/bl"
             }
           ]
@@ -25993,7 +25993,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/tar-fs/node_modules/chownr"
             }
           ]
@@ -26019,7 +26019,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/tar-fs/node_modules/readable-stream"
             }
           ]
@@ -26045,7 +26045,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/tar-fs/node_modules/tar-stream"
             }
           ]
@@ -26073,7 +26073,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tar-stream"
         }
       ]
@@ -26099,7 +26099,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tar"
         }
       ]
@@ -26125,7 +26125,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tdigest"
         }
       ]
@@ -26151,7 +26151,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/text-hex"
         }
       ]
@@ -26177,7 +26177,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/thirty-two"
         }
       ]
@@ -26203,7 +26203,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/through"
         }
       ]
@@ -26229,7 +26229,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/timed-out"
         }
       ]
@@ -26255,7 +26255,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tiny-inflate"
         }
       ]
@@ -26281,7 +26281,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-buffer"
         }
       ]
@@ -26307,7 +26307,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-fast-properties"
         }
       ]
@@ -26333,7 +26333,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-object-path"
         }
       ],
@@ -26359,7 +26359,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/to-object-path/node_modules/kind-of"
             }
           ]
@@ -26387,7 +26387,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-regex-range"
         }
       ]
@@ -26413,7 +26413,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-regex"
         }
       ]
@@ -26439,7 +26439,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/toidentifier"
         }
       ]
@@ -26465,7 +26465,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/token-stream"
         }
       ]
@@ -26491,7 +26491,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/token-types"
         }
       ]
@@ -26517,7 +26517,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/toposort-class"
         }
       ]
@@ -26543,7 +26543,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tough-cookie"
         }
       ]
@@ -26569,7 +26569,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tr46"
         }
       ]
@@ -26595,7 +26595,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/traverse"
         }
       ]
@@ -26621,7 +26621,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tree-kill"
         }
       ]
@@ -26647,7 +26647,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/trim-repeated"
         }
       ]
@@ -26673,7 +26673,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/triple-beam"
         }
       ]
@@ -26699,7 +26699,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/truncate-utf8-bytes"
         }
       ]
@@ -26725,7 +26725,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ts-node-dev"
         }
       ],
@@ -26751,7 +26751,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/ts-node-dev/node_modules/rimraf"
             }
           ]
@@ -26779,7 +26779,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ts-node"
         }
       ]
@@ -26805,7 +26805,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tsconfig"
         }
       ]
@@ -26831,7 +26831,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tslib"
         }
       ]
@@ -26857,7 +26857,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tunnel-agent"
         }
       ]
@@ -26883,7 +26883,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tweetnacl"
         }
       ]
@@ -26909,7 +26909,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/type-check"
         }
       ]
@@ -26935,7 +26935,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/type-is"
         }
       ]
@@ -26961,7 +26961,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/typecast"
         }
       ]
@@ -26987,7 +26987,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/typedarray"
         }
       ]
@@ -27013,7 +27013,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/typescript"
         }
       ]
@@ -27039,7 +27039,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/uglify-js"
         }
       ]
@@ -27065,7 +27065,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unbox-primitive"
         }
       ]
@@ -27091,7 +27091,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unbzip2-stream"
         }
       ]
@@ -27117,7 +27117,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unc-path-regex"
         }
       ]
@@ -27143,7 +27143,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/underscore.string"
         }
       ]
@@ -27169,7 +27169,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unicode-properties"
         }
       ]
@@ -27195,7 +27195,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unicode-trie"
         }
       ]
@@ -27221,7 +27221,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/union-value"
         }
       ],
@@ -27247,7 +27247,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/union-value/node_modules/is-extendable"
             }
           ]
@@ -27275,7 +27275,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unique-filename"
         }
       ]
@@ -27301,7 +27301,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unique-slug"
         }
       ]
@@ -27327,7 +27327,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unit-compare"
         }
       ]
@@ -27353,7 +27353,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/universalify"
         }
       ]
@@ -27379,7 +27379,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unpipe"
         }
       ]
@@ -27405,7 +27405,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unset-value"
         }
       ],
@@ -27431,7 +27431,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/unset-value/node_modules/has-value"
             }
           ],
@@ -27457,7 +27457,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/unset-value/node_modules/has-value/node_modules/isobject"
                 }
               ]
@@ -27485,7 +27485,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/unset-value/node_modules/has-values"
             }
           ]
@@ -27511,7 +27511,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/unset-value/node_modules/isarray"
             }
           ]
@@ -27539,7 +27539,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/untildify"
         }
       ]
@@ -27565,7 +27565,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unzipper"
         }
       ],
@@ -27591,7 +27591,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/unzipper/node_modules/bluebird"
             }
           ]
@@ -27619,7 +27619,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/uri-js"
         }
       ]
@@ -27645,7 +27645,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/urix"
         }
       ]
@@ -27671,7 +27671,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/url-parse-lax"
         }
       ]
@@ -27697,7 +27697,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/url-to-options"
         }
       ]
@@ -27723,7 +27723,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/use"
         }
       ]
@@ -27749,7 +27749,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/utf8-byte-length"
         }
       ]
@@ -27775,7 +27775,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/util-deprecate"
         }
       ]
@@ -27801,7 +27801,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/util"
         }
       ]
@@ -27827,7 +27827,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/utils-merge"
         }
       ]
@@ -27853,7 +27853,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/uuid"
         }
       ]
@@ -27879,7 +27879,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/v8flags"
         }
       ]
@@ -27905,7 +27905,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/validate-npm-package-license"
         }
       ]
@@ -27931,7 +27931,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/validate"
         }
       ]
@@ -27957,7 +27957,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/validator"
         }
       ]
@@ -27983,7 +27983,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/vary"
         }
       ]
@@ -28009,7 +28009,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/verror"
         }
       ],
@@ -28035,7 +28035,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/verror/node_modules/core-util-is"
             }
           ]
@@ -28063,7 +28063,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/vm2"
         }
       ],
@@ -28089,7 +28089,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/vm2/node_modules/acorn"
             }
           ]
@@ -28117,7 +28117,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/void-elements"
         }
       ]
@@ -28143,7 +28143,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/walk"
         }
       ]
@@ -28169,7 +28169,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/walkdir"
         }
       ]
@@ -28195,7 +28195,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/webidl-conversions"
         }
       ]
@@ -28221,7 +28221,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/whatwg-url"
         }
       ]
@@ -28247,7 +28247,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-boxed-primitive"
         }
       ]
@@ -28273,7 +28273,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-collection"
         }
       ]
@@ -28299,7 +28299,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-module"
         }
       ]
@@ -28325,7 +28325,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-pm-runs"
         }
       ]
@@ -28351,7 +28351,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-typed-array"
         }
       ]
@@ -28377,7 +28377,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which"
         }
       ]
@@ -28403,7 +28403,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wide-align"
         }
       ]
@@ -28429,7 +28429,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/winston-transport"
         }
       ],
@@ -28455,7 +28455,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/winston-transport/node_modules/readable-stream"
             }
           ]
@@ -28483,7 +28483,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/winston"
         }
       ],
@@ -28509,7 +28509,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/winston/node_modules/async"
             }
           ]
@@ -28535,7 +28535,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/winston/node_modules/is-stream"
             }
           ]
@@ -28561,7 +28561,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/winston/node_modules/readable-stream"
             }
           ]
@@ -28589,7 +28589,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/with"
         }
       ]
@@ -28615,7 +28615,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wkx"
         }
       ]
@@ -28641,7 +28641,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/word-wrap"
         }
       ]
@@ -28667,7 +28667,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wordwrap"
         }
       ]
@@ -28693,7 +28693,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wrap-ansi"
         }
       ],
@@ -28719,7 +28719,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi/node_modules/ansi-regex"
             }
           ]
@@ -28745,7 +28745,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi/node_modules/emoji-regex"
             }
           ]
@@ -28771,7 +28771,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -28797,7 +28797,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi/node_modules/string-width"
             }
           ]
@@ -28823,7 +28823,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi/node_modules/strip-ansi"
             }
           ]
@@ -28851,7 +28851,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wrappy"
         }
       ]
@@ -28877,7 +28877,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ws"
         }
       ]
@@ -28903,7 +28903,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/xtend"
         }
       ]
@@ -28929,7 +28929,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/y18n"
         }
       ]
@@ -28955,7 +28955,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yallist"
         }
       ]
@@ -28981,7 +28981,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yaml-schema-validator"
         }
       ]
@@ -29007,7 +29007,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yargs-parser"
         }
       ]
@@ -29033,7 +29033,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yargs"
         }
       ],
@@ -29059,7 +29059,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs/node_modules/ansi-regex"
             }
           ]
@@ -29085,7 +29085,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs/node_modules/emoji-regex"
             }
           ]
@@ -29111,7 +29111,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -29137,7 +29137,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs/node_modules/string-width"
             }
           ]
@@ -29163,7 +29163,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs/node_modules/strip-ansi"
             }
           ]
@@ -29191,7 +29191,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yauzl"
         }
       ]
@@ -29217,7 +29217,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yn"
         }
       ]
@@ -29243,7 +29243,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/z85"
         }
       ]
@@ -29269,7 +29269,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/zip-stream"
         }
       ]
@@ -29295,7 +29295,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/zlibjs"
         }
       ]

--- a/tests/_data/sbom_demo-results/juice-shop_npm8_node16_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/juice-shop_npm8_node16_macos-latest.snap.json
@@ -62,6 +62,10 @@
       ],
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -88,6 +92,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@babel/helper-string-parser"
+        }
       ]
     },
     {
@@ -108,6 +118,12 @@
           "url": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@babel/helper-validator-identifier"
         }
       ]
     },
@@ -130,6 +146,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@babel/parser"
+        }
       ]
     },
     {
@@ -150,6 +172,12 @@
           "url": "https://registry.npmjs.org/@babel/types/-/types-7.20.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@babel/types"
         }
       ]
     },
@@ -172,6 +200,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@colors/colors"
+        }
       ]
     },
     {
@@ -193,6 +227,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@dabh/diagnostics"
+        }
       ]
     },
     {
@@ -213,6 +253,12 @@
           "url": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@gar/promisify"
         }
       ]
     },
@@ -236,6 +282,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@mapbox/node-pre-gyp"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -254,6 +306,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/ansi-regex"
             }
           ]
         },
@@ -275,6 +333,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/are-we-there-yet"
+            }
           ]
         },
         {
@@ -294,6 +358,12 @@
               "url": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/detect-libc"
             }
           ]
         },
@@ -315,6 +385,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/gauge"
+            }
           ]
         },
         {
@@ -334,6 +410,12 @@
               "url": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/is-fullwidth-code-point"
             }
           ]
         },
@@ -356,6 +438,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/make-dir"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -374,6 +462,12 @@
                   "url": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/@mapbox/node-pre-gyp/node_modules/make-dir/node_modules/semver"
                 }
               ]
             }
@@ -397,6 +491,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/nopt"
+            }
           ]
         },
         {
@@ -416,6 +516,12 @@
               "url": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/npmlog"
             }
           ]
         },
@@ -437,6 +543,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/readable-stream"
+            }
           ]
         },
         {
@@ -457,6 +569,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/string-width"
+            }
           ]
         },
         {
@@ -476,6 +594,12 @@
               "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/strip-ansi"
             }
           ]
         }
@@ -500,6 +624,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/core-loader"
+        }
       ]
     },
     {
@@ -520,6 +650,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/core/-/core-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/core"
         }
       ]
     },
@@ -542,6 +678,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/evaluator"
+        }
       ]
     },
     {
@@ -562,6 +704,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-all/-/lang-all-4.24.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-all"
         }
       ]
     },
@@ -584,6 +732,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ar"
+        }
       ]
     },
     {
@@ -604,6 +758,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-bn/-/lang-bn-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-bn"
         }
       ]
     },
@@ -626,6 +786,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ca"
+        }
       ]
     },
     {
@@ -646,6 +812,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-cs/-/lang-cs-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-cs"
         }
       ]
     },
@@ -668,6 +840,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-da"
+        }
       ]
     },
     {
@@ -688,6 +866,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-de/-/lang-de-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-de"
         }
       ]
     },
@@ -710,6 +894,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-el"
+        }
       ]
     },
     {
@@ -730,6 +920,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-en-min/-/lang-en-min-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-en-min"
         }
       ]
     },
@@ -752,6 +948,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-en"
+        }
       ]
     },
     {
@@ -772,6 +974,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-es/-/lang-es-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-es"
         }
       ]
     },
@@ -794,6 +1002,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-eu"
+        }
       ]
     },
     {
@@ -814,6 +1028,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-fa/-/lang-fa-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-fa"
         }
       ]
     },
@@ -836,6 +1056,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-fi"
+        }
       ]
     },
     {
@@ -856,6 +1082,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-fr/-/lang-fr-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-fr"
         }
       ]
     },
@@ -878,6 +1110,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ga"
+        }
       ]
     },
     {
@@ -898,6 +1136,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-gl/-/lang-gl-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-gl"
         }
       ]
     },
@@ -920,6 +1164,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-hi"
+        }
       ]
     },
     {
@@ -940,6 +1190,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-hu/-/lang-hu-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-hu"
         }
       ]
     },
@@ -962,6 +1218,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-hy"
+        }
       ]
     },
     {
@@ -982,6 +1244,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-id/-/lang-id-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-id"
         }
       ]
     },
@@ -1004,6 +1272,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-it"
+        }
       ]
     },
     {
@@ -1024,6 +1298,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-ja/-/lang-ja-4.24.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ja"
         }
       ]
     },
@@ -1046,6 +1326,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ko"
+        }
       ]
     },
     {
@@ -1066,6 +1352,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-lt/-/lang-lt-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-lt"
         }
       ]
     },
@@ -1088,6 +1380,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ms"
+        }
       ]
     },
     {
@@ -1108,6 +1406,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-ne/-/lang-ne-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ne"
         }
       ]
     },
@@ -1130,6 +1434,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-nl"
+        }
       ]
     },
     {
@@ -1150,6 +1460,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-no/-/lang-no-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-no"
         }
       ]
     },
@@ -1172,6 +1488,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-pl"
+        }
       ]
     },
     {
@@ -1192,6 +1514,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-pt/-/lang-pt-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-pt"
         }
       ]
     },
@@ -1214,6 +1542,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ro"
+        }
       ]
     },
     {
@@ -1234,6 +1568,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-ru/-/lang-ru-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ru"
         }
       ]
     },
@@ -1256,6 +1596,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-sl"
+        }
       ]
     },
     {
@@ -1276,6 +1622,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-sr/-/lang-sr-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-sr"
         }
       ]
     },
@@ -1298,6 +1650,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-sv"
+        }
       ]
     },
     {
@@ -1318,6 +1676,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-ta/-/lang-ta-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ta"
         }
       ]
     },
@@ -1340,6 +1704,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-th"
+        }
       ]
     },
     {
@@ -1360,6 +1730,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-tl/-/lang-tl-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-tl"
         }
       ]
     },
@@ -1382,6 +1758,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-tr"
+        }
       ]
     },
     {
@@ -1402,6 +1784,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-uk/-/lang-uk-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-uk"
         }
       ]
     },
@@ -1424,6 +1812,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-zh"
+        }
       ]
     },
     {
@@ -1444,6 +1838,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/language-min/-/language-min-4.22.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/language-min"
         }
       ]
     },
@@ -1466,6 +1866,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/language"
+        }
       ]
     },
     {
@@ -1486,6 +1892,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/ner/-/ner-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/ner"
         }
       ]
     },
@@ -1508,6 +1920,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/neural"
+        }
       ]
     },
     {
@@ -1528,6 +1946,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/nlg/-/nlg-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/nlg"
         }
       ]
     },
@@ -1550,6 +1974,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/nlp"
+        }
       ]
     },
     {
@@ -1570,6 +2000,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/nlu/-/nlu-4.23.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/nlu"
         }
       ]
     },
@@ -1592,6 +2028,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/request"
+        }
       ]
     },
     {
@@ -1612,6 +2054,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/sentiment/-/sentiment-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/sentiment"
         }
       ]
     },
@@ -1634,6 +2082,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/similarity"
+        }
       ]
     },
     {
@@ -1654,6 +2108,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/slot/-/slot-4.22.17.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/slot"
         }
       ]
     },
@@ -1676,6 +2136,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@npmcli/fs"
+        }
       ]
     },
     {
@@ -1696,6 +2162,12 @@
           "url": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@npmcli/move-file"
         }
       ]
     },
@@ -1718,6 +2190,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib/core"
+        }
       ]
     },
     {
@@ -1738,6 +2216,12 @@
           "url": "https://registry.npmjs.org/@otplib/plugin-crypto/-/plugin-crypto-12.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib/plugin-crypto"
         }
       ]
     },
@@ -1760,6 +2244,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib/plugin-thirty-two"
+        }
       ]
     },
     {
@@ -1780,6 +2270,12 @@
           "url": "https://registry.npmjs.org/@otplib/preset-default/-/preset-default-12.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib/preset-default"
         }
       ]
     },
@@ -1802,6 +2298,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib/preset-v11"
+        }
       ]
     },
     {
@@ -1822,6 +2324,12 @@
           "url": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@sindresorhus/is"
         }
       ]
     },
@@ -1844,6 +2352,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@swc/helpers"
+        }
       ]
     },
     {
@@ -1864,6 +2378,12 @@
           "url": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@tokenizer/token"
         }
       ]
     },
@@ -1886,6 +2406,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@tootallnate/once"
+        }
       ]
     },
     {
@@ -1906,6 +2432,12 @@
           "url": "https://registry.npmjs.org/@types/component-emitter/-/component-emitter-1.2.11.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/component-emitter"
         }
       ]
     },
@@ -1928,6 +2460,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/cookie"
+        }
       ]
     },
     {
@@ -1948,6 +2486,12 @@
           "url": "https://registry.npmjs.org/@types/cors/-/cors-2.8.12.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/cors"
         }
       ]
     },
@@ -1970,6 +2514,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/debug"
+        }
       ]
     },
     {
@@ -1990,6 +2540,12 @@
           "url": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/ms"
         }
       ]
     },
@@ -2012,6 +2568,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/node"
+        }
       ]
     },
     {
@@ -2032,6 +2594,12 @@
           "url": "https://registry.npmjs.org/@types/strip-bom/-/strip-bom-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/strip-bom"
         }
       ]
     },
@@ -2054,6 +2622,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/strip-json-comments"
+        }
       ]
     },
     {
@@ -2075,6 +2649,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/validator"
+        }
       ]
     },
     {
@@ -2094,6 +2674,12 @@
           "url": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/abbrev"
         }
       ]
     },
@@ -2115,6 +2701,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/accepts"
+        }
       ]
     },
     {
@@ -2135,6 +2727,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/acorn-walk"
+        }
       ]
     },
     {
@@ -2154,6 +2752,12 @@
           "url": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/acorn"
         }
       ]
     },
@@ -2176,6 +2780,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/agent-base"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -2194,6 +2804,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agent-base/node_modules/debug"
             }
           ]
         },
@@ -2214,6 +2830,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agent-base/node_modules/ms"
             }
           ]
         }
@@ -2238,6 +2860,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/agentkeepalive"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -2256,6 +2884,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agentkeepalive/node_modules/debug"
             }
           ]
         },
@@ -2277,6 +2911,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agentkeepalive/node_modules/depd"
+            }
           ]
         },
         {
@@ -2296,6 +2936,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agentkeepalive/node_modules/ms"
             }
           ]
         }
@@ -2319,6 +2965,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/aggregate-error"
+        }
       ]
     },
     {
@@ -2338,6 +2990,12 @@
           "url": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ajv"
         }
       ]
     },
@@ -2359,6 +3017,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ansi-regex"
+        }
       ]
     },
     {
@@ -2378,6 +3042,12 @@
           "url": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ansi-styles"
         }
       ]
     },
@@ -2400,6 +3070,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/anymatch"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -2418,6 +3094,12 @@
               "url": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/anymatch/node_modules/normalize-path"
             }
           ]
         }
@@ -2441,6 +3123,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/append-field"
+        }
       ]
     },
     {
@@ -2460,6 +3148,12 @@
           "url": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/aproba"
         }
       ]
     },
@@ -2482,6 +3176,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/archive-type"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -2500,6 +3200,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-4.4.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/archive-type/node_modules/file-type"
             }
           ]
         }
@@ -2523,6 +3229,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/archiver-utils"
+        }
       ]
     },
     {
@@ -2542,6 +3254,12 @@
           "url": "https://registry.npmjs.org/archiver/-/archiver-1.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/archiver"
         }
       ]
     },
@@ -2563,6 +3281,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/are-we-there-yet"
+        }
       ]
     },
     {
@@ -2582,6 +3306,12 @@
           "url": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/arg"
         }
       ]
     },
@@ -2604,6 +3334,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/argparse"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -2622,6 +3358,12 @@
               "url": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/argparse/node_modules/sprintf-js"
             }
           ]
         }
@@ -2645,6 +3387,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/arr-diff"
+        }
       ]
     },
     {
@@ -2664,6 +3412,12 @@
           "url": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/arr-flatten"
         }
       ]
     },
@@ -2685,6 +3439,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/arr-union"
+        }
       ]
     },
     {
@@ -2704,6 +3464,12 @@
           "url": "https://registry.npmjs.org/array-each/-/array-each-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/array-each"
         }
       ]
     },
@@ -2725,6 +3491,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/array-flatten"
+        }
       ]
     },
     {
@@ -2744,6 +3516,12 @@
           "url": "https://registry.npmjs.org/array-slice/-/array-slice-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/array-slice"
         }
       ]
     },
@@ -2765,6 +3543,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/array-unique"
+        }
       ]
     },
     {
@@ -2784,6 +3568,12 @@
           "url": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/asap"
         }
       ]
     },
@@ -2805,6 +3595,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/asn1"
+        }
       ]
     },
     {
@@ -2824,6 +3620,12 @@
           "url": "https://registry.npmjs.org/assert-never/-/assert-never-1.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/assert-never"
         }
       ]
     },
@@ -2845,6 +3647,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/assert-plus"
+        }
       ]
     },
     {
@@ -2864,6 +3672,12 @@
           "url": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/assign-symbols"
         }
       ]
     },
@@ -2885,6 +3699,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/async"
+        }
       ]
     },
     {
@@ -2904,6 +3724,12 @@
           "url": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/asynckit"
         }
       ]
     },
@@ -2925,6 +3751,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/at-least-node"
+        }
       ]
     },
     {
@@ -2944,6 +3776,12 @@
           "url": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/atob"
         }
       ]
     },
@@ -2965,6 +3803,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/available-typed-arrays"
+        }
       ]
     },
     {
@@ -2984,6 +3828,12 @@
           "url": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/aws-sign2"
         }
       ]
     },
@@ -3005,6 +3855,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/aws4"
+        }
       ]
     },
     {
@@ -3025,6 +3881,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/babel-walk"
+        }
       ]
     },
     {
@@ -3044,6 +3906,12 @@
           "url": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/balanced-match"
         }
       ]
     },
@@ -3066,6 +3934,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -3084,6 +3958,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/base/node_modules/define-property"
             }
           ]
         }
@@ -3107,6 +3987,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base64-arraybuffer"
+        }
       ]
     },
     {
@@ -3126,6 +4012,12 @@
           "url": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base64-js"
         }
       ]
     },
@@ -3147,6 +4039,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base64id"
+        }
       ]
     },
     {
@@ -3166,6 +4064,12 @@
           "url": "https://registry.npmjs.org/base64url/-/base64url-0.0.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base64url"
         }
       ]
     },
@@ -3187,6 +4091,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/basic-auth"
+        }
       ]
     },
     {
@@ -3206,6 +4116,12 @@
           "url": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/batch"
         }
       ]
     },
@@ -3227,6 +4143,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bcrypt-pbkdf"
+        }
       ]
     },
     {
@@ -3246,6 +4168,12 @@
           "url": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/big-integer"
         }
       ]
     },
@@ -3267,6 +4195,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/binary-extensions"
+        }
       ]
     },
     {
@@ -3286,6 +4220,12 @@
           "url": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/binary"
         }
       ]
     },
@@ -3307,6 +4247,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bindings"
+        }
       ]
     },
     {
@@ -3326,6 +4272,12 @@
           "url": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bintrees"
         }
       ]
     },
@@ -3347,6 +4299,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bl"
+        }
       ]
     },
     {
@@ -3367,6 +4325,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bluebird"
+        }
       ]
     },
     {
@@ -3386,6 +4350,12 @@
           "url": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/body-parser"
         }
       ]
     },
@@ -3408,6 +4378,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bower-config"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -3426,6 +4402,12 @@
               "url": "https://registry.npmjs.org/minimist/-/minimist-0.2.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bower-config/node_modules/minimist"
             }
           ]
         }
@@ -3449,6 +4431,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/brace-expansion"
+        }
       ]
     },
     {
@@ -3470,6 +4458,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/braces"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -3488,6 +4482,12 @@
               "url": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/braces/node_modules/extend-shallow"
             }
           ]
         },
@@ -3508,6 +4508,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/braces/node_modules/is-extendable"
             }
           ]
         }
@@ -3531,6 +4537,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/brotli"
+        }
       ]
     },
     {
@@ -3550,6 +4562,12 @@
           "url": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-alloc-unsafe"
         }
       ]
     },
@@ -3571,6 +4589,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-alloc"
+        }
       ]
     },
     {
@@ -3590,6 +4614,12 @@
           "url": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-crc32"
         }
       ]
     },
@@ -3611,6 +4641,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-fill"
+        }
       ]
     },
     {
@@ -3630,6 +4666,12 @@
           "url": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-from"
         }
       ]
     },
@@ -3651,6 +4693,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-indexof-polyfill"
+        }
       ]
     },
     {
@@ -3671,6 +4719,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer"
+        }
       ]
     },
     {
@@ -3690,6 +4744,12 @@
           "url": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffers"
         }
       ]
     },
@@ -3712,6 +4772,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/busboy"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -3730,6 +4796,12 @@
               "url": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/busboy/node_modules/isarray"
             }
           ]
         },
@@ -3751,6 +4823,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/busboy/node_modules/readable-stream"
+            }
           ]
         },
         {
@@ -3770,6 +4848,12 @@
               "url": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/busboy/node_modules/string_decoder"
             }
           ]
         }
@@ -3793,6 +4877,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/byline"
+        }
       ]
     },
     {
@@ -3812,6 +4902,12 @@
           "url": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bytes"
         }
       ]
     },
@@ -3833,6 +4929,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cacache"
+        }
       ]
     },
     {
@@ -3852,6 +4954,12 @@
           "url": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cache-base"
         }
       ]
     },
@@ -3874,6 +4982,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cacheable-request"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -3892,6 +5006,12 @@
               "url": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cacheable-request/node_modules/get-stream"
             }
           ]
         },
@@ -3912,6 +5032,12 @@
               "url": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cacheable-request/node_modules/lowercase-keys"
             }
           ]
         }
@@ -3935,6 +5061,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/call-bind"
+        }
       ]
     },
     {
@@ -3954,6 +5086,12 @@
           "url": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/camelcase"
         }
       ]
     },
@@ -3975,6 +5113,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/caseless"
+        }
       ]
     },
     {
@@ -3994,6 +5138,12 @@
           "url": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/chainsaw"
         }
       ]
     },
@@ -4015,6 +5165,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/chalk"
+        }
       ]
     },
     {
@@ -4034,6 +5190,12 @@
           "url": "https://registry.npmjs.org/character-parser/-/character-parser-2.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/character-parser"
         }
       ]
     },
@@ -4056,6 +5218,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/check-dependencies"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4074,6 +5242,12 @@
               "url": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/check-dependencies/node_modules/semver"
             }
           ]
         }
@@ -4097,6 +5271,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/check-types"
+        }
       ]
     },
     {
@@ -4118,6 +5298,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/chokidar"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4136,6 +5322,12 @@
               "url": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar/node_modules/braces"
             }
           ]
         },
@@ -4157,6 +5349,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar/node_modules/fill-range"
+            }
           ]
         },
         {
@@ -4176,6 +5374,12 @@
               "url": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar/node_modules/is-glob"
             }
           ]
         },
@@ -4197,6 +5401,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar/node_modules/is-number"
+            }
           ]
         },
         {
@@ -4217,6 +5427,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar/node_modules/normalize-path"
+            }
           ]
         },
         {
@@ -4236,6 +5452,12 @@
               "url": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar/node_modules/to-regex-range"
             }
           ]
         }
@@ -4259,6 +5481,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/chownr"
+        }
       ]
     },
     {
@@ -4278,6 +5506,12 @@
           "url": "https://registry.npmjs.org/clarinet/-/clarinet-0.12.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/clarinet"
         }
       ]
     },
@@ -4300,6 +5534,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/class-utils"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4318,6 +5558,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils/node_modules/define-property"
             }
           ]
         },
@@ -4340,6 +5586,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils/node_modules/is-accessor-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -4358,6 +5610,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/class-utils/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -4382,6 +5640,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils/node_modules/is-data-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -4400,6 +5664,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/class-utils/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -4423,6 +5693,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils/node_modules/is-descriptor"
+            }
           ]
         },
         {
@@ -4442,6 +5718,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils/node_modules/kind-of"
             }
           ]
         }
@@ -4465,6 +5747,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/clean-stack"
+        }
       ]
     },
     {
@@ -4486,6 +5774,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cliui"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4504,6 +5798,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui/node_modules/ansi-regex"
             }
           ]
         },
@@ -4525,6 +5825,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui/node_modules/emoji-regex"
+            }
           ]
         },
         {
@@ -4544,6 +5850,12 @@
               "url": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui/node_modules/is-fullwidth-code-point"
             }
           ]
         },
@@ -4565,6 +5877,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui/node_modules/string-width"
+            }
           ]
         },
         {
@@ -4584,6 +5902,12 @@
               "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui/node_modules/strip-ansi"
             }
           ]
         }
@@ -4607,6 +5931,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/clone-response"
+        }
       ]
     },
     {
@@ -4626,6 +5956,12 @@
           "url": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/clone"
         }
       ]
     },
@@ -4647,6 +5983,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/code-point-at"
+        }
       ]
     },
     {
@@ -4666,6 +6008,12 @@
           "url": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/collection-visit"
         }
       ]
     },
@@ -4687,6 +6035,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color-convert"
+        }
       ]
     },
     {
@@ -4706,6 +6060,12 @@
           "url": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color-name"
         }
       ]
     },
@@ -4727,6 +6087,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color-string"
+        }
       ]
     },
     {
@@ -4746,6 +6112,12 @@
           "url": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color-support"
         }
       ]
     },
@@ -4767,6 +6139,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color"
+        }
       ]
     },
     {
@@ -4786,6 +6164,12 @@
           "url": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/colors"
         }
       ]
     },
@@ -4807,6 +6191,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/colorspace"
+        }
       ]
     },
     {
@@ -4826,6 +6216,12 @@
           "url": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/combined-stream"
         }
       ]
     },
@@ -4847,6 +6243,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/commander"
+        }
       ]
     },
     {
@@ -4866,6 +6268,12 @@
           "url": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/component-emitter"
         }
       ]
     },
@@ -4887,6 +6295,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/component-type"
+        }
       ]
     },
     {
@@ -4907,6 +6321,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/compress-commons"
+        }
       ]
     },
     {
@@ -4926,6 +6346,12 @@
           "url": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/compressible"
         }
       ]
     },
@@ -4948,6 +6374,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/compression"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4966,6 +6398,12 @@
               "url": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/compression/node_modules/bytes"
             }
           ]
         }
@@ -4989,6 +6427,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/concat-map"
+        }
       ]
     },
     {
@@ -5008,6 +6452,12 @@
           "url": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/concat-stream"
         }
       ]
     },
@@ -5030,6 +6480,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/concurrently"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5048,6 +6504,12 @@
               "url": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/concurrently/node_modules/supports-color"
             }
           ]
         }
@@ -5071,6 +6533,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/config"
+        }
       ]
     },
     {
@@ -5091,6 +6559,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/console-control-strings"
+        }
       ]
     },
     {
@@ -5110,6 +6584,12 @@
           "url": "https://registry.npmjs.org/constantinople/-/constantinople-4.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/constantinople"
         }
       ]
     },
@@ -5132,6 +6612,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/content-disposition"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5150,6 +6636,12 @@
               "url": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/content-disposition/node_modules/safe-buffer"
             }
           ]
         }
@@ -5173,6 +6665,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/content-type"
+        }
       ]
     },
     {
@@ -5192,6 +6690,12 @@
           "url": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cookie-parser"
         }
       ]
     },
@@ -5213,6 +6717,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cookie-signature"
+        }
       ]
     },
     {
@@ -5232,6 +6742,12 @@
           "url": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cookie"
         }
       ]
     },
@@ -5253,6 +6769,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/copy-descriptor"
+        }
       ]
     },
     {
@@ -5272,6 +6794,12 @@
           "url": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/core-util-is"
         }
       ]
     },
@@ -5293,6 +6821,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cors"
+        }
       ]
     },
     {
@@ -5312,6 +6846,12 @@
           "url": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/crc"
         }
       ]
     },
@@ -5333,6 +6873,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/crc32-stream"
+        }
       ]
     },
     {
@@ -5352,6 +6898,12 @@
           "url": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/create-require"
         }
       ]
     },
@@ -5373,6 +6925,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/crypto-js"
+        }
       ]
     },
     {
@@ -5392,6 +6950,12 @@
           "url": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dashdash"
         }
       ]
     },
@@ -5413,6 +6977,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/date-fns"
+        }
       ]
     },
     {
@@ -5432,6 +7002,12 @@
           "url": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dateformat"
         }
       ]
     },
@@ -5453,6 +7029,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/debug"
+        }
       ]
     },
     {
@@ -5472,6 +7054,12 @@
           "url": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decamelize"
         }
       ]
     },
@@ -5493,6 +7081,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decode-uri-component"
+        }
       ]
     },
     {
@@ -5512,6 +7106,12 @@
           "url": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-response"
         }
       ]
     },
@@ -5534,6 +7134,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-tar"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5552,6 +7158,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-tar/node_modules/file-type"
             }
           ]
         }
@@ -5576,6 +7188,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-tarbz2"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5594,6 +7212,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-6.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-tarbz2/node_modules/file-type"
             }
           ]
         }
@@ -5618,6 +7242,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-targz"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5636,6 +7266,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-targz/node_modules/file-type"
             }
           ]
         }
@@ -5660,6 +7296,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-unzip"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5678,6 +7320,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-unzip/node_modules/file-type"
             }
           ]
         },
@@ -5699,6 +7347,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-unzip/node_modules/get-stream"
+            }
           ]
         },
         {
@@ -5718,6 +7372,12 @@
               "url": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-unzip/node_modules/pify"
             }
           ]
         }
@@ -5742,6 +7402,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5762,6 +7428,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress/node_modules/make-dir"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -5780,6 +7452,12 @@
                   "url": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/decompress/node_modules/make-dir/node_modules/pify"
                 }
               ]
             }
@@ -5803,6 +7481,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress/node_modules/pify"
+            }
           ]
         }
       ]
@@ -5825,6 +7509,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/deep-equal"
+        }
       ]
     },
     {
@@ -5844,6 +7534,12 @@
           "url": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/deep-extend"
         }
       ]
     },
@@ -5865,6 +7561,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/deep-is"
+        }
       ]
     },
     {
@@ -5884,6 +7586,12 @@
           "url": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/define-properties"
         }
       ]
     },
@@ -5905,6 +7613,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/define-property"
+        }
       ]
     },
     {
@@ -5924,6 +7638,12 @@
           "url": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/delayed-stream"
         }
       ]
     },
@@ -5945,6 +7665,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/delegates"
+        }
       ]
     },
     {
@@ -5964,6 +7690,12 @@
           "url": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/depd"
         }
       ]
     },
@@ -5985,6 +7717,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/destroy"
+        }
       ]
     },
     {
@@ -6004,6 +7742,12 @@
           "url": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/detect-file"
         }
       ]
     },
@@ -6025,6 +7769,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/detect-libc"
+        }
       ]
     },
     {
@@ -6044,6 +7794,12 @@
           "url": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dfa"
         }
       ]
     },
@@ -6066,6 +7822,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dicer"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -6084,6 +7846,12 @@
               "url": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/dicer/node_modules/isarray"
             }
           ]
         },
@@ -6105,6 +7873,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/dicer/node_modules/readable-stream"
+            }
           ]
         },
         {
@@ -6124,6 +7898,12 @@
               "url": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/dicer/node_modules/string_decoder"
             }
           ]
         }
@@ -6147,6 +7927,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/diff"
+        }
       ]
     },
     {
@@ -6166,6 +7952,12 @@
           "url": "https://registry.npmjs.org/doctypes/-/doctypes-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/doctypes"
         }
       ]
     },
@@ -6187,6 +7979,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/domelementtype"
+        }
       ]
     },
     {
@@ -6206,6 +8004,12 @@
           "url": "https://registry.npmjs.org/domhandler/-/domhandler-2.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/domhandler"
         }
       ]
     },
@@ -6227,6 +8031,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/domutils"
+        }
       ]
     },
     {
@@ -6246,6 +8056,12 @@
           "url": "https://registry.npmjs.org/dottie/-/dottie-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dottie"
         }
       ]
     },
@@ -6267,6 +8083,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/double-ended-queue"
+        }
       ]
     },
     {
@@ -6286,6 +8108,12 @@
           "url": "https://registry.npmjs.org/doublearray/-/doublearray-0.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/doublearray"
         }
       ]
     },
@@ -6308,6 +8136,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/download"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -6326,6 +8160,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-11.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/download/node_modules/file-type"
             }
           ]
         }
@@ -6349,6 +8189,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/duplexer2"
+        }
       ]
     },
     {
@@ -6368,6 +8214,12 @@
           "url": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/duplexer3"
         }
       ]
     },
@@ -6389,6 +8241,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dynamic-dedupe"
+        }
       ]
     },
     {
@@ -6408,6 +8266,12 @@
           "url": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ecc-jsbn"
         }
       ]
     },
@@ -6429,6 +8293,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ee-first"
+        }
       ]
     },
     {
@@ -6448,6 +8318,12 @@
           "url": "https://registry.npmjs.org/eivindfjeldstad-dot/-/eivindfjeldstad-dot-0.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/eivindfjeldstad-dot"
         }
       ]
     },
@@ -6469,6 +8345,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/emoji-regex"
+        }
       ]
     },
     {
@@ -6489,6 +8371,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/enabled"
+        }
       ]
     },
     {
@@ -6508,6 +8396,12 @@
           "url": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/encodeurl"
         }
       ]
     },
@@ -6530,6 +8424,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/encoding"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -6548,6 +8448,12 @@
               "url": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/encoding/node_modules/iconv-lite"
             }
           ]
         }
@@ -6571,6 +8477,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/end-of-stream"
+        }
       ]
     },
     {
@@ -6590,6 +8502,12 @@
           "url": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-4.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/engine.io-parser"
         }
       ]
     },
@@ -6612,6 +8530,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/engine.io"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -6630,6 +8554,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/engine.io/node_modules/debug"
             }
           ]
         },
@@ -6650,6 +8580,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/engine.io/node_modules/ms"
             }
           ]
         }
@@ -6673,6 +8609,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/env-paths"
+        }
       ]
     },
     {
@@ -6692,6 +8634,12 @@
           "url": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/err-code"
         }
       ]
     },
@@ -6713,6 +8661,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/error-ex"
+        }
       ]
     },
     {
@@ -6732,6 +8686,12 @@
           "url": "https://registry.npmjs.org/errorhandler/-/errorhandler-1.5.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/errorhandler"
         }
       ]
     },
@@ -6753,6 +8713,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/es-abstract"
+        }
       ]
     },
     {
@@ -6772,6 +8738,12 @@
           "url": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/es-get-iterator"
         }
       ]
     },
@@ -6793,6 +8765,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/es-to-primitive"
+        }
       ]
     },
     {
@@ -6812,6 +8790,12 @@
           "url": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/escape-html"
         }
       ]
     },
@@ -6833,6 +8817,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/escape-string-regexp"
+        }
       ]
     },
     {
@@ -6852,6 +8842,12 @@
           "url": "https://registry.npmjs.org/escodegen/-/escodegen-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/escodegen"
         }
       ]
     },
@@ -6873,6 +8869,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/esprima"
+        }
       ]
     },
     {
@@ -6892,6 +8894,12 @@
           "url": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/estraverse"
         }
       ]
     },
@@ -6913,6 +8921,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/esutils"
+        }
       ]
     },
     {
@@ -6932,6 +8946,12 @@
           "url": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/etag"
         }
       ]
     },
@@ -6953,6 +8973,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/eventemitter2"
+        }
       ]
     },
     {
@@ -6972,6 +8998,12 @@
           "url": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/eventemitter3"
         }
       ]
     },
@@ -6993,6 +9025,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/exif"
+        }
       ]
     },
     {
@@ -7012,6 +9050,12 @@
           "url": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/exit"
         }
       ]
     },
@@ -7034,6 +9078,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/expand-brackets"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7052,6 +9102,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/define-property"
             }
           ]
         },
@@ -7072,6 +9128,12 @@
               "url": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/extend-shallow"
             }
           ]
         },
@@ -7094,6 +9156,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/is-accessor-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -7112,6 +9180,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/expand-brackets/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -7136,6 +9210,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/is-data-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -7154,6 +9234,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/expand-brackets/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -7177,6 +9263,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/is-descriptor"
+            }
           ]
         },
         {
@@ -7197,6 +9289,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/is-extendable"
+            }
           ]
         },
         {
@@ -7216,6 +9314,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/kind-of"
             }
           ]
         }
@@ -7239,6 +9343,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/expand-template"
+        }
       ]
     },
     {
@@ -7259,6 +9369,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/expand-tilde"
+        }
       ]
     },
     {
@@ -7278,6 +9394,12 @@
           "url": "https://registry.npmjs.org/express-ipfilter/-/express-ipfilter-1.3.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-ipfilter"
         }
       ]
     },
@@ -7300,6 +9422,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-jwt"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7318,6 +9446,12 @@
               "url": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-0.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/express-jwt/node_modules/jsonwebtoken"
             }
           ]
         },
@@ -7338,6 +9472,12 @@
               "url": "https://registry.npmjs.org/moment/-/moment-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/express-jwt/node_modules/moment"
             }
           ]
         }
@@ -7361,6 +9501,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-rate-limit"
+        }
       ]
     },
     {
@@ -7381,6 +9527,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-robots-txt"
+        }
       ]
     },
     {
@@ -7400,6 +9552,12 @@
           "url": "https://registry.npmjs.org/express-security.txt/-/express-security.txt-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-security.txt"
         }
       ]
     },
@@ -7422,6 +9580,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7440,6 +9604,12 @@
               "url": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/express/node_modules/cookie"
             }
           ]
         },
@@ -7460,6 +9630,12 @@
               "url": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/express/node_modules/safe-buffer"
             }
           ]
         }
@@ -7483,6 +9659,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ext-list"
+        }
       ]
     },
     {
@@ -7502,6 +9684,12 @@
           "url": "https://registry.npmjs.org/ext-name/-/ext-name-5.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ext-name"
         }
       ]
     },
@@ -7523,6 +9711,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/extend-shallow"
+        }
       ]
     },
     {
@@ -7542,6 +9736,12 @@
           "url": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/extend"
         }
       ]
     },
@@ -7564,6 +9764,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/extglob"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7582,6 +9788,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/extglob/node_modules/define-property"
             }
           ]
         },
@@ -7603,6 +9815,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/extglob/node_modules/extend-shallow"
+            }
           ]
         },
         {
@@ -7622,6 +9840,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/extglob/node_modules/is-extendable"
             }
           ]
         }
@@ -7645,6 +9869,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/extsprintf"
+        }
       ]
     },
     {
@@ -7664,6 +9894,12 @@
           "url": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fast-deep-equal"
         }
       ]
     },
@@ -7685,6 +9921,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fast-json-stable-stringify"
+        }
       ]
     },
     {
@@ -7704,6 +9946,12 @@
           "url": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fast-levenshtein"
         }
       ]
     },
@@ -7725,6 +9973,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fast.js"
+        }
       ]
     },
     {
@@ -7744,6 +9998,12 @@
           "url": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fd-slicer"
         }
       ]
     },
@@ -7765,6 +10025,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/feature-policy"
+        }
       ]
     },
     {
@@ -7784,6 +10050,12 @@
           "url": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fecha"
         }
       ]
     },
@@ -7806,6 +10078,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/file-js"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7824,6 +10102,12 @@
               "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/file-js/node_modules/brace-expansion"
             }
           ]
         },
@@ -7844,6 +10128,12 @@
               "url": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/file-js/node_modules/minimatch"
             }
           ]
         }
@@ -7867,6 +10157,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/file-stream-rotator"
+        }
       ]
     },
     {
@@ -7886,6 +10182,12 @@
           "url": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/file-type"
         }
       ]
     },
@@ -7907,6 +10209,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/file-uri-to-path"
+        }
       ]
     },
     {
@@ -7926,6 +10234,12 @@
           "url": "https://registry.npmjs.org/filehound/-/filehound-1.17.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/filehound"
         }
       ]
     },
@@ -7947,6 +10261,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/filename-reserved-regex"
+        }
       ]
     },
     {
@@ -7967,6 +10287,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/filenamify"
+        }
       ]
     },
     {
@@ -7986,6 +10312,12 @@
           "url": "https://registry.npmjs.org/filesniffer/-/filesniffer-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/filesniffer"
         }
       ]
     },
@@ -8008,6 +10340,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fill-range"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -8026,6 +10364,12 @@
               "url": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/fill-range/node_modules/extend-shallow"
             }
           ]
         },
@@ -8046,6 +10390,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/fill-range/node_modules/is-extendable"
             }
           ]
         }
@@ -8069,6 +10419,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/finale-rest"
+        }
       ]
     },
     {
@@ -8088,6 +10444,12 @@
           "url": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/finalhandler"
         }
       ]
     },
@@ -8109,6 +10471,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/find-up"
+        }
       ]
     },
     {
@@ -8128,6 +10496,12 @@
           "url": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/findup-sync"
         }
       ]
     },
@@ -8149,6 +10523,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fined"
+        }
       ]
     },
     {
@@ -8168,6 +10548,12 @@
           "url": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/flagged-respawn"
         }
       ]
     },
@@ -8189,6 +10575,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fn.name"
+        }
       ]
     },
     {
@@ -8208,6 +10600,12 @@
           "url": "https://registry.npmjs.org/fontkit/-/fontkit-1.9.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fontkit"
         }
       ]
     },
@@ -8229,6 +10627,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/for-each"
+        }
       ]
     },
     {
@@ -8248,6 +10652,12 @@
           "url": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/for-in"
         }
       ]
     },
@@ -8269,6 +10679,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/for-own"
+        }
       ]
     },
     {
@@ -8288,6 +10704,12 @@
           "url": "https://registry.npmjs.org/foreachasync/-/foreachasync-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/foreachasync"
         }
       ]
     },
@@ -8309,6 +10731,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/forever-agent"
+        }
       ]
     },
     {
@@ -8328,6 +10756,12 @@
           "url": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/form-data"
         }
       ]
     },
@@ -8349,6 +10783,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/formatio"
+        }
       ]
     },
     {
@@ -8368,6 +10808,12 @@
           "url": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/forwarded"
         }
       ]
     },
@@ -8389,6 +10835,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fragment-cache"
+        }
       ]
     },
     {
@@ -8408,6 +10860,12 @@
           "url": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fresh"
         }
       ]
     },
@@ -8429,6 +10887,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/from2"
+        }
       ]
     },
     {
@@ -8448,6 +10912,12 @@
           "url": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fs-constants"
         }
       ]
     },
@@ -8469,6 +10939,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fs-extra"
+        }
       ]
     },
     {
@@ -8488,6 +10964,12 @@
           "url": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fs-minipass"
         }
       ]
     },
@@ -8509,6 +10991,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fs.realpath"
+        }
       ]
     },
     {
@@ -8528,6 +11016,12 @@
           "url": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fsevents"
         }
       ]
     },
@@ -8550,6 +11044,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fstream"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -8568,6 +11068,12 @@
               "url": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/fstream/node_modules/mkdirp"
             }
           ]
         },
@@ -8588,6 +11094,12 @@
               "url": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/fstream/node_modules/rimraf"
             }
           ]
         }
@@ -8611,6 +11123,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/function-bind"
+        }
       ]
     },
     {
@@ -8630,6 +11148,12 @@
           "url": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/function.prototype.name"
         }
       ]
     },
@@ -8651,6 +11175,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/functions-have-names"
+        }
       ]
     },
     {
@@ -8670,6 +11200,12 @@
           "url": "https://registry.npmjs.org/fuzzball/-/fuzzball-1.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fuzzball"
         }
       ]
     },
@@ -8691,6 +11227,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/gauge"
+        }
       ]
     },
     {
@@ -8710,6 +11252,12 @@
           "url": "https://registry.npmjs.org/geojson-utils/-/geojson-utils-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/geojson-utils"
         }
       ]
     },
@@ -8731,6 +11279,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-caller-file"
+        }
       ]
     },
     {
@@ -8750,6 +11304,12 @@
           "url": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-intrinsic"
         }
       ]
     },
@@ -8771,6 +11331,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-stream"
+        }
       ]
     },
     {
@@ -8790,6 +11356,12 @@
           "url": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-symbol-description"
         }
       ]
     },
@@ -8811,6 +11383,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-value"
+        }
       ]
     },
     {
@@ -8830,6 +11408,12 @@
           "url": "https://registry.npmjs.org/getobject/-/getobject-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/getobject"
         }
       ]
     },
@@ -8851,6 +11435,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/getpass"
+        }
       ]
     },
     {
@@ -8870,6 +11460,12 @@
           "url": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/github-from-package"
         }
       ]
     },
@@ -8892,6 +11488,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/glob-parent"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -8910,6 +11512,12 @@
               "url": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/glob-parent/node_modules/is-glob"
             }
           ]
         }
@@ -8934,6 +11542,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/glob"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -8952,6 +11566,12 @@
               "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/glob/node_modules/brace-expansion"
             }
           ]
         },
@@ -8972,6 +11592,12 @@
               "url": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/glob/node_modules/minimatch"
             }
           ]
         }
@@ -8995,6 +11621,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/global-modules"
+        }
       ]
     },
     {
@@ -9016,6 +11648,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/global-prefix"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9034,6 +11672,12 @@
               "url": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/global-prefix/node_modules/which"
             }
           ]
         }
@@ -9058,6 +11702,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/got"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9076,6 +11726,12 @@
               "url": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/got/node_modules/get-stream"
             }
           ]
         },
@@ -9096,6 +11752,12 @@
               "url": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/got/node_modules/pify"
             }
           ]
         }
@@ -9119,6 +11781,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/graceful-fs"
+        }
       ]
     },
     {
@@ -9140,6 +11808,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-cli"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9158,6 +11832,12 @@
               "url": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-cli/node_modules/nopt"
             }
           ]
         }
@@ -9182,6 +11862,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-contrib-compress"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9200,6 +11886,12 @@
               "url": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-contrib-compress/node_modules/ansi-styles"
             }
           ]
         },
@@ -9221,6 +11913,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-contrib-compress/node_modules/chalk"
+            }
           ]
         },
         {
@@ -9240,6 +11938,12 @@
               "url": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-contrib-compress/node_modules/supports-color"
             }
           ]
         }
@@ -9263,6 +11967,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-known-options"
+        }
       ]
     },
     {
@@ -9284,6 +11994,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-legacy-log-utils"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9302,6 +12018,12 @@
               "url": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils/node_modules/ansi-styles"
             }
           ]
         },
@@ -9323,6 +12045,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils/node_modules/chalk"
+            }
           ]
         },
         {
@@ -9342,6 +12070,12 @@
               "url": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils/node_modules/color-convert"
             }
           ]
         },
@@ -9363,6 +12097,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils/node_modules/color-name"
+            }
           ]
         },
         {
@@ -9383,6 +12123,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils/node_modules/has-flag"
+            }
           ]
         },
         {
@@ -9402,6 +12148,12 @@
               "url": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils/node_modules/supports-color"
             }
           ]
         }
@@ -9426,6 +12178,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-legacy-log"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9444,6 +12202,12 @@
               "url": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log/node_modules/colors"
             }
           ]
         }
@@ -9468,6 +12232,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-legacy-util"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9486,6 +12256,12 @@
               "url": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-util/node_modules/async"
             }
           ]
         }
@@ -9509,6 +12285,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-replace-json"
+        }
       ]
     },
     {
@@ -9530,6 +12312,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9548,6 +12336,12 @@
               "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt/node_modules/brace-expansion"
             }
           ]
         },
@@ -9570,6 +12364,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt/node_modules/findup-sync"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -9588,6 +12388,12 @@
                   "url": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/grunt/node_modules/findup-sync/node_modules/glob"
                 }
               ]
             }
@@ -9611,6 +12417,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt/node_modules/glob"
+            }
           ]
         },
         {
@@ -9630,6 +12442,12 @@
               "url": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.8.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt/node_modules/minimatch"
             }
           ]
         }
@@ -9654,6 +12472,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/handlebars"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9672,6 +12496,12 @@
               "url": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/handlebars/node_modules/wordwrap"
             }
           ]
         }
@@ -9695,6 +12525,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/har-schema"
+        }
       ]
     },
     {
@@ -9714,6 +12550,12 @@
           "url": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/har-validator"
         }
       ]
     },
@@ -9735,6 +12577,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-ansi"
+        }
       ]
     },
     {
@@ -9754,6 +12602,12 @@
           "url": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-bigints"
         }
       ]
     },
@@ -9775,6 +12629,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-flag"
+        }
       ]
     },
     {
@@ -9794,6 +12654,12 @@
           "url": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-property-descriptors"
         }
       ]
     },
@@ -9815,6 +12681,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-symbol-support-x"
+        }
       ]
     },
     {
@@ -9834,6 +12706,12 @@
           "url": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-symbols"
         }
       ]
     },
@@ -9855,6 +12733,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-to-string-tag-x"
+        }
       ]
     },
     {
@@ -9874,6 +12758,12 @@
           "url": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-tostringtag"
         }
       ]
     },
@@ -9895,6 +12785,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-unicode"
+        }
       ]
     },
     {
@@ -9914,6 +12810,12 @@
           "url": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-value"
         }
       ]
     },
@@ -9936,6 +12838,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-values"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9954,6 +12862,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/has-values/node_modules/kind-of"
             }
           ]
         }
@@ -9977,6 +12891,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has"
+        }
       ]
     },
     {
@@ -9996,6 +12916,12 @@
           "url": "https://registry.npmjs.org/hashids/-/hashids-2.2.10.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hashids"
         }
       ]
     },
@@ -10017,6 +12943,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hbs"
+        }
       ]
     },
     {
@@ -10036,6 +12968,12 @@
           "url": "https://registry.npmjs.org/he/-/he-0.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/he"
         }
       ]
     },
@@ -10057,6 +12995,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/heap"
+        }
       ]
     },
     {
@@ -10076,6 +13020,12 @@
           "url": "https://registry.npmjs.org/helmet/-/helmet-4.6.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/helmet"
         }
       ]
     },
@@ -10097,6 +13047,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hoister"
+        }
       ]
     },
     {
@@ -10116,6 +13072,12 @@
           "url": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/homedir-polyfill"
         }
       ]
     },
@@ -10137,6 +13099,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hooker"
+        }
       ]
     },
     {
@@ -10157,6 +13125,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hosted-git-info"
+        }
       ]
     },
     {
@@ -10176,6 +13150,12 @@
           "url": "https://registry.npmjs.org/html-entities/-/html-entities-1.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/html-entities"
         }
       ]
     },
@@ -10198,6 +13178,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/htmlparser2"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -10216,6 +13202,12 @@
               "url": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/htmlparser2/node_modules/isarray"
             }
           ]
         },
@@ -10237,6 +13229,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/htmlparser2/node_modules/readable-stream"
+            }
           ]
         },
         {
@@ -10256,6 +13254,12 @@
               "url": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/htmlparser2/node_modules/string_decoder"
             }
           ]
         }
@@ -10279,6 +13283,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/http-cache-semantics"
+        }
       ]
     },
     {
@@ -10298,6 +13308,12 @@
           "url": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/http-errors"
         }
       ]
     },
@@ -10320,6 +13336,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/http-proxy-agent"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -10338,6 +13360,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/http-proxy-agent/node_modules/debug"
             }
           ]
         },
@@ -10358,6 +13386,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/http-proxy-agent/node_modules/ms"
             }
           ]
         }
@@ -10381,6 +13415,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/http-signature"
+        }
       ]
     },
     {
@@ -10402,6 +13442,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/https-proxy-agent"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -10420,6 +13466,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/https-proxy-agent/node_modules/debug"
             }
           ]
         },
@@ -10440,6 +13492,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/https-proxy-agent/node_modules/ms"
             }
           ]
         }
@@ -10463,6 +13521,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/humanize-ms"
+        }
       ]
     },
     {
@@ -10482,6 +13546,12 @@
           "url": "https://registry.npmjs.org/i18n/-/i18n-0.11.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/i18n"
         }
       ]
     },
@@ -10503,6 +13573,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/iconv-lite"
+        }
       ]
     },
     {
@@ -10522,6 +13598,12 @@
           "url": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ieee754"
         }
       ]
     },
@@ -10544,6 +13626,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ignore-walk"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -10562,6 +13650,12 @@
               "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/ignore-walk/node_modules/brace-expansion"
             }
           ]
         },
@@ -10582,6 +13676,12 @@
               "url": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/ignore-walk/node_modules/minimatch"
             }
           ]
         }
@@ -10605,6 +13705,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/iltorb"
+        }
       ]
     },
     {
@@ -10624,6 +13730,12 @@
           "url": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/imurmurhash"
         }
       ]
     },
@@ -10645,6 +13757,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/indent-string"
+        }
       ]
     },
     {
@@ -10664,6 +13782,12 @@
           "url": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/infer-owner"
         }
       ]
     },
@@ -10685,6 +13809,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/inflection"
+        }
       ]
     },
     {
@@ -10704,6 +13834,12 @@
           "url": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/inflight"
         }
       ]
     },
@@ -10725,6 +13861,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/inherits"
+        }
       ]
     },
     {
@@ -10744,6 +13886,12 @@
           "url": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ini"
         }
       ]
     },
@@ -10765,6 +13913,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/internal-slot"
+        }
       ]
     },
     {
@@ -10784,6 +13938,12 @@
           "url": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/interpret"
         }
       ]
     },
@@ -10805,6 +13965,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/into-stream"
+        }
       ]
     },
     {
@@ -10824,6 +13990,12 @@
           "url": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/invariant"
         }
       ]
     },
@@ -10845,6 +14017,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ip"
+        }
       ]
     },
     {
@@ -10864,6 +14042,12 @@
           "url": "https://registry.npmjs.org/ip6/-/ip6-0.2.10.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ip6"
         }
       ]
     },
@@ -10885,6 +14069,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ipaddr.js"
+        }
       ]
     },
     {
@@ -10904,6 +14094,12 @@
           "url": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-absolute"
         }
       ]
     },
@@ -10925,6 +14121,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-accessor-descriptor"
+        }
       ]
     },
     {
@@ -10944,6 +14146,12 @@
           "url": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-arguments"
         }
       ]
     },
@@ -10965,6 +14173,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-arrayish"
+        }
       ]
     },
     {
@@ -10984,6 +14198,12 @@
           "url": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-bigint"
         }
       ]
     },
@@ -11005,6 +14225,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-binary-path"
+        }
       ]
     },
     {
@@ -11024,6 +14250,12 @@
           "url": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-boolean-object"
         }
       ]
     },
@@ -11045,6 +14277,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-buffer"
+        }
       ]
     },
     {
@@ -11064,6 +14302,12 @@
           "url": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-callable"
         }
       ]
     },
@@ -11085,6 +14329,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-core-module"
+        }
       ]
     },
     {
@@ -11104,6 +14354,12 @@
           "url": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-data-descriptor"
         }
       ]
     },
@@ -11125,6 +14381,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-date-object"
+        }
       ]
     },
     {
@@ -11144,6 +14406,12 @@
           "url": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-descriptor"
         }
       ]
     },
@@ -11165,6 +14433,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-docker"
+        }
       ]
     },
     {
@@ -11184,6 +14458,12 @@
           "url": "https://registry.npmjs.org/is-expression/-/is-expression-4.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-expression"
         }
       ]
     },
@@ -11205,6 +14485,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-extendable"
+        }
       ]
     },
     {
@@ -11224,6 +14510,12 @@
           "url": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-extglob"
         }
       ]
     },
@@ -11245,6 +14537,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-fullwidth-code-point"
+        }
       ]
     },
     {
@@ -11264,6 +14562,12 @@
           "url": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-generator-function"
         }
       ]
     },
@@ -11285,6 +14589,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-glob"
+        }
       ]
     },
     {
@@ -11304,6 +14614,12 @@
           "url": "https://registry.npmjs.org/is-heroku/-/is-heroku-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-heroku"
         }
       ]
     },
@@ -11325,6 +14641,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-lambda"
+        }
       ]
     },
     {
@@ -11344,6 +14666,12 @@
           "url": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-map"
         }
       ]
     },
@@ -11365,6 +14693,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-natural-number"
+        }
       ]
     },
     {
@@ -11384,6 +14718,12 @@
           "url": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-negative-zero"
         }
       ]
     },
@@ -11405,6 +14745,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-number-like"
+        }
       ]
     },
     {
@@ -11424,6 +14770,12 @@
           "url": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-number-object"
         }
       ]
     },
@@ -11446,6 +14798,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-number"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -11464,6 +14822,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/is-number/node_modules/kind-of"
             }
           ]
         }
@@ -11487,6 +14851,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-object"
+        }
       ]
     },
     {
@@ -11506,6 +14876,12 @@
           "url": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-plain-obj"
         }
       ]
     },
@@ -11527,6 +14903,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-plain-object"
+        }
       ]
     },
     {
@@ -11546,6 +14928,12 @@
           "url": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-promise"
         }
       ]
     },
@@ -11567,6 +14955,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-regex"
+        }
       ]
     },
     {
@@ -11586,6 +14980,12 @@
           "url": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-relative"
         }
       ]
     },
@@ -11607,6 +15007,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-retry-allowed"
+        }
       ]
     },
     {
@@ -11626,6 +15032,12 @@
           "url": "https://registry.npmjs.org/is-set/-/is-set-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-set"
         }
       ]
     },
@@ -11647,6 +15059,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-shared-array-buffer"
+        }
       ]
     },
     {
@@ -11666,6 +15084,12 @@
           "url": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-stream"
         }
       ]
     },
@@ -11687,6 +15111,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-string"
+        }
       ]
     },
     {
@@ -11706,6 +15136,12 @@
           "url": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-symbol"
         }
       ]
     },
@@ -11727,6 +15163,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-typed-array"
+        }
       ]
     },
     {
@@ -11746,6 +15188,12 @@
           "url": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-typedarray"
         }
       ]
     },
@@ -11767,6 +15215,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-unc-path"
+        }
       ]
     },
     {
@@ -11786,6 +15240,12 @@
           "url": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-weakmap"
         }
       ]
     },
@@ -11807,6 +15267,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-weakref"
+        }
       ]
     },
     {
@@ -11826,6 +15292,12 @@
           "url": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-weakset"
         }
       ]
     },
@@ -11847,6 +15319,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-windows"
+        }
       ]
     },
     {
@@ -11866,6 +15344,12 @@
           "url": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isarray"
         }
       ]
     },
@@ -11887,6 +15371,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isexe"
+        }
       ]
     },
     {
@@ -11906,6 +15396,12 @@
           "url": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isobject"
         }
       ]
     },
@@ -11927,6 +15423,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isstream"
+        }
       ]
     },
     {
@@ -11946,6 +15448,12 @@
           "url": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isurl"
         }
       ]
     },
@@ -11967,6 +15475,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/js-stringify"
+        }
       ]
     },
     {
@@ -11986,6 +15500,12 @@
           "url": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/js-tokens"
         }
       ]
     },
@@ -12007,6 +15527,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/js-yaml"
+        }
       ]
     },
     {
@@ -12026,6 +15552,12 @@
           "url": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jsbn"
         }
       ]
     },
@@ -12047,6 +15579,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-buffer"
+        }
       ]
     },
     {
@@ -12066,6 +15604,12 @@
           "url": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-parse-better-errors"
         }
       ]
     },
@@ -12087,6 +15631,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-schema-traverse"
+        }
       ]
     },
     {
@@ -12106,6 +15656,12 @@
           "url": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-schema"
         }
       ]
     },
@@ -12127,6 +15683,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-stringify-safe"
+        }
       ]
     },
     {
@@ -12146,6 +15708,12 @@
           "url": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json5"
         }
       ]
     },
@@ -12167,6 +15735,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jsonfile"
+        }
       ]
     },
     {
@@ -12186,6 +15760,12 @@
           "url": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-0.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jsonwebtoken"
         }
       ]
     },
@@ -12207,6 +15787,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jsprim"
+        }
       ]
     },
     {
@@ -12226,6 +15812,12 @@
           "url": "https://registry.npmjs.org/jssha/-/jssha-3.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jssha"
         }
       ]
     },
@@ -12247,6 +15839,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jstransformer"
+        }
       ]
     },
     {
@@ -12266,6 +15864,12 @@
           "url": "https://registry.npmjs.org/juicy-chat-bot/-/juicy-chat-bot-0.6.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/juicy-chat-bot"
         }
       ]
     },
@@ -12287,6 +15891,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jwa"
+        }
       ]
     },
     {
@@ -12306,6 +15916,12 @@
           "url": "https://registry.npmjs.org/jws/-/jws-0.2.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jws"
         }
       ]
     },
@@ -12327,6 +15943,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/keyv"
+        }
       ]
     },
     {
@@ -12346,6 +15968,12 @@
           "url": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/kind-of"
         }
       ]
     },
@@ -12367,6 +15995,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/kuler"
+        }
       ]
     },
     {
@@ -12386,6 +16020,12 @@
           "url": "https://registry.npmjs.org/kuromoji/-/kuromoji-0.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/kuromoji"
         }
       ]
     },
@@ -12407,6 +16047,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lazystream"
+        }
       ]
     },
     {
@@ -12426,6 +16072,12 @@
           "url": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/levn"
         }
       ]
     },
@@ -12448,6 +16100,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/libxmljs2"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12466,6 +16124,12 @@
               "url": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/libxmljs2/node_modules/nan"
             }
           ]
         }
@@ -12490,6 +16154,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/liftup"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12508,6 +16178,12 @@
               "url": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/braces"
             }
           ]
         },
@@ -12529,6 +16205,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/fill-range"
+            }
           ]
         },
         {
@@ -12548,6 +16230,12 @@
               "url": "https://registry.npmjs.org/findup-sync/-/findup-sync-4.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/findup-sync"
             }
           ]
         },
@@ -12569,6 +16257,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/is-glob"
+            }
           ]
         },
         {
@@ -12588,6 +16282,12 @@
               "url": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/is-number"
             }
           ]
         },
@@ -12609,6 +16309,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/micromatch"
+            }
           ]
         },
         {
@@ -12628,6 +16334,12 @@
               "url": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/to-regex-range"
             }
           ]
         }
@@ -12652,6 +16364,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/linebreak"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12670,6 +16388,12 @@
               "url": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/linebreak/node_modules/base64-js"
             }
           ]
         }
@@ -12693,6 +16417,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/listenercount"
+        }
       ]
     },
     {
@@ -12712,6 +16442,12 @@
           "url": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/locate-path"
         }
       ]
     },
@@ -12733,6 +16469,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lodash.camelcase"
+        }
       ]
     },
     {
@@ -12752,6 +16494,12 @@
           "url": "https://registry.npmjs.org/lodash.isfinite/-/lodash.isfinite-3.3.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lodash.isfinite"
         }
       ]
     },
@@ -12773,6 +16521,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lodash.set"
+        }
       ]
     },
     {
@@ -12792,6 +16546,12 @@
           "url": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lodash"
         }
       ]
     },
@@ -12814,6 +16574,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/logform"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12832,6 +16598,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/logform/node_modules/ms"
             }
           ]
         }
@@ -12855,6 +16627,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lolex"
+        }
       ]
     },
     {
@@ -12874,6 +16652,12 @@
           "url": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/loose-envify"
         }
       ]
     },
@@ -12895,6 +16679,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lowercase-keys"
+        }
       ]
     },
     {
@@ -12914,6 +16704,12 @@
           "url": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lru-cache"
         }
       ]
     },
@@ -12936,6 +16732,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-dir"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12954,6 +16756,12 @@
               "url": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-dir/node_modules/semver"
             }
           ]
         }
@@ -12977,6 +16785,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-error"
+        }
       ]
     },
     {
@@ -12996,6 +16810,12 @@
           "url": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-9.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-fetch-happen"
         }
       ],
       "components": [
@@ -13018,6 +16838,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen/node_modules/@tootallnate/once"
+            }
           ]
         },
         {
@@ -13037,6 +16863,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen/node_modules/debug"
             }
           ]
         },
@@ -13058,6 +16890,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen/node_modules/http-cache-semantics"
+            }
           ]
         },
         {
@@ -13078,6 +16916,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen/node_modules/http-proxy-agent"
+            }
           ]
         },
         {
@@ -13097,6 +16941,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen/node_modules/ms"
             }
           ]
         }
@@ -13120,6 +16970,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-iterator"
+        }
       ]
     },
     {
@@ -13139,6 +16995,12 @@
           "url": "https://registry.npmjs.org/make-plural/-/make-plural-6.2.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-plural"
         }
       ]
     },
@@ -13160,6 +17022,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/map-cache"
+        }
       ]
     },
     {
@@ -13179,6 +17047,12 @@
           "url": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/map-visit"
         }
       ]
     },
@@ -13200,6 +17074,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/marsdb"
+        }
       ]
     },
     {
@@ -13219,6 +17099,12 @@
           "url": "https://registry.npmjs.org/math-interval-parser/-/math-interval-parser-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/math-interval-parser"
         }
       ]
     },
@@ -13240,6 +17126,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/media-typer"
+        }
       ]
     },
     {
@@ -13259,6 +17151,12 @@
           "url": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/merge-descriptors"
         }
       ]
     },
@@ -13280,6 +17178,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/messageformat-formatters"
+        }
       ]
     },
     {
@@ -13299,6 +17203,12 @@
           "url": "https://registry.npmjs.org/messageformat-parser/-/messageformat-parser-4.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/messageformat-parser"
         }
       ]
     },
@@ -13321,6 +17231,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/messageformat"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -13339,6 +17255,12 @@
               "url": "https://registry.npmjs.org/make-plural/-/make-plural-4.3.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/messageformat/node_modules/make-plural"
             }
           ]
         }
@@ -13362,6 +17284,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/methods"
+        }
       ]
     },
     {
@@ -13381,6 +17309,12 @@
           "url": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/micromatch"
         }
       ]
     },
@@ -13402,6 +17336,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mime-db"
+        }
       ]
     },
     {
@@ -13421,6 +17361,12 @@
           "url": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mime-types"
         }
       ]
     },
@@ -13442,6 +17388,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mime"
+        }
       ]
     },
     {
@@ -13461,6 +17413,12 @@
           "url": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mimic-response"
         }
       ]
     },
@@ -13482,6 +17440,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minimatch"
+        }
       ]
     },
     {
@@ -13501,6 +17465,12 @@
           "url": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minimist"
         }
       ]
     },
@@ -13522,6 +17492,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-collect"
+        }
       ]
     },
     {
@@ -13541,6 +17517,12 @@
           "url": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-1.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-fetch"
         }
       ]
     },
@@ -13562,6 +17544,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-flush"
+        }
       ]
     },
     {
@@ -13581,6 +17569,12 @@
           "url": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-pipeline"
         }
       ]
     },
@@ -13602,6 +17596,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-sized"
+        }
       ]
     },
     {
@@ -13621,6 +17621,12 @@
           "url": "https://registry.npmjs.org/minipass/-/minipass-3.3.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass"
         }
       ]
     },
@@ -13642,6 +17648,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minizlib"
+        }
       ]
     },
     {
@@ -13661,6 +17673,12 @@
           "url": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mixin-deep"
         }
       ]
     },
@@ -13682,6 +17700,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mkdirp-classic"
+        }
       ]
     },
     {
@@ -13701,6 +17725,12 @@
           "url": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mkdirp"
         }
       ]
     },
@@ -13722,6 +17752,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/moment-timezone"
+        }
       ]
     },
     {
@@ -13741,6 +17777,12 @@
           "url": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/moment"
         }
       ]
     },
@@ -13763,6 +17805,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/morgan"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -13781,6 +17829,12 @@
               "url": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/morgan/node_modules/on-finished"
             }
           ]
         }
@@ -13804,6 +17858,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mout"
+        }
       ]
     },
     {
@@ -13823,6 +17883,12 @@
           "url": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ms"
         }
       ]
     },
@@ -13845,6 +17911,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/multer"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -13863,6 +17935,12 @@
               "url": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/multer/node_modules/mkdirp"
             }
           ]
         }
@@ -13886,6 +17964,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mustache"
+        }
       ]
     },
     {
@@ -13905,6 +17989,12 @@
           "url": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/nan"
         }
       ]
     },
@@ -13926,6 +18016,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/nanomatch"
+        }
       ]
     },
     {
@@ -13945,6 +18041,12 @@
           "url": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/napi-build-utils"
         }
       ]
     },
@@ -13967,6 +18069,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/needle"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -13985,6 +18093,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/needle/node_modules/debug"
             }
           ]
         },
@@ -14005,6 +18119,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/needle/node_modules/ms"
             }
           ]
         }
@@ -14028,6 +18148,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/negotiator"
+        }
       ]
     },
     {
@@ -14047,6 +18173,12 @@
           "url": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/neo-async"
         }
       ]
     },
@@ -14069,6 +18201,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-abi"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14087,6 +18225,12 @@
               "url": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-abi/node_modules/semver"
             }
           ]
         }
@@ -14110,6 +18254,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-addon-api"
+        }
       ]
     },
     {
@@ -14129,6 +18279,12 @@
           "url": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-fetch"
         }
       ]
     },
@@ -14151,6 +18307,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-gyp"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14169,6 +18331,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/ansi-regex"
             }
           ]
         },
@@ -14190,6 +18358,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/are-we-there-yet"
+            }
           ]
         },
         {
@@ -14209,6 +18383,12 @@
               "url": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/gauge"
             }
           ]
         },
@@ -14230,6 +18410,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/is-fullwidth-code-point"
+            }
           ]
         },
         {
@@ -14249,6 +18435,12 @@
               "url": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/nopt"
             }
           ]
         },
@@ -14270,6 +18462,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/npmlog"
+            }
           ]
         },
         {
@@ -14289,6 +18487,12 @@
               "url": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/readable-stream"
             }
           ]
         },
@@ -14310,6 +18514,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/string-width"
+            }
           ]
         },
         {
@@ -14329,6 +18539,12 @@
               "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/strip-ansi"
             }
           ]
         }
@@ -14353,6 +18569,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-pre-gyp"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14371,6 +18593,12 @@
               "url": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/chownr"
             }
           ]
         },
@@ -14392,6 +18620,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/fs-minipass"
+            }
           ]
         },
         {
@@ -14411,6 +18645,12 @@
               "url": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/minipass"
             }
           ]
         },
@@ -14432,6 +18672,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/minizlib"
+            }
           ]
         },
         {
@@ -14451,6 +18697,12 @@
               "url": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/mkdirp"
             }
           ]
         },
@@ -14472,6 +18724,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/nopt"
+            }
           ]
         },
         {
@@ -14491,6 +18749,12 @@
               "url": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/rimraf"
             }
           ]
         },
@@ -14512,6 +18776,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/safe-buffer"
+            }
           ]
         },
         {
@@ -14531,6 +18801,12 @@
               "url": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/semver"
             }
           ]
         },
@@ -14552,6 +18828,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/tar"
+            }
           ]
         },
         {
@@ -14571,6 +18853,12 @@
               "url": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/yallist"
             }
           ]
         }
@@ -14594,6 +18882,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/noop-logger"
+        }
       ]
     },
     {
@@ -14613,6 +18907,12 @@
           "url": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/nopt"
         }
       ]
     },
@@ -14635,6 +18935,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/normalize-package-data"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14653,6 +18959,12 @@
               "url": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/normalize-package-data/node_modules/semver"
             }
           ]
         }
@@ -14676,6 +18988,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/normalize-path"
+        }
       ]
     },
     {
@@ -14695,6 +19013,12 @@
           "url": "https://registry.npmjs.org/normalize-url/-/normalize-url-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/normalize-url"
         }
       ]
     },
@@ -14717,6 +19041,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/notevil"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14735,6 +19065,12 @@
               "url": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/notevil/node_modules/esprima"
             }
           ]
         }
@@ -14758,6 +19094,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/npm-bundled"
+        }
       ]
     },
     {
@@ -14777,6 +19119,12 @@
           "url": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/npm-normalize-package-bin"
         }
       ]
     },
@@ -14798,6 +19146,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/npm-packlist"
+        }
       ]
     },
     {
@@ -14817,6 +19171,12 @@
           "url": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/npmlog"
         }
       ]
     },
@@ -14838,6 +19198,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/number-is-nan"
+        }
       ]
     },
     {
@@ -14858,6 +19224,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/oauth-sign"
+        }
       ]
     },
     {
@@ -14877,6 +19249,12 @@
           "url": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-assign"
         }
       ]
     },
@@ -14899,6 +19277,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-copy"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14917,6 +19301,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy/node_modules/define-property"
             }
           ]
         },
@@ -14938,6 +19328,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy/node_modules/is-accessor-descriptor"
+            }
           ]
         },
         {
@@ -14957,6 +19353,12 @@
               "url": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy/node_modules/is-data-descriptor"
             }
           ]
         },
@@ -14979,6 +19381,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy/node_modules/is-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -14997,6 +19405,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/object-copy/node_modules/is-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -15020,6 +19434,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy/node_modules/kind-of"
+            }
           ]
         }
       ]
@@ -15042,6 +19462,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-inspect"
+        }
       ]
     },
     {
@@ -15061,6 +19487,12 @@
           "url": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-is"
         }
       ]
     },
@@ -15082,6 +19514,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-keys"
+        }
       ]
     },
     {
@@ -15101,6 +19539,12 @@
           "url": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-visit"
         }
       ]
     },
@@ -15122,6 +19566,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object.assign"
+        }
       ]
     },
     {
@@ -15141,6 +19591,12 @@
           "url": "https://registry.npmjs.org/object.defaults/-/object.defaults-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object.defaults"
         }
       ]
     },
@@ -15162,6 +19618,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object.map"
+        }
       ]
     },
     {
@@ -15181,6 +19643,12 @@
           "url": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object.pick"
         }
       ]
     },
@@ -15202,6 +19670,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/on-finished"
+        }
       ]
     },
     {
@@ -15221,6 +19695,12 @@
           "url": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/on-headers"
         }
       ]
     },
@@ -15242,6 +19722,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/once"
+        }
       ]
     },
     {
@@ -15261,6 +19747,12 @@
           "url": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/one-time"
         }
       ]
     },
@@ -15282,6 +19774,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/opentype.js"
+        }
       ]
     },
     {
@@ -15301,6 +19799,12 @@
           "url": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/optionator"
         }
       ]
     },
@@ -15322,6 +19826,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/os-homedir"
+        }
       ]
     },
     {
@@ -15341,6 +19851,12 @@
           "url": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/os-tmpdir"
         }
       ]
     },
@@ -15362,6 +19878,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/osenv"
+        }
       ]
     },
     {
@@ -15381,6 +19903,12 @@
           "url": "https://registry.npmjs.org/otplib/-/otplib-12.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/otplib"
         }
       ]
     },
@@ -15402,6 +19930,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-cancelable"
+        }
       ]
     },
     {
@@ -15421,6 +19955,12 @@
           "url": "https://registry.npmjs.org/p-event/-/p-event-2.3.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-event"
         }
       ]
     },
@@ -15442,6 +19982,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-finally"
+        }
       ]
     },
     {
@@ -15461,6 +20007,12 @@
           "url": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-is-promise"
         }
       ]
     },
@@ -15482,6 +20034,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-limit"
+        }
       ]
     },
     {
@@ -15501,6 +20059,12 @@
           "url": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-locate"
         }
       ]
     },
@@ -15522,6 +20086,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-map"
+        }
       ]
     },
     {
@@ -15541,6 +20111,12 @@
           "url": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-timeout"
         }
       ]
     },
@@ -15562,6 +20138,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-try"
+        }
       ]
     },
     {
@@ -15581,6 +20163,12 @@
           "url": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pako"
         }
       ]
     },
@@ -15602,6 +20190,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/parse-filepath"
+        }
       ]
     },
     {
@@ -15621,6 +20215,12 @@
           "url": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/parse-json"
         }
       ]
     },
@@ -15642,6 +20242,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/parse-passwd"
+        }
       ]
     },
     {
@@ -15661,6 +20267,12 @@
           "url": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/parseurl"
         }
       ]
     },
@@ -15682,6 +20294,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pascalcase"
+        }
       ]
     },
     {
@@ -15701,6 +20319,12 @@
           "url": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-exists"
         }
       ]
     },
@@ -15722,6 +20346,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-is-absolute"
+        }
       ]
     },
     {
@@ -15741,6 +20371,12 @@
           "url": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-parse"
         }
       ]
     },
@@ -15762,6 +20398,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-root-regex"
+        }
       ]
     },
     {
@@ -15781,6 +20423,12 @@
           "url": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-root"
         }
       ]
     },
@@ -15802,6 +20450,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-to-regexp"
+        }
       ]
     },
     {
@@ -15821,6 +20475,12 @@
           "url": "https://registry.npmjs.org/pdfkit/-/pdfkit-0.11.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pdfkit"
         }
       ]
     },
@@ -15842,6 +20502,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/peek-readable"
+        }
       ]
     },
     {
@@ -15861,6 +20527,12 @@
           "url": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pend"
         }
       ]
     },
@@ -15882,6 +20554,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/performance-now"
+        }
       ]
     },
     {
@@ -15901,6 +20579,12 @@
           "url": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.5.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pg-connection-string"
         }
       ]
     },
@@ -15922,6 +20606,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/picomatch"
+        }
       ]
     },
     {
@@ -15941,6 +20631,12 @@
           "url": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pify"
         }
       ]
     },
@@ -15962,6 +20658,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pinkie-promise"
+        }
       ]
     },
     {
@@ -15981,6 +20683,12 @@
           "url": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pinkie"
         }
       ]
     },
@@ -16002,6 +20710,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/png-js"
+        }
       ]
     },
     {
@@ -16021,6 +20735,12 @@
           "url": "https://registry.npmjs.org/portscanner/-/portscanner-2.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/portscanner"
         }
       ]
     },
@@ -16042,6 +20762,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/posix-character-classes"
+        }
       ]
     },
     {
@@ -16061,6 +20787,12 @@
           "url": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.3.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/prebuild-install"
         }
       ]
     },
@@ -16082,6 +20814,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/prelude-ls"
+        }
       ]
     },
     {
@@ -16101,6 +20839,12 @@
           "url": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/prepend-http"
         }
       ]
     },
@@ -16122,6 +20866,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pretty-bytes"
+        }
       ]
     },
     {
@@ -16141,6 +20891,12 @@
           "url": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/process-nextick-args"
         }
       ]
     },
@@ -16162,6 +20918,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/prom-client"
+        }
       ]
     },
     {
@@ -16181,6 +20943,12 @@
           "url": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/promise-inflight"
         }
       ]
     },
@@ -16203,6 +20971,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/promise-retry"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -16221,6 +20995,12 @@
               "url": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/promise-retry/node_modules/err-code"
             }
           ]
         },
@@ -16241,6 +21021,12 @@
               "url": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/promise-retry/node_modules/retry"
             }
           ]
         }
@@ -16264,6 +21050,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/promise"
+        }
       ]
     },
     {
@@ -16283,6 +21075,12 @@
           "url": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/proper-lockfile"
         }
       ]
     },
@@ -16304,6 +21102,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/proxy-addr"
+        }
       ]
     },
     {
@@ -16323,6 +21127,12 @@
           "url": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/psl"
         }
       ]
     },
@@ -16344,6 +21154,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-attrs"
+        }
       ]
     },
     {
@@ -16363,6 +21179,12 @@
           "url": "https://registry.npmjs.org/pug-code-gen/-/pug-code-gen-3.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-code-gen"
         }
       ]
     },
@@ -16384,6 +21206,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-error"
+        }
       ]
     },
     {
@@ -16403,6 +21231,12 @@
           "url": "https://registry.npmjs.org/pug-filters/-/pug-filters-4.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-filters"
         }
       ]
     },
@@ -16424,6 +21258,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-lexer"
+        }
       ]
     },
     {
@@ -16443,6 +21283,12 @@
           "url": "https://registry.npmjs.org/pug-linker/-/pug-linker-4.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-linker"
         }
       ]
     },
@@ -16464,6 +21310,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-load"
+        }
       ]
     },
     {
@@ -16483,6 +21335,12 @@
           "url": "https://registry.npmjs.org/pug-parser/-/pug-parser-6.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-parser"
         }
       ]
     },
@@ -16504,6 +21362,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-runtime"
+        }
       ]
     },
     {
@@ -16523,6 +21387,12 @@
           "url": "https://registry.npmjs.org/pug-strip-comments/-/pug-strip-comments-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-strip-comments"
         }
       ]
     },
@@ -16544,6 +21414,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-walk"
+        }
       ]
     },
     {
@@ -16563,6 +21439,12 @@
           "url": "https://registry.npmjs.org/pug/-/pug-3.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug"
         }
       ]
     },
@@ -16584,6 +21466,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pump"
+        }
       ]
     },
     {
@@ -16603,6 +21491,12 @@
           "url": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/punycode"
         }
       ]
     },
@@ -16624,6 +21518,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/qs"
+        }
       ]
     },
     {
@@ -16643,6 +21543,12 @@
           "url": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/query-string"
         }
       ]
     },
@@ -16664,6 +21570,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/range_check"
+        }
       ]
     },
     {
@@ -16683,6 +21595,12 @@
           "url": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/range-parser"
         }
       ]
     },
@@ -16704,6 +21622,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/raw-body"
+        }
       ]
     },
     {
@@ -16723,6 +21647,12 @@
           "url": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/rc"
         }
       ]
     },
@@ -16745,6 +21675,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/read-pkg"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -16763,6 +21699,12 @@
               "url": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/read-pkg/node_modules/pify"
             }
           ]
         }
@@ -16787,6 +21729,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/readable-stream"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -16805,6 +21753,12 @@
               "url": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/readable-stream/node_modules/isarray"
             }
           ]
         }
@@ -16829,6 +21783,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/readable-web-to-node-stream"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -16847,6 +21807,12 @@
               "url": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/readable-web-to-node-stream/node_modules/readable-stream"
             }
           ]
         }
@@ -16870,6 +21836,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/readdirp"
+        }
       ]
     },
     {
@@ -16889,6 +21861,12 @@
           "url": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/rechoir"
         }
       ]
     },
@@ -16910,6 +21888,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/regex-not"
+        }
       ]
     },
     {
@@ -16929,6 +21913,12 @@
           "url": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/regexp.prototype.flags"
         }
       ]
     },
@@ -16950,6 +21940,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/remove-trailing-separator"
+        }
       ]
     },
     {
@@ -16970,6 +21966,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/repeat-element"
+        }
       ]
     },
     {
@@ -16989,6 +21991,12 @@
           "url": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/repeat-string"
         }
       ]
     },
@@ -17011,6 +22019,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/replace"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17029,6 +22043,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/ansi-regex"
             }
           ]
         },
@@ -17050,6 +22070,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/ansi-styles"
+            }
           ]
         },
         {
@@ -17069,6 +22095,12 @@
               "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/brace-expansion"
             }
           ]
         },
@@ -17090,6 +22122,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/cliui"
+            }
           ]
         },
         {
@@ -17109,6 +22147,12 @@
               "url": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/color-convert"
             }
           ]
         },
@@ -17130,6 +22174,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/color-name"
+            }
           ]
         },
         {
@@ -17149,6 +22199,12 @@
               "url": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/find-up"
             }
           ]
         },
@@ -17170,6 +22226,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/is-fullwidth-code-point"
+            }
           ]
         },
         {
@@ -17189,6 +22251,12 @@
               "url": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/locate-path"
             }
           ]
         },
@@ -17210,6 +22278,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/minimatch"
+            }
           ]
         },
         {
@@ -17229,6 +22303,12 @@
               "url": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/p-locate"
             }
           ]
         },
@@ -17250,6 +22330,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/path-exists"
+            }
           ]
         },
         {
@@ -17269,6 +22355,12 @@
               "url": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/string-width"
             }
           ]
         },
@@ -17290,6 +22382,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/strip-ansi"
+            }
           ]
         },
         {
@@ -17309,6 +22407,12 @@
               "url": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/wrap-ansi"
             }
           ]
         },
@@ -17330,6 +22434,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/yargs-parser"
+            }
           ]
         },
         {
@@ -17349,6 +22459,12 @@
               "url": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/yargs"
             }
           ]
         }
@@ -17373,6 +22489,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/request"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17391,6 +22513,12 @@
               "url": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/request/node_modules/qs"
             }
           ]
         }
@@ -17414,6 +22542,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/require-directory"
+        }
       ]
     },
     {
@@ -17433,6 +22567,12 @@
           "url": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/require-main-filename"
         }
       ]
     },
@@ -17454,6 +22594,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/resolve-dir"
+        }
       ]
     },
     {
@@ -17473,6 +22619,12 @@
           "url": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/resolve-url"
         }
       ]
     },
@@ -17494,6 +22646,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/resolve"
+        }
       ]
     },
     {
@@ -17513,6 +22671,12 @@
           "url": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/responselike"
         }
       ]
     },
@@ -17534,6 +22698,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/restructure"
+        }
       ]
     },
     {
@@ -17553,6 +22723,12 @@
           "url": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ret"
         }
       ]
     },
@@ -17574,6 +22750,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/retry-as-promised"
+        }
       ]
     },
     {
@@ -17594,6 +22776,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/retry"
+        }
       ]
     },
     {
@@ -17613,6 +22801,12 @@
           "url": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/rimraf"
         }
       ]
     },
@@ -17635,6 +22829,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/rxjs"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17653,6 +22853,12 @@
               "url": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/rxjs/node_modules/tslib"
             }
           ]
         }
@@ -17676,6 +22882,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safe-buffer"
+        }
       ]
     },
     {
@@ -17695,6 +22907,12 @@
           "url": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safe-regex-test"
         }
       ]
     },
@@ -17716,6 +22934,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safe-regex"
+        }
       ]
     },
     {
@@ -17735,6 +22959,12 @@
           "url": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safe-stable-stringify"
         }
       ]
     },
@@ -17756,6 +22986,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safer-buffer"
+        }
       ]
     },
     {
@@ -17776,6 +23012,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/samsam"
+        }
       ]
     },
     {
@@ -17795,6 +23037,12 @@
           "url": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sanitize-filename"
         }
       ]
     },
@@ -17817,6 +23065,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sanitize-html"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17835,6 +23089,12 @@
               "url": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sanitize-html/node_modules/lodash"
             }
           ]
         }
@@ -17858,6 +23118,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sax"
+        }
       ]
     },
     {
@@ -17878,6 +23144,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/seek-bzip"
+        }
       ]
     },
     {
@@ -17897,6 +23169,12 @@
           "url": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/semver"
         }
       ]
     },
@@ -17919,6 +23197,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/send"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17937,6 +23221,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/send/node_modules/ms"
             }
           ]
         }
@@ -17960,6 +23250,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sequelize-pool"
+        }
       ]
     },
     {
@@ -17981,6 +23277,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sequelize"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17999,6 +23301,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sequelize/node_modules/debug"
             }
           ]
         },
@@ -18020,6 +23328,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sequelize/node_modules/ms"
+            }
           ]
         },
         {
@@ -18039,6 +23353,12 @@
               "url": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sequelize/node_modules/uuid"
             }
           ]
         }
@@ -18063,6 +23383,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/serve-index"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18081,6 +23407,12 @@
               "url": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index/node_modules/depd"
             }
           ]
         },
@@ -18102,6 +23434,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index/node_modules/http-errors"
+            }
           ]
         },
         {
@@ -18121,6 +23459,12 @@
               "url": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index/node_modules/inherits"
             }
           ]
         },
@@ -18142,6 +23486,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index/node_modules/setprototypeof"
+            }
           ]
         },
         {
@@ -18161,6 +23511,12 @@
               "url": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index/node_modules/statuses"
             }
           ]
         }
@@ -18184,6 +23540,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/serve-static"
+        }
       ]
     },
     {
@@ -18203,6 +23565,12 @@
           "url": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/set-blocking"
         }
       ]
     },
@@ -18225,6 +23593,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/set-value"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18243,6 +23617,12 @@
               "url": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/set-value/node_modules/extend-shallow"
             }
           ]
         },
@@ -18263,6 +23643,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/set-value/node_modules/is-extendable"
             }
           ]
         }
@@ -18286,6 +23672,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/setimmediate"
+        }
       ]
     },
     {
@@ -18305,6 +23697,12 @@
           "url": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/setprototypeof"
         }
       ]
     },
@@ -18326,6 +23724,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/side-channel"
+        }
       ]
     },
     {
@@ -18346,6 +23750,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/signal-exit"
+        }
       ]
     },
     {
@@ -18365,6 +23775,12 @@
           "url": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/simple-concat"
         }
       ]
     },
@@ -18387,6 +23803,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/simple-get"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18405,6 +23827,12 @@
               "url": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/simple-get/node_modules/decompress-response"
             }
           ]
         },
@@ -18425,6 +23853,12 @@
               "url": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/simple-get/node_modules/mimic-response"
             }
           ]
         }
@@ -18449,6 +23883,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/simple-swizzle"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18467,6 +23907,12 @@
               "url": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/simple-swizzle/node_modules/is-arrayish"
             }
           ]
         }
@@ -18490,6 +23936,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sinon"
+        }
       ]
     },
     {
@@ -18509,6 +23961,12 @@
           "url": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/smart-buffer"
         }
       ]
     },
@@ -18531,6 +23989,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/snapdragon-node"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18549,6 +24013,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon-node/node_modules/define-property"
             }
           ]
         }
@@ -18573,6 +24043,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/snapdragon-util"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18591,6 +24067,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon-util/node_modules/kind-of"
             }
           ]
         }
@@ -18615,6 +24097,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/snapdragon"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18633,6 +24121,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/define-property"
             }
           ]
         },
@@ -18653,6 +24147,12 @@
               "url": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/extend-shallow"
             }
           ]
         },
@@ -18675,6 +24175,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/is-accessor-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -18693,6 +24199,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/snapdragon/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -18717,6 +24229,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/is-data-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -18735,6 +24253,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/snapdragon/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -18758,6 +24282,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/is-descriptor"
+            }
           ]
         },
         {
@@ -18777,6 +24307,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/is-extendable"
             }
           ]
         },
@@ -18798,6 +24334,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/kind-of"
+            }
           ]
         },
         {
@@ -18817,6 +24359,12 @@
               "url": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/source-map"
             }
           ]
         }
@@ -18840,6 +24388,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socket.io-adapter"
+        }
       ]
     },
     {
@@ -18861,6 +24415,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socket.io-parser"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18879,6 +24439,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socket.io-parser/node_modules/debug"
             }
           ]
         },
@@ -18899,6 +24465,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socket.io-parser/node_modules/ms"
             }
           ]
         }
@@ -18923,6 +24495,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socket.io"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18941,6 +24519,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socket.io/node_modules/debug"
             }
           ]
         },
@@ -18961,6 +24545,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socket.io/node_modules/ms"
             }
           ]
         }
@@ -18985,6 +24575,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socks-proxy-agent"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -19003,6 +24599,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socks-proxy-agent/node_modules/debug"
             }
           ]
         },
@@ -19023,6 +24625,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socks-proxy-agent/node_modules/ms"
             }
           ]
         }
@@ -19047,6 +24655,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socks"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -19065,6 +24679,12 @@
               "url": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socks/node_modules/ip"
             }
           ]
         }
@@ -19089,6 +24709,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sort-keys-length"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -19107,6 +24733,12 @@
               "url": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sort-keys-length/node_modules/sort-keys"
             }
           ]
         }
@@ -19130,6 +24762,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sort-keys"
+        }
       ]
     },
     {
@@ -19149,6 +24787,12 @@
           "url": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/source-map-resolve"
         }
       ]
     },
@@ -19170,6 +24814,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/source-map-support"
+        }
       ]
     },
     {
@@ -19189,6 +24839,12 @@
           "url": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/source-map-url"
         }
       ]
     },
@@ -19210,6 +24866,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/source-map"
+        }
       ]
     },
     {
@@ -19229,6 +24891,12 @@
           "url": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2-1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spawn-command"
         }
       ]
     },
@@ -19250,6 +24918,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spdx-correct"
+        }
       ]
     },
     {
@@ -19269,6 +24943,12 @@
           "url": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spdx-exceptions"
         }
       ]
     },
@@ -19290,6 +24970,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spdx-expression-parse"
+        }
       ]
     },
     {
@@ -19309,6 +24995,12 @@
           "url": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.12.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spdx-license-ids"
         }
       ]
     },
@@ -19330,6 +25022,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/split-string"
+        }
       ]
     },
     {
@@ -19349,6 +25047,12 @@
           "url": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sprintf-js"
         }
       ]
     },
@@ -19370,6 +25074,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sqlite3"
+        }
       ]
     },
     {
@@ -19389,6 +25099,12 @@
           "url": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sshpk"
         }
       ]
     },
@@ -19410,6 +25126,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ssri"
+        }
       ]
     },
     {
@@ -19429,6 +25151,12 @@
           "url": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/stack-trace"
         }
       ]
     },
@@ -19451,6 +25179,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/static-extend"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -19469,6 +25203,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend/node_modules/define-property"
             }
           ]
         },
@@ -19491,6 +25231,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend/node_modules/is-accessor-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -19509,6 +25255,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/static-extend/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -19533,6 +25285,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend/node_modules/is-data-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -19551,6 +25309,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/static-extend/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -19574,6 +25338,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend/node_modules/is-descriptor"
+            }
           ]
         },
         {
@@ -19593,6 +25363,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend/node_modules/kind-of"
             }
           ]
         }
@@ -19616,6 +25392,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/statuses"
+        }
       ]
     },
     {
@@ -19635,6 +25417,12 @@
           "url": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-2.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/stream-buffers"
         }
       ]
     },
@@ -19656,6 +25444,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/streamsearch"
+        }
       ]
     },
     {
@@ -19675,6 +25469,12 @@
           "url": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strict-uri-encode"
         }
       ]
     },
@@ -19696,6 +25496,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string_decoder"
+        }
       ]
     },
     {
@@ -19715,6 +25521,12 @@
           "url": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string-width"
         }
       ]
     },
@@ -19736,6 +25548,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string.fromcodepoint"
+        }
       ]
     },
     {
@@ -19755,6 +25573,12 @@
           "url": "https://registry.npmjs.org/string.prototype.codepointat/-/string.prototype.codepointat-0.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string.prototype.codepointat"
         }
       ]
     },
@@ -19776,6 +25600,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string.prototype.trimend"
+        }
       ]
     },
     {
@@ -19795,6 +25625,12 @@
           "url": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string.prototype.trimstart"
         }
       ]
     },
@@ -19816,6 +25652,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-ansi"
+        }
       ]
     },
     {
@@ -19835,6 +25677,12 @@
           "url": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-bom"
         }
       ]
     },
@@ -19856,6 +25704,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-dirs"
+        }
       ]
     },
     {
@@ -19875,6 +25729,12 @@
           "url": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-json-comments"
         }
       ]
     },
@@ -19896,6 +25756,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-outer"
+        }
       ]
     },
     {
@@ -19915,6 +25781,12 @@
           "url": "https://registry.npmjs.org/strtok3/-/strtok3-6.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strtok3"
         }
       ]
     },
@@ -19936,6 +25808,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/supports-color"
+        }
       ]
     },
     {
@@ -19955,6 +25833,12 @@
           "url": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/supports-preserve-symlinks-flag"
         }
       ]
     },
@@ -19976,6 +25860,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/svg-captcha"
+        }
       ]
     },
     {
@@ -19996,6 +25886,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/swagger-ui-dist"
+        }
       ]
     },
     {
@@ -20015,6 +25911,12 @@
           "url": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-4.5.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/swagger-ui-express"
         }
       ]
     },
@@ -20037,6 +25939,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tar-fs"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -20055,6 +25963,12 @@
               "url": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/tar-fs/node_modules/bl"
             }
           ]
         },
@@ -20076,6 +25990,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/tar-fs/node_modules/chownr"
+            }
           ]
         },
         {
@@ -20096,6 +26016,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/tar-fs/node_modules/readable-stream"
+            }
           ]
         },
         {
@@ -20115,6 +26041,12 @@
               "url": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/tar-fs/node_modules/tar-stream"
             }
           ]
         }
@@ -20138,6 +26070,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tar-stream"
+        }
       ]
     },
     {
@@ -20157,6 +26095,12 @@
           "url": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tar"
         }
       ]
     },
@@ -20178,6 +26122,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tdigest"
+        }
       ]
     },
     {
@@ -20197,6 +26147,12 @@
           "url": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/text-hex"
         }
       ]
     },
@@ -20218,6 +26174,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/thirty-two"
+        }
       ]
     },
     {
@@ -20237,6 +26199,12 @@
           "url": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/through"
         }
       ]
     },
@@ -20258,6 +26226,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/timed-out"
+        }
       ]
     },
     {
@@ -20277,6 +26251,12 @@
           "url": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tiny-inflate"
         }
       ]
     },
@@ -20298,6 +26278,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-buffer"
+        }
       ]
     },
     {
@@ -20317,6 +26303,12 @@
           "url": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-fast-properties"
         }
       ]
     },
@@ -20339,6 +26331,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-object-path"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -20357,6 +26355,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/to-object-path/node_modules/kind-of"
             }
           ]
         }
@@ -20380,6 +26384,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-regex-range"
+        }
       ]
     },
     {
@@ -20399,6 +26409,12 @@
           "url": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-regex"
         }
       ]
     },
@@ -20420,6 +26436,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/toidentifier"
+        }
       ]
     },
     {
@@ -20439,6 +26461,12 @@
           "url": "https://registry.npmjs.org/token-stream/-/token-stream-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/token-stream"
         }
       ]
     },
@@ -20460,6 +26488,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/token-types"
+        }
       ]
     },
     {
@@ -20479,6 +26513,12 @@
           "url": "https://registry.npmjs.org/toposort-class/-/toposort-class-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/toposort-class"
         }
       ]
     },
@@ -20500,6 +26540,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tough-cookie"
+        }
       ]
     },
     {
@@ -20519,6 +26565,12 @@
           "url": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tr46"
         }
       ]
     },
@@ -20540,6 +26592,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/traverse"
+        }
       ]
     },
     {
@@ -20559,6 +26617,12 @@
           "url": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tree-kill"
         }
       ]
     },
@@ -20580,6 +26644,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/trim-repeated"
+        }
       ]
     },
     {
@@ -20600,6 +26670,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/triple-beam"
+        }
       ]
     },
     {
@@ -20619,6 +26695,12 @@
           "url": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/truncate-utf8-bytes"
         }
       ]
     },
@@ -20641,6 +26723,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ts-node-dev"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -20659,6 +26747,12 @@
               "url": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/ts-node-dev/node_modules/rimraf"
             }
           ]
         }
@@ -20682,6 +26776,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ts-node"
+        }
       ]
     },
     {
@@ -20701,6 +26801,12 @@
           "url": "https://registry.npmjs.org/tsconfig/-/tsconfig-7.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tsconfig"
         }
       ]
     },
@@ -20722,6 +26828,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tslib"
+        }
       ]
     },
     {
@@ -20741,6 +26853,12 @@
           "url": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tunnel-agent"
         }
       ]
     },
@@ -20762,6 +26880,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tweetnacl"
+        }
       ]
     },
     {
@@ -20781,6 +26905,12 @@
           "url": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/type-check"
         }
       ]
     },
@@ -20802,6 +26932,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/type-is"
+        }
       ]
     },
     {
@@ -20821,6 +26957,12 @@
           "url": "https://registry.npmjs.org/typecast/-/typecast-0.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/typecast"
         }
       ]
     },
@@ -20842,6 +26984,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/typedarray"
+        }
       ]
     },
     {
@@ -20861,6 +27009,12 @@
           "url": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/typescript"
         }
       ]
     },
@@ -20882,6 +27036,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/uglify-js"
+        }
       ]
     },
     {
@@ -20901,6 +27061,12 @@
           "url": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unbox-primitive"
         }
       ]
     },
@@ -20922,6 +27088,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unbzip2-stream"
+        }
       ]
     },
     {
@@ -20941,6 +27113,12 @@
           "url": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unc-path-regex"
         }
       ]
     },
@@ -20962,6 +27140,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/underscore.string"
+        }
       ]
     },
     {
@@ -20982,6 +27166,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unicode-properties"
+        }
       ]
     },
     {
@@ -21001,6 +27191,12 @@
           "url": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unicode-trie"
         }
       ]
     },
@@ -21023,6 +27219,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/union-value"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21041,6 +27243,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/union-value/node_modules/is-extendable"
             }
           ]
         }
@@ -21064,6 +27272,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unique-filename"
+        }
       ]
     },
     {
@@ -21083,6 +27297,12 @@
           "url": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unique-slug"
         }
       ]
     },
@@ -21104,6 +27324,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unit-compare"
+        }
       ]
     },
     {
@@ -21124,6 +27350,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/universalify"
+        }
       ]
     },
     {
@@ -21143,6 +27375,12 @@
           "url": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unpipe"
         }
       ]
     },
@@ -21165,6 +27403,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unset-value"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21185,6 +27429,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/unset-value/node_modules/has-value"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -21203,6 +27453,12 @@
                   "url": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/unset-value/node_modules/has-value/node_modules/isobject"
                 }
               ]
             }
@@ -21226,6 +27482,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/unset-value/node_modules/has-values"
+            }
           ]
         },
         {
@@ -21245,6 +27507,12 @@
               "url": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/unset-value/node_modules/isarray"
             }
           ]
         }
@@ -21268,6 +27536,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/untildify"
+        }
       ]
     },
     {
@@ -21289,6 +27563,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unzipper"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21307,6 +27587,12 @@
               "url": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/unzipper/node_modules/bluebird"
             }
           ]
         }
@@ -21330,6 +27616,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/uri-js"
+        }
       ]
     },
     {
@@ -21349,6 +27641,12 @@
           "url": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/urix"
         }
       ]
     },
@@ -21370,6 +27668,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/url-parse-lax"
+        }
       ]
     },
     {
@@ -21389,6 +27693,12 @@
           "url": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/url-to-options"
         }
       ]
     },
@@ -21410,6 +27720,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/use"
+        }
       ]
     },
     {
@@ -21429,6 +27745,12 @@
           "url": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/utf8-byte-length"
         }
       ]
     },
@@ -21450,6 +27772,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/util-deprecate"
+        }
       ]
     },
     {
@@ -21469,6 +27797,12 @@
           "url": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/util"
         }
       ]
     },
@@ -21490,6 +27824,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/utils-merge"
+        }
       ]
     },
     {
@@ -21509,6 +27849,12 @@
           "url": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/uuid"
         }
       ]
     },
@@ -21530,6 +27876,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/v8flags"
+        }
       ]
     },
     {
@@ -21549,6 +27901,12 @@
           "url": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/validate-npm-package-license"
         }
       ]
     },
@@ -21570,6 +27928,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/validate"
+        }
       ]
     },
     {
@@ -21590,6 +27954,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/validator"
+        }
       ]
     },
     {
@@ -21609,6 +27979,12 @@
           "url": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/vary"
         }
       ]
     },
@@ -21631,6 +28007,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/verror"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21649,6 +28031,12 @@
               "url": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/verror/node_modules/core-util-is"
             }
           ]
         }
@@ -21673,6 +28061,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/vm2"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21691,6 +28085,12 @@
               "url": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/vm2/node_modules/acorn"
             }
           ]
         }
@@ -21714,6 +28114,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/void-elements"
+        }
       ]
     },
     {
@@ -21733,6 +28139,12 @@
           "url": "https://registry.npmjs.org/walk/-/walk-2.3.15.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/walk"
         }
       ]
     },
@@ -21754,6 +28166,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/walkdir"
+        }
       ]
     },
     {
@@ -21773,6 +28191,12 @@
           "url": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/webidl-conversions"
         }
       ]
     },
@@ -21794,6 +28218,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/whatwg-url"
+        }
       ]
     },
     {
@@ -21813,6 +28243,12 @@
           "url": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-boxed-primitive"
         }
       ]
     },
@@ -21834,6 +28270,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-collection"
+        }
       ]
     },
     {
@@ -21853,6 +28295,12 @@
           "url": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-module"
         }
       ]
     },
@@ -21874,6 +28322,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-pm-runs"
+        }
       ]
     },
     {
@@ -21893,6 +28347,12 @@
           "url": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-typed-array"
         }
       ]
     },
@@ -21914,6 +28374,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which"
+        }
       ]
     },
     {
@@ -21933,6 +28399,12 @@
           "url": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wide-align"
         }
       ]
     },
@@ -21955,6 +28427,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/winston-transport"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21973,6 +28451,12 @@
               "url": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/winston-transport/node_modules/readable-stream"
             }
           ]
         }
@@ -21997,6 +28481,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/winston"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -22015,6 +28505,12 @@
               "url": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/winston/node_modules/async"
             }
           ]
         },
@@ -22036,6 +28532,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/winston/node_modules/is-stream"
+            }
           ]
         },
         {
@@ -22055,6 +28557,12 @@
               "url": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/winston/node_modules/readable-stream"
             }
           ]
         }
@@ -22078,6 +28586,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/with"
+        }
       ]
     },
     {
@@ -22097,6 +28611,12 @@
           "url": "https://registry.npmjs.org/wkx/-/wkx-0.5.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wkx"
         }
       ]
     },
@@ -22118,6 +28638,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/word-wrap"
+        }
       ]
     },
     {
@@ -22137,6 +28663,12 @@
           "url": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wordwrap"
         }
       ]
     },
@@ -22159,6 +28691,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wrap-ansi"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -22177,6 +28715,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi/node_modules/ansi-regex"
             }
           ]
         },
@@ -22198,6 +28742,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi/node_modules/emoji-regex"
+            }
           ]
         },
         {
@@ -22217,6 +28767,12 @@
               "url": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi/node_modules/is-fullwidth-code-point"
             }
           ]
         },
@@ -22238,6 +28794,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi/node_modules/string-width"
+            }
           ]
         },
         {
@@ -22257,6 +28819,12 @@
               "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi/node_modules/strip-ansi"
             }
           ]
         }
@@ -22280,6 +28848,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wrappy"
+        }
       ]
     },
     {
@@ -22299,6 +28873,12 @@
           "url": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ws"
         }
       ]
     },
@@ -22320,6 +28900,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/xtend"
+        }
       ]
     },
     {
@@ -22339,6 +28925,12 @@
           "url": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/y18n"
         }
       ]
     },
@@ -22360,6 +28952,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yallist"
+        }
       ]
     },
     {
@@ -22380,6 +28978,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yaml-schema-validator"
+        }
       ]
     },
     {
@@ -22399,6 +29003,12 @@
           "url": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yargs-parser"
         }
       ]
     },
@@ -22421,6 +29031,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yargs"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -22439,6 +29055,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs/node_modules/ansi-regex"
             }
           ]
         },
@@ -22460,6 +29082,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs/node_modules/emoji-regex"
+            }
           ]
         },
         {
@@ -22479,6 +29107,12 @@
               "url": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs/node_modules/is-fullwidth-code-point"
             }
           ]
         },
@@ -22500,6 +29134,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs/node_modules/string-width"
+            }
           ]
         },
         {
@@ -22519,6 +29159,12 @@
               "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs/node_modules/strip-ansi"
             }
           ]
         }
@@ -22542,6 +29188,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yauzl"
+        }
       ]
     },
     {
@@ -22561,6 +29213,12 @@
           "url": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yn"
         }
       ]
     },
@@ -22582,6 +29240,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/z85"
+        }
       ]
     },
     {
@@ -22602,6 +29266,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/zip-stream"
+        }
       ]
     },
     {
@@ -22621,6 +29291,12 @@
           "url": "https://registry.npmjs.org/zlibjs/-/zlibjs-0.3.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/zlibjs"
         }
       ]
     }

--- a/tests/_data/sbom_demo-results/juice-shop_npm8_node16_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/juice-shop_npm8_node16_ubuntu-latest.snap.json
@@ -62,6 +62,10 @@
       ],
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -88,6 +92,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@babel/helper-string-parser"
+        }
       ]
     },
     {
@@ -108,6 +118,12 @@
           "url": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@babel/helper-validator-identifier"
         }
       ]
     },
@@ -130,6 +146,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@babel/parser"
+        }
       ]
     },
     {
@@ -150,6 +172,12 @@
           "url": "https://registry.npmjs.org/@babel/types/-/types-7.20.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@babel/types"
         }
       ]
     },
@@ -172,6 +200,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@colors/colors"
+        }
       ]
     },
     {
@@ -193,6 +227,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@dabh/diagnostics"
+        }
       ]
     },
     {
@@ -213,6 +253,12 @@
           "url": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@gar/promisify"
         }
       ]
     },
@@ -236,6 +282,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@mapbox/node-pre-gyp"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -254,6 +306,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/ansi-regex"
             }
           ]
         },
@@ -275,6 +333,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/are-we-there-yet"
+            }
           ]
         },
         {
@@ -294,6 +358,12 @@
               "url": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/detect-libc"
             }
           ]
         },
@@ -315,6 +385,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/gauge"
+            }
           ]
         },
         {
@@ -334,6 +410,12 @@
               "url": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/is-fullwidth-code-point"
             }
           ]
         },
@@ -356,6 +438,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/make-dir"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -374,6 +462,12 @@
                   "url": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/@mapbox/node-pre-gyp/node_modules/make-dir/node_modules/semver"
                 }
               ]
             }
@@ -397,6 +491,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/nopt"
+            }
           ]
         },
         {
@@ -416,6 +516,12 @@
               "url": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/npmlog"
             }
           ]
         },
@@ -437,6 +543,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/readable-stream"
+            }
           ]
         },
         {
@@ -457,6 +569,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/string-width"
+            }
           ]
         },
         {
@@ -476,6 +594,12 @@
               "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/strip-ansi"
             }
           ]
         }
@@ -500,6 +624,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/core-loader"
+        }
       ]
     },
     {
@@ -520,6 +650,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/core/-/core-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/core"
         }
       ]
     },
@@ -542,6 +678,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/evaluator"
+        }
       ]
     },
     {
@@ -562,6 +704,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-all/-/lang-all-4.24.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-all"
         }
       ]
     },
@@ -584,6 +732,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ar"
+        }
       ]
     },
     {
@@ -604,6 +758,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-bn/-/lang-bn-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-bn"
         }
       ]
     },
@@ -626,6 +786,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ca"
+        }
       ]
     },
     {
@@ -646,6 +812,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-cs/-/lang-cs-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-cs"
         }
       ]
     },
@@ -668,6 +840,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-da"
+        }
       ]
     },
     {
@@ -688,6 +866,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-de/-/lang-de-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-de"
         }
       ]
     },
@@ -710,6 +894,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-el"
+        }
       ]
     },
     {
@@ -730,6 +920,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-en-min/-/lang-en-min-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-en-min"
         }
       ]
     },
@@ -752,6 +948,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-en"
+        }
       ]
     },
     {
@@ -772,6 +974,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-es/-/lang-es-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-es"
         }
       ]
     },
@@ -794,6 +1002,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-eu"
+        }
       ]
     },
     {
@@ -814,6 +1028,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-fa/-/lang-fa-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-fa"
         }
       ]
     },
@@ -836,6 +1056,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-fi"
+        }
       ]
     },
     {
@@ -856,6 +1082,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-fr/-/lang-fr-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-fr"
         }
       ]
     },
@@ -878,6 +1110,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ga"
+        }
       ]
     },
     {
@@ -898,6 +1136,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-gl/-/lang-gl-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-gl"
         }
       ]
     },
@@ -920,6 +1164,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-hi"
+        }
       ]
     },
     {
@@ -940,6 +1190,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-hu/-/lang-hu-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-hu"
         }
       ]
     },
@@ -962,6 +1218,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-hy"
+        }
       ]
     },
     {
@@ -982,6 +1244,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-id/-/lang-id-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-id"
         }
       ]
     },
@@ -1004,6 +1272,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-it"
+        }
       ]
     },
     {
@@ -1024,6 +1298,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-ja/-/lang-ja-4.24.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ja"
         }
       ]
     },
@@ -1046,6 +1326,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ko"
+        }
       ]
     },
     {
@@ -1066,6 +1352,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-lt/-/lang-lt-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-lt"
         }
       ]
     },
@@ -1088,6 +1380,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ms"
+        }
       ]
     },
     {
@@ -1108,6 +1406,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-ne/-/lang-ne-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ne"
         }
       ]
     },
@@ -1130,6 +1434,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-nl"
+        }
       ]
     },
     {
@@ -1150,6 +1460,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-no/-/lang-no-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-no"
         }
       ]
     },
@@ -1172,6 +1488,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-pl"
+        }
       ]
     },
     {
@@ -1192,6 +1514,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-pt/-/lang-pt-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-pt"
         }
       ]
     },
@@ -1214,6 +1542,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ro"
+        }
       ]
     },
     {
@@ -1234,6 +1568,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-ru/-/lang-ru-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ru"
         }
       ]
     },
@@ -1256,6 +1596,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-sl"
+        }
       ]
     },
     {
@@ -1276,6 +1622,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-sr/-/lang-sr-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-sr"
         }
       ]
     },
@@ -1298,6 +1650,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-sv"
+        }
       ]
     },
     {
@@ -1318,6 +1676,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-ta/-/lang-ta-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ta"
         }
       ]
     },
@@ -1340,6 +1704,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-th"
+        }
       ]
     },
     {
@@ -1360,6 +1730,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-tl/-/lang-tl-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-tl"
         }
       ]
     },
@@ -1382,6 +1758,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-tr"
+        }
       ]
     },
     {
@@ -1402,6 +1784,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-uk/-/lang-uk-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-uk"
         }
       ]
     },
@@ -1424,6 +1812,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-zh"
+        }
       ]
     },
     {
@@ -1444,6 +1838,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/language-min/-/language-min-4.22.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/language-min"
         }
       ]
     },
@@ -1466,6 +1866,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/language"
+        }
       ]
     },
     {
@@ -1486,6 +1892,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/ner/-/ner-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/ner"
         }
       ]
     },
@@ -1508,6 +1920,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/neural"
+        }
       ]
     },
     {
@@ -1528,6 +1946,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/nlg/-/nlg-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/nlg"
         }
       ]
     },
@@ -1550,6 +1974,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/nlp"
+        }
       ]
     },
     {
@@ -1570,6 +2000,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/nlu/-/nlu-4.23.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/nlu"
         }
       ]
     },
@@ -1592,6 +2028,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/request"
+        }
       ]
     },
     {
@@ -1612,6 +2054,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/sentiment/-/sentiment-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/sentiment"
         }
       ]
     },
@@ -1634,6 +2082,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/similarity"
+        }
       ]
     },
     {
@@ -1654,6 +2108,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/slot/-/slot-4.22.17.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/slot"
         }
       ]
     },
@@ -1676,6 +2136,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@npmcli/fs"
+        }
       ]
     },
     {
@@ -1696,6 +2162,12 @@
           "url": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@npmcli/move-file"
         }
       ]
     },
@@ -1718,6 +2190,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib/core"
+        }
       ]
     },
     {
@@ -1738,6 +2216,12 @@
           "url": "https://registry.npmjs.org/@otplib/plugin-crypto/-/plugin-crypto-12.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib/plugin-crypto"
         }
       ]
     },
@@ -1760,6 +2244,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib/plugin-thirty-two"
+        }
       ]
     },
     {
@@ -1780,6 +2270,12 @@
           "url": "https://registry.npmjs.org/@otplib/preset-default/-/preset-default-12.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib/preset-default"
         }
       ]
     },
@@ -1802,6 +2298,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib/preset-v11"
+        }
       ]
     },
     {
@@ -1822,6 +2324,12 @@
           "url": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@sindresorhus/is"
         }
       ]
     },
@@ -1844,6 +2352,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@swc/helpers"
+        }
       ]
     },
     {
@@ -1864,6 +2378,12 @@
           "url": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@tokenizer/token"
         }
       ]
     },
@@ -1886,6 +2406,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@tootallnate/once"
+        }
       ]
     },
     {
@@ -1906,6 +2432,12 @@
           "url": "https://registry.npmjs.org/@types/component-emitter/-/component-emitter-1.2.11.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/component-emitter"
         }
       ]
     },
@@ -1928,6 +2460,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/cookie"
+        }
       ]
     },
     {
@@ -1948,6 +2486,12 @@
           "url": "https://registry.npmjs.org/@types/cors/-/cors-2.8.12.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/cors"
         }
       ]
     },
@@ -1970,6 +2514,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/debug"
+        }
       ]
     },
     {
@@ -1990,6 +2540,12 @@
           "url": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/ms"
         }
       ]
     },
@@ -2012,6 +2568,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/node"
+        }
       ]
     },
     {
@@ -2032,6 +2594,12 @@
           "url": "https://registry.npmjs.org/@types/strip-bom/-/strip-bom-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/strip-bom"
         }
       ]
     },
@@ -2054,6 +2622,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/strip-json-comments"
+        }
       ]
     },
     {
@@ -2075,6 +2649,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/validator"
+        }
       ]
     },
     {
@@ -2094,6 +2674,12 @@
           "url": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/abbrev"
         }
       ]
     },
@@ -2115,6 +2701,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/accepts"
+        }
       ]
     },
     {
@@ -2135,6 +2727,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/acorn-walk"
+        }
       ]
     },
     {
@@ -2154,6 +2752,12 @@
           "url": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/acorn"
         }
       ]
     },
@@ -2176,6 +2780,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/agent-base"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -2194,6 +2804,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agent-base/node_modules/debug"
             }
           ]
         },
@@ -2214,6 +2830,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agent-base/node_modules/ms"
             }
           ]
         }
@@ -2238,6 +2860,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/agentkeepalive"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -2256,6 +2884,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agentkeepalive/node_modules/debug"
             }
           ]
         },
@@ -2277,6 +2911,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agentkeepalive/node_modules/depd"
+            }
           ]
         },
         {
@@ -2296,6 +2936,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agentkeepalive/node_modules/ms"
             }
           ]
         }
@@ -2319,6 +2965,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/aggregate-error"
+        }
       ]
     },
     {
@@ -2338,6 +2990,12 @@
           "url": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ajv"
         }
       ]
     },
@@ -2359,6 +3017,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ansi-regex"
+        }
       ]
     },
     {
@@ -2378,6 +3042,12 @@
           "url": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ansi-styles"
         }
       ]
     },
@@ -2400,6 +3070,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/anymatch"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -2418,6 +3094,12 @@
               "url": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/anymatch/node_modules/normalize-path"
             }
           ]
         }
@@ -2441,6 +3123,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/append-field"
+        }
       ]
     },
     {
@@ -2460,6 +3148,12 @@
           "url": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/aproba"
         }
       ]
     },
@@ -2482,6 +3176,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/archive-type"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -2500,6 +3200,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-4.4.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/archive-type/node_modules/file-type"
             }
           ]
         }
@@ -2523,6 +3229,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/archiver-utils"
+        }
       ]
     },
     {
@@ -2542,6 +3254,12 @@
           "url": "https://registry.npmjs.org/archiver/-/archiver-1.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/archiver"
         }
       ]
     },
@@ -2563,6 +3281,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/are-we-there-yet"
+        }
       ]
     },
     {
@@ -2582,6 +3306,12 @@
           "url": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/arg"
         }
       ]
     },
@@ -2604,6 +3334,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/argparse"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -2622,6 +3358,12 @@
               "url": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/argparse/node_modules/sprintf-js"
             }
           ]
         }
@@ -2645,6 +3387,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/arr-diff"
+        }
       ]
     },
     {
@@ -2664,6 +3412,12 @@
           "url": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/arr-flatten"
         }
       ]
     },
@@ -2685,6 +3439,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/arr-union"
+        }
       ]
     },
     {
@@ -2704,6 +3464,12 @@
           "url": "https://registry.npmjs.org/array-each/-/array-each-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/array-each"
         }
       ]
     },
@@ -2725,6 +3491,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/array-flatten"
+        }
       ]
     },
     {
@@ -2744,6 +3516,12 @@
           "url": "https://registry.npmjs.org/array-slice/-/array-slice-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/array-slice"
         }
       ]
     },
@@ -2765,6 +3543,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/array-unique"
+        }
       ]
     },
     {
@@ -2784,6 +3568,12 @@
           "url": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/asap"
         }
       ]
     },
@@ -2805,6 +3595,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/asn1"
+        }
       ]
     },
     {
@@ -2824,6 +3620,12 @@
           "url": "https://registry.npmjs.org/assert-never/-/assert-never-1.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/assert-never"
         }
       ]
     },
@@ -2845,6 +3647,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/assert-plus"
+        }
       ]
     },
     {
@@ -2864,6 +3672,12 @@
           "url": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/assign-symbols"
         }
       ]
     },
@@ -2885,6 +3699,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/async"
+        }
       ]
     },
     {
@@ -2904,6 +3724,12 @@
           "url": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/asynckit"
         }
       ]
     },
@@ -2925,6 +3751,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/at-least-node"
+        }
       ]
     },
     {
@@ -2944,6 +3776,12 @@
           "url": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/atob"
         }
       ]
     },
@@ -2965,6 +3803,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/available-typed-arrays"
+        }
       ]
     },
     {
@@ -2984,6 +3828,12 @@
           "url": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/aws-sign2"
         }
       ]
     },
@@ -3005,6 +3855,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/aws4"
+        }
       ]
     },
     {
@@ -3025,6 +3881,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/babel-walk"
+        }
       ]
     },
     {
@@ -3044,6 +3906,12 @@
           "url": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/balanced-match"
         }
       ]
     },
@@ -3066,6 +3934,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -3084,6 +3958,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/base/node_modules/define-property"
             }
           ]
         }
@@ -3107,6 +3987,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base64-arraybuffer"
+        }
       ]
     },
     {
@@ -3126,6 +4012,12 @@
           "url": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base64-js"
         }
       ]
     },
@@ -3147,6 +4039,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base64id"
+        }
       ]
     },
     {
@@ -3166,6 +4064,12 @@
           "url": "https://registry.npmjs.org/base64url/-/base64url-0.0.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base64url"
         }
       ]
     },
@@ -3187,6 +4091,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/basic-auth"
+        }
       ]
     },
     {
@@ -3206,6 +4116,12 @@
           "url": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/batch"
         }
       ]
     },
@@ -3227,6 +4143,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bcrypt-pbkdf"
+        }
       ]
     },
     {
@@ -3246,6 +4168,12 @@
           "url": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/big-integer"
         }
       ]
     },
@@ -3267,6 +4195,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/binary-extensions"
+        }
       ]
     },
     {
@@ -3286,6 +4220,12 @@
           "url": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/binary"
         }
       ]
     },
@@ -3307,6 +4247,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bindings"
+        }
       ]
     },
     {
@@ -3326,6 +4272,12 @@
           "url": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bintrees"
         }
       ]
     },
@@ -3347,6 +4299,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bl"
+        }
       ]
     },
     {
@@ -3367,6 +4325,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bluebird"
+        }
       ]
     },
     {
@@ -3386,6 +4350,12 @@
           "url": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/body-parser"
         }
       ]
     },
@@ -3408,6 +4378,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bower-config"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -3426,6 +4402,12 @@
               "url": "https://registry.npmjs.org/minimist/-/minimist-0.2.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bower-config/node_modules/minimist"
             }
           ]
         }
@@ -3449,6 +4431,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/brace-expansion"
+        }
       ]
     },
     {
@@ -3470,6 +4458,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/braces"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -3488,6 +4482,12 @@
               "url": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/braces/node_modules/extend-shallow"
             }
           ]
         },
@@ -3508,6 +4508,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/braces/node_modules/is-extendable"
             }
           ]
         }
@@ -3531,6 +4537,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/brotli"
+        }
       ]
     },
     {
@@ -3550,6 +4562,12 @@
           "url": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-alloc-unsafe"
         }
       ]
     },
@@ -3571,6 +4589,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-alloc"
+        }
       ]
     },
     {
@@ -3590,6 +4614,12 @@
           "url": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-crc32"
         }
       ]
     },
@@ -3611,6 +4641,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-fill"
+        }
       ]
     },
     {
@@ -3630,6 +4666,12 @@
           "url": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-from"
         }
       ]
     },
@@ -3651,6 +4693,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-indexof-polyfill"
+        }
       ]
     },
     {
@@ -3671,6 +4719,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer"
+        }
       ]
     },
     {
@@ -3690,6 +4744,12 @@
           "url": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffers"
         }
       ]
     },
@@ -3712,6 +4772,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/busboy"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -3730,6 +4796,12 @@
               "url": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/busboy/node_modules/isarray"
             }
           ]
         },
@@ -3751,6 +4823,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/busboy/node_modules/readable-stream"
+            }
           ]
         },
         {
@@ -3770,6 +4848,12 @@
               "url": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/busboy/node_modules/string_decoder"
             }
           ]
         }
@@ -3793,6 +4877,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/byline"
+        }
       ]
     },
     {
@@ -3812,6 +4902,12 @@
           "url": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bytes"
         }
       ]
     },
@@ -3833,6 +4929,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cacache"
+        }
       ]
     },
     {
@@ -3852,6 +4954,12 @@
           "url": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cache-base"
         }
       ]
     },
@@ -3874,6 +4982,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cacheable-request"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -3892,6 +5006,12 @@
               "url": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cacheable-request/node_modules/get-stream"
             }
           ]
         },
@@ -3912,6 +5032,12 @@
               "url": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cacheable-request/node_modules/lowercase-keys"
             }
           ]
         }
@@ -3935,6 +5061,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/call-bind"
+        }
       ]
     },
     {
@@ -3954,6 +5086,12 @@
           "url": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/camelcase"
         }
       ]
     },
@@ -3975,6 +5113,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/caseless"
+        }
       ]
     },
     {
@@ -3994,6 +5138,12 @@
           "url": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/chainsaw"
         }
       ]
     },
@@ -4015,6 +5165,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/chalk"
+        }
       ]
     },
     {
@@ -4034,6 +5190,12 @@
           "url": "https://registry.npmjs.org/character-parser/-/character-parser-2.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/character-parser"
         }
       ]
     },
@@ -4056,6 +5218,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/check-dependencies"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4074,6 +5242,12 @@
               "url": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/check-dependencies/node_modules/semver"
             }
           ]
         }
@@ -4097,6 +5271,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/check-types"
+        }
       ]
     },
     {
@@ -4118,6 +5298,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/chokidar"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4136,6 +5322,12 @@
               "url": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar/node_modules/braces"
             }
           ]
         },
@@ -4157,6 +5349,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar/node_modules/fill-range"
+            }
           ]
         },
         {
@@ -4176,6 +5374,12 @@
               "url": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar/node_modules/is-glob"
             }
           ]
         },
@@ -4197,6 +5401,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar/node_modules/is-number"
+            }
           ]
         },
         {
@@ -4217,6 +5427,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar/node_modules/normalize-path"
+            }
           ]
         },
         {
@@ -4236,6 +5452,12 @@
               "url": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar/node_modules/to-regex-range"
             }
           ]
         }
@@ -4259,6 +5481,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/chownr"
+        }
       ]
     },
     {
@@ -4278,6 +5506,12 @@
           "url": "https://registry.npmjs.org/clarinet/-/clarinet-0.12.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/clarinet"
         }
       ]
     },
@@ -4300,6 +5534,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/class-utils"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4318,6 +5558,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils/node_modules/define-property"
             }
           ]
         },
@@ -4340,6 +5586,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils/node_modules/is-accessor-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -4358,6 +5610,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/class-utils/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -4382,6 +5640,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils/node_modules/is-data-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -4400,6 +5664,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/class-utils/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -4423,6 +5693,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils/node_modules/is-descriptor"
+            }
           ]
         },
         {
@@ -4442,6 +5718,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils/node_modules/kind-of"
             }
           ]
         }
@@ -4465,6 +5747,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/clean-stack"
+        }
       ]
     },
     {
@@ -4486,6 +5774,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cliui"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4504,6 +5798,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui/node_modules/ansi-regex"
             }
           ]
         },
@@ -4525,6 +5825,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui/node_modules/emoji-regex"
+            }
           ]
         },
         {
@@ -4544,6 +5850,12 @@
               "url": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui/node_modules/is-fullwidth-code-point"
             }
           ]
         },
@@ -4565,6 +5877,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui/node_modules/string-width"
+            }
           ]
         },
         {
@@ -4584,6 +5902,12 @@
               "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui/node_modules/strip-ansi"
             }
           ]
         }
@@ -4607,6 +5931,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/clone-response"
+        }
       ]
     },
     {
@@ -4626,6 +5956,12 @@
           "url": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/clone"
         }
       ]
     },
@@ -4647,6 +5983,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/code-point-at"
+        }
       ]
     },
     {
@@ -4666,6 +6008,12 @@
           "url": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/collection-visit"
         }
       ]
     },
@@ -4687,6 +6035,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color-convert"
+        }
       ]
     },
     {
@@ -4706,6 +6060,12 @@
           "url": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color-name"
         }
       ]
     },
@@ -4727,6 +6087,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color-string"
+        }
       ]
     },
     {
@@ -4746,6 +6112,12 @@
           "url": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color-support"
         }
       ]
     },
@@ -4767,6 +6139,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color"
+        }
       ]
     },
     {
@@ -4786,6 +6164,12 @@
           "url": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/colors"
         }
       ]
     },
@@ -4807,6 +6191,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/colorspace"
+        }
       ]
     },
     {
@@ -4826,6 +6216,12 @@
           "url": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/combined-stream"
         }
       ]
     },
@@ -4847,6 +6243,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/commander"
+        }
       ]
     },
     {
@@ -4866,6 +6268,12 @@
           "url": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/component-emitter"
         }
       ]
     },
@@ -4887,6 +6295,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/component-type"
+        }
       ]
     },
     {
@@ -4907,6 +6321,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/compress-commons"
+        }
       ]
     },
     {
@@ -4926,6 +6346,12 @@
           "url": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/compressible"
         }
       ]
     },
@@ -4948,6 +6374,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/compression"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4966,6 +6398,12 @@
               "url": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/compression/node_modules/bytes"
             }
           ]
         }
@@ -4989,6 +6427,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/concat-map"
+        }
       ]
     },
     {
@@ -5008,6 +6452,12 @@
           "url": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/concat-stream"
         }
       ]
     },
@@ -5030,6 +6480,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/concurrently"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5048,6 +6504,12 @@
               "url": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/concurrently/node_modules/supports-color"
             }
           ]
         }
@@ -5071,6 +6533,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/config"
+        }
       ]
     },
     {
@@ -5091,6 +6559,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/console-control-strings"
+        }
       ]
     },
     {
@@ -5110,6 +6584,12 @@
           "url": "https://registry.npmjs.org/constantinople/-/constantinople-4.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/constantinople"
         }
       ]
     },
@@ -5132,6 +6612,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/content-disposition"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5150,6 +6636,12 @@
               "url": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/content-disposition/node_modules/safe-buffer"
             }
           ]
         }
@@ -5173,6 +6665,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/content-type"
+        }
       ]
     },
     {
@@ -5192,6 +6690,12 @@
           "url": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cookie-parser"
         }
       ]
     },
@@ -5213,6 +6717,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cookie-signature"
+        }
       ]
     },
     {
@@ -5232,6 +6742,12 @@
           "url": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cookie"
         }
       ]
     },
@@ -5253,6 +6769,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/copy-descriptor"
+        }
       ]
     },
     {
@@ -5272,6 +6794,12 @@
           "url": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/core-util-is"
         }
       ]
     },
@@ -5293,6 +6821,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cors"
+        }
       ]
     },
     {
@@ -5312,6 +6846,12 @@
           "url": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/crc"
         }
       ]
     },
@@ -5333,6 +6873,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/crc32-stream"
+        }
       ]
     },
     {
@@ -5352,6 +6898,12 @@
           "url": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/create-require"
         }
       ]
     },
@@ -5373,6 +6925,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/crypto-js"
+        }
       ]
     },
     {
@@ -5392,6 +6950,12 @@
           "url": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dashdash"
         }
       ]
     },
@@ -5413,6 +6977,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/date-fns"
+        }
       ]
     },
     {
@@ -5432,6 +7002,12 @@
           "url": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dateformat"
         }
       ]
     },
@@ -5453,6 +7029,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/debug"
+        }
       ]
     },
     {
@@ -5472,6 +7054,12 @@
           "url": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decamelize"
         }
       ]
     },
@@ -5493,6 +7081,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decode-uri-component"
+        }
       ]
     },
     {
@@ -5512,6 +7106,12 @@
           "url": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-response"
         }
       ]
     },
@@ -5534,6 +7134,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-tar"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5552,6 +7158,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-tar/node_modules/file-type"
             }
           ]
         }
@@ -5576,6 +7188,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-tarbz2"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5594,6 +7212,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-6.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-tarbz2/node_modules/file-type"
             }
           ]
         }
@@ -5618,6 +7242,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-targz"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5636,6 +7266,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-targz/node_modules/file-type"
             }
           ]
         }
@@ -5660,6 +7296,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-unzip"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5678,6 +7320,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-unzip/node_modules/file-type"
             }
           ]
         },
@@ -5699,6 +7347,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-unzip/node_modules/get-stream"
+            }
           ]
         },
         {
@@ -5718,6 +7372,12 @@
               "url": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-unzip/node_modules/pify"
             }
           ]
         }
@@ -5742,6 +7402,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5762,6 +7428,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress/node_modules/make-dir"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -5780,6 +7452,12 @@
                   "url": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/decompress/node_modules/make-dir/node_modules/pify"
                 }
               ]
             }
@@ -5803,6 +7481,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress/node_modules/pify"
+            }
           ]
         }
       ]
@@ -5825,6 +7509,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/deep-equal"
+        }
       ]
     },
     {
@@ -5844,6 +7534,12 @@
           "url": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/deep-extend"
         }
       ]
     },
@@ -5865,6 +7561,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/deep-is"
+        }
       ]
     },
     {
@@ -5884,6 +7586,12 @@
           "url": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/define-properties"
         }
       ]
     },
@@ -5905,6 +7613,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/define-property"
+        }
       ]
     },
     {
@@ -5924,6 +7638,12 @@
           "url": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/delayed-stream"
         }
       ]
     },
@@ -5945,6 +7665,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/delegates"
+        }
       ]
     },
     {
@@ -5964,6 +7690,12 @@
           "url": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/depd"
         }
       ]
     },
@@ -5985,6 +7717,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/destroy"
+        }
       ]
     },
     {
@@ -6004,6 +7742,12 @@
           "url": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/detect-file"
         }
       ]
     },
@@ -6025,6 +7769,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/detect-libc"
+        }
       ]
     },
     {
@@ -6044,6 +7794,12 @@
           "url": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dfa"
         }
       ]
     },
@@ -6066,6 +7822,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dicer"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -6084,6 +7846,12 @@
               "url": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/dicer/node_modules/isarray"
             }
           ]
         },
@@ -6105,6 +7873,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/dicer/node_modules/readable-stream"
+            }
           ]
         },
         {
@@ -6124,6 +7898,12 @@
               "url": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/dicer/node_modules/string_decoder"
             }
           ]
         }
@@ -6147,6 +7927,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/diff"
+        }
       ]
     },
     {
@@ -6166,6 +7952,12 @@
           "url": "https://registry.npmjs.org/doctypes/-/doctypes-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/doctypes"
         }
       ]
     },
@@ -6187,6 +7979,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/domelementtype"
+        }
       ]
     },
     {
@@ -6206,6 +8004,12 @@
           "url": "https://registry.npmjs.org/domhandler/-/domhandler-2.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/domhandler"
         }
       ]
     },
@@ -6227,6 +8031,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/domutils"
+        }
       ]
     },
     {
@@ -6246,6 +8056,12 @@
           "url": "https://registry.npmjs.org/dottie/-/dottie-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dottie"
         }
       ]
     },
@@ -6267,6 +8083,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/double-ended-queue"
+        }
       ]
     },
     {
@@ -6286,6 +8108,12 @@
           "url": "https://registry.npmjs.org/doublearray/-/doublearray-0.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/doublearray"
         }
       ]
     },
@@ -6308,6 +8136,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/download"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -6326,6 +8160,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-11.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/download/node_modules/file-type"
             }
           ]
         }
@@ -6349,6 +8189,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/duplexer2"
+        }
       ]
     },
     {
@@ -6368,6 +8214,12 @@
           "url": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/duplexer3"
         }
       ]
     },
@@ -6389,6 +8241,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dynamic-dedupe"
+        }
       ]
     },
     {
@@ -6408,6 +8266,12 @@
           "url": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ecc-jsbn"
         }
       ]
     },
@@ -6429,6 +8293,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ee-first"
+        }
       ]
     },
     {
@@ -6448,6 +8318,12 @@
           "url": "https://registry.npmjs.org/eivindfjeldstad-dot/-/eivindfjeldstad-dot-0.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/eivindfjeldstad-dot"
         }
       ]
     },
@@ -6469,6 +8345,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/emoji-regex"
+        }
       ]
     },
     {
@@ -6489,6 +8371,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/enabled"
+        }
       ]
     },
     {
@@ -6508,6 +8396,12 @@
           "url": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/encodeurl"
         }
       ]
     },
@@ -6530,6 +8424,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/encoding"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -6548,6 +8448,12 @@
               "url": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/encoding/node_modules/iconv-lite"
             }
           ]
         }
@@ -6571,6 +8477,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/end-of-stream"
+        }
       ]
     },
     {
@@ -6590,6 +8502,12 @@
           "url": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-4.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/engine.io-parser"
         }
       ]
     },
@@ -6612,6 +8530,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/engine.io"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -6630,6 +8554,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/engine.io/node_modules/debug"
             }
           ]
         },
@@ -6650,6 +8580,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/engine.io/node_modules/ms"
             }
           ]
         }
@@ -6673,6 +8609,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/env-paths"
+        }
       ]
     },
     {
@@ -6692,6 +8634,12 @@
           "url": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/err-code"
         }
       ]
     },
@@ -6713,6 +8661,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/error-ex"
+        }
       ]
     },
     {
@@ -6732,6 +8686,12 @@
           "url": "https://registry.npmjs.org/errorhandler/-/errorhandler-1.5.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/errorhandler"
         }
       ]
     },
@@ -6753,6 +8713,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/es-abstract"
+        }
       ]
     },
     {
@@ -6772,6 +8738,12 @@
           "url": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/es-get-iterator"
         }
       ]
     },
@@ -6793,6 +8765,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/es-to-primitive"
+        }
       ]
     },
     {
@@ -6812,6 +8790,12 @@
           "url": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/escape-html"
         }
       ]
     },
@@ -6833,6 +8817,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/escape-string-regexp"
+        }
       ]
     },
     {
@@ -6852,6 +8842,12 @@
           "url": "https://registry.npmjs.org/escodegen/-/escodegen-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/escodegen"
         }
       ]
     },
@@ -6873,6 +8869,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/esprima"
+        }
       ]
     },
     {
@@ -6892,6 +8894,12 @@
           "url": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/estraverse"
         }
       ]
     },
@@ -6913,6 +8921,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/esutils"
+        }
       ]
     },
     {
@@ -6932,6 +8946,12 @@
           "url": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/etag"
         }
       ]
     },
@@ -6953,6 +8973,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/eventemitter2"
+        }
       ]
     },
     {
@@ -6972,6 +8998,12 @@
           "url": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/eventemitter3"
         }
       ]
     },
@@ -6993,6 +9025,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/exif"
+        }
       ]
     },
     {
@@ -7012,6 +9050,12 @@
           "url": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/exit"
         }
       ]
     },
@@ -7034,6 +9078,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/expand-brackets"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7052,6 +9102,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/define-property"
             }
           ]
         },
@@ -7072,6 +9128,12 @@
               "url": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/extend-shallow"
             }
           ]
         },
@@ -7094,6 +9156,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/is-accessor-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -7112,6 +9180,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/expand-brackets/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -7136,6 +9210,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/is-data-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -7154,6 +9234,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/expand-brackets/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -7177,6 +9263,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/is-descriptor"
+            }
           ]
         },
         {
@@ -7197,6 +9289,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/is-extendable"
+            }
           ]
         },
         {
@@ -7216,6 +9314,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/kind-of"
             }
           ]
         }
@@ -7239,6 +9343,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/expand-template"
+        }
       ]
     },
     {
@@ -7259,6 +9369,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/expand-tilde"
+        }
       ]
     },
     {
@@ -7278,6 +9394,12 @@
           "url": "https://registry.npmjs.org/express-ipfilter/-/express-ipfilter-1.3.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-ipfilter"
         }
       ]
     },
@@ -7300,6 +9422,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-jwt"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7318,6 +9446,12 @@
               "url": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-0.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/express-jwt/node_modules/jsonwebtoken"
             }
           ]
         },
@@ -7338,6 +9472,12 @@
               "url": "https://registry.npmjs.org/moment/-/moment-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/express-jwt/node_modules/moment"
             }
           ]
         }
@@ -7361,6 +9501,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-rate-limit"
+        }
       ]
     },
     {
@@ -7381,6 +9527,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-robots-txt"
+        }
       ]
     },
     {
@@ -7400,6 +9552,12 @@
           "url": "https://registry.npmjs.org/express-security.txt/-/express-security.txt-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-security.txt"
         }
       ]
     },
@@ -7422,6 +9580,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7440,6 +9604,12 @@
               "url": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/express/node_modules/cookie"
             }
           ]
         },
@@ -7460,6 +9630,12 @@
               "url": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/express/node_modules/safe-buffer"
             }
           ]
         }
@@ -7483,6 +9659,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ext-list"
+        }
       ]
     },
     {
@@ -7502,6 +9684,12 @@
           "url": "https://registry.npmjs.org/ext-name/-/ext-name-5.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ext-name"
         }
       ]
     },
@@ -7523,6 +9711,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/extend-shallow"
+        }
       ]
     },
     {
@@ -7542,6 +9736,12 @@
           "url": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/extend"
         }
       ]
     },
@@ -7564,6 +9764,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/extglob"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7582,6 +9788,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/extglob/node_modules/define-property"
             }
           ]
         },
@@ -7603,6 +9815,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/extglob/node_modules/extend-shallow"
+            }
           ]
         },
         {
@@ -7622,6 +9840,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/extglob/node_modules/is-extendable"
             }
           ]
         }
@@ -7645,6 +9869,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/extsprintf"
+        }
       ]
     },
     {
@@ -7664,6 +9894,12 @@
           "url": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fast-deep-equal"
         }
       ]
     },
@@ -7685,6 +9921,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fast-json-stable-stringify"
+        }
       ]
     },
     {
@@ -7704,6 +9946,12 @@
           "url": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fast-levenshtein"
         }
       ]
     },
@@ -7725,6 +9973,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fast.js"
+        }
       ]
     },
     {
@@ -7744,6 +9998,12 @@
           "url": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fd-slicer"
         }
       ]
     },
@@ -7765,6 +10025,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/feature-policy"
+        }
       ]
     },
     {
@@ -7784,6 +10050,12 @@
           "url": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fecha"
         }
       ]
     },
@@ -7806,6 +10078,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/file-js"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7824,6 +10102,12 @@
               "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/file-js/node_modules/brace-expansion"
             }
           ]
         },
@@ -7844,6 +10128,12 @@
               "url": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/file-js/node_modules/minimatch"
             }
           ]
         }
@@ -7867,6 +10157,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/file-stream-rotator"
+        }
       ]
     },
     {
@@ -7886,6 +10182,12 @@
           "url": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/file-type"
         }
       ]
     },
@@ -7907,6 +10209,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/file-uri-to-path"
+        }
       ]
     },
     {
@@ -7926,6 +10234,12 @@
           "url": "https://registry.npmjs.org/filehound/-/filehound-1.17.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/filehound"
         }
       ]
     },
@@ -7947,6 +10261,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/filename-reserved-regex"
+        }
       ]
     },
     {
@@ -7967,6 +10287,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/filenamify"
+        }
       ]
     },
     {
@@ -7986,6 +10312,12 @@
           "url": "https://registry.npmjs.org/filesniffer/-/filesniffer-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/filesniffer"
         }
       ]
     },
@@ -8008,6 +10340,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fill-range"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -8026,6 +10364,12 @@
               "url": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/fill-range/node_modules/extend-shallow"
             }
           ]
         },
@@ -8046,6 +10390,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/fill-range/node_modules/is-extendable"
             }
           ]
         }
@@ -8069,6 +10419,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/finale-rest"
+        }
       ]
     },
     {
@@ -8088,6 +10444,12 @@
           "url": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/finalhandler"
         }
       ]
     },
@@ -8109,6 +10471,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/find-up"
+        }
       ]
     },
     {
@@ -8128,6 +10496,12 @@
           "url": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/findup-sync"
         }
       ]
     },
@@ -8149,6 +10523,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fined"
+        }
       ]
     },
     {
@@ -8168,6 +10548,12 @@
           "url": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/flagged-respawn"
         }
       ]
     },
@@ -8189,6 +10575,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fn.name"
+        }
       ]
     },
     {
@@ -8208,6 +10600,12 @@
           "url": "https://registry.npmjs.org/fontkit/-/fontkit-1.9.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fontkit"
         }
       ]
     },
@@ -8229,6 +10627,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/for-each"
+        }
       ]
     },
     {
@@ -8248,6 +10652,12 @@
           "url": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/for-in"
         }
       ]
     },
@@ -8269,6 +10679,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/for-own"
+        }
       ]
     },
     {
@@ -8288,6 +10704,12 @@
           "url": "https://registry.npmjs.org/foreachasync/-/foreachasync-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/foreachasync"
         }
       ]
     },
@@ -8309,6 +10731,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/forever-agent"
+        }
       ]
     },
     {
@@ -8328,6 +10756,12 @@
           "url": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/form-data"
         }
       ]
     },
@@ -8349,6 +10783,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/formatio"
+        }
       ]
     },
     {
@@ -8368,6 +10808,12 @@
           "url": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/forwarded"
         }
       ]
     },
@@ -8389,6 +10835,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fragment-cache"
+        }
       ]
     },
     {
@@ -8408,6 +10860,12 @@
           "url": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fresh"
         }
       ]
     },
@@ -8429,6 +10887,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/from2"
+        }
       ]
     },
     {
@@ -8448,6 +10912,12 @@
           "url": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fs-constants"
         }
       ]
     },
@@ -8469,6 +10939,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fs-extra"
+        }
       ]
     },
     {
@@ -8489,6 +10965,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fs-minipass"
+        }
       ]
     },
     {
@@ -8508,6 +10990,12 @@
           "url": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fs.realpath"
         }
       ]
     },
@@ -8530,6 +11018,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fstream"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -8548,6 +11042,12 @@
               "url": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/fstream/node_modules/mkdirp"
             }
           ]
         },
@@ -8568,6 +11068,12 @@
               "url": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/fstream/node_modules/rimraf"
             }
           ]
         }
@@ -8591,6 +11097,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/function-bind"
+        }
       ]
     },
     {
@@ -8610,6 +11122,12 @@
           "url": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/function.prototype.name"
         }
       ]
     },
@@ -8631,6 +11149,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/functions-have-names"
+        }
       ]
     },
     {
@@ -8650,6 +11174,12 @@
           "url": "https://registry.npmjs.org/fuzzball/-/fuzzball-1.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fuzzball"
         }
       ]
     },
@@ -8671,6 +11201,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/gauge"
+        }
       ]
     },
     {
@@ -8690,6 +11226,12 @@
           "url": "https://registry.npmjs.org/geojson-utils/-/geojson-utils-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/geojson-utils"
         }
       ]
     },
@@ -8711,6 +11253,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-caller-file"
+        }
       ]
     },
     {
@@ -8730,6 +11278,12 @@
           "url": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-intrinsic"
         }
       ]
     },
@@ -8751,6 +11305,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-stream"
+        }
       ]
     },
     {
@@ -8770,6 +11330,12 @@
           "url": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-symbol-description"
         }
       ]
     },
@@ -8791,6 +11357,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-value"
+        }
       ]
     },
     {
@@ -8810,6 +11382,12 @@
           "url": "https://registry.npmjs.org/getobject/-/getobject-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/getobject"
         }
       ]
     },
@@ -8831,6 +11409,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/getpass"
+        }
       ]
     },
     {
@@ -8850,6 +11434,12 @@
           "url": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/github-from-package"
         }
       ]
     },
@@ -8872,6 +11462,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/glob-parent"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -8890,6 +11486,12 @@
               "url": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/glob-parent/node_modules/is-glob"
             }
           ]
         }
@@ -8914,6 +11516,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/glob"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -8932,6 +11540,12 @@
               "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/glob/node_modules/brace-expansion"
             }
           ]
         },
@@ -8952,6 +11566,12 @@
               "url": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/glob/node_modules/minimatch"
             }
           ]
         }
@@ -8975,6 +11595,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/global-modules"
+        }
       ]
     },
     {
@@ -8996,6 +11622,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/global-prefix"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9014,6 +11646,12 @@
               "url": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/global-prefix/node_modules/which"
             }
           ]
         }
@@ -9038,6 +11676,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/got"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9056,6 +11700,12 @@
               "url": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/got/node_modules/get-stream"
             }
           ]
         },
@@ -9076,6 +11726,12 @@
               "url": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/got/node_modules/pify"
             }
           ]
         }
@@ -9099,6 +11755,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/graceful-fs"
+        }
       ]
     },
     {
@@ -9120,6 +11782,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-cli"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9138,6 +11806,12 @@
               "url": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-cli/node_modules/nopt"
             }
           ]
         }
@@ -9162,6 +11836,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-contrib-compress"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9180,6 +11860,12 @@
               "url": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-contrib-compress/node_modules/ansi-styles"
             }
           ]
         },
@@ -9201,6 +11887,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-contrib-compress/node_modules/chalk"
+            }
           ]
         },
         {
@@ -9220,6 +11912,12 @@
               "url": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-contrib-compress/node_modules/supports-color"
             }
           ]
         }
@@ -9243,6 +11941,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-known-options"
+        }
       ]
     },
     {
@@ -9264,6 +11968,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-legacy-log-utils"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9282,6 +11992,12 @@
               "url": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils/node_modules/ansi-styles"
             }
           ]
         },
@@ -9303,6 +12019,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils/node_modules/chalk"
+            }
           ]
         },
         {
@@ -9322,6 +12044,12 @@
               "url": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils/node_modules/color-convert"
             }
           ]
         },
@@ -9343,6 +12071,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils/node_modules/color-name"
+            }
           ]
         },
         {
@@ -9363,6 +12097,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils/node_modules/has-flag"
+            }
           ]
         },
         {
@@ -9382,6 +12122,12 @@
               "url": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils/node_modules/supports-color"
             }
           ]
         }
@@ -9406,6 +12152,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-legacy-log"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9424,6 +12176,12 @@
               "url": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log/node_modules/colors"
             }
           ]
         }
@@ -9448,6 +12206,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-legacy-util"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9466,6 +12230,12 @@
               "url": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-util/node_modules/async"
             }
           ]
         }
@@ -9489,6 +12259,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-replace-json"
+        }
       ]
     },
     {
@@ -9510,6 +12286,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9528,6 +12310,12 @@
               "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt/node_modules/brace-expansion"
             }
           ]
         },
@@ -9550,6 +12338,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt/node_modules/findup-sync"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -9568,6 +12362,12 @@
                   "url": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/grunt/node_modules/findup-sync/node_modules/glob"
                 }
               ]
             }
@@ -9591,6 +12391,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt/node_modules/glob"
+            }
           ]
         },
         {
@@ -9610,6 +12416,12 @@
               "url": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.8.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt/node_modules/minimatch"
             }
           ]
         }
@@ -9634,6 +12446,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/handlebars"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9652,6 +12470,12 @@
               "url": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/handlebars/node_modules/wordwrap"
             }
           ]
         }
@@ -9675,6 +12499,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/har-schema"
+        }
       ]
     },
     {
@@ -9694,6 +12524,12 @@
           "url": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/har-validator"
         }
       ]
     },
@@ -9715,6 +12551,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-ansi"
+        }
       ]
     },
     {
@@ -9734,6 +12576,12 @@
           "url": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-bigints"
         }
       ]
     },
@@ -9755,6 +12603,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-flag"
+        }
       ]
     },
     {
@@ -9774,6 +12628,12 @@
           "url": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-property-descriptors"
         }
       ]
     },
@@ -9795,6 +12655,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-symbol-support-x"
+        }
       ]
     },
     {
@@ -9814,6 +12680,12 @@
           "url": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-symbols"
         }
       ]
     },
@@ -9835,6 +12707,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-to-string-tag-x"
+        }
       ]
     },
     {
@@ -9854,6 +12732,12 @@
           "url": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-tostringtag"
         }
       ]
     },
@@ -9875,6 +12759,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-unicode"
+        }
       ]
     },
     {
@@ -9894,6 +12784,12 @@
           "url": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-value"
         }
       ]
     },
@@ -9916,6 +12812,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-values"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9934,6 +12836,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/has-values/node_modules/kind-of"
             }
           ]
         }
@@ -9957,6 +12865,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has"
+        }
       ]
     },
     {
@@ -9976,6 +12890,12 @@
           "url": "https://registry.npmjs.org/hashids/-/hashids-2.2.10.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hashids"
         }
       ]
     },
@@ -9997,6 +12917,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hbs"
+        }
       ]
     },
     {
@@ -10016,6 +12942,12 @@
           "url": "https://registry.npmjs.org/he/-/he-0.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/he"
         }
       ]
     },
@@ -10037,6 +12969,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/heap"
+        }
       ]
     },
     {
@@ -10056,6 +12994,12 @@
           "url": "https://registry.npmjs.org/helmet/-/helmet-4.6.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/helmet"
         }
       ]
     },
@@ -10077,6 +13021,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hoister"
+        }
       ]
     },
     {
@@ -10096,6 +13046,12 @@
           "url": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/homedir-polyfill"
         }
       ]
     },
@@ -10117,6 +13073,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hooker"
+        }
       ]
     },
     {
@@ -10137,6 +13099,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hosted-git-info"
+        }
       ]
     },
     {
@@ -10156,6 +13124,12 @@
           "url": "https://registry.npmjs.org/html-entities/-/html-entities-1.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/html-entities"
         }
       ]
     },
@@ -10178,6 +13152,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/htmlparser2"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -10196,6 +13176,12 @@
               "url": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/htmlparser2/node_modules/isarray"
             }
           ]
         },
@@ -10217,6 +13203,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/htmlparser2/node_modules/readable-stream"
+            }
           ]
         },
         {
@@ -10236,6 +13228,12 @@
               "url": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/htmlparser2/node_modules/string_decoder"
             }
           ]
         }
@@ -10259,6 +13257,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/http-cache-semantics"
+        }
       ]
     },
     {
@@ -10278,6 +13282,12 @@
           "url": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/http-errors"
         }
       ]
     },
@@ -10300,6 +13310,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/http-proxy-agent"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -10318,6 +13334,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/http-proxy-agent/node_modules/debug"
             }
           ]
         },
@@ -10338,6 +13360,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/http-proxy-agent/node_modules/ms"
             }
           ]
         }
@@ -10361,6 +13389,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/http-signature"
+        }
       ]
     },
     {
@@ -10382,6 +13416,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/https-proxy-agent"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -10400,6 +13440,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/https-proxy-agent/node_modules/debug"
             }
           ]
         },
@@ -10420,6 +13466,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/https-proxy-agent/node_modules/ms"
             }
           ]
         }
@@ -10443,6 +13495,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/humanize-ms"
+        }
       ]
     },
     {
@@ -10462,6 +13520,12 @@
           "url": "https://registry.npmjs.org/i18n/-/i18n-0.11.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/i18n"
         }
       ]
     },
@@ -10483,6 +13547,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/iconv-lite"
+        }
       ]
     },
     {
@@ -10502,6 +13572,12 @@
           "url": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ieee754"
         }
       ]
     },
@@ -10524,6 +13600,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ignore-walk"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -10542,6 +13624,12 @@
               "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/ignore-walk/node_modules/brace-expansion"
             }
           ]
         },
@@ -10562,6 +13650,12 @@
               "url": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/ignore-walk/node_modules/minimatch"
             }
           ]
         }
@@ -10585,6 +13679,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/iltorb"
+        }
       ]
     },
     {
@@ -10604,6 +13704,12 @@
           "url": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/imurmurhash"
         }
       ]
     },
@@ -10625,6 +13731,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/indent-string"
+        }
       ]
     },
     {
@@ -10644,6 +13756,12 @@
           "url": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/infer-owner"
         }
       ]
     },
@@ -10665,6 +13783,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/inflection"
+        }
       ]
     },
     {
@@ -10684,6 +13808,12 @@
           "url": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/inflight"
         }
       ]
     },
@@ -10705,6 +13835,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/inherits"
+        }
       ]
     },
     {
@@ -10724,6 +13860,12 @@
           "url": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ini"
         }
       ]
     },
@@ -10745,6 +13887,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/internal-slot"
+        }
       ]
     },
     {
@@ -10764,6 +13912,12 @@
           "url": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/interpret"
         }
       ]
     },
@@ -10785,6 +13939,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/into-stream"
+        }
       ]
     },
     {
@@ -10804,6 +13964,12 @@
           "url": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/invariant"
         }
       ]
     },
@@ -10825,6 +13991,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ip"
+        }
       ]
     },
     {
@@ -10844,6 +14016,12 @@
           "url": "https://registry.npmjs.org/ip6/-/ip6-0.2.10.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ip6"
         }
       ]
     },
@@ -10865,6 +14043,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ipaddr.js"
+        }
       ]
     },
     {
@@ -10884,6 +14068,12 @@
           "url": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-absolute"
         }
       ]
     },
@@ -10905,6 +14095,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-accessor-descriptor"
+        }
       ]
     },
     {
@@ -10924,6 +14120,12 @@
           "url": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-arguments"
         }
       ]
     },
@@ -10945,6 +14147,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-arrayish"
+        }
       ]
     },
     {
@@ -10964,6 +14172,12 @@
           "url": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-bigint"
         }
       ]
     },
@@ -10985,6 +14199,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-binary-path"
+        }
       ]
     },
     {
@@ -11004,6 +14224,12 @@
           "url": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-boolean-object"
         }
       ]
     },
@@ -11025,6 +14251,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-buffer"
+        }
       ]
     },
     {
@@ -11044,6 +14276,12 @@
           "url": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-callable"
         }
       ]
     },
@@ -11065,6 +14303,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-core-module"
+        }
       ]
     },
     {
@@ -11084,6 +14328,12 @@
           "url": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-data-descriptor"
         }
       ]
     },
@@ -11105,6 +14355,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-date-object"
+        }
       ]
     },
     {
@@ -11124,6 +14380,12 @@
           "url": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-descriptor"
         }
       ]
     },
@@ -11145,6 +14407,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-docker"
+        }
       ]
     },
     {
@@ -11164,6 +14432,12 @@
           "url": "https://registry.npmjs.org/is-expression/-/is-expression-4.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-expression"
         }
       ]
     },
@@ -11185,6 +14459,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-extendable"
+        }
       ]
     },
     {
@@ -11204,6 +14484,12 @@
           "url": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-extglob"
         }
       ]
     },
@@ -11225,6 +14511,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-fullwidth-code-point"
+        }
       ]
     },
     {
@@ -11244,6 +14536,12 @@
           "url": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-generator-function"
         }
       ]
     },
@@ -11265,6 +14563,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-glob"
+        }
       ]
     },
     {
@@ -11284,6 +14588,12 @@
           "url": "https://registry.npmjs.org/is-heroku/-/is-heroku-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-heroku"
         }
       ]
     },
@@ -11305,6 +14615,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-lambda"
+        }
       ]
     },
     {
@@ -11324,6 +14640,12 @@
           "url": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-map"
         }
       ]
     },
@@ -11345,6 +14667,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-natural-number"
+        }
       ]
     },
     {
@@ -11364,6 +14692,12 @@
           "url": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-negative-zero"
         }
       ]
     },
@@ -11385,6 +14719,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-number-like"
+        }
       ]
     },
     {
@@ -11404,6 +14744,12 @@
           "url": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-number-object"
         }
       ]
     },
@@ -11426,6 +14772,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-number"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -11444,6 +14796,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/is-number/node_modules/kind-of"
             }
           ]
         }
@@ -11467,6 +14825,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-object"
+        }
       ]
     },
     {
@@ -11486,6 +14850,12 @@
           "url": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-plain-obj"
         }
       ]
     },
@@ -11507,6 +14877,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-plain-object"
+        }
       ]
     },
     {
@@ -11526,6 +14902,12 @@
           "url": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-promise"
         }
       ]
     },
@@ -11547,6 +14929,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-regex"
+        }
       ]
     },
     {
@@ -11566,6 +14954,12 @@
           "url": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-relative"
         }
       ]
     },
@@ -11587,6 +14981,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-retry-allowed"
+        }
       ]
     },
     {
@@ -11606,6 +15006,12 @@
           "url": "https://registry.npmjs.org/is-set/-/is-set-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-set"
         }
       ]
     },
@@ -11627,6 +15033,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-shared-array-buffer"
+        }
       ]
     },
     {
@@ -11646,6 +15058,12 @@
           "url": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-stream"
         }
       ]
     },
@@ -11667,6 +15085,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-string"
+        }
       ]
     },
     {
@@ -11686,6 +15110,12 @@
           "url": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-symbol"
         }
       ]
     },
@@ -11707,6 +15137,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-typed-array"
+        }
       ]
     },
     {
@@ -11726,6 +15162,12 @@
           "url": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-typedarray"
         }
       ]
     },
@@ -11747,6 +15189,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-unc-path"
+        }
       ]
     },
     {
@@ -11766,6 +15214,12 @@
           "url": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-weakmap"
         }
       ]
     },
@@ -11787,6 +15241,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-weakref"
+        }
       ]
     },
     {
@@ -11806,6 +15266,12 @@
           "url": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-weakset"
         }
       ]
     },
@@ -11827,6 +15293,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-windows"
+        }
       ]
     },
     {
@@ -11846,6 +15318,12 @@
           "url": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isarray"
         }
       ]
     },
@@ -11867,6 +15345,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isexe"
+        }
       ]
     },
     {
@@ -11886,6 +15370,12 @@
           "url": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isobject"
         }
       ]
     },
@@ -11907,6 +15397,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isstream"
+        }
       ]
     },
     {
@@ -11926,6 +15422,12 @@
           "url": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isurl"
         }
       ]
     },
@@ -11947,6 +15449,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/js-stringify"
+        }
       ]
     },
     {
@@ -11966,6 +15474,12 @@
           "url": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/js-tokens"
         }
       ]
     },
@@ -11987,6 +15501,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/js-yaml"
+        }
       ]
     },
     {
@@ -12006,6 +15526,12 @@
           "url": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jsbn"
         }
       ]
     },
@@ -12027,6 +15553,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-buffer"
+        }
       ]
     },
     {
@@ -12046,6 +15578,12 @@
           "url": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-parse-better-errors"
         }
       ]
     },
@@ -12067,6 +15605,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-schema-traverse"
+        }
       ]
     },
     {
@@ -12086,6 +15630,12 @@
           "url": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-schema"
         }
       ]
     },
@@ -12107,6 +15657,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-stringify-safe"
+        }
       ]
     },
     {
@@ -12126,6 +15682,12 @@
           "url": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json5"
         }
       ]
     },
@@ -12147,6 +15709,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jsonfile"
+        }
       ]
     },
     {
@@ -12166,6 +15734,12 @@
           "url": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-0.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jsonwebtoken"
         }
       ]
     },
@@ -12187,6 +15761,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jsprim"
+        }
       ]
     },
     {
@@ -12206,6 +15786,12 @@
           "url": "https://registry.npmjs.org/jssha/-/jssha-3.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jssha"
         }
       ]
     },
@@ -12227,6 +15813,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jstransformer"
+        }
       ]
     },
     {
@@ -12246,6 +15838,12 @@
           "url": "https://registry.npmjs.org/juicy-chat-bot/-/juicy-chat-bot-0.6.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/juicy-chat-bot"
         }
       ]
     },
@@ -12267,6 +15865,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jwa"
+        }
       ]
     },
     {
@@ -12286,6 +15890,12 @@
           "url": "https://registry.npmjs.org/jws/-/jws-0.2.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jws"
         }
       ]
     },
@@ -12307,6 +15917,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/keyv"
+        }
       ]
     },
     {
@@ -12326,6 +15942,12 @@
           "url": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/kind-of"
         }
       ]
     },
@@ -12347,6 +15969,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/kuler"
+        }
       ]
     },
     {
@@ -12366,6 +15994,12 @@
           "url": "https://registry.npmjs.org/kuromoji/-/kuromoji-0.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/kuromoji"
         }
       ]
     },
@@ -12387,6 +16021,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lazystream"
+        }
       ]
     },
     {
@@ -12406,6 +16046,12 @@
           "url": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/levn"
         }
       ]
     },
@@ -12428,6 +16074,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/libxmljs2"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12446,6 +16098,12 @@
               "url": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/libxmljs2/node_modules/nan"
             }
           ]
         }
@@ -12470,6 +16128,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/liftup"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12488,6 +16152,12 @@
               "url": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/braces"
             }
           ]
         },
@@ -12509,6 +16179,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/fill-range"
+            }
           ]
         },
         {
@@ -12528,6 +16204,12 @@
               "url": "https://registry.npmjs.org/findup-sync/-/findup-sync-4.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/findup-sync"
             }
           ]
         },
@@ -12549,6 +16231,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/is-glob"
+            }
           ]
         },
         {
@@ -12568,6 +16256,12 @@
               "url": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/is-number"
             }
           ]
         },
@@ -12589,6 +16283,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/micromatch"
+            }
           ]
         },
         {
@@ -12608,6 +16308,12 @@
               "url": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/to-regex-range"
             }
           ]
         }
@@ -12632,6 +16338,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/linebreak"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12650,6 +16362,12 @@
               "url": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/linebreak/node_modules/base64-js"
             }
           ]
         }
@@ -12673,6 +16391,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/listenercount"
+        }
       ]
     },
     {
@@ -12692,6 +16416,12 @@
           "url": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/locate-path"
         }
       ]
     },
@@ -12713,6 +16443,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lodash.camelcase"
+        }
       ]
     },
     {
@@ -12732,6 +16468,12 @@
           "url": "https://registry.npmjs.org/lodash.isfinite/-/lodash.isfinite-3.3.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lodash.isfinite"
         }
       ]
     },
@@ -12753,6 +16495,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lodash.set"
+        }
       ]
     },
     {
@@ -12772,6 +16520,12 @@
           "url": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lodash"
         }
       ]
     },
@@ -12794,6 +16548,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/logform"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12812,6 +16572,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/logform/node_modules/ms"
             }
           ]
         }
@@ -12835,6 +16601,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lolex"
+        }
       ]
     },
     {
@@ -12854,6 +16626,12 @@
           "url": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/loose-envify"
         }
       ]
     },
@@ -12875,6 +16653,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lowercase-keys"
+        }
       ]
     },
     {
@@ -12894,6 +16678,12 @@
           "url": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lru-cache"
         }
       ]
     },
@@ -12916,6 +16706,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-dir"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12934,6 +16730,12 @@
               "url": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-dir/node_modules/semver"
             }
           ]
         }
@@ -12957,6 +16759,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-error"
+        }
       ]
     },
     {
@@ -12976,6 +16784,12 @@
           "url": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-9.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-fetch-happen"
         }
       ],
       "components": [
@@ -12998,6 +16812,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen/node_modules/@tootallnate/once"
+            }
           ]
         },
         {
@@ -13017,6 +16837,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen/node_modules/debug"
             }
           ]
         },
@@ -13038,6 +16864,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen/node_modules/http-cache-semantics"
+            }
           ]
         },
         {
@@ -13058,6 +16890,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen/node_modules/http-proxy-agent"
+            }
           ]
         },
         {
@@ -13077,6 +16915,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen/node_modules/ms"
             }
           ]
         }
@@ -13100,6 +16944,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-iterator"
+        }
       ]
     },
     {
@@ -13119,6 +16969,12 @@
           "url": "https://registry.npmjs.org/make-plural/-/make-plural-6.2.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-plural"
         }
       ]
     },
@@ -13140,6 +16996,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/map-cache"
+        }
       ]
     },
     {
@@ -13159,6 +17021,12 @@
           "url": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/map-visit"
         }
       ]
     },
@@ -13180,6 +17048,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/marsdb"
+        }
       ]
     },
     {
@@ -13199,6 +17073,12 @@
           "url": "https://registry.npmjs.org/math-interval-parser/-/math-interval-parser-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/math-interval-parser"
         }
       ]
     },
@@ -13220,6 +17100,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/media-typer"
+        }
       ]
     },
     {
@@ -13239,6 +17125,12 @@
           "url": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/merge-descriptors"
         }
       ]
     },
@@ -13260,6 +17152,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/messageformat-formatters"
+        }
       ]
     },
     {
@@ -13279,6 +17177,12 @@
           "url": "https://registry.npmjs.org/messageformat-parser/-/messageformat-parser-4.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/messageformat-parser"
         }
       ]
     },
@@ -13301,6 +17205,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/messageformat"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -13319,6 +17229,12 @@
               "url": "https://registry.npmjs.org/make-plural/-/make-plural-4.3.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/messageformat/node_modules/make-plural"
             }
           ]
         }
@@ -13342,6 +17258,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/methods"
+        }
       ]
     },
     {
@@ -13361,6 +17283,12 @@
           "url": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/micromatch"
         }
       ]
     },
@@ -13382,6 +17310,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mime-db"
+        }
       ]
     },
     {
@@ -13401,6 +17335,12 @@
           "url": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mime-types"
         }
       ]
     },
@@ -13422,6 +17362,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mime"
+        }
       ]
     },
     {
@@ -13441,6 +17387,12 @@
           "url": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mimic-response"
         }
       ]
     },
@@ -13462,6 +17414,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minimatch"
+        }
       ]
     },
     {
@@ -13481,6 +17439,12 @@
           "url": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minimist"
         }
       ]
     },
@@ -13502,6 +17466,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-collect"
+        }
       ]
     },
     {
@@ -13521,6 +17491,12 @@
           "url": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-1.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-fetch"
         }
       ]
     },
@@ -13542,6 +17518,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-flush"
+        }
       ]
     },
     {
@@ -13561,6 +17543,12 @@
           "url": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-pipeline"
         }
       ]
     },
@@ -13582,6 +17570,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-sized"
+        }
       ]
     },
     {
@@ -13601,6 +17595,12 @@
           "url": "https://registry.npmjs.org/minipass/-/minipass-3.3.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass"
         }
       ]
     },
@@ -13622,6 +17622,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minizlib"
+        }
       ]
     },
     {
@@ -13641,6 +17647,12 @@
           "url": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mixin-deep"
         }
       ]
     },
@@ -13662,6 +17674,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mkdirp-classic"
+        }
       ]
     },
     {
@@ -13681,6 +17699,12 @@
           "url": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mkdirp"
         }
       ]
     },
@@ -13702,6 +17726,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/moment-timezone"
+        }
       ]
     },
     {
@@ -13721,6 +17751,12 @@
           "url": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/moment"
         }
       ]
     },
@@ -13743,6 +17779,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/morgan"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -13761,6 +17803,12 @@
               "url": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/morgan/node_modules/on-finished"
             }
           ]
         }
@@ -13784,6 +17832,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mout"
+        }
       ]
     },
     {
@@ -13803,6 +17857,12 @@
           "url": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ms"
         }
       ]
     },
@@ -13825,6 +17885,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/multer"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -13843,6 +17909,12 @@
               "url": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/multer/node_modules/mkdirp"
             }
           ]
         }
@@ -13866,6 +17938,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mustache"
+        }
       ]
     },
     {
@@ -13885,6 +17963,12 @@
           "url": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/nan"
         }
       ]
     },
@@ -13906,6 +17990,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/nanomatch"
+        }
       ]
     },
     {
@@ -13925,6 +18015,12 @@
           "url": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/napi-build-utils"
         }
       ]
     },
@@ -13947,6 +18043,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/needle"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -13965,6 +18067,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/needle/node_modules/debug"
             }
           ]
         },
@@ -13985,6 +18093,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/needle/node_modules/ms"
             }
           ]
         }
@@ -14008,6 +18122,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/negotiator"
+        }
       ]
     },
     {
@@ -14027,6 +18147,12 @@
           "url": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/neo-async"
         }
       ]
     },
@@ -14049,6 +18175,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-abi"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14067,6 +18199,12 @@
               "url": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-abi/node_modules/semver"
             }
           ]
         }
@@ -14090,6 +18228,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-addon-api"
+        }
       ]
     },
     {
@@ -14109,6 +18253,12 @@
           "url": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-fetch"
         }
       ]
     },
@@ -14131,6 +18281,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-gyp"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14149,6 +18305,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/ansi-regex"
             }
           ]
         },
@@ -14170,6 +18332,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/are-we-there-yet"
+            }
           ]
         },
         {
@@ -14189,6 +18357,12 @@
               "url": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/gauge"
             }
           ]
         },
@@ -14210,6 +18384,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/is-fullwidth-code-point"
+            }
           ]
         },
         {
@@ -14229,6 +18409,12 @@
               "url": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/nopt"
             }
           ]
         },
@@ -14250,6 +18436,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/npmlog"
+            }
           ]
         },
         {
@@ -14269,6 +18461,12 @@
               "url": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/readable-stream"
             }
           ]
         },
@@ -14290,6 +18488,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/string-width"
+            }
           ]
         },
         {
@@ -14309,6 +18513,12 @@
               "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/strip-ansi"
             }
           ]
         }
@@ -14333,6 +18543,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-pre-gyp"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14351,6 +18567,12 @@
               "url": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/chownr"
             }
           ]
         },
@@ -14372,6 +18594,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/fs-minipass"
+            }
           ]
         },
         {
@@ -14391,6 +18619,12 @@
               "url": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/minipass"
             }
           ]
         },
@@ -14412,6 +18646,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/minizlib"
+            }
           ]
         },
         {
@@ -14431,6 +18671,12 @@
               "url": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/mkdirp"
             }
           ]
         },
@@ -14452,6 +18698,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/nopt"
+            }
           ]
         },
         {
@@ -14471,6 +18723,12 @@
               "url": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/rimraf"
             }
           ]
         },
@@ -14492,6 +18750,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/safe-buffer"
+            }
           ]
         },
         {
@@ -14511,6 +18775,12 @@
               "url": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/semver"
             }
           ]
         },
@@ -14532,6 +18802,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/tar"
+            }
           ]
         },
         {
@@ -14551,6 +18827,12 @@
               "url": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/yallist"
             }
           ]
         }
@@ -14574,6 +18856,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/noop-logger"
+        }
       ]
     },
     {
@@ -14593,6 +18881,12 @@
           "url": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/nopt"
         }
       ]
     },
@@ -14615,6 +18909,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/normalize-package-data"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14633,6 +18933,12 @@
               "url": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/normalize-package-data/node_modules/semver"
             }
           ]
         }
@@ -14656,6 +18962,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/normalize-path"
+        }
       ]
     },
     {
@@ -14675,6 +18987,12 @@
           "url": "https://registry.npmjs.org/normalize-url/-/normalize-url-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/normalize-url"
         }
       ]
     },
@@ -14697,6 +19015,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/notevil"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14715,6 +19039,12 @@
               "url": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/notevil/node_modules/esprima"
             }
           ]
         }
@@ -14738,6 +19068,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/npm-bundled"
+        }
       ]
     },
     {
@@ -14757,6 +19093,12 @@
           "url": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/npm-normalize-package-bin"
         }
       ]
     },
@@ -14778,6 +19120,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/npm-packlist"
+        }
       ]
     },
     {
@@ -14797,6 +19145,12 @@
           "url": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/npmlog"
         }
       ]
     },
@@ -14818,6 +19172,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/number-is-nan"
+        }
       ]
     },
     {
@@ -14838,6 +19198,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/oauth-sign"
+        }
       ]
     },
     {
@@ -14857,6 +19223,12 @@
           "url": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-assign"
         }
       ]
     },
@@ -14879,6 +19251,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-copy"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14897,6 +19275,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy/node_modules/define-property"
             }
           ]
         },
@@ -14918,6 +19302,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy/node_modules/is-accessor-descriptor"
+            }
           ]
         },
         {
@@ -14937,6 +19327,12 @@
               "url": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy/node_modules/is-data-descriptor"
             }
           ]
         },
@@ -14959,6 +19355,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy/node_modules/is-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -14977,6 +19379,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/object-copy/node_modules/is-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -15000,6 +19408,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy/node_modules/kind-of"
+            }
           ]
         }
       ]
@@ -15022,6 +19436,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-inspect"
+        }
       ]
     },
     {
@@ -15041,6 +19461,12 @@
           "url": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-is"
         }
       ]
     },
@@ -15062,6 +19488,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-keys"
+        }
       ]
     },
     {
@@ -15081,6 +19513,12 @@
           "url": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-visit"
         }
       ]
     },
@@ -15102,6 +19540,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object.assign"
+        }
       ]
     },
     {
@@ -15121,6 +19565,12 @@
           "url": "https://registry.npmjs.org/object.defaults/-/object.defaults-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object.defaults"
         }
       ]
     },
@@ -15142,6 +19592,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object.map"
+        }
       ]
     },
     {
@@ -15161,6 +19617,12 @@
           "url": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object.pick"
         }
       ]
     },
@@ -15182,6 +19644,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/on-finished"
+        }
       ]
     },
     {
@@ -15201,6 +19669,12 @@
           "url": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/on-headers"
         }
       ]
     },
@@ -15222,6 +19696,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/once"
+        }
       ]
     },
     {
@@ -15241,6 +19721,12 @@
           "url": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/one-time"
         }
       ]
     },
@@ -15262,6 +19748,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/opentype.js"
+        }
       ]
     },
     {
@@ -15281,6 +19773,12 @@
           "url": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/optionator"
         }
       ]
     },
@@ -15302,6 +19800,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/os-homedir"
+        }
       ]
     },
     {
@@ -15321,6 +19825,12 @@
           "url": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/os-tmpdir"
         }
       ]
     },
@@ -15342,6 +19852,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/osenv"
+        }
       ]
     },
     {
@@ -15361,6 +19877,12 @@
           "url": "https://registry.npmjs.org/otplib/-/otplib-12.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/otplib"
         }
       ]
     },
@@ -15382,6 +19904,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-cancelable"
+        }
       ]
     },
     {
@@ -15401,6 +19929,12 @@
           "url": "https://registry.npmjs.org/p-event/-/p-event-2.3.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-event"
         }
       ]
     },
@@ -15422,6 +19956,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-finally"
+        }
       ]
     },
     {
@@ -15441,6 +19981,12 @@
           "url": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-is-promise"
         }
       ]
     },
@@ -15462,6 +20008,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-limit"
+        }
       ]
     },
     {
@@ -15481,6 +20033,12 @@
           "url": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-locate"
         }
       ]
     },
@@ -15502,6 +20060,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-map"
+        }
       ]
     },
     {
@@ -15521,6 +20085,12 @@
           "url": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-timeout"
         }
       ]
     },
@@ -15542,6 +20112,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-try"
+        }
       ]
     },
     {
@@ -15561,6 +20137,12 @@
           "url": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pako"
         }
       ]
     },
@@ -15582,6 +20164,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/parse-filepath"
+        }
       ]
     },
     {
@@ -15601,6 +20189,12 @@
           "url": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/parse-json"
         }
       ]
     },
@@ -15622,6 +20216,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/parse-passwd"
+        }
       ]
     },
     {
@@ -15641,6 +20241,12 @@
           "url": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/parseurl"
         }
       ]
     },
@@ -15662,6 +20268,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pascalcase"
+        }
       ]
     },
     {
@@ -15681,6 +20293,12 @@
           "url": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-exists"
         }
       ]
     },
@@ -15702,6 +20320,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-is-absolute"
+        }
       ]
     },
     {
@@ -15721,6 +20345,12 @@
           "url": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-parse"
         }
       ]
     },
@@ -15742,6 +20372,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-root-regex"
+        }
       ]
     },
     {
@@ -15761,6 +20397,12 @@
           "url": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-root"
         }
       ]
     },
@@ -15782,6 +20424,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-to-regexp"
+        }
       ]
     },
     {
@@ -15801,6 +20449,12 @@
           "url": "https://registry.npmjs.org/pdfkit/-/pdfkit-0.11.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pdfkit"
         }
       ]
     },
@@ -15822,6 +20476,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/peek-readable"
+        }
       ]
     },
     {
@@ -15841,6 +20501,12 @@
           "url": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pend"
         }
       ]
     },
@@ -15862,6 +20528,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/performance-now"
+        }
       ]
     },
     {
@@ -15881,6 +20553,12 @@
           "url": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.5.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pg-connection-string"
         }
       ]
     },
@@ -15902,6 +20580,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/picomatch"
+        }
       ]
     },
     {
@@ -15921,6 +20605,12 @@
           "url": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pify"
         }
       ]
     },
@@ -15942,6 +20632,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pinkie-promise"
+        }
       ]
     },
     {
@@ -15961,6 +20657,12 @@
           "url": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pinkie"
         }
       ]
     },
@@ -15982,6 +20684,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/png-js"
+        }
       ]
     },
     {
@@ -16001,6 +20709,12 @@
           "url": "https://registry.npmjs.org/portscanner/-/portscanner-2.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/portscanner"
         }
       ]
     },
@@ -16022,6 +20736,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/posix-character-classes"
+        }
       ]
     },
     {
@@ -16041,6 +20761,12 @@
           "url": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.3.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/prebuild-install"
         }
       ]
     },
@@ -16062,6 +20788,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/prelude-ls"
+        }
       ]
     },
     {
@@ -16081,6 +20813,12 @@
           "url": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/prepend-http"
         }
       ]
     },
@@ -16102,6 +20840,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pretty-bytes"
+        }
       ]
     },
     {
@@ -16121,6 +20865,12 @@
           "url": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/process-nextick-args"
         }
       ]
     },
@@ -16142,6 +20892,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/prom-client"
+        }
       ]
     },
     {
@@ -16161,6 +20917,12 @@
           "url": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/promise-inflight"
         }
       ]
     },
@@ -16183,6 +20945,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/promise-retry"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -16201,6 +20969,12 @@
               "url": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/promise-retry/node_modules/err-code"
             }
           ]
         },
@@ -16221,6 +20995,12 @@
               "url": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/promise-retry/node_modules/retry"
             }
           ]
         }
@@ -16244,6 +21024,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/promise"
+        }
       ]
     },
     {
@@ -16263,6 +21049,12 @@
           "url": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/proper-lockfile"
         }
       ]
     },
@@ -16284,6 +21076,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/proxy-addr"
+        }
       ]
     },
     {
@@ -16303,6 +21101,12 @@
           "url": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/psl"
         }
       ]
     },
@@ -16324,6 +21128,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-attrs"
+        }
       ]
     },
     {
@@ -16343,6 +21153,12 @@
           "url": "https://registry.npmjs.org/pug-code-gen/-/pug-code-gen-3.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-code-gen"
         }
       ]
     },
@@ -16364,6 +21180,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-error"
+        }
       ]
     },
     {
@@ -16383,6 +21205,12 @@
           "url": "https://registry.npmjs.org/pug-filters/-/pug-filters-4.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-filters"
         }
       ]
     },
@@ -16404,6 +21232,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-lexer"
+        }
       ]
     },
     {
@@ -16423,6 +21257,12 @@
           "url": "https://registry.npmjs.org/pug-linker/-/pug-linker-4.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-linker"
         }
       ]
     },
@@ -16444,6 +21284,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-load"
+        }
       ]
     },
     {
@@ -16463,6 +21309,12 @@
           "url": "https://registry.npmjs.org/pug-parser/-/pug-parser-6.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-parser"
         }
       ]
     },
@@ -16484,6 +21336,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-runtime"
+        }
       ]
     },
     {
@@ -16503,6 +21361,12 @@
           "url": "https://registry.npmjs.org/pug-strip-comments/-/pug-strip-comments-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-strip-comments"
         }
       ]
     },
@@ -16524,6 +21388,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-walk"
+        }
       ]
     },
     {
@@ -16543,6 +21413,12 @@
           "url": "https://registry.npmjs.org/pug/-/pug-3.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug"
         }
       ]
     },
@@ -16564,6 +21440,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pump"
+        }
       ]
     },
     {
@@ -16583,6 +21465,12 @@
           "url": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/punycode"
         }
       ]
     },
@@ -16604,6 +21492,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/qs"
+        }
       ]
     },
     {
@@ -16623,6 +21517,12 @@
           "url": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/query-string"
         }
       ]
     },
@@ -16644,6 +21544,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/range_check"
+        }
       ]
     },
     {
@@ -16663,6 +21569,12 @@
           "url": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/range-parser"
         }
       ]
     },
@@ -16684,6 +21596,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/raw-body"
+        }
       ]
     },
     {
@@ -16703,6 +21621,12 @@
           "url": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/rc"
         }
       ]
     },
@@ -16725,6 +21649,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/read-pkg"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -16743,6 +21673,12 @@
               "url": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/read-pkg/node_modules/pify"
             }
           ]
         }
@@ -16767,6 +21703,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/readable-stream"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -16785,6 +21727,12 @@
               "url": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/readable-stream/node_modules/isarray"
             }
           ]
         }
@@ -16809,6 +21757,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/readable-web-to-node-stream"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -16827,6 +21781,12 @@
               "url": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/readable-web-to-node-stream/node_modules/readable-stream"
             }
           ]
         }
@@ -16850,6 +21810,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/readdirp"
+        }
       ]
     },
     {
@@ -16869,6 +21835,12 @@
           "url": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/rechoir"
         }
       ]
     },
@@ -16890,6 +21862,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/regex-not"
+        }
       ]
     },
     {
@@ -16909,6 +21887,12 @@
           "url": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/regexp.prototype.flags"
         }
       ]
     },
@@ -16930,6 +21914,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/remove-trailing-separator"
+        }
       ]
     },
     {
@@ -16950,6 +21940,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/repeat-element"
+        }
       ]
     },
     {
@@ -16969,6 +21965,12 @@
           "url": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/repeat-string"
         }
       ]
     },
@@ -16991,6 +21993,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/replace"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17009,6 +22017,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/ansi-regex"
             }
           ]
         },
@@ -17030,6 +22044,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/ansi-styles"
+            }
           ]
         },
         {
@@ -17049,6 +22069,12 @@
               "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/brace-expansion"
             }
           ]
         },
@@ -17070,6 +22096,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/cliui"
+            }
           ]
         },
         {
@@ -17089,6 +22121,12 @@
               "url": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/color-convert"
             }
           ]
         },
@@ -17110,6 +22148,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/color-name"
+            }
           ]
         },
         {
@@ -17129,6 +22173,12 @@
               "url": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/find-up"
             }
           ]
         },
@@ -17150,6 +22200,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/is-fullwidth-code-point"
+            }
           ]
         },
         {
@@ -17169,6 +22225,12 @@
               "url": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/locate-path"
             }
           ]
         },
@@ -17190,6 +22252,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/minimatch"
+            }
           ]
         },
         {
@@ -17209,6 +22277,12 @@
               "url": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/p-locate"
             }
           ]
         },
@@ -17230,6 +22304,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/path-exists"
+            }
           ]
         },
         {
@@ -17249,6 +22329,12 @@
               "url": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/string-width"
             }
           ]
         },
@@ -17270,6 +22356,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/strip-ansi"
+            }
           ]
         },
         {
@@ -17289,6 +22381,12 @@
               "url": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/wrap-ansi"
             }
           ]
         },
@@ -17310,6 +22408,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/yargs-parser"
+            }
           ]
         },
         {
@@ -17329,6 +22433,12 @@
               "url": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/yargs"
             }
           ]
         }
@@ -17353,6 +22463,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/request"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17371,6 +22487,12 @@
               "url": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/request/node_modules/qs"
             }
           ]
         }
@@ -17394,6 +22516,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/require-directory"
+        }
       ]
     },
     {
@@ -17413,6 +22541,12 @@
           "url": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/require-main-filename"
         }
       ]
     },
@@ -17434,6 +22568,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/resolve-dir"
+        }
       ]
     },
     {
@@ -17453,6 +22593,12 @@
           "url": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/resolve-url"
         }
       ]
     },
@@ -17474,6 +22620,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/resolve"
+        }
       ]
     },
     {
@@ -17493,6 +22645,12 @@
           "url": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/responselike"
         }
       ]
     },
@@ -17514,6 +22672,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/restructure"
+        }
       ]
     },
     {
@@ -17533,6 +22697,12 @@
           "url": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ret"
         }
       ]
     },
@@ -17554,6 +22724,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/retry-as-promised"
+        }
       ]
     },
     {
@@ -17574,6 +22750,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/retry"
+        }
       ]
     },
     {
@@ -17593,6 +22775,12 @@
           "url": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/rimraf"
         }
       ]
     },
@@ -17615,6 +22803,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/rxjs"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17633,6 +22827,12 @@
               "url": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/rxjs/node_modules/tslib"
             }
           ]
         }
@@ -17656,6 +22856,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safe-buffer"
+        }
       ]
     },
     {
@@ -17675,6 +22881,12 @@
           "url": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safe-regex-test"
         }
       ]
     },
@@ -17696,6 +22908,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safe-regex"
+        }
       ]
     },
     {
@@ -17715,6 +22933,12 @@
           "url": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safe-stable-stringify"
         }
       ]
     },
@@ -17736,6 +22960,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safer-buffer"
+        }
       ]
     },
     {
@@ -17756,6 +22986,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/samsam"
+        }
       ]
     },
     {
@@ -17775,6 +23011,12 @@
           "url": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sanitize-filename"
         }
       ]
     },
@@ -17797,6 +23039,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sanitize-html"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17815,6 +23063,12 @@
               "url": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sanitize-html/node_modules/lodash"
             }
           ]
         }
@@ -17838,6 +23092,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sax"
+        }
       ]
     },
     {
@@ -17858,6 +23118,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/seek-bzip"
+        }
       ]
     },
     {
@@ -17877,6 +23143,12 @@
           "url": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/semver"
         }
       ]
     },
@@ -17899,6 +23171,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/send"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17917,6 +23195,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/send/node_modules/ms"
             }
           ]
         }
@@ -17940,6 +23224,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sequelize-pool"
+        }
       ]
     },
     {
@@ -17961,6 +23251,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sequelize"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17979,6 +23275,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sequelize/node_modules/debug"
             }
           ]
         },
@@ -18000,6 +23302,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sequelize/node_modules/ms"
+            }
           ]
         },
         {
@@ -18019,6 +23327,12 @@
               "url": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sequelize/node_modules/uuid"
             }
           ]
         }
@@ -18043,6 +23357,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/serve-index"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18061,6 +23381,12 @@
               "url": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index/node_modules/depd"
             }
           ]
         },
@@ -18082,6 +23408,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index/node_modules/http-errors"
+            }
           ]
         },
         {
@@ -18101,6 +23433,12 @@
               "url": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index/node_modules/inherits"
             }
           ]
         },
@@ -18122,6 +23460,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index/node_modules/setprototypeof"
+            }
           ]
         },
         {
@@ -18141,6 +23485,12 @@
               "url": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index/node_modules/statuses"
             }
           ]
         }
@@ -18164,6 +23514,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/serve-static"
+        }
       ]
     },
     {
@@ -18183,6 +23539,12 @@
           "url": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/set-blocking"
         }
       ]
     },
@@ -18205,6 +23567,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/set-value"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18223,6 +23591,12 @@
               "url": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/set-value/node_modules/extend-shallow"
             }
           ]
         },
@@ -18243,6 +23617,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/set-value/node_modules/is-extendable"
             }
           ]
         }
@@ -18266,6 +23646,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/setimmediate"
+        }
       ]
     },
     {
@@ -18285,6 +23671,12 @@
           "url": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/setprototypeof"
         }
       ]
     },
@@ -18306,6 +23698,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/side-channel"
+        }
       ]
     },
     {
@@ -18326,6 +23724,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/signal-exit"
+        }
       ]
     },
     {
@@ -18345,6 +23749,12 @@
           "url": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/simple-concat"
         }
       ]
     },
@@ -18367,6 +23777,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/simple-get"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18385,6 +23801,12 @@
               "url": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/simple-get/node_modules/decompress-response"
             }
           ]
         },
@@ -18405,6 +23827,12 @@
               "url": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/simple-get/node_modules/mimic-response"
             }
           ]
         }
@@ -18429,6 +23857,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/simple-swizzle"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18447,6 +23881,12 @@
               "url": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/simple-swizzle/node_modules/is-arrayish"
             }
           ]
         }
@@ -18470,6 +23910,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sinon"
+        }
       ]
     },
     {
@@ -18489,6 +23935,12 @@
           "url": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/smart-buffer"
         }
       ]
     },
@@ -18511,6 +23963,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/snapdragon-node"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18529,6 +23987,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon-node/node_modules/define-property"
             }
           ]
         }
@@ -18553,6 +24017,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/snapdragon-util"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18571,6 +24041,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon-util/node_modules/kind-of"
             }
           ]
         }
@@ -18595,6 +24071,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/snapdragon"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18613,6 +24095,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/define-property"
             }
           ]
         },
@@ -18633,6 +24121,12 @@
               "url": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/extend-shallow"
             }
           ]
         },
@@ -18655,6 +24149,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/is-accessor-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -18673,6 +24173,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/snapdragon/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -18697,6 +24203,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/is-data-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -18715,6 +24227,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/snapdragon/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -18738,6 +24256,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/is-descriptor"
+            }
           ]
         },
         {
@@ -18757,6 +24281,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/is-extendable"
             }
           ]
         },
@@ -18778,6 +24308,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/kind-of"
+            }
           ]
         },
         {
@@ -18797,6 +24333,12 @@
               "url": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/source-map"
             }
           ]
         }
@@ -18820,6 +24362,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socket.io-adapter"
+        }
       ]
     },
     {
@@ -18841,6 +24389,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socket.io-parser"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18859,6 +24413,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socket.io-parser/node_modules/debug"
             }
           ]
         },
@@ -18879,6 +24439,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socket.io-parser/node_modules/ms"
             }
           ]
         }
@@ -18903,6 +24469,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socket.io"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18921,6 +24493,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socket.io/node_modules/debug"
             }
           ]
         },
@@ -18941,6 +24519,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socket.io/node_modules/ms"
             }
           ]
         }
@@ -18965,6 +24549,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socks-proxy-agent"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18983,6 +24573,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socks-proxy-agent/node_modules/debug"
             }
           ]
         },
@@ -19003,6 +24599,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socks-proxy-agent/node_modules/ms"
             }
           ]
         }
@@ -19027,6 +24629,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socks"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -19045,6 +24653,12 @@
               "url": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socks/node_modules/ip"
             }
           ]
         }
@@ -19069,6 +24683,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sort-keys-length"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -19087,6 +24707,12 @@
               "url": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sort-keys-length/node_modules/sort-keys"
             }
           ]
         }
@@ -19110,6 +24736,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sort-keys"
+        }
       ]
     },
     {
@@ -19129,6 +24761,12 @@
           "url": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/source-map-resolve"
         }
       ]
     },
@@ -19150,6 +24788,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/source-map-support"
+        }
       ]
     },
     {
@@ -19169,6 +24813,12 @@
           "url": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/source-map-url"
         }
       ]
     },
@@ -19190,6 +24840,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/source-map"
+        }
       ]
     },
     {
@@ -19209,6 +24865,12 @@
           "url": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2-1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spawn-command"
         }
       ]
     },
@@ -19230,6 +24892,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spdx-correct"
+        }
       ]
     },
     {
@@ -19249,6 +24917,12 @@
           "url": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spdx-exceptions"
         }
       ]
     },
@@ -19270,6 +24944,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spdx-expression-parse"
+        }
       ]
     },
     {
@@ -19289,6 +24969,12 @@
           "url": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.12.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spdx-license-ids"
         }
       ]
     },
@@ -19310,6 +24996,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/split-string"
+        }
       ]
     },
     {
@@ -19329,6 +25021,12 @@
           "url": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sprintf-js"
         }
       ]
     },
@@ -19350,6 +25048,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sqlite3"
+        }
       ]
     },
     {
@@ -19369,6 +25073,12 @@
           "url": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sshpk"
         }
       ]
     },
@@ -19390,6 +25100,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ssri"
+        }
       ]
     },
     {
@@ -19409,6 +25125,12 @@
           "url": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/stack-trace"
         }
       ]
     },
@@ -19431,6 +25153,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/static-extend"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -19449,6 +25177,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend/node_modules/define-property"
             }
           ]
         },
@@ -19471,6 +25205,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend/node_modules/is-accessor-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -19489,6 +25229,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/static-extend/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -19513,6 +25259,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend/node_modules/is-data-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -19531,6 +25283,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/static-extend/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -19554,6 +25312,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend/node_modules/is-descriptor"
+            }
           ]
         },
         {
@@ -19573,6 +25337,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend/node_modules/kind-of"
             }
           ]
         }
@@ -19596,6 +25366,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/statuses"
+        }
       ]
     },
     {
@@ -19615,6 +25391,12 @@
           "url": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-2.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/stream-buffers"
         }
       ]
     },
@@ -19636,6 +25418,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/streamsearch"
+        }
       ]
     },
     {
@@ -19655,6 +25443,12 @@
           "url": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strict-uri-encode"
         }
       ]
     },
@@ -19676,6 +25470,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string_decoder"
+        }
       ]
     },
     {
@@ -19695,6 +25495,12 @@
           "url": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string-width"
         }
       ]
     },
@@ -19716,6 +25522,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string.fromcodepoint"
+        }
       ]
     },
     {
@@ -19735,6 +25547,12 @@
           "url": "https://registry.npmjs.org/string.prototype.codepointat/-/string.prototype.codepointat-0.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string.prototype.codepointat"
         }
       ]
     },
@@ -19756,6 +25574,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string.prototype.trimend"
+        }
       ]
     },
     {
@@ -19775,6 +25599,12 @@
           "url": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string.prototype.trimstart"
         }
       ]
     },
@@ -19796,6 +25626,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-ansi"
+        }
       ]
     },
     {
@@ -19815,6 +25651,12 @@
           "url": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-bom"
         }
       ]
     },
@@ -19836,6 +25678,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-dirs"
+        }
       ]
     },
     {
@@ -19855,6 +25703,12 @@
           "url": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-json-comments"
         }
       ]
     },
@@ -19876,6 +25730,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-outer"
+        }
       ]
     },
     {
@@ -19895,6 +25755,12 @@
           "url": "https://registry.npmjs.org/strtok3/-/strtok3-6.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strtok3"
         }
       ]
     },
@@ -19916,6 +25782,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/supports-color"
+        }
       ]
     },
     {
@@ -19935,6 +25807,12 @@
           "url": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/supports-preserve-symlinks-flag"
         }
       ]
     },
@@ -19956,6 +25834,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/svg-captcha"
+        }
       ]
     },
     {
@@ -19976,6 +25860,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/swagger-ui-dist"
+        }
       ]
     },
     {
@@ -19995,6 +25885,12 @@
           "url": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-4.5.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/swagger-ui-express"
         }
       ]
     },
@@ -20017,6 +25913,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tar-fs"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -20035,6 +25937,12 @@
               "url": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/tar-fs/node_modules/bl"
             }
           ]
         },
@@ -20056,6 +25964,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/tar-fs/node_modules/chownr"
+            }
           ]
         },
         {
@@ -20076,6 +25990,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/tar-fs/node_modules/readable-stream"
+            }
           ]
         },
         {
@@ -20095,6 +26015,12 @@
               "url": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/tar-fs/node_modules/tar-stream"
             }
           ]
         }
@@ -20118,6 +26044,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tar-stream"
+        }
       ]
     },
     {
@@ -20137,6 +26069,12 @@
           "url": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tar"
         }
       ]
     },
@@ -20158,6 +26096,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tdigest"
+        }
       ]
     },
     {
@@ -20177,6 +26121,12 @@
           "url": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/text-hex"
         }
       ]
     },
@@ -20198,6 +26148,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/thirty-two"
+        }
       ]
     },
     {
@@ -20217,6 +26173,12 @@
           "url": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/through"
         }
       ]
     },
@@ -20238,6 +26200,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/timed-out"
+        }
       ]
     },
     {
@@ -20257,6 +26225,12 @@
           "url": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tiny-inflate"
         }
       ]
     },
@@ -20278,6 +26252,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-buffer"
+        }
       ]
     },
     {
@@ -20297,6 +26277,12 @@
           "url": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-fast-properties"
         }
       ]
     },
@@ -20319,6 +26305,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-object-path"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -20337,6 +26329,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/to-object-path/node_modules/kind-of"
             }
           ]
         }
@@ -20360,6 +26358,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-regex-range"
+        }
       ]
     },
     {
@@ -20379,6 +26383,12 @@
           "url": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-regex"
         }
       ]
     },
@@ -20400,6 +26410,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/toidentifier"
+        }
       ]
     },
     {
@@ -20419,6 +26435,12 @@
           "url": "https://registry.npmjs.org/token-stream/-/token-stream-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/token-stream"
         }
       ]
     },
@@ -20440,6 +26462,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/token-types"
+        }
       ]
     },
     {
@@ -20459,6 +26487,12 @@
           "url": "https://registry.npmjs.org/toposort-class/-/toposort-class-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/toposort-class"
         }
       ]
     },
@@ -20480,6 +26514,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tough-cookie"
+        }
       ]
     },
     {
@@ -20499,6 +26539,12 @@
           "url": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tr46"
         }
       ]
     },
@@ -20520,6 +26566,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/traverse"
+        }
       ]
     },
     {
@@ -20539,6 +26591,12 @@
           "url": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tree-kill"
         }
       ]
     },
@@ -20560,6 +26618,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/trim-repeated"
+        }
       ]
     },
     {
@@ -20580,6 +26644,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/triple-beam"
+        }
       ]
     },
     {
@@ -20599,6 +26669,12 @@
           "url": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/truncate-utf8-bytes"
         }
       ]
     },
@@ -20621,6 +26697,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ts-node-dev"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -20639,6 +26721,12 @@
               "url": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/ts-node-dev/node_modules/rimraf"
             }
           ]
         }
@@ -20662,6 +26750,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ts-node"
+        }
       ]
     },
     {
@@ -20681,6 +26775,12 @@
           "url": "https://registry.npmjs.org/tsconfig/-/tsconfig-7.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tsconfig"
         }
       ]
     },
@@ -20702,6 +26802,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tslib"
+        }
       ]
     },
     {
@@ -20721,6 +26827,12 @@
           "url": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tunnel-agent"
         }
       ]
     },
@@ -20742,6 +26854,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tweetnacl"
+        }
       ]
     },
     {
@@ -20761,6 +26879,12 @@
           "url": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/type-check"
         }
       ]
     },
@@ -20782,6 +26906,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/type-is"
+        }
       ]
     },
     {
@@ -20801,6 +26931,12 @@
           "url": "https://registry.npmjs.org/typecast/-/typecast-0.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/typecast"
         }
       ]
     },
@@ -20822,6 +26958,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/typedarray"
+        }
       ]
     },
     {
@@ -20841,6 +26983,12 @@
           "url": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/typescript"
         }
       ]
     },
@@ -20862,6 +27010,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/uglify-js"
+        }
       ]
     },
     {
@@ -20881,6 +27035,12 @@
           "url": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unbox-primitive"
         }
       ]
     },
@@ -20902,6 +27062,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unbzip2-stream"
+        }
       ]
     },
     {
@@ -20921,6 +27087,12 @@
           "url": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unc-path-regex"
         }
       ]
     },
@@ -20942,6 +27114,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/underscore.string"
+        }
       ]
     },
     {
@@ -20962,6 +27140,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unicode-properties"
+        }
       ]
     },
     {
@@ -20981,6 +27165,12 @@
           "url": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unicode-trie"
         }
       ]
     },
@@ -21003,6 +27193,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/union-value"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21021,6 +27217,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/union-value/node_modules/is-extendable"
             }
           ]
         }
@@ -21044,6 +27246,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unique-filename"
+        }
       ]
     },
     {
@@ -21063,6 +27271,12 @@
           "url": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unique-slug"
         }
       ]
     },
@@ -21084,6 +27298,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unit-compare"
+        }
       ]
     },
     {
@@ -21104,6 +27324,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/universalify"
+        }
       ]
     },
     {
@@ -21123,6 +27349,12 @@
           "url": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unpipe"
         }
       ]
     },
@@ -21145,6 +27377,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unset-value"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21165,6 +27403,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/unset-value/node_modules/has-value"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -21183,6 +27427,12 @@
                   "url": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/unset-value/node_modules/has-value/node_modules/isobject"
                 }
               ]
             }
@@ -21206,6 +27456,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/unset-value/node_modules/has-values"
+            }
           ]
         },
         {
@@ -21225,6 +27481,12 @@
               "url": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/unset-value/node_modules/isarray"
             }
           ]
         }
@@ -21248,6 +27510,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/untildify"
+        }
       ]
     },
     {
@@ -21269,6 +27537,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unzipper"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21287,6 +27561,12 @@
               "url": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/unzipper/node_modules/bluebird"
             }
           ]
         }
@@ -21310,6 +27590,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/uri-js"
+        }
       ]
     },
     {
@@ -21329,6 +27615,12 @@
           "url": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/urix"
         }
       ]
     },
@@ -21350,6 +27642,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/url-parse-lax"
+        }
       ]
     },
     {
@@ -21369,6 +27667,12 @@
           "url": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/url-to-options"
         }
       ]
     },
@@ -21390,6 +27694,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/use"
+        }
       ]
     },
     {
@@ -21409,6 +27719,12 @@
           "url": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/utf8-byte-length"
         }
       ]
     },
@@ -21430,6 +27746,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/util-deprecate"
+        }
       ]
     },
     {
@@ -21449,6 +27771,12 @@
           "url": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/util"
         }
       ]
     },
@@ -21470,6 +27798,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/utils-merge"
+        }
       ]
     },
     {
@@ -21489,6 +27823,12 @@
           "url": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/uuid"
         }
       ]
     },
@@ -21510,6 +27850,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/v8flags"
+        }
       ]
     },
     {
@@ -21529,6 +27875,12 @@
           "url": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/validate-npm-package-license"
         }
       ]
     },
@@ -21550,6 +27902,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/validate"
+        }
       ]
     },
     {
@@ -21570,6 +27928,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/validator"
+        }
       ]
     },
     {
@@ -21589,6 +27953,12 @@
           "url": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/vary"
         }
       ]
     },
@@ -21611,6 +27981,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/verror"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21629,6 +28005,12 @@
               "url": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/verror/node_modules/core-util-is"
             }
           ]
         }
@@ -21653,6 +28035,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/vm2"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21671,6 +28059,12 @@
               "url": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/vm2/node_modules/acorn"
             }
           ]
         }
@@ -21694,6 +28088,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/void-elements"
+        }
       ]
     },
     {
@@ -21713,6 +28113,12 @@
           "url": "https://registry.npmjs.org/walk/-/walk-2.3.15.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/walk"
         }
       ]
     },
@@ -21734,6 +28140,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/walkdir"
+        }
       ]
     },
     {
@@ -21753,6 +28165,12 @@
           "url": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/webidl-conversions"
         }
       ]
     },
@@ -21774,6 +28192,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/whatwg-url"
+        }
       ]
     },
     {
@@ -21793,6 +28217,12 @@
           "url": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-boxed-primitive"
         }
       ]
     },
@@ -21814,6 +28244,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-collection"
+        }
       ]
     },
     {
@@ -21833,6 +28269,12 @@
           "url": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-module"
         }
       ]
     },
@@ -21854,6 +28296,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-pm-runs"
+        }
       ]
     },
     {
@@ -21873,6 +28321,12 @@
           "url": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-typed-array"
         }
       ]
     },
@@ -21894,6 +28348,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which"
+        }
       ]
     },
     {
@@ -21913,6 +28373,12 @@
           "url": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wide-align"
         }
       ]
     },
@@ -21935,6 +28401,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/winston-transport"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21953,6 +28425,12 @@
               "url": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/winston-transport/node_modules/readable-stream"
             }
           ]
         }
@@ -21977,6 +28455,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/winston"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21995,6 +28479,12 @@
               "url": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/winston/node_modules/async"
             }
           ]
         },
@@ -22016,6 +28506,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/winston/node_modules/is-stream"
+            }
           ]
         },
         {
@@ -22035,6 +28531,12 @@
               "url": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/winston/node_modules/readable-stream"
             }
           ]
         }
@@ -22058,6 +28560,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/with"
+        }
       ]
     },
     {
@@ -22077,6 +28585,12 @@
           "url": "https://registry.npmjs.org/wkx/-/wkx-0.5.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wkx"
         }
       ]
     },
@@ -22098,6 +28612,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/word-wrap"
+        }
       ]
     },
     {
@@ -22117,6 +28637,12 @@
           "url": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wordwrap"
         }
       ]
     },
@@ -22139,6 +28665,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wrap-ansi"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -22157,6 +28689,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi/node_modules/ansi-regex"
             }
           ]
         },
@@ -22178,6 +28716,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi/node_modules/emoji-regex"
+            }
           ]
         },
         {
@@ -22197,6 +28741,12 @@
               "url": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi/node_modules/is-fullwidth-code-point"
             }
           ]
         },
@@ -22218,6 +28768,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi/node_modules/string-width"
+            }
           ]
         },
         {
@@ -22237,6 +28793,12 @@
               "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi/node_modules/strip-ansi"
             }
           ]
         }
@@ -22260,6 +28822,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wrappy"
+        }
       ]
     },
     {
@@ -22279,6 +28847,12 @@
           "url": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ws"
         }
       ]
     },
@@ -22300,6 +28874,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/xtend"
+        }
       ]
     },
     {
@@ -22319,6 +28899,12 @@
           "url": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/y18n"
         }
       ]
     },
@@ -22340,6 +28926,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yallist"
+        }
       ]
     },
     {
@@ -22360,6 +28952,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yaml-schema-validator"
+        }
       ]
     },
     {
@@ -22379,6 +28977,12 @@
           "url": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yargs-parser"
         }
       ]
     },
@@ -22401,6 +29005,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yargs"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -22419,6 +29029,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs/node_modules/ansi-regex"
             }
           ]
         },
@@ -22440,6 +29056,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs/node_modules/emoji-regex"
+            }
           ]
         },
         {
@@ -22459,6 +29081,12 @@
               "url": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs/node_modules/is-fullwidth-code-point"
             }
           ]
         },
@@ -22480,6 +29108,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs/node_modules/string-width"
+            }
           ]
         },
         {
@@ -22499,6 +29133,12 @@
               "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs/node_modules/strip-ansi"
             }
           ]
         }
@@ -22522,6 +29162,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yauzl"
+        }
       ]
     },
     {
@@ -22541,6 +29187,12 @@
           "url": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yn"
         }
       ]
     },
@@ -22562,6 +29214,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/z85"
+        }
       ]
     },
     {
@@ -22582,6 +29240,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/zip-stream"
+        }
       ]
     },
     {
@@ -22601,6 +29265,12 @@
           "url": "https://registry.npmjs.org/zlibjs/-/zlibjs-0.3.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/zlibjs"
         }
       ]
     }

--- a/tests/_data/sbom_demo-results/juice-shop_npm8_node16_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/juice-shop_npm8_node16_ubuntu-latest.snap.json
@@ -62,7 +62,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -95,7 +95,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@babel/helper-string-parser"
         }
       ]
@@ -122,7 +122,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@babel/helper-validator-identifier"
         }
       ]
@@ -149,7 +149,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@babel/parser"
         }
       ]
@@ -176,7 +176,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@babel/types"
         }
       ]
@@ -203,7 +203,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@colors/colors"
         }
       ]
@@ -230,7 +230,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@dabh/diagnostics"
         }
       ]
@@ -257,7 +257,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@gar/promisify"
         }
       ]
@@ -284,7 +284,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@mapbox/node-pre-gyp"
         }
       ],
@@ -310,7 +310,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/ansi-regex"
             }
           ]
@@ -336,7 +336,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/are-we-there-yet"
             }
           ]
@@ -362,7 +362,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/detect-libc"
             }
           ]
@@ -388,7 +388,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/gauge"
             }
           ]
@@ -414,7 +414,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -440,7 +440,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/make-dir"
             }
           ],
@@ -466,7 +466,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/@mapbox/node-pre-gyp/node_modules/make-dir/node_modules/semver"
                 }
               ]
@@ -494,7 +494,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/nopt"
             }
           ]
@@ -520,7 +520,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/npmlog"
             }
           ]
@@ -546,7 +546,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/readable-stream"
             }
           ]
@@ -572,7 +572,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/string-width"
             }
           ]
@@ -598,7 +598,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/strip-ansi"
             }
           ]
@@ -627,7 +627,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/core-loader"
         }
       ]
@@ -654,7 +654,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/core"
         }
       ]
@@ -681,7 +681,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/evaluator"
         }
       ]
@@ -708,7 +708,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-all"
         }
       ]
@@ -735,7 +735,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ar"
         }
       ]
@@ -762,7 +762,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-bn"
         }
       ]
@@ -789,7 +789,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ca"
         }
       ]
@@ -816,7 +816,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-cs"
         }
       ]
@@ -843,7 +843,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-da"
         }
       ]
@@ -870,7 +870,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-de"
         }
       ]
@@ -897,7 +897,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-el"
         }
       ]
@@ -924,7 +924,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-en-min"
         }
       ]
@@ -951,7 +951,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-en"
         }
       ]
@@ -978,7 +978,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-es"
         }
       ]
@@ -1005,7 +1005,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-eu"
         }
       ]
@@ -1032,7 +1032,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-fa"
         }
       ]
@@ -1059,7 +1059,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-fi"
         }
       ]
@@ -1086,7 +1086,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-fr"
         }
       ]
@@ -1113,7 +1113,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ga"
         }
       ]
@@ -1140,7 +1140,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-gl"
         }
       ]
@@ -1167,7 +1167,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-hi"
         }
       ]
@@ -1194,7 +1194,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-hu"
         }
       ]
@@ -1221,7 +1221,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-hy"
         }
       ]
@@ -1248,7 +1248,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-id"
         }
       ]
@@ -1275,7 +1275,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-it"
         }
       ]
@@ -1302,7 +1302,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ja"
         }
       ]
@@ -1329,7 +1329,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ko"
         }
       ]
@@ -1356,7 +1356,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-lt"
         }
       ]
@@ -1383,7 +1383,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ms"
         }
       ]
@@ -1410,7 +1410,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ne"
         }
       ]
@@ -1437,7 +1437,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-nl"
         }
       ]
@@ -1464,7 +1464,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-no"
         }
       ]
@@ -1491,7 +1491,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-pl"
         }
       ]
@@ -1518,7 +1518,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-pt"
         }
       ]
@@ -1545,7 +1545,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ro"
         }
       ]
@@ -1572,7 +1572,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ru"
         }
       ]
@@ -1599,7 +1599,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-sl"
         }
       ]
@@ -1626,7 +1626,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-sr"
         }
       ]
@@ -1653,7 +1653,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-sv"
         }
       ]
@@ -1680,7 +1680,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ta"
         }
       ]
@@ -1707,7 +1707,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-th"
         }
       ]
@@ -1734,7 +1734,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-tl"
         }
       ]
@@ -1761,7 +1761,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-tr"
         }
       ]
@@ -1788,7 +1788,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-uk"
         }
       ]
@@ -1815,7 +1815,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-zh"
         }
       ]
@@ -1842,7 +1842,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/language-min"
         }
       ]
@@ -1869,7 +1869,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/language"
         }
       ]
@@ -1896,7 +1896,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/ner"
         }
       ]
@@ -1923,7 +1923,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/neural"
         }
       ]
@@ -1950,7 +1950,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/nlg"
         }
       ]
@@ -1977,7 +1977,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/nlp"
         }
       ]
@@ -2004,7 +2004,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/nlu"
         }
       ]
@@ -2031,7 +2031,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/request"
         }
       ]
@@ -2058,7 +2058,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/sentiment"
         }
       ]
@@ -2085,7 +2085,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/similarity"
         }
       ]
@@ -2112,7 +2112,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/slot"
         }
       ]
@@ -2139,7 +2139,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@npmcli/fs"
         }
       ]
@@ -2166,7 +2166,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@npmcli/move-file"
         }
       ]
@@ -2193,7 +2193,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib/core"
         }
       ]
@@ -2220,7 +2220,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib/plugin-crypto"
         }
       ]
@@ -2247,7 +2247,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib/plugin-thirty-two"
         }
       ]
@@ -2274,7 +2274,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib/preset-default"
         }
       ]
@@ -2301,7 +2301,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib/preset-v11"
         }
       ]
@@ -2328,7 +2328,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@sindresorhus/is"
         }
       ]
@@ -2355,7 +2355,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@swc/helpers"
         }
       ]
@@ -2382,7 +2382,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@tokenizer/token"
         }
       ]
@@ -2409,7 +2409,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@tootallnate/once"
         }
       ]
@@ -2436,7 +2436,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/component-emitter"
         }
       ]
@@ -2463,7 +2463,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/cookie"
         }
       ]
@@ -2490,7 +2490,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/cors"
         }
       ]
@@ -2517,7 +2517,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/debug"
         }
       ]
@@ -2544,7 +2544,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/ms"
         }
       ]
@@ -2571,7 +2571,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/node"
         }
       ]
@@ -2598,7 +2598,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/strip-bom"
         }
       ]
@@ -2625,7 +2625,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/strip-json-comments"
         }
       ]
@@ -2652,7 +2652,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/validator"
         }
       ]
@@ -2678,7 +2678,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/abbrev"
         }
       ]
@@ -2704,7 +2704,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/accepts"
         }
       ]
@@ -2730,7 +2730,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/acorn-walk"
         }
       ]
@@ -2756,7 +2756,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/acorn"
         }
       ]
@@ -2782,7 +2782,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/agent-base"
         }
       ],
@@ -2808,7 +2808,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agent-base/node_modules/debug"
             }
           ]
@@ -2834,7 +2834,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agent-base/node_modules/ms"
             }
           ]
@@ -2862,7 +2862,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/agentkeepalive"
         }
       ],
@@ -2888,7 +2888,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agentkeepalive/node_modules/debug"
             }
           ]
@@ -2914,7 +2914,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agentkeepalive/node_modules/depd"
             }
           ]
@@ -2940,7 +2940,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agentkeepalive/node_modules/ms"
             }
           ]
@@ -2968,7 +2968,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/aggregate-error"
         }
       ]
@@ -2994,7 +2994,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ajv"
         }
       ]
@@ -3020,7 +3020,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ansi-regex"
         }
       ]
@@ -3046,7 +3046,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ansi-styles"
         }
       ]
@@ -3072,7 +3072,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/anymatch"
         }
       ],
@@ -3098,7 +3098,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/anymatch/node_modules/normalize-path"
             }
           ]
@@ -3126,7 +3126,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/append-field"
         }
       ]
@@ -3152,7 +3152,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/aproba"
         }
       ]
@@ -3178,7 +3178,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/archive-type"
         }
       ],
@@ -3204,7 +3204,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/archive-type/node_modules/file-type"
             }
           ]
@@ -3232,7 +3232,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/archiver-utils"
         }
       ]
@@ -3258,7 +3258,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/archiver"
         }
       ]
@@ -3284,7 +3284,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/are-we-there-yet"
         }
       ]
@@ -3310,7 +3310,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/arg"
         }
       ]
@@ -3336,7 +3336,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/argparse"
         }
       ],
@@ -3362,7 +3362,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/argparse/node_modules/sprintf-js"
             }
           ]
@@ -3390,7 +3390,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/arr-diff"
         }
       ]
@@ -3416,7 +3416,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/arr-flatten"
         }
       ]
@@ -3442,7 +3442,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/arr-union"
         }
       ]
@@ -3468,7 +3468,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/array-each"
         }
       ]
@@ -3494,7 +3494,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/array-flatten"
         }
       ]
@@ -3520,7 +3520,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/array-slice"
         }
       ]
@@ -3546,7 +3546,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/array-unique"
         }
       ]
@@ -3572,7 +3572,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/asap"
         }
       ]
@@ -3598,7 +3598,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/asn1"
         }
       ]
@@ -3624,7 +3624,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/assert-never"
         }
       ]
@@ -3650,7 +3650,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/assert-plus"
         }
       ]
@@ -3676,7 +3676,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/assign-symbols"
         }
       ]
@@ -3702,7 +3702,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/async"
         }
       ]
@@ -3728,7 +3728,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/asynckit"
         }
       ]
@@ -3754,7 +3754,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/at-least-node"
         }
       ]
@@ -3780,7 +3780,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/atob"
         }
       ]
@@ -3806,7 +3806,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/available-typed-arrays"
         }
       ]
@@ -3832,7 +3832,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/aws-sign2"
         }
       ]
@@ -3858,7 +3858,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/aws4"
         }
       ]
@@ -3884,7 +3884,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/babel-walk"
         }
       ]
@@ -3910,7 +3910,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/balanced-match"
         }
       ]
@@ -3936,7 +3936,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base"
         }
       ],
@@ -3962,7 +3962,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/base/node_modules/define-property"
             }
           ]
@@ -3990,7 +3990,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base64-arraybuffer"
         }
       ]
@@ -4016,7 +4016,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base64-js"
         }
       ]
@@ -4042,7 +4042,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base64id"
         }
       ]
@@ -4068,7 +4068,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base64url"
         }
       ]
@@ -4094,7 +4094,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/basic-auth"
         }
       ]
@@ -4120,7 +4120,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/batch"
         }
       ]
@@ -4146,7 +4146,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bcrypt-pbkdf"
         }
       ]
@@ -4172,7 +4172,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/big-integer"
         }
       ]
@@ -4198,7 +4198,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/binary-extensions"
         }
       ]
@@ -4224,7 +4224,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/binary"
         }
       ]
@@ -4250,7 +4250,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bindings"
         }
       ]
@@ -4276,7 +4276,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bintrees"
         }
       ]
@@ -4302,7 +4302,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bl"
         }
       ]
@@ -4328,7 +4328,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bluebird"
         }
       ]
@@ -4354,7 +4354,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/body-parser"
         }
       ]
@@ -4380,7 +4380,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bower-config"
         }
       ],
@@ -4406,7 +4406,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bower-config/node_modules/minimist"
             }
           ]
@@ -4434,7 +4434,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/brace-expansion"
         }
       ]
@@ -4460,7 +4460,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/braces"
         }
       ],
@@ -4486,7 +4486,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/braces/node_modules/extend-shallow"
             }
           ]
@@ -4512,7 +4512,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/braces/node_modules/is-extendable"
             }
           ]
@@ -4540,7 +4540,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/brotli"
         }
       ]
@@ -4566,7 +4566,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-alloc-unsafe"
         }
       ]
@@ -4592,7 +4592,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-alloc"
         }
       ]
@@ -4618,7 +4618,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-crc32"
         }
       ]
@@ -4644,7 +4644,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-fill"
         }
       ]
@@ -4670,7 +4670,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-from"
         }
       ]
@@ -4696,7 +4696,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-indexof-polyfill"
         }
       ]
@@ -4722,7 +4722,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer"
         }
       ]
@@ -4748,7 +4748,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffers"
         }
       ]
@@ -4774,7 +4774,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/busboy"
         }
       ],
@@ -4800,7 +4800,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/busboy/node_modules/isarray"
             }
           ]
@@ -4826,7 +4826,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/busboy/node_modules/readable-stream"
             }
           ]
@@ -4852,7 +4852,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/busboy/node_modules/string_decoder"
             }
           ]
@@ -4880,7 +4880,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/byline"
         }
       ]
@@ -4906,7 +4906,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bytes"
         }
       ]
@@ -4932,7 +4932,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cacache"
         }
       ]
@@ -4958,7 +4958,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cache-base"
         }
       ]
@@ -4984,7 +4984,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cacheable-request"
         }
       ],
@@ -5010,7 +5010,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cacheable-request/node_modules/get-stream"
             }
           ]
@@ -5036,7 +5036,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cacheable-request/node_modules/lowercase-keys"
             }
           ]
@@ -5064,7 +5064,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/call-bind"
         }
       ]
@@ -5090,7 +5090,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/camelcase"
         }
       ]
@@ -5116,7 +5116,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/caseless"
         }
       ]
@@ -5142,7 +5142,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/chainsaw"
         }
       ]
@@ -5168,7 +5168,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/chalk"
         }
       ]
@@ -5194,7 +5194,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/character-parser"
         }
       ]
@@ -5220,7 +5220,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/check-dependencies"
         }
       ],
@@ -5246,7 +5246,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/check-dependencies/node_modules/semver"
             }
           ]
@@ -5274,7 +5274,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/check-types"
         }
       ]
@@ -5300,7 +5300,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/chokidar"
         }
       ],
@@ -5326,7 +5326,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar/node_modules/braces"
             }
           ]
@@ -5352,7 +5352,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar/node_modules/fill-range"
             }
           ]
@@ -5378,7 +5378,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar/node_modules/is-glob"
             }
           ]
@@ -5404,7 +5404,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar/node_modules/is-number"
             }
           ]
@@ -5430,7 +5430,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar/node_modules/normalize-path"
             }
           ]
@@ -5456,7 +5456,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar/node_modules/to-regex-range"
             }
           ]
@@ -5484,7 +5484,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/chownr"
         }
       ]
@@ -5510,7 +5510,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/clarinet"
         }
       ]
@@ -5536,7 +5536,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/class-utils"
         }
       ],
@@ -5562,7 +5562,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils/node_modules/define-property"
             }
           ]
@@ -5588,7 +5588,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils/node_modules/is-accessor-descriptor"
             }
           ],
@@ -5614,7 +5614,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/class-utils/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
@@ -5642,7 +5642,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils/node_modules/is-data-descriptor"
             }
           ],
@@ -5668,7 +5668,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/class-utils/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
@@ -5696,7 +5696,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils/node_modules/is-descriptor"
             }
           ]
@@ -5722,7 +5722,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils/node_modules/kind-of"
             }
           ]
@@ -5750,7 +5750,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/clean-stack"
         }
       ]
@@ -5776,7 +5776,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cliui"
         }
       ],
@@ -5802,7 +5802,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui/node_modules/ansi-regex"
             }
           ]
@@ -5828,7 +5828,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui/node_modules/emoji-regex"
             }
           ]
@@ -5854,7 +5854,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -5880,7 +5880,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui/node_modules/string-width"
             }
           ]
@@ -5906,7 +5906,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui/node_modules/strip-ansi"
             }
           ]
@@ -5934,7 +5934,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/clone-response"
         }
       ]
@@ -5960,7 +5960,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/clone"
         }
       ]
@@ -5986,7 +5986,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/code-point-at"
         }
       ]
@@ -6012,7 +6012,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/collection-visit"
         }
       ]
@@ -6038,7 +6038,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color-convert"
         }
       ]
@@ -6064,7 +6064,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color-name"
         }
       ]
@@ -6090,7 +6090,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color-string"
         }
       ]
@@ -6116,7 +6116,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color-support"
         }
       ]
@@ -6142,7 +6142,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color"
         }
       ]
@@ -6168,7 +6168,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/colors"
         }
       ]
@@ -6194,7 +6194,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/colorspace"
         }
       ]
@@ -6220,7 +6220,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/combined-stream"
         }
       ]
@@ -6246,7 +6246,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/commander"
         }
       ]
@@ -6272,7 +6272,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/component-emitter"
         }
       ]
@@ -6298,7 +6298,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/component-type"
         }
       ]
@@ -6324,7 +6324,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/compress-commons"
         }
       ]
@@ -6350,7 +6350,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/compressible"
         }
       ]
@@ -6376,7 +6376,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/compression"
         }
       ],
@@ -6402,7 +6402,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/compression/node_modules/bytes"
             }
           ]
@@ -6430,7 +6430,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/concat-map"
         }
       ]
@@ -6456,7 +6456,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/concat-stream"
         }
       ]
@@ -6482,7 +6482,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/concurrently"
         }
       ],
@@ -6508,7 +6508,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/concurrently/node_modules/supports-color"
             }
           ]
@@ -6536,7 +6536,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/config"
         }
       ]
@@ -6562,7 +6562,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/console-control-strings"
         }
       ]
@@ -6588,7 +6588,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/constantinople"
         }
       ]
@@ -6614,7 +6614,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/content-disposition"
         }
       ],
@@ -6640,7 +6640,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/content-disposition/node_modules/safe-buffer"
             }
           ]
@@ -6668,7 +6668,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/content-type"
         }
       ]
@@ -6694,7 +6694,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cookie-parser"
         }
       ]
@@ -6720,7 +6720,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cookie-signature"
         }
       ]
@@ -6746,7 +6746,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cookie"
         }
       ]
@@ -6772,7 +6772,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/copy-descriptor"
         }
       ]
@@ -6798,7 +6798,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/core-util-is"
         }
       ]
@@ -6824,7 +6824,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cors"
         }
       ]
@@ -6850,7 +6850,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/crc"
         }
       ]
@@ -6876,7 +6876,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/crc32-stream"
         }
       ]
@@ -6902,7 +6902,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/create-require"
         }
       ]
@@ -6928,7 +6928,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/crypto-js"
         }
       ]
@@ -6954,7 +6954,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dashdash"
         }
       ]
@@ -6980,7 +6980,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/date-fns"
         }
       ]
@@ -7006,7 +7006,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dateformat"
         }
       ]
@@ -7032,7 +7032,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/debug"
         }
       ]
@@ -7058,7 +7058,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decamelize"
         }
       ]
@@ -7084,7 +7084,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decode-uri-component"
         }
       ]
@@ -7110,7 +7110,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-response"
         }
       ]
@@ -7136,7 +7136,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-tar"
         }
       ],
@@ -7162,7 +7162,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-tar/node_modules/file-type"
             }
           ]
@@ -7190,7 +7190,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-tarbz2"
         }
       ],
@@ -7216,7 +7216,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-tarbz2/node_modules/file-type"
             }
           ]
@@ -7244,7 +7244,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-targz"
         }
       ],
@@ -7270,7 +7270,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-targz/node_modules/file-type"
             }
           ]
@@ -7298,7 +7298,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-unzip"
         }
       ],
@@ -7324,7 +7324,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-unzip/node_modules/file-type"
             }
           ]
@@ -7350,7 +7350,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-unzip/node_modules/get-stream"
             }
           ]
@@ -7376,7 +7376,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-unzip/node_modules/pify"
             }
           ]
@@ -7404,7 +7404,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress"
         }
       ],
@@ -7430,7 +7430,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress/node_modules/make-dir"
             }
           ],
@@ -7456,7 +7456,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/decompress/node_modules/make-dir/node_modules/pify"
                 }
               ]
@@ -7484,7 +7484,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress/node_modules/pify"
             }
           ]
@@ -7512,7 +7512,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/deep-equal"
         }
       ]
@@ -7538,7 +7538,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/deep-extend"
         }
       ]
@@ -7564,7 +7564,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/deep-is"
         }
       ]
@@ -7590,7 +7590,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/define-properties"
         }
       ]
@@ -7616,7 +7616,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/define-property"
         }
       ]
@@ -7642,7 +7642,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/delayed-stream"
         }
       ]
@@ -7668,7 +7668,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/delegates"
         }
       ]
@@ -7694,7 +7694,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/depd"
         }
       ]
@@ -7720,7 +7720,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/destroy"
         }
       ]
@@ -7746,7 +7746,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/detect-file"
         }
       ]
@@ -7772,7 +7772,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/detect-libc"
         }
       ]
@@ -7798,7 +7798,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dfa"
         }
       ]
@@ -7824,7 +7824,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dicer"
         }
       ],
@@ -7850,7 +7850,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/dicer/node_modules/isarray"
             }
           ]
@@ -7876,7 +7876,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/dicer/node_modules/readable-stream"
             }
           ]
@@ -7902,7 +7902,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/dicer/node_modules/string_decoder"
             }
           ]
@@ -7930,7 +7930,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/diff"
         }
       ]
@@ -7956,7 +7956,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/doctypes"
         }
       ]
@@ -7982,7 +7982,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/domelementtype"
         }
       ]
@@ -8008,7 +8008,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/domhandler"
         }
       ]
@@ -8034,7 +8034,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/domutils"
         }
       ]
@@ -8060,7 +8060,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dottie"
         }
       ]
@@ -8086,7 +8086,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/double-ended-queue"
         }
       ]
@@ -8112,7 +8112,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/doublearray"
         }
       ]
@@ -8138,7 +8138,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/download"
         }
       ],
@@ -8164,7 +8164,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/download/node_modules/file-type"
             }
           ]
@@ -8192,7 +8192,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/duplexer2"
         }
       ]
@@ -8218,7 +8218,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/duplexer3"
         }
       ]
@@ -8244,7 +8244,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dynamic-dedupe"
         }
       ]
@@ -8270,7 +8270,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ecc-jsbn"
         }
       ]
@@ -8296,7 +8296,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ee-first"
         }
       ]
@@ -8322,7 +8322,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/eivindfjeldstad-dot"
         }
       ]
@@ -8348,7 +8348,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/emoji-regex"
         }
       ]
@@ -8374,7 +8374,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/enabled"
         }
       ]
@@ -8400,7 +8400,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/encodeurl"
         }
       ]
@@ -8426,7 +8426,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/encoding"
         }
       ],
@@ -8452,7 +8452,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/encoding/node_modules/iconv-lite"
             }
           ]
@@ -8480,7 +8480,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/end-of-stream"
         }
       ]
@@ -8506,7 +8506,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/engine.io-parser"
         }
       ]
@@ -8532,7 +8532,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/engine.io"
         }
       ],
@@ -8558,7 +8558,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/engine.io/node_modules/debug"
             }
           ]
@@ -8584,7 +8584,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/engine.io/node_modules/ms"
             }
           ]
@@ -8612,7 +8612,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/env-paths"
         }
       ]
@@ -8638,7 +8638,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/err-code"
         }
       ]
@@ -8664,7 +8664,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/error-ex"
         }
       ]
@@ -8690,7 +8690,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/errorhandler"
         }
       ]
@@ -8716,7 +8716,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/es-abstract"
         }
       ]
@@ -8742,7 +8742,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/es-get-iterator"
         }
       ]
@@ -8768,7 +8768,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/es-to-primitive"
         }
       ]
@@ -8794,7 +8794,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/escape-html"
         }
       ]
@@ -8820,7 +8820,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/escape-string-regexp"
         }
       ]
@@ -8846,7 +8846,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/escodegen"
         }
       ]
@@ -8872,7 +8872,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/esprima"
         }
       ]
@@ -8898,7 +8898,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/estraverse"
         }
       ]
@@ -8924,7 +8924,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/esutils"
         }
       ]
@@ -8950,7 +8950,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/etag"
         }
       ]
@@ -8976,7 +8976,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/eventemitter2"
         }
       ]
@@ -9002,7 +9002,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/eventemitter3"
         }
       ]
@@ -9028,7 +9028,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/exif"
         }
       ]
@@ -9054,7 +9054,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/exit"
         }
       ]
@@ -9080,7 +9080,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/expand-brackets"
         }
       ],
@@ -9106,7 +9106,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/define-property"
             }
           ]
@@ -9132,7 +9132,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/extend-shallow"
             }
           ]
@@ -9158,7 +9158,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/is-accessor-descriptor"
             }
           ],
@@ -9184,7 +9184,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/expand-brackets/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
@@ -9212,7 +9212,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/is-data-descriptor"
             }
           ],
@@ -9238,7 +9238,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/expand-brackets/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
@@ -9266,7 +9266,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/is-descriptor"
             }
           ]
@@ -9292,7 +9292,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/is-extendable"
             }
           ]
@@ -9318,7 +9318,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/kind-of"
             }
           ]
@@ -9346,7 +9346,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/expand-template"
         }
       ]
@@ -9372,7 +9372,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/expand-tilde"
         }
       ]
@@ -9398,7 +9398,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-ipfilter"
         }
       ]
@@ -9424,7 +9424,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-jwt"
         }
       ],
@@ -9450,7 +9450,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/express-jwt/node_modules/jsonwebtoken"
             }
           ]
@@ -9476,7 +9476,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/express-jwt/node_modules/moment"
             }
           ]
@@ -9504,7 +9504,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-rate-limit"
         }
       ]
@@ -9530,7 +9530,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-robots-txt"
         }
       ]
@@ -9556,7 +9556,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-security.txt"
         }
       ]
@@ -9582,7 +9582,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express"
         }
       ],
@@ -9608,7 +9608,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/express/node_modules/cookie"
             }
           ]
@@ -9634,7 +9634,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/express/node_modules/safe-buffer"
             }
           ]
@@ -9662,7 +9662,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ext-list"
         }
       ]
@@ -9688,7 +9688,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ext-name"
         }
       ]
@@ -9714,7 +9714,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/extend-shallow"
         }
       ]
@@ -9740,7 +9740,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/extend"
         }
       ]
@@ -9766,7 +9766,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/extglob"
         }
       ],
@@ -9792,7 +9792,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/extglob/node_modules/define-property"
             }
           ]
@@ -9818,7 +9818,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/extglob/node_modules/extend-shallow"
             }
           ]
@@ -9844,7 +9844,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/extglob/node_modules/is-extendable"
             }
           ]
@@ -9872,7 +9872,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/extsprintf"
         }
       ]
@@ -9898,7 +9898,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fast-deep-equal"
         }
       ]
@@ -9924,7 +9924,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fast-json-stable-stringify"
         }
       ]
@@ -9950,7 +9950,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fast-levenshtein"
         }
       ]
@@ -9976,7 +9976,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fast.js"
         }
       ]
@@ -10002,7 +10002,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fd-slicer"
         }
       ]
@@ -10028,7 +10028,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/feature-policy"
         }
       ]
@@ -10054,7 +10054,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fecha"
         }
       ]
@@ -10080,7 +10080,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/file-js"
         }
       ],
@@ -10106,7 +10106,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/file-js/node_modules/brace-expansion"
             }
           ]
@@ -10132,7 +10132,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/file-js/node_modules/minimatch"
             }
           ]
@@ -10160,7 +10160,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/file-stream-rotator"
         }
       ]
@@ -10186,7 +10186,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/file-type"
         }
       ]
@@ -10212,7 +10212,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/file-uri-to-path"
         }
       ]
@@ -10238,7 +10238,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/filehound"
         }
       ]
@@ -10264,7 +10264,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/filename-reserved-regex"
         }
       ]
@@ -10290,7 +10290,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/filenamify"
         }
       ]
@@ -10316,7 +10316,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/filesniffer"
         }
       ]
@@ -10342,7 +10342,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fill-range"
         }
       ],
@@ -10368,7 +10368,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/fill-range/node_modules/extend-shallow"
             }
           ]
@@ -10394,7 +10394,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/fill-range/node_modules/is-extendable"
             }
           ]
@@ -10422,7 +10422,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/finale-rest"
         }
       ]
@@ -10448,7 +10448,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/finalhandler"
         }
       ]
@@ -10474,7 +10474,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/find-up"
         }
       ]
@@ -10500,7 +10500,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/findup-sync"
         }
       ]
@@ -10526,7 +10526,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fined"
         }
       ]
@@ -10552,7 +10552,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/flagged-respawn"
         }
       ]
@@ -10578,7 +10578,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fn.name"
         }
       ]
@@ -10604,7 +10604,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fontkit"
         }
       ]
@@ -10630,7 +10630,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/for-each"
         }
       ]
@@ -10656,7 +10656,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/for-in"
         }
       ]
@@ -10682,7 +10682,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/for-own"
         }
       ]
@@ -10708,7 +10708,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/foreachasync"
         }
       ]
@@ -10734,7 +10734,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/forever-agent"
         }
       ]
@@ -10760,7 +10760,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/form-data"
         }
       ]
@@ -10786,7 +10786,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/formatio"
         }
       ]
@@ -10812,7 +10812,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/forwarded"
         }
       ]
@@ -10838,7 +10838,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fragment-cache"
         }
       ]
@@ -10864,7 +10864,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fresh"
         }
       ]
@@ -10890,7 +10890,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/from2"
         }
       ]
@@ -10916,7 +10916,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fs-constants"
         }
       ]
@@ -10942,7 +10942,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fs-extra"
         }
       ]
@@ -10968,7 +10968,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fs-minipass"
         }
       ]
@@ -10994,7 +10994,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fs.realpath"
         }
       ]
@@ -11020,7 +11020,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fstream"
         }
       ],
@@ -11046,7 +11046,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/fstream/node_modules/mkdirp"
             }
           ]
@@ -11072,7 +11072,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/fstream/node_modules/rimraf"
             }
           ]
@@ -11100,7 +11100,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/function-bind"
         }
       ]
@@ -11126,7 +11126,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/function.prototype.name"
         }
       ]
@@ -11152,7 +11152,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/functions-have-names"
         }
       ]
@@ -11178,7 +11178,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fuzzball"
         }
       ]
@@ -11204,7 +11204,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/gauge"
         }
       ]
@@ -11230,7 +11230,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/geojson-utils"
         }
       ]
@@ -11256,7 +11256,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-caller-file"
         }
       ]
@@ -11282,7 +11282,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-intrinsic"
         }
       ]
@@ -11308,7 +11308,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-stream"
         }
       ]
@@ -11334,7 +11334,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-symbol-description"
         }
       ]
@@ -11360,7 +11360,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-value"
         }
       ]
@@ -11386,7 +11386,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/getobject"
         }
       ]
@@ -11412,7 +11412,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/getpass"
         }
       ]
@@ -11438,7 +11438,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/github-from-package"
         }
       ]
@@ -11464,7 +11464,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/glob-parent"
         }
       ],
@@ -11490,7 +11490,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/glob-parent/node_modules/is-glob"
             }
           ]
@@ -11518,7 +11518,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/glob"
         }
       ],
@@ -11544,7 +11544,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/glob/node_modules/brace-expansion"
             }
           ]
@@ -11570,7 +11570,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/glob/node_modules/minimatch"
             }
           ]
@@ -11598,7 +11598,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/global-modules"
         }
       ]
@@ -11624,7 +11624,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/global-prefix"
         }
       ],
@@ -11650,7 +11650,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/global-prefix/node_modules/which"
             }
           ]
@@ -11678,7 +11678,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/got"
         }
       ],
@@ -11704,7 +11704,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/got/node_modules/get-stream"
             }
           ]
@@ -11730,7 +11730,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/got/node_modules/pify"
             }
           ]
@@ -11758,7 +11758,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/graceful-fs"
         }
       ]
@@ -11784,7 +11784,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-cli"
         }
       ],
@@ -11810,7 +11810,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-cli/node_modules/nopt"
             }
           ]
@@ -11838,7 +11838,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-contrib-compress"
         }
       ],
@@ -11864,7 +11864,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-contrib-compress/node_modules/ansi-styles"
             }
           ]
@@ -11890,7 +11890,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-contrib-compress/node_modules/chalk"
             }
           ]
@@ -11916,7 +11916,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-contrib-compress/node_modules/supports-color"
             }
           ]
@@ -11944,7 +11944,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-known-options"
         }
       ]
@@ -11970,7 +11970,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-legacy-log-utils"
         }
       ],
@@ -11996,7 +11996,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils/node_modules/ansi-styles"
             }
           ]
@@ -12022,7 +12022,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils/node_modules/chalk"
             }
           ]
@@ -12048,7 +12048,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils/node_modules/color-convert"
             }
           ]
@@ -12074,7 +12074,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils/node_modules/color-name"
             }
           ]
@@ -12100,7 +12100,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils/node_modules/has-flag"
             }
           ]
@@ -12126,7 +12126,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils/node_modules/supports-color"
             }
           ]
@@ -12154,7 +12154,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-legacy-log"
         }
       ],
@@ -12180,7 +12180,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log/node_modules/colors"
             }
           ]
@@ -12208,7 +12208,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-legacy-util"
         }
       ],
@@ -12234,7 +12234,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-util/node_modules/async"
             }
           ]
@@ -12262,7 +12262,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-replace-json"
         }
       ]
@@ -12288,7 +12288,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt"
         }
       ],
@@ -12314,7 +12314,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt/node_modules/brace-expansion"
             }
           ]
@@ -12340,7 +12340,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt/node_modules/findup-sync"
             }
           ],
@@ -12366,7 +12366,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/grunt/node_modules/findup-sync/node_modules/glob"
                 }
               ]
@@ -12394,7 +12394,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt/node_modules/glob"
             }
           ]
@@ -12420,7 +12420,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt/node_modules/minimatch"
             }
           ]
@@ -12448,7 +12448,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/handlebars"
         }
       ],
@@ -12474,7 +12474,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/handlebars/node_modules/wordwrap"
             }
           ]
@@ -12502,7 +12502,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/har-schema"
         }
       ]
@@ -12528,7 +12528,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/har-validator"
         }
       ]
@@ -12554,7 +12554,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-ansi"
         }
       ]
@@ -12580,7 +12580,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-bigints"
         }
       ]
@@ -12606,7 +12606,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-flag"
         }
       ]
@@ -12632,7 +12632,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-property-descriptors"
         }
       ]
@@ -12658,7 +12658,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-symbol-support-x"
         }
       ]
@@ -12684,7 +12684,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-symbols"
         }
       ]
@@ -12710,7 +12710,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-to-string-tag-x"
         }
       ]
@@ -12736,7 +12736,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-tostringtag"
         }
       ]
@@ -12762,7 +12762,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-unicode"
         }
       ]
@@ -12788,7 +12788,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-value"
         }
       ]
@@ -12814,7 +12814,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-values"
         }
       ],
@@ -12840,7 +12840,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/has-values/node_modules/kind-of"
             }
           ]
@@ -12868,7 +12868,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has"
         }
       ]
@@ -12894,7 +12894,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hashids"
         }
       ]
@@ -12920,7 +12920,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hbs"
         }
       ]
@@ -12946,7 +12946,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/he"
         }
       ]
@@ -12972,7 +12972,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/heap"
         }
       ]
@@ -12998,7 +12998,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/helmet"
         }
       ]
@@ -13024,7 +13024,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hoister"
         }
       ]
@@ -13050,7 +13050,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/homedir-polyfill"
         }
       ]
@@ -13076,7 +13076,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hooker"
         }
       ]
@@ -13102,7 +13102,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hosted-git-info"
         }
       ]
@@ -13128,7 +13128,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/html-entities"
         }
       ]
@@ -13154,7 +13154,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/htmlparser2"
         }
       ],
@@ -13180,7 +13180,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/htmlparser2/node_modules/isarray"
             }
           ]
@@ -13206,7 +13206,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/htmlparser2/node_modules/readable-stream"
             }
           ]
@@ -13232,7 +13232,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/htmlparser2/node_modules/string_decoder"
             }
           ]
@@ -13260,7 +13260,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/http-cache-semantics"
         }
       ]
@@ -13286,7 +13286,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/http-errors"
         }
       ]
@@ -13312,7 +13312,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/http-proxy-agent"
         }
       ],
@@ -13338,7 +13338,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/http-proxy-agent/node_modules/debug"
             }
           ]
@@ -13364,7 +13364,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/http-proxy-agent/node_modules/ms"
             }
           ]
@@ -13392,7 +13392,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/http-signature"
         }
       ]
@@ -13418,7 +13418,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/https-proxy-agent"
         }
       ],
@@ -13444,7 +13444,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/https-proxy-agent/node_modules/debug"
             }
           ]
@@ -13470,7 +13470,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/https-proxy-agent/node_modules/ms"
             }
           ]
@@ -13498,7 +13498,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/humanize-ms"
         }
       ]
@@ -13524,7 +13524,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/i18n"
         }
       ]
@@ -13550,7 +13550,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/iconv-lite"
         }
       ]
@@ -13576,7 +13576,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ieee754"
         }
       ]
@@ -13602,7 +13602,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ignore-walk"
         }
       ],
@@ -13628,7 +13628,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/ignore-walk/node_modules/brace-expansion"
             }
           ]
@@ -13654,7 +13654,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/ignore-walk/node_modules/minimatch"
             }
           ]
@@ -13682,7 +13682,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/iltorb"
         }
       ]
@@ -13708,7 +13708,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/imurmurhash"
         }
       ]
@@ -13734,7 +13734,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/indent-string"
         }
       ]
@@ -13760,7 +13760,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/infer-owner"
         }
       ]
@@ -13786,7 +13786,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/inflection"
         }
       ]
@@ -13812,7 +13812,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/inflight"
         }
       ]
@@ -13838,7 +13838,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/inherits"
         }
       ]
@@ -13864,7 +13864,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ini"
         }
       ]
@@ -13890,7 +13890,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/internal-slot"
         }
       ]
@@ -13916,7 +13916,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/interpret"
         }
       ]
@@ -13942,7 +13942,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/into-stream"
         }
       ]
@@ -13968,7 +13968,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/invariant"
         }
       ]
@@ -13994,7 +13994,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ip"
         }
       ]
@@ -14020,7 +14020,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ip6"
         }
       ]
@@ -14046,7 +14046,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ipaddr.js"
         }
       ]
@@ -14072,7 +14072,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-absolute"
         }
       ]
@@ -14098,7 +14098,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-accessor-descriptor"
         }
       ]
@@ -14124,7 +14124,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-arguments"
         }
       ]
@@ -14150,7 +14150,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-arrayish"
         }
       ]
@@ -14176,7 +14176,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-bigint"
         }
       ]
@@ -14202,7 +14202,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-binary-path"
         }
       ]
@@ -14228,7 +14228,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-boolean-object"
         }
       ]
@@ -14254,7 +14254,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-buffer"
         }
       ]
@@ -14280,7 +14280,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-callable"
         }
       ]
@@ -14306,7 +14306,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-core-module"
         }
       ]
@@ -14332,7 +14332,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-data-descriptor"
         }
       ]
@@ -14358,7 +14358,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-date-object"
         }
       ]
@@ -14384,7 +14384,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-descriptor"
         }
       ]
@@ -14410,7 +14410,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-docker"
         }
       ]
@@ -14436,7 +14436,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-expression"
         }
       ]
@@ -14462,7 +14462,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-extendable"
         }
       ]
@@ -14488,7 +14488,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-extglob"
         }
       ]
@@ -14514,7 +14514,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-fullwidth-code-point"
         }
       ]
@@ -14540,7 +14540,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-generator-function"
         }
       ]
@@ -14566,7 +14566,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-glob"
         }
       ]
@@ -14592,7 +14592,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-heroku"
         }
       ]
@@ -14618,7 +14618,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-lambda"
         }
       ]
@@ -14644,7 +14644,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-map"
         }
       ]
@@ -14670,7 +14670,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-natural-number"
         }
       ]
@@ -14696,7 +14696,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-negative-zero"
         }
       ]
@@ -14722,7 +14722,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-number-like"
         }
       ]
@@ -14748,7 +14748,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-number-object"
         }
       ]
@@ -14774,7 +14774,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-number"
         }
       ],
@@ -14800,7 +14800,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/is-number/node_modules/kind-of"
             }
           ]
@@ -14828,7 +14828,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-object"
         }
       ]
@@ -14854,7 +14854,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-plain-obj"
         }
       ]
@@ -14880,7 +14880,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-plain-object"
         }
       ]
@@ -14906,7 +14906,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-promise"
         }
       ]
@@ -14932,7 +14932,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-regex"
         }
       ]
@@ -14958,7 +14958,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-relative"
         }
       ]
@@ -14984,7 +14984,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-retry-allowed"
         }
       ]
@@ -15010,7 +15010,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-set"
         }
       ]
@@ -15036,7 +15036,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-shared-array-buffer"
         }
       ]
@@ -15062,7 +15062,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-stream"
         }
       ]
@@ -15088,7 +15088,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-string"
         }
       ]
@@ -15114,7 +15114,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-symbol"
         }
       ]
@@ -15140,7 +15140,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-typed-array"
         }
       ]
@@ -15166,7 +15166,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-typedarray"
         }
       ]
@@ -15192,7 +15192,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-unc-path"
         }
       ]
@@ -15218,7 +15218,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-weakmap"
         }
       ]
@@ -15244,7 +15244,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-weakref"
         }
       ]
@@ -15270,7 +15270,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-weakset"
         }
       ]
@@ -15296,7 +15296,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-windows"
         }
       ]
@@ -15322,7 +15322,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isarray"
         }
       ]
@@ -15348,7 +15348,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isexe"
         }
       ]
@@ -15374,7 +15374,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isobject"
         }
       ]
@@ -15400,7 +15400,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isstream"
         }
       ]
@@ -15426,7 +15426,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isurl"
         }
       ]
@@ -15452,7 +15452,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/js-stringify"
         }
       ]
@@ -15478,7 +15478,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/js-tokens"
         }
       ]
@@ -15504,7 +15504,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/js-yaml"
         }
       ]
@@ -15530,7 +15530,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jsbn"
         }
       ]
@@ -15556,7 +15556,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-buffer"
         }
       ]
@@ -15582,7 +15582,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-parse-better-errors"
         }
       ]
@@ -15608,7 +15608,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-schema-traverse"
         }
       ]
@@ -15634,7 +15634,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-schema"
         }
       ]
@@ -15660,7 +15660,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-stringify-safe"
         }
       ]
@@ -15686,7 +15686,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json5"
         }
       ]
@@ -15712,7 +15712,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jsonfile"
         }
       ]
@@ -15738,7 +15738,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jsonwebtoken"
         }
       ]
@@ -15764,7 +15764,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jsprim"
         }
       ]
@@ -15790,7 +15790,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jssha"
         }
       ]
@@ -15816,7 +15816,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jstransformer"
         }
       ]
@@ -15842,7 +15842,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/juicy-chat-bot"
         }
       ]
@@ -15868,7 +15868,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jwa"
         }
       ]
@@ -15894,7 +15894,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jws"
         }
       ]
@@ -15920,7 +15920,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/keyv"
         }
       ]
@@ -15946,7 +15946,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/kind-of"
         }
       ]
@@ -15972,7 +15972,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/kuler"
         }
       ]
@@ -15998,7 +15998,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/kuromoji"
         }
       ]
@@ -16024,7 +16024,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lazystream"
         }
       ]
@@ -16050,7 +16050,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/levn"
         }
       ]
@@ -16076,7 +16076,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/libxmljs2"
         }
       ],
@@ -16102,7 +16102,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/libxmljs2/node_modules/nan"
             }
           ]
@@ -16130,7 +16130,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/liftup"
         }
       ],
@@ -16156,7 +16156,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/braces"
             }
           ]
@@ -16182,7 +16182,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/fill-range"
             }
           ]
@@ -16208,7 +16208,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/findup-sync"
             }
           ]
@@ -16234,7 +16234,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/is-glob"
             }
           ]
@@ -16260,7 +16260,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/is-number"
             }
           ]
@@ -16286,7 +16286,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/micromatch"
             }
           ]
@@ -16312,7 +16312,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/to-regex-range"
             }
           ]
@@ -16340,7 +16340,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/linebreak"
         }
       ],
@@ -16366,7 +16366,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/linebreak/node_modules/base64-js"
             }
           ]
@@ -16394,7 +16394,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/listenercount"
         }
       ]
@@ -16420,7 +16420,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/locate-path"
         }
       ]
@@ -16446,7 +16446,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lodash.camelcase"
         }
       ]
@@ -16472,7 +16472,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lodash.isfinite"
         }
       ]
@@ -16498,7 +16498,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lodash.set"
         }
       ]
@@ -16524,7 +16524,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lodash"
         }
       ]
@@ -16550,7 +16550,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/logform"
         }
       ],
@@ -16576,7 +16576,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/logform/node_modules/ms"
             }
           ]
@@ -16604,7 +16604,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lolex"
         }
       ]
@@ -16630,7 +16630,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/loose-envify"
         }
       ]
@@ -16656,7 +16656,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lowercase-keys"
         }
       ]
@@ -16682,7 +16682,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lru-cache"
         }
       ]
@@ -16708,7 +16708,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-dir"
         }
       ],
@@ -16734,7 +16734,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-dir/node_modules/semver"
             }
           ]
@@ -16762,7 +16762,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-error"
         }
       ]
@@ -16788,7 +16788,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-fetch-happen"
         }
       ],
@@ -16815,7 +16815,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen/node_modules/@tootallnate/once"
             }
           ]
@@ -16841,7 +16841,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen/node_modules/debug"
             }
           ]
@@ -16867,7 +16867,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen/node_modules/http-cache-semantics"
             }
           ]
@@ -16893,7 +16893,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen/node_modules/http-proxy-agent"
             }
           ]
@@ -16919,7 +16919,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen/node_modules/ms"
             }
           ]
@@ -16947,7 +16947,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-iterator"
         }
       ]
@@ -16973,7 +16973,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-plural"
         }
       ]
@@ -16999,7 +16999,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/map-cache"
         }
       ]
@@ -17025,7 +17025,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/map-visit"
         }
       ]
@@ -17051,7 +17051,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/marsdb"
         }
       ]
@@ -17077,7 +17077,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/math-interval-parser"
         }
       ]
@@ -17103,7 +17103,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/media-typer"
         }
       ]
@@ -17129,7 +17129,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/merge-descriptors"
         }
       ]
@@ -17155,7 +17155,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/messageformat-formatters"
         }
       ]
@@ -17181,7 +17181,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/messageformat-parser"
         }
       ]
@@ -17207,7 +17207,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/messageformat"
         }
       ],
@@ -17233,7 +17233,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/messageformat/node_modules/make-plural"
             }
           ]
@@ -17261,7 +17261,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/methods"
         }
       ]
@@ -17287,7 +17287,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/micromatch"
         }
       ]
@@ -17313,7 +17313,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mime-db"
         }
       ]
@@ -17339,7 +17339,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mime-types"
         }
       ]
@@ -17365,7 +17365,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mime"
         }
       ]
@@ -17391,7 +17391,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mimic-response"
         }
       ]
@@ -17417,7 +17417,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minimatch"
         }
       ]
@@ -17443,7 +17443,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minimist"
         }
       ]
@@ -17469,7 +17469,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-collect"
         }
       ]
@@ -17495,7 +17495,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-fetch"
         }
       ]
@@ -17521,7 +17521,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-flush"
         }
       ]
@@ -17547,7 +17547,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-pipeline"
         }
       ]
@@ -17573,7 +17573,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-sized"
         }
       ]
@@ -17599,7 +17599,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass"
         }
       ]
@@ -17625,7 +17625,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minizlib"
         }
       ]
@@ -17651,7 +17651,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mixin-deep"
         }
       ]
@@ -17677,7 +17677,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mkdirp-classic"
         }
       ]
@@ -17703,7 +17703,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mkdirp"
         }
       ]
@@ -17729,7 +17729,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/moment-timezone"
         }
       ]
@@ -17755,7 +17755,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/moment"
         }
       ]
@@ -17781,7 +17781,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/morgan"
         }
       ],
@@ -17807,7 +17807,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/morgan/node_modules/on-finished"
             }
           ]
@@ -17835,7 +17835,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mout"
         }
       ]
@@ -17861,7 +17861,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ms"
         }
       ]
@@ -17887,7 +17887,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/multer"
         }
       ],
@@ -17913,7 +17913,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/multer/node_modules/mkdirp"
             }
           ]
@@ -17941,7 +17941,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mustache"
         }
       ]
@@ -17967,7 +17967,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/nan"
         }
       ]
@@ -17993,7 +17993,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/nanomatch"
         }
       ]
@@ -18019,7 +18019,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/napi-build-utils"
         }
       ]
@@ -18045,7 +18045,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/needle"
         }
       ],
@@ -18071,7 +18071,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/needle/node_modules/debug"
             }
           ]
@@ -18097,7 +18097,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/needle/node_modules/ms"
             }
           ]
@@ -18125,7 +18125,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/negotiator"
         }
       ]
@@ -18151,7 +18151,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/neo-async"
         }
       ]
@@ -18177,7 +18177,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-abi"
         }
       ],
@@ -18203,7 +18203,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-abi/node_modules/semver"
             }
           ]
@@ -18231,7 +18231,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-addon-api"
         }
       ]
@@ -18257,7 +18257,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-fetch"
         }
       ]
@@ -18283,7 +18283,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-gyp"
         }
       ],
@@ -18309,7 +18309,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/ansi-regex"
             }
           ]
@@ -18335,7 +18335,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/are-we-there-yet"
             }
           ]
@@ -18361,7 +18361,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/gauge"
             }
           ]
@@ -18387,7 +18387,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -18413,7 +18413,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/nopt"
             }
           ]
@@ -18439,7 +18439,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/npmlog"
             }
           ]
@@ -18465,7 +18465,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/readable-stream"
             }
           ]
@@ -18491,7 +18491,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/string-width"
             }
           ]
@@ -18517,7 +18517,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/strip-ansi"
             }
           ]
@@ -18545,7 +18545,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-pre-gyp"
         }
       ],
@@ -18571,7 +18571,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/chownr"
             }
           ]
@@ -18597,7 +18597,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/fs-minipass"
             }
           ]
@@ -18623,7 +18623,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/minipass"
             }
           ]
@@ -18649,7 +18649,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/minizlib"
             }
           ]
@@ -18675,7 +18675,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/mkdirp"
             }
           ]
@@ -18701,7 +18701,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/nopt"
             }
           ]
@@ -18727,7 +18727,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/rimraf"
             }
           ]
@@ -18753,7 +18753,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/safe-buffer"
             }
           ]
@@ -18779,7 +18779,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/semver"
             }
           ]
@@ -18805,7 +18805,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/tar"
             }
           ]
@@ -18831,7 +18831,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/yallist"
             }
           ]
@@ -18859,7 +18859,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/noop-logger"
         }
       ]
@@ -18885,7 +18885,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/nopt"
         }
       ]
@@ -18911,7 +18911,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/normalize-package-data"
         }
       ],
@@ -18937,7 +18937,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/normalize-package-data/node_modules/semver"
             }
           ]
@@ -18965,7 +18965,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/normalize-path"
         }
       ]
@@ -18991,7 +18991,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/normalize-url"
         }
       ]
@@ -19017,7 +19017,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/notevil"
         }
       ],
@@ -19043,7 +19043,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/notevil/node_modules/esprima"
             }
           ]
@@ -19071,7 +19071,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/npm-bundled"
         }
       ]
@@ -19097,7 +19097,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/npm-normalize-package-bin"
         }
       ]
@@ -19123,7 +19123,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/npm-packlist"
         }
       ]
@@ -19149,7 +19149,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/npmlog"
         }
       ]
@@ -19175,7 +19175,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/number-is-nan"
         }
       ]
@@ -19201,7 +19201,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/oauth-sign"
         }
       ]
@@ -19227,7 +19227,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-assign"
         }
       ]
@@ -19253,7 +19253,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-copy"
         }
       ],
@@ -19279,7 +19279,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy/node_modules/define-property"
             }
           ]
@@ -19305,7 +19305,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy/node_modules/is-accessor-descriptor"
             }
           ]
@@ -19331,7 +19331,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy/node_modules/is-data-descriptor"
             }
           ]
@@ -19357,7 +19357,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy/node_modules/is-descriptor"
             }
           ],
@@ -19383,7 +19383,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/object-copy/node_modules/is-descriptor/node_modules/kind-of"
                 }
               ]
@@ -19411,7 +19411,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy/node_modules/kind-of"
             }
           ]
@@ -19439,7 +19439,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-inspect"
         }
       ]
@@ -19465,7 +19465,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-is"
         }
       ]
@@ -19491,7 +19491,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-keys"
         }
       ]
@@ -19517,7 +19517,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-visit"
         }
       ]
@@ -19543,7 +19543,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object.assign"
         }
       ]
@@ -19569,7 +19569,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object.defaults"
         }
       ]
@@ -19595,7 +19595,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object.map"
         }
       ]
@@ -19621,7 +19621,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object.pick"
         }
       ]
@@ -19647,7 +19647,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/on-finished"
         }
       ]
@@ -19673,7 +19673,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/on-headers"
         }
       ]
@@ -19699,7 +19699,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/once"
         }
       ]
@@ -19725,7 +19725,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/one-time"
         }
       ]
@@ -19751,7 +19751,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/opentype.js"
         }
       ]
@@ -19777,7 +19777,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/optionator"
         }
       ]
@@ -19803,7 +19803,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/os-homedir"
         }
       ]
@@ -19829,7 +19829,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/os-tmpdir"
         }
       ]
@@ -19855,7 +19855,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/osenv"
         }
       ]
@@ -19881,7 +19881,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/otplib"
         }
       ]
@@ -19907,7 +19907,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-cancelable"
         }
       ]
@@ -19933,7 +19933,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-event"
         }
       ]
@@ -19959,7 +19959,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-finally"
         }
       ]
@@ -19985,7 +19985,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-is-promise"
         }
       ]
@@ -20011,7 +20011,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-limit"
         }
       ]
@@ -20037,7 +20037,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-locate"
         }
       ]
@@ -20063,7 +20063,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-map"
         }
       ]
@@ -20089,7 +20089,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-timeout"
         }
       ]
@@ -20115,7 +20115,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-try"
         }
       ]
@@ -20141,7 +20141,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pako"
         }
       ]
@@ -20167,7 +20167,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/parse-filepath"
         }
       ]
@@ -20193,7 +20193,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/parse-json"
         }
       ]
@@ -20219,7 +20219,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/parse-passwd"
         }
       ]
@@ -20245,7 +20245,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/parseurl"
         }
       ]
@@ -20271,7 +20271,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pascalcase"
         }
       ]
@@ -20297,7 +20297,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-exists"
         }
       ]
@@ -20323,7 +20323,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-is-absolute"
         }
       ]
@@ -20349,7 +20349,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-parse"
         }
       ]
@@ -20375,7 +20375,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-root-regex"
         }
       ]
@@ -20401,7 +20401,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-root"
         }
       ]
@@ -20427,7 +20427,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-to-regexp"
         }
       ]
@@ -20453,7 +20453,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pdfkit"
         }
       ]
@@ -20479,7 +20479,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/peek-readable"
         }
       ]
@@ -20505,7 +20505,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pend"
         }
       ]
@@ -20531,7 +20531,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/performance-now"
         }
       ]
@@ -20557,7 +20557,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pg-connection-string"
         }
       ]
@@ -20583,7 +20583,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/picomatch"
         }
       ]
@@ -20609,7 +20609,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pify"
         }
       ]
@@ -20635,7 +20635,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pinkie-promise"
         }
       ]
@@ -20661,7 +20661,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pinkie"
         }
       ]
@@ -20687,7 +20687,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/png-js"
         }
       ]
@@ -20713,7 +20713,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/portscanner"
         }
       ]
@@ -20739,7 +20739,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/posix-character-classes"
         }
       ]
@@ -20765,7 +20765,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/prebuild-install"
         }
       ]
@@ -20791,7 +20791,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/prelude-ls"
         }
       ]
@@ -20817,7 +20817,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/prepend-http"
         }
       ]
@@ -20843,7 +20843,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pretty-bytes"
         }
       ]
@@ -20869,7 +20869,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/process-nextick-args"
         }
       ]
@@ -20895,7 +20895,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/prom-client"
         }
       ]
@@ -20921,7 +20921,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/promise-inflight"
         }
       ]
@@ -20947,7 +20947,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/promise-retry"
         }
       ],
@@ -20973,7 +20973,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/promise-retry/node_modules/err-code"
             }
           ]
@@ -20999,7 +20999,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/promise-retry/node_modules/retry"
             }
           ]
@@ -21027,7 +21027,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/promise"
         }
       ]
@@ -21053,7 +21053,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/proper-lockfile"
         }
       ]
@@ -21079,7 +21079,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/proxy-addr"
         }
       ]
@@ -21105,7 +21105,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/psl"
         }
       ]
@@ -21131,7 +21131,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-attrs"
         }
       ]
@@ -21157,7 +21157,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-code-gen"
         }
       ]
@@ -21183,7 +21183,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-error"
         }
       ]
@@ -21209,7 +21209,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-filters"
         }
       ]
@@ -21235,7 +21235,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-lexer"
         }
       ]
@@ -21261,7 +21261,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-linker"
         }
       ]
@@ -21287,7 +21287,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-load"
         }
       ]
@@ -21313,7 +21313,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-parser"
         }
       ]
@@ -21339,7 +21339,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-runtime"
         }
       ]
@@ -21365,7 +21365,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-strip-comments"
         }
       ]
@@ -21391,7 +21391,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-walk"
         }
       ]
@@ -21417,7 +21417,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug"
         }
       ]
@@ -21443,7 +21443,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pump"
         }
       ]
@@ -21469,7 +21469,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/punycode"
         }
       ]
@@ -21495,7 +21495,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/qs"
         }
       ]
@@ -21521,7 +21521,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/query-string"
         }
       ]
@@ -21547,7 +21547,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/range_check"
         }
       ]
@@ -21573,7 +21573,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/range-parser"
         }
       ]
@@ -21599,7 +21599,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/raw-body"
         }
       ]
@@ -21625,7 +21625,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/rc"
         }
       ]
@@ -21651,7 +21651,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/read-pkg"
         }
       ],
@@ -21677,7 +21677,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/read-pkg/node_modules/pify"
             }
           ]
@@ -21705,7 +21705,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/readable-stream"
         }
       ],
@@ -21731,7 +21731,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/readable-stream/node_modules/isarray"
             }
           ]
@@ -21759,7 +21759,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/readable-web-to-node-stream"
         }
       ],
@@ -21785,7 +21785,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/readable-web-to-node-stream/node_modules/readable-stream"
             }
           ]
@@ -21813,7 +21813,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/readdirp"
         }
       ]
@@ -21839,7 +21839,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/rechoir"
         }
       ]
@@ -21865,7 +21865,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/regex-not"
         }
       ]
@@ -21891,7 +21891,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/regexp.prototype.flags"
         }
       ]
@@ -21917,7 +21917,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/remove-trailing-separator"
         }
       ]
@@ -21943,7 +21943,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/repeat-element"
         }
       ]
@@ -21969,7 +21969,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/repeat-string"
         }
       ]
@@ -21995,7 +21995,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/replace"
         }
       ],
@@ -22021,7 +22021,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/ansi-regex"
             }
           ]
@@ -22047,7 +22047,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/ansi-styles"
             }
           ]
@@ -22073,7 +22073,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/brace-expansion"
             }
           ]
@@ -22099,7 +22099,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/cliui"
             }
           ]
@@ -22125,7 +22125,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/color-convert"
             }
           ]
@@ -22151,7 +22151,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/color-name"
             }
           ]
@@ -22177,7 +22177,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/find-up"
             }
           ]
@@ -22203,7 +22203,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -22229,7 +22229,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/locate-path"
             }
           ]
@@ -22255,7 +22255,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/minimatch"
             }
           ]
@@ -22281,7 +22281,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/p-locate"
             }
           ]
@@ -22307,7 +22307,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/path-exists"
             }
           ]
@@ -22333,7 +22333,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/string-width"
             }
           ]
@@ -22359,7 +22359,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/strip-ansi"
             }
           ]
@@ -22385,7 +22385,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/wrap-ansi"
             }
           ]
@@ -22411,7 +22411,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/yargs-parser"
             }
           ]
@@ -22437,7 +22437,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/yargs"
             }
           ]
@@ -22465,7 +22465,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/request"
         }
       ],
@@ -22491,7 +22491,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/request/node_modules/qs"
             }
           ]
@@ -22519,7 +22519,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/require-directory"
         }
       ]
@@ -22545,7 +22545,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/require-main-filename"
         }
       ]
@@ -22571,7 +22571,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/resolve-dir"
         }
       ]
@@ -22597,7 +22597,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/resolve-url"
         }
       ]
@@ -22623,7 +22623,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/resolve"
         }
       ]
@@ -22649,7 +22649,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/responselike"
         }
       ]
@@ -22675,7 +22675,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/restructure"
         }
       ]
@@ -22701,7 +22701,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ret"
         }
       ]
@@ -22727,7 +22727,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/retry-as-promised"
         }
       ]
@@ -22753,7 +22753,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/retry"
         }
       ]
@@ -22779,7 +22779,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/rimraf"
         }
       ]
@@ -22805,7 +22805,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/rxjs"
         }
       ],
@@ -22831,7 +22831,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/rxjs/node_modules/tslib"
             }
           ]
@@ -22859,7 +22859,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safe-buffer"
         }
       ]
@@ -22885,7 +22885,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safe-regex-test"
         }
       ]
@@ -22911,7 +22911,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safe-regex"
         }
       ]
@@ -22937,7 +22937,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safe-stable-stringify"
         }
       ]
@@ -22963,7 +22963,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safer-buffer"
         }
       ]
@@ -22989,7 +22989,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/samsam"
         }
       ]
@@ -23015,7 +23015,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sanitize-filename"
         }
       ]
@@ -23041,7 +23041,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sanitize-html"
         }
       ],
@@ -23067,7 +23067,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sanitize-html/node_modules/lodash"
             }
           ]
@@ -23095,7 +23095,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sax"
         }
       ]
@@ -23121,7 +23121,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/seek-bzip"
         }
       ]
@@ -23147,7 +23147,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/semver"
         }
       ]
@@ -23173,7 +23173,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/send"
         }
       ],
@@ -23199,7 +23199,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/send/node_modules/ms"
             }
           ]
@@ -23227,7 +23227,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sequelize-pool"
         }
       ]
@@ -23253,7 +23253,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sequelize"
         }
       ],
@@ -23279,7 +23279,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sequelize/node_modules/debug"
             }
           ]
@@ -23305,7 +23305,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sequelize/node_modules/ms"
             }
           ]
@@ -23331,7 +23331,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sequelize/node_modules/uuid"
             }
           ]
@@ -23359,7 +23359,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/serve-index"
         }
       ],
@@ -23385,7 +23385,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index/node_modules/depd"
             }
           ]
@@ -23411,7 +23411,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index/node_modules/http-errors"
             }
           ]
@@ -23437,7 +23437,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index/node_modules/inherits"
             }
           ]
@@ -23463,7 +23463,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index/node_modules/setprototypeof"
             }
           ]
@@ -23489,7 +23489,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index/node_modules/statuses"
             }
           ]
@@ -23517,7 +23517,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/serve-static"
         }
       ]
@@ -23543,7 +23543,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/set-blocking"
         }
       ]
@@ -23569,7 +23569,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/set-value"
         }
       ],
@@ -23595,7 +23595,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/set-value/node_modules/extend-shallow"
             }
           ]
@@ -23621,7 +23621,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/set-value/node_modules/is-extendable"
             }
           ]
@@ -23649,7 +23649,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/setimmediate"
         }
       ]
@@ -23675,7 +23675,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/setprototypeof"
         }
       ]
@@ -23701,7 +23701,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/side-channel"
         }
       ]
@@ -23727,7 +23727,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/signal-exit"
         }
       ]
@@ -23753,7 +23753,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/simple-concat"
         }
       ]
@@ -23779,7 +23779,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/simple-get"
         }
       ],
@@ -23805,7 +23805,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/simple-get/node_modules/decompress-response"
             }
           ]
@@ -23831,7 +23831,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/simple-get/node_modules/mimic-response"
             }
           ]
@@ -23859,7 +23859,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/simple-swizzle"
         }
       ],
@@ -23885,7 +23885,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/simple-swizzle/node_modules/is-arrayish"
             }
           ]
@@ -23913,7 +23913,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sinon"
         }
       ]
@@ -23939,7 +23939,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/smart-buffer"
         }
       ]
@@ -23965,7 +23965,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/snapdragon-node"
         }
       ],
@@ -23991,7 +23991,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon-node/node_modules/define-property"
             }
           ]
@@ -24019,7 +24019,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/snapdragon-util"
         }
       ],
@@ -24045,7 +24045,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon-util/node_modules/kind-of"
             }
           ]
@@ -24073,7 +24073,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/snapdragon"
         }
       ],
@@ -24099,7 +24099,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/define-property"
             }
           ]
@@ -24125,7 +24125,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/extend-shallow"
             }
           ]
@@ -24151,7 +24151,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/is-accessor-descriptor"
             }
           ],
@@ -24177,7 +24177,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/snapdragon/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
@@ -24205,7 +24205,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/is-data-descriptor"
             }
           ],
@@ -24231,7 +24231,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/snapdragon/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
@@ -24259,7 +24259,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/is-descriptor"
             }
           ]
@@ -24285,7 +24285,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/is-extendable"
             }
           ]
@@ -24311,7 +24311,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/kind-of"
             }
           ]
@@ -24337,7 +24337,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/source-map"
             }
           ]
@@ -24365,7 +24365,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socket.io-adapter"
         }
       ]
@@ -24391,7 +24391,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socket.io-parser"
         }
       ],
@@ -24417,7 +24417,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socket.io-parser/node_modules/debug"
             }
           ]
@@ -24443,7 +24443,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socket.io-parser/node_modules/ms"
             }
           ]
@@ -24471,7 +24471,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socket.io"
         }
       ],
@@ -24497,7 +24497,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socket.io/node_modules/debug"
             }
           ]
@@ -24523,7 +24523,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socket.io/node_modules/ms"
             }
           ]
@@ -24551,7 +24551,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socks-proxy-agent"
         }
       ],
@@ -24577,7 +24577,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socks-proxy-agent/node_modules/debug"
             }
           ]
@@ -24603,7 +24603,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socks-proxy-agent/node_modules/ms"
             }
           ]
@@ -24631,7 +24631,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socks"
         }
       ],
@@ -24657,7 +24657,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socks/node_modules/ip"
             }
           ]
@@ -24685,7 +24685,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sort-keys-length"
         }
       ],
@@ -24711,7 +24711,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sort-keys-length/node_modules/sort-keys"
             }
           ]
@@ -24739,7 +24739,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sort-keys"
         }
       ]
@@ -24765,7 +24765,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/source-map-resolve"
         }
       ]
@@ -24791,7 +24791,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/source-map-support"
         }
       ]
@@ -24817,7 +24817,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/source-map-url"
         }
       ]
@@ -24843,7 +24843,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/source-map"
         }
       ]
@@ -24869,7 +24869,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spawn-command"
         }
       ]
@@ -24895,7 +24895,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spdx-correct"
         }
       ]
@@ -24921,7 +24921,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spdx-exceptions"
         }
       ]
@@ -24947,7 +24947,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spdx-expression-parse"
         }
       ]
@@ -24973,7 +24973,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spdx-license-ids"
         }
       ]
@@ -24999,7 +24999,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/split-string"
         }
       ]
@@ -25025,7 +25025,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sprintf-js"
         }
       ]
@@ -25051,7 +25051,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sqlite3"
         }
       ]
@@ -25077,7 +25077,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sshpk"
         }
       ]
@@ -25103,7 +25103,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ssri"
         }
       ]
@@ -25129,7 +25129,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/stack-trace"
         }
       ]
@@ -25155,7 +25155,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/static-extend"
         }
       ],
@@ -25181,7 +25181,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend/node_modules/define-property"
             }
           ]
@@ -25207,7 +25207,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend/node_modules/is-accessor-descriptor"
             }
           ],
@@ -25233,7 +25233,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/static-extend/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
@@ -25261,7 +25261,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend/node_modules/is-data-descriptor"
             }
           ],
@@ -25287,7 +25287,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/static-extend/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
@@ -25315,7 +25315,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend/node_modules/is-descriptor"
             }
           ]
@@ -25341,7 +25341,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend/node_modules/kind-of"
             }
           ]
@@ -25369,7 +25369,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/statuses"
         }
       ]
@@ -25395,7 +25395,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/stream-buffers"
         }
       ]
@@ -25421,7 +25421,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/streamsearch"
         }
       ]
@@ -25447,7 +25447,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strict-uri-encode"
         }
       ]
@@ -25473,7 +25473,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string_decoder"
         }
       ]
@@ -25499,7 +25499,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string-width"
         }
       ]
@@ -25525,7 +25525,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string.fromcodepoint"
         }
       ]
@@ -25551,7 +25551,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string.prototype.codepointat"
         }
       ]
@@ -25577,7 +25577,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string.prototype.trimend"
         }
       ]
@@ -25603,7 +25603,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string.prototype.trimstart"
         }
       ]
@@ -25629,7 +25629,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-ansi"
         }
       ]
@@ -25655,7 +25655,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-bom"
         }
       ]
@@ -25681,7 +25681,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-dirs"
         }
       ]
@@ -25707,7 +25707,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-json-comments"
         }
       ]
@@ -25733,7 +25733,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-outer"
         }
       ]
@@ -25759,7 +25759,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strtok3"
         }
       ]
@@ -25785,7 +25785,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/supports-color"
         }
       ]
@@ -25811,7 +25811,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/supports-preserve-symlinks-flag"
         }
       ]
@@ -25837,7 +25837,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/svg-captcha"
         }
       ]
@@ -25863,7 +25863,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/swagger-ui-dist"
         }
       ]
@@ -25889,7 +25889,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/swagger-ui-express"
         }
       ]
@@ -25915,7 +25915,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tar-fs"
         }
       ],
@@ -25941,7 +25941,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/tar-fs/node_modules/bl"
             }
           ]
@@ -25967,7 +25967,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/tar-fs/node_modules/chownr"
             }
           ]
@@ -25993,7 +25993,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/tar-fs/node_modules/readable-stream"
             }
           ]
@@ -26019,7 +26019,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/tar-fs/node_modules/tar-stream"
             }
           ]
@@ -26047,7 +26047,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tar-stream"
         }
       ]
@@ -26073,7 +26073,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tar"
         }
       ]
@@ -26099,7 +26099,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tdigest"
         }
       ]
@@ -26125,7 +26125,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/text-hex"
         }
       ]
@@ -26151,7 +26151,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/thirty-two"
         }
       ]
@@ -26177,7 +26177,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/through"
         }
       ]
@@ -26203,7 +26203,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/timed-out"
         }
       ]
@@ -26229,7 +26229,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tiny-inflate"
         }
       ]
@@ -26255,7 +26255,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-buffer"
         }
       ]
@@ -26281,7 +26281,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-fast-properties"
         }
       ]
@@ -26307,7 +26307,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-object-path"
         }
       ],
@@ -26333,7 +26333,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/to-object-path/node_modules/kind-of"
             }
           ]
@@ -26361,7 +26361,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-regex-range"
         }
       ]
@@ -26387,7 +26387,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-regex"
         }
       ]
@@ -26413,7 +26413,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/toidentifier"
         }
       ]
@@ -26439,7 +26439,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/token-stream"
         }
       ]
@@ -26465,7 +26465,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/token-types"
         }
       ]
@@ -26491,7 +26491,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/toposort-class"
         }
       ]
@@ -26517,7 +26517,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tough-cookie"
         }
       ]
@@ -26543,7 +26543,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tr46"
         }
       ]
@@ -26569,7 +26569,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/traverse"
         }
       ]
@@ -26595,7 +26595,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tree-kill"
         }
       ]
@@ -26621,7 +26621,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/trim-repeated"
         }
       ]
@@ -26647,7 +26647,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/triple-beam"
         }
       ]
@@ -26673,7 +26673,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/truncate-utf8-bytes"
         }
       ]
@@ -26699,7 +26699,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ts-node-dev"
         }
       ],
@@ -26725,7 +26725,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/ts-node-dev/node_modules/rimraf"
             }
           ]
@@ -26753,7 +26753,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ts-node"
         }
       ]
@@ -26779,7 +26779,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tsconfig"
         }
       ]
@@ -26805,7 +26805,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tslib"
         }
       ]
@@ -26831,7 +26831,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tunnel-agent"
         }
       ]
@@ -26857,7 +26857,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tweetnacl"
         }
       ]
@@ -26883,7 +26883,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/type-check"
         }
       ]
@@ -26909,7 +26909,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/type-is"
         }
       ]
@@ -26935,7 +26935,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/typecast"
         }
       ]
@@ -26961,7 +26961,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/typedarray"
         }
       ]
@@ -26987,7 +26987,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/typescript"
         }
       ]
@@ -27013,7 +27013,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/uglify-js"
         }
       ]
@@ -27039,7 +27039,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unbox-primitive"
         }
       ]
@@ -27065,7 +27065,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unbzip2-stream"
         }
       ]
@@ -27091,7 +27091,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unc-path-regex"
         }
       ]
@@ -27117,7 +27117,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/underscore.string"
         }
       ]
@@ -27143,7 +27143,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unicode-properties"
         }
       ]
@@ -27169,7 +27169,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unicode-trie"
         }
       ]
@@ -27195,7 +27195,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/union-value"
         }
       ],
@@ -27221,7 +27221,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/union-value/node_modules/is-extendable"
             }
           ]
@@ -27249,7 +27249,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unique-filename"
         }
       ]
@@ -27275,7 +27275,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unique-slug"
         }
       ]
@@ -27301,7 +27301,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unit-compare"
         }
       ]
@@ -27327,7 +27327,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/universalify"
         }
       ]
@@ -27353,7 +27353,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unpipe"
         }
       ]
@@ -27379,7 +27379,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unset-value"
         }
       ],
@@ -27405,7 +27405,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/unset-value/node_modules/has-value"
             }
           ],
@@ -27431,7 +27431,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/unset-value/node_modules/has-value/node_modules/isobject"
                 }
               ]
@@ -27459,7 +27459,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/unset-value/node_modules/has-values"
             }
           ]
@@ -27485,7 +27485,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/unset-value/node_modules/isarray"
             }
           ]
@@ -27513,7 +27513,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/untildify"
         }
       ]
@@ -27539,7 +27539,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unzipper"
         }
       ],
@@ -27565,7 +27565,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/unzipper/node_modules/bluebird"
             }
           ]
@@ -27593,7 +27593,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/uri-js"
         }
       ]
@@ -27619,7 +27619,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/urix"
         }
       ]
@@ -27645,7 +27645,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/url-parse-lax"
         }
       ]
@@ -27671,7 +27671,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/url-to-options"
         }
       ]
@@ -27697,7 +27697,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/use"
         }
       ]
@@ -27723,7 +27723,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/utf8-byte-length"
         }
       ]
@@ -27749,7 +27749,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/util-deprecate"
         }
       ]
@@ -27775,7 +27775,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/util"
         }
       ]
@@ -27801,7 +27801,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/utils-merge"
         }
       ]
@@ -27827,7 +27827,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/uuid"
         }
       ]
@@ -27853,7 +27853,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/v8flags"
         }
       ]
@@ -27879,7 +27879,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/validate-npm-package-license"
         }
       ]
@@ -27905,7 +27905,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/validate"
         }
       ]
@@ -27931,7 +27931,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/validator"
         }
       ]
@@ -27957,7 +27957,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/vary"
         }
       ]
@@ -27983,7 +27983,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/verror"
         }
       ],
@@ -28009,7 +28009,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/verror/node_modules/core-util-is"
             }
           ]
@@ -28037,7 +28037,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/vm2"
         }
       ],
@@ -28063,7 +28063,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/vm2/node_modules/acorn"
             }
           ]
@@ -28091,7 +28091,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/void-elements"
         }
       ]
@@ -28117,7 +28117,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/walk"
         }
       ]
@@ -28143,7 +28143,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/walkdir"
         }
       ]
@@ -28169,7 +28169,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/webidl-conversions"
         }
       ]
@@ -28195,7 +28195,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/whatwg-url"
         }
       ]
@@ -28221,7 +28221,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-boxed-primitive"
         }
       ]
@@ -28247,7 +28247,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-collection"
         }
       ]
@@ -28273,7 +28273,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-module"
         }
       ]
@@ -28299,7 +28299,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-pm-runs"
         }
       ]
@@ -28325,7 +28325,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-typed-array"
         }
       ]
@@ -28351,7 +28351,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which"
         }
       ]
@@ -28377,7 +28377,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wide-align"
         }
       ]
@@ -28403,7 +28403,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/winston-transport"
         }
       ],
@@ -28429,7 +28429,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/winston-transport/node_modules/readable-stream"
             }
           ]
@@ -28457,7 +28457,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/winston"
         }
       ],
@@ -28483,7 +28483,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/winston/node_modules/async"
             }
           ]
@@ -28509,7 +28509,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/winston/node_modules/is-stream"
             }
           ]
@@ -28535,7 +28535,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/winston/node_modules/readable-stream"
             }
           ]
@@ -28563,7 +28563,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/with"
         }
       ]
@@ -28589,7 +28589,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wkx"
         }
       ]
@@ -28615,7 +28615,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/word-wrap"
         }
       ]
@@ -28641,7 +28641,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wordwrap"
         }
       ]
@@ -28667,7 +28667,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wrap-ansi"
         }
       ],
@@ -28693,7 +28693,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi/node_modules/ansi-regex"
             }
           ]
@@ -28719,7 +28719,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi/node_modules/emoji-regex"
             }
           ]
@@ -28745,7 +28745,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -28771,7 +28771,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi/node_modules/string-width"
             }
           ]
@@ -28797,7 +28797,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi/node_modules/strip-ansi"
             }
           ]
@@ -28825,7 +28825,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wrappy"
         }
       ]
@@ -28851,7 +28851,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ws"
         }
       ]
@@ -28877,7 +28877,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/xtend"
         }
       ]
@@ -28903,7 +28903,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/y18n"
         }
       ]
@@ -28929,7 +28929,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yallist"
         }
       ]
@@ -28955,7 +28955,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yaml-schema-validator"
         }
       ]
@@ -28981,7 +28981,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yargs-parser"
         }
       ]
@@ -29007,7 +29007,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yargs"
         }
       ],
@@ -29033,7 +29033,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs/node_modules/ansi-regex"
             }
           ]
@@ -29059,7 +29059,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs/node_modules/emoji-regex"
             }
           ]
@@ -29085,7 +29085,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -29111,7 +29111,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs/node_modules/string-width"
             }
           ]
@@ -29137,7 +29137,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs/node_modules/strip-ansi"
             }
           ]
@@ -29165,7 +29165,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yauzl"
         }
       ]
@@ -29191,7 +29191,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yn"
         }
       ]
@@ -29217,7 +29217,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/z85"
         }
       ]
@@ -29243,7 +29243,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/zip-stream"
         }
       ]
@@ -29269,7 +29269,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/zlibjs"
         }
       ]

--- a/tests/_data/sbom_demo-results/juice-shop_npm8_node16_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/juice-shop_npm8_node16_windows-latest.snap.json
@@ -62,6 +62,10 @@
       ],
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -88,6 +92,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@babel\\helper-string-parser"
+        }
       ]
     },
     {
@@ -108,6 +118,12 @@
           "url": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@babel\\helper-validator-identifier"
         }
       ]
     },
@@ -130,6 +146,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@babel\\parser"
+        }
       ]
     },
     {
@@ -150,6 +172,12 @@
           "url": "https://registry.npmjs.org/@babel/types/-/types-7.20.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@babel\\types"
         }
       ]
     },
@@ -172,6 +200,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@colors\\colors"
+        }
       ]
     },
     {
@@ -193,6 +227,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@dabh\\diagnostics"
+        }
       ]
     },
     {
@@ -213,6 +253,12 @@
           "url": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@gar\\promisify"
         }
       ]
     },
@@ -236,6 +282,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@mapbox\\node-pre-gyp"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -254,6 +306,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\ansi-regex"
             }
           ]
         },
@@ -275,6 +333,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\are-we-there-yet"
+            }
           ]
         },
         {
@@ -294,6 +358,12 @@
               "url": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\detect-libc"
             }
           ]
         },
@@ -315,6 +385,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\gauge"
+            }
           ]
         },
         {
@@ -334,6 +410,12 @@
               "url": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\is-fullwidth-code-point"
             }
           ]
         },
@@ -356,6 +438,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\make-dir"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -374,6 +462,12 @@
                   "url": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\make-dir\\node_modules\\semver"
                 }
               ]
             }
@@ -397,6 +491,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\nopt"
+            }
           ]
         },
         {
@@ -416,6 +516,12 @@
               "url": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\npmlog"
             }
           ]
         },
@@ -437,6 +543,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\readable-stream"
+            }
           ]
         },
         {
@@ -457,6 +569,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\string-width"
+            }
           ]
         },
         {
@@ -476,6 +594,12 @@
               "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\strip-ansi"
             }
           ]
         }
@@ -500,6 +624,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\core-loader"
+        }
       ]
     },
     {
@@ -520,6 +650,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/core/-/core-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\core"
         }
       ]
     },
@@ -542,6 +678,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\evaluator"
+        }
       ]
     },
     {
@@ -562,6 +704,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-all/-/lang-all-4.24.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-all"
         }
       ]
     },
@@ -584,6 +732,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-ar"
+        }
       ]
     },
     {
@@ -604,6 +758,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-bn/-/lang-bn-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-bn"
         }
       ]
     },
@@ -626,6 +786,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-ca"
+        }
       ]
     },
     {
@@ -646,6 +812,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-cs/-/lang-cs-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-cs"
         }
       ]
     },
@@ -668,6 +840,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-da"
+        }
       ]
     },
     {
@@ -688,6 +866,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-de/-/lang-de-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-de"
         }
       ]
     },
@@ -710,6 +894,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-el"
+        }
       ]
     },
     {
@@ -730,6 +920,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-en-min/-/lang-en-min-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-en-min"
         }
       ]
     },
@@ -752,6 +948,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-en"
+        }
       ]
     },
     {
@@ -772,6 +974,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-es/-/lang-es-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-es"
         }
       ]
     },
@@ -794,6 +1002,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-eu"
+        }
       ]
     },
     {
@@ -814,6 +1028,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-fa/-/lang-fa-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-fa"
         }
       ]
     },
@@ -836,6 +1056,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-fi"
+        }
       ]
     },
     {
@@ -856,6 +1082,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-fr/-/lang-fr-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-fr"
         }
       ]
     },
@@ -878,6 +1110,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-ga"
+        }
       ]
     },
     {
@@ -898,6 +1136,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-gl/-/lang-gl-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-gl"
         }
       ]
     },
@@ -920,6 +1164,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-hi"
+        }
       ]
     },
     {
@@ -940,6 +1190,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-hu/-/lang-hu-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-hu"
         }
       ]
     },
@@ -962,6 +1218,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-hy"
+        }
       ]
     },
     {
@@ -982,6 +1244,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-id/-/lang-id-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-id"
         }
       ]
     },
@@ -1004,6 +1272,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-it"
+        }
       ]
     },
     {
@@ -1024,6 +1298,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-ja/-/lang-ja-4.24.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-ja"
         }
       ]
     },
@@ -1046,6 +1326,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-ko"
+        }
       ]
     },
     {
@@ -1066,6 +1352,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-lt/-/lang-lt-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-lt"
         }
       ]
     },
@@ -1088,6 +1380,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-ms"
+        }
       ]
     },
     {
@@ -1108,6 +1406,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-ne/-/lang-ne-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-ne"
         }
       ]
     },
@@ -1130,6 +1434,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-nl"
+        }
       ]
     },
     {
@@ -1150,6 +1460,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-no/-/lang-no-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-no"
         }
       ]
     },
@@ -1172,6 +1488,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-pl"
+        }
       ]
     },
     {
@@ -1192,6 +1514,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-pt/-/lang-pt-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-pt"
         }
       ]
     },
@@ -1214,6 +1542,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-ro"
+        }
       ]
     },
     {
@@ -1234,6 +1568,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-ru/-/lang-ru-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-ru"
         }
       ]
     },
@@ -1256,6 +1596,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-sl"
+        }
       ]
     },
     {
@@ -1276,6 +1622,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-sr/-/lang-sr-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-sr"
         }
       ]
     },
@@ -1298,6 +1650,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-sv"
+        }
       ]
     },
     {
@@ -1318,6 +1676,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-ta/-/lang-ta-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-ta"
         }
       ]
     },
@@ -1340,6 +1704,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-th"
+        }
       ]
     },
     {
@@ -1360,6 +1730,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-tl/-/lang-tl-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-tl"
         }
       ]
     },
@@ -1382,6 +1758,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-tr"
+        }
       ]
     },
     {
@@ -1402,6 +1784,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-uk/-/lang-uk-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-uk"
         }
       ]
     },
@@ -1424,6 +1812,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-zh"
+        }
       ]
     },
     {
@@ -1444,6 +1838,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/language-min/-/language-min-4.22.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\language-min"
         }
       ]
     },
@@ -1466,6 +1866,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\language"
+        }
       ]
     },
     {
@@ -1486,6 +1892,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/ner/-/ner-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\ner"
         }
       ]
     },
@@ -1508,6 +1920,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\neural"
+        }
       ]
     },
     {
@@ -1528,6 +1946,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/nlg/-/nlg-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\nlg"
         }
       ]
     },
@@ -1550,6 +1974,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\nlp"
+        }
       ]
     },
     {
@@ -1570,6 +2000,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/nlu/-/nlu-4.23.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\nlu"
         }
       ]
     },
@@ -1592,6 +2028,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\request"
+        }
       ]
     },
     {
@@ -1612,6 +2054,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/sentiment/-/sentiment-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\sentiment"
         }
       ]
     },
@@ -1634,6 +2082,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\similarity"
+        }
       ]
     },
     {
@@ -1654,6 +2108,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/slot/-/slot-4.22.17.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\slot"
         }
       ]
     },
@@ -1676,6 +2136,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@npmcli\\fs"
+        }
       ]
     },
     {
@@ -1696,6 +2162,12 @@
           "url": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@npmcli\\move-file"
         }
       ]
     },
@@ -1718,6 +2190,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib\\core"
+        }
       ]
     },
     {
@@ -1738,6 +2216,12 @@
           "url": "https://registry.npmjs.org/@otplib/plugin-crypto/-/plugin-crypto-12.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib\\plugin-crypto"
         }
       ]
     },
@@ -1760,6 +2244,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib\\plugin-thirty-two"
+        }
       ]
     },
     {
@@ -1780,6 +2270,12 @@
           "url": "https://registry.npmjs.org/@otplib/preset-default/-/preset-default-12.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib\\preset-default"
         }
       ]
     },
@@ -1802,6 +2298,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib\\preset-v11"
+        }
       ]
     },
     {
@@ -1822,6 +2324,12 @@
           "url": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@sindresorhus\\is"
         }
       ]
     },
@@ -1844,6 +2352,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@swc\\helpers"
+        }
       ]
     },
     {
@@ -1864,6 +2378,12 @@
           "url": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@tokenizer\\token"
         }
       ]
     },
@@ -1886,6 +2406,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@tootallnate\\once"
+        }
       ]
     },
     {
@@ -1906,6 +2432,12 @@
           "url": "https://registry.npmjs.org/@types/component-emitter/-/component-emitter-1.2.11.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types\\component-emitter"
         }
       ]
     },
@@ -1928,6 +2460,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types\\cookie"
+        }
       ]
     },
     {
@@ -1948,6 +2486,12 @@
           "url": "https://registry.npmjs.org/@types/cors/-/cors-2.8.12.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types\\cors"
         }
       ]
     },
@@ -1970,6 +2514,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types\\debug"
+        }
       ]
     },
     {
@@ -1990,6 +2540,12 @@
           "url": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types\\ms"
         }
       ]
     },
@@ -2012,6 +2568,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types\\node"
+        }
       ]
     },
     {
@@ -2032,6 +2594,12 @@
           "url": "https://registry.npmjs.org/@types/strip-bom/-/strip-bom-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types\\strip-bom"
         }
       ]
     },
@@ -2054,6 +2622,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types\\strip-json-comments"
+        }
       ]
     },
     {
@@ -2075,6 +2649,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types\\validator"
+        }
       ]
     },
     {
@@ -2094,6 +2674,12 @@
           "url": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/abbrev"
         }
       ]
     },
@@ -2115,6 +2701,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/accepts"
+        }
       ]
     },
     {
@@ -2135,6 +2727,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/acorn-walk"
+        }
       ]
     },
     {
@@ -2154,6 +2752,12 @@
           "url": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/acorn"
         }
       ]
     },
@@ -2176,6 +2780,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/agent-base"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -2194,6 +2804,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agent-base\\node_modules\\debug"
             }
           ]
         },
@@ -2214,6 +2830,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agent-base\\node_modules\\ms"
             }
           ]
         }
@@ -2238,6 +2860,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/agentkeepalive"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -2256,6 +2884,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agentkeepalive\\node_modules\\debug"
             }
           ]
         },
@@ -2277,6 +2911,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agentkeepalive\\node_modules\\depd"
+            }
           ]
         },
         {
@@ -2296,6 +2936,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agentkeepalive\\node_modules\\ms"
             }
           ]
         }
@@ -2319,6 +2965,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/aggregate-error"
+        }
       ]
     },
     {
@@ -2338,6 +2990,12 @@
           "url": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ajv"
         }
       ]
     },
@@ -2359,6 +3017,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ansi-regex"
+        }
       ]
     },
     {
@@ -2378,6 +3042,12 @@
           "url": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ansi-styles"
         }
       ]
     },
@@ -2400,6 +3070,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/anymatch"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -2418,6 +3094,12 @@
               "url": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/anymatch\\node_modules\\normalize-path"
             }
           ]
         }
@@ -2441,6 +3123,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/append-field"
+        }
       ]
     },
     {
@@ -2460,6 +3148,12 @@
           "url": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/aproba"
         }
       ]
     },
@@ -2482,6 +3176,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/archive-type"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -2500,6 +3200,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-4.4.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/archive-type\\node_modules\\file-type"
             }
           ]
         }
@@ -2523,6 +3229,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/archiver-utils"
+        }
       ]
     },
     {
@@ -2542,6 +3254,12 @@
           "url": "https://registry.npmjs.org/archiver/-/archiver-1.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/archiver"
         }
       ]
     },
@@ -2563,6 +3281,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/are-we-there-yet"
+        }
       ]
     },
     {
@@ -2582,6 +3306,12 @@
           "url": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/arg"
         }
       ]
     },
@@ -2604,6 +3334,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/argparse"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -2622,6 +3358,12 @@
               "url": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/argparse\\node_modules\\sprintf-js"
             }
           ]
         }
@@ -2645,6 +3387,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/arr-diff"
+        }
       ]
     },
     {
@@ -2664,6 +3412,12 @@
           "url": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/arr-flatten"
         }
       ]
     },
@@ -2685,6 +3439,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/arr-union"
+        }
       ]
     },
     {
@@ -2704,6 +3464,12 @@
           "url": "https://registry.npmjs.org/array-each/-/array-each-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/array-each"
         }
       ]
     },
@@ -2725,6 +3491,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/array-flatten"
+        }
       ]
     },
     {
@@ -2744,6 +3516,12 @@
           "url": "https://registry.npmjs.org/array-slice/-/array-slice-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/array-slice"
         }
       ]
     },
@@ -2765,6 +3543,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/array-unique"
+        }
       ]
     },
     {
@@ -2784,6 +3568,12 @@
           "url": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/asap"
         }
       ]
     },
@@ -2805,6 +3595,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/asn1"
+        }
       ]
     },
     {
@@ -2824,6 +3620,12 @@
           "url": "https://registry.npmjs.org/assert-never/-/assert-never-1.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/assert-never"
         }
       ]
     },
@@ -2845,6 +3647,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/assert-plus"
+        }
       ]
     },
     {
@@ -2864,6 +3672,12 @@
           "url": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/assign-symbols"
         }
       ]
     },
@@ -2885,6 +3699,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/async"
+        }
       ]
     },
     {
@@ -2904,6 +3724,12 @@
           "url": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/asynckit"
         }
       ]
     },
@@ -2925,6 +3751,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/at-least-node"
+        }
       ]
     },
     {
@@ -2944,6 +3776,12 @@
           "url": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/atob"
         }
       ]
     },
@@ -2965,6 +3803,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/available-typed-arrays"
+        }
       ]
     },
     {
@@ -2984,6 +3828,12 @@
           "url": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/aws-sign2"
         }
       ]
     },
@@ -3005,6 +3855,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/aws4"
+        }
       ]
     },
     {
@@ -3025,6 +3881,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/babel-walk"
+        }
       ]
     },
     {
@@ -3044,6 +3906,12 @@
           "url": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/balanced-match"
         }
       ]
     },
@@ -3066,6 +3934,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -3084,6 +3958,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/base\\node_modules\\define-property"
             }
           ]
         }
@@ -3107,6 +3987,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base64-arraybuffer"
+        }
       ]
     },
     {
@@ -3126,6 +4012,12 @@
           "url": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base64-js"
         }
       ]
     },
@@ -3147,6 +4039,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base64id"
+        }
       ]
     },
     {
@@ -3166,6 +4064,12 @@
           "url": "https://registry.npmjs.org/base64url/-/base64url-0.0.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base64url"
         }
       ]
     },
@@ -3187,6 +4091,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/basic-auth"
+        }
       ]
     },
     {
@@ -3206,6 +4116,12 @@
           "url": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/batch"
         }
       ]
     },
@@ -3227,6 +4143,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bcrypt-pbkdf"
+        }
       ]
     },
     {
@@ -3246,6 +4168,12 @@
           "url": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/big-integer"
         }
       ]
     },
@@ -3267,6 +4195,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/binary-extensions"
+        }
       ]
     },
     {
@@ -3286,6 +4220,12 @@
           "url": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/binary"
         }
       ]
     },
@@ -3307,6 +4247,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bindings"
+        }
       ]
     },
     {
@@ -3326,6 +4272,12 @@
           "url": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bintrees"
         }
       ]
     },
@@ -3347,6 +4299,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bl"
+        }
       ]
     },
     {
@@ -3367,6 +4325,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bluebird"
+        }
       ]
     },
     {
@@ -3386,6 +4350,12 @@
           "url": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/body-parser"
         }
       ]
     },
@@ -3408,6 +4378,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bower-config"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -3426,6 +4402,12 @@
               "url": "https://registry.npmjs.org/minimist/-/minimist-0.2.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bower-config\\node_modules\\minimist"
             }
           ]
         }
@@ -3449,6 +4431,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/brace-expansion"
+        }
       ]
     },
     {
@@ -3470,6 +4458,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/braces"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -3488,6 +4482,12 @@
               "url": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/braces\\node_modules\\extend-shallow"
             }
           ]
         },
@@ -3508,6 +4508,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/braces\\node_modules\\is-extendable"
             }
           ]
         }
@@ -3531,6 +4537,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/brotli"
+        }
       ]
     },
     {
@@ -3550,6 +4562,12 @@
           "url": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-alloc-unsafe"
         }
       ]
     },
@@ -3571,6 +4589,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-alloc"
+        }
       ]
     },
     {
@@ -3590,6 +4614,12 @@
           "url": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-crc32"
         }
       ]
     },
@@ -3611,6 +4641,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-fill"
+        }
       ]
     },
     {
@@ -3630,6 +4666,12 @@
           "url": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-from"
         }
       ]
     },
@@ -3651,6 +4693,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-indexof-polyfill"
+        }
       ]
     },
     {
@@ -3671,6 +4719,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer"
+        }
       ]
     },
     {
@@ -3690,6 +4744,12 @@
           "url": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffers"
         }
       ]
     },
@@ -3712,6 +4772,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/busboy"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -3730,6 +4796,12 @@
               "url": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/busboy\\node_modules\\isarray"
             }
           ]
         },
@@ -3751,6 +4823,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/busboy\\node_modules\\readable-stream"
+            }
           ]
         },
         {
@@ -3770,6 +4848,12 @@
               "url": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/busboy\\node_modules\\string_decoder"
             }
           ]
         }
@@ -3793,6 +4877,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/byline"
+        }
       ]
     },
     {
@@ -3812,6 +4902,12 @@
           "url": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bytes"
         }
       ]
     },
@@ -3833,6 +4929,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cacache"
+        }
       ]
     },
     {
@@ -3852,6 +4954,12 @@
           "url": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cache-base"
         }
       ]
     },
@@ -3874,6 +4982,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cacheable-request"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -3892,6 +5006,12 @@
               "url": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cacheable-request\\node_modules\\get-stream"
             }
           ]
         },
@@ -3912,6 +5032,12 @@
               "url": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cacheable-request\\node_modules\\lowercase-keys"
             }
           ]
         }
@@ -3935,6 +5061,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/call-bind"
+        }
       ]
     },
     {
@@ -3954,6 +5086,12 @@
           "url": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/camelcase"
         }
       ]
     },
@@ -3975,6 +5113,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/caseless"
+        }
       ]
     },
     {
@@ -3994,6 +5138,12 @@
           "url": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/chainsaw"
         }
       ]
     },
@@ -4015,6 +5165,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/chalk"
+        }
       ]
     },
     {
@@ -4034,6 +5190,12 @@
           "url": "https://registry.npmjs.org/character-parser/-/character-parser-2.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/character-parser"
         }
       ]
     },
@@ -4056,6 +5218,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/check-dependencies"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4074,6 +5242,12 @@
               "url": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/check-dependencies\\node_modules\\semver"
             }
           ]
         }
@@ -4097,6 +5271,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/check-types"
+        }
       ]
     },
     {
@@ -4118,6 +5298,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/chokidar"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4136,6 +5322,12 @@
               "url": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar\\node_modules\\braces"
             }
           ]
         },
@@ -4157,6 +5349,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar\\node_modules\\fill-range"
+            }
           ]
         },
         {
@@ -4176,6 +5374,12 @@
               "url": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar\\node_modules\\is-glob"
             }
           ]
         },
@@ -4197,6 +5401,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar\\node_modules\\is-number"
+            }
           ]
         },
         {
@@ -4217,6 +5427,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar\\node_modules\\normalize-path"
+            }
           ]
         },
         {
@@ -4236,6 +5452,12 @@
               "url": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar\\node_modules\\to-regex-range"
             }
           ]
         }
@@ -4259,6 +5481,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/chownr"
+        }
       ]
     },
     {
@@ -4278,6 +5506,12 @@
           "url": "https://registry.npmjs.org/clarinet/-/clarinet-0.12.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/clarinet"
         }
       ]
     },
@@ -4300,6 +5534,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/class-utils"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4318,6 +5558,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils\\node_modules\\define-property"
             }
           ]
         },
@@ -4340,6 +5586,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils\\node_modules\\is-accessor-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -4358,6 +5610,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/class-utils\\node_modules\\is-accessor-descriptor\\node_modules\\kind-of"
                 }
               ]
             }
@@ -4382,6 +5640,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils\\node_modules\\is-data-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -4400,6 +5664,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/class-utils\\node_modules\\is-data-descriptor\\node_modules\\kind-of"
                 }
               ]
             }
@@ -4423,6 +5693,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils\\node_modules\\is-descriptor"
+            }
           ]
         },
         {
@@ -4442,6 +5718,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils\\node_modules\\kind-of"
             }
           ]
         }
@@ -4465,6 +5747,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/clean-stack"
+        }
       ]
     },
     {
@@ -4486,6 +5774,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cliui"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4504,6 +5798,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui\\node_modules\\ansi-regex"
             }
           ]
         },
@@ -4525,6 +5825,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui\\node_modules\\emoji-regex"
+            }
           ]
         },
         {
@@ -4544,6 +5850,12 @@
               "url": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui\\node_modules\\is-fullwidth-code-point"
             }
           ]
         },
@@ -4565,6 +5877,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui\\node_modules\\string-width"
+            }
           ]
         },
         {
@@ -4584,6 +5902,12 @@
               "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui\\node_modules\\strip-ansi"
             }
           ]
         }
@@ -4607,6 +5931,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/clone-response"
+        }
       ]
     },
     {
@@ -4626,6 +5956,12 @@
           "url": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/clone"
         }
       ]
     },
@@ -4647,6 +5983,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/code-point-at"
+        }
       ]
     },
     {
@@ -4666,6 +6008,12 @@
           "url": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/collection-visit"
         }
       ]
     },
@@ -4687,6 +6035,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color-convert"
+        }
       ]
     },
     {
@@ -4706,6 +6060,12 @@
           "url": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color-name"
         }
       ]
     },
@@ -4727,6 +6087,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color-string"
+        }
       ]
     },
     {
@@ -4746,6 +6112,12 @@
           "url": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color-support"
         }
       ]
     },
@@ -4767,6 +6139,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color"
+        }
       ]
     },
     {
@@ -4786,6 +6164,12 @@
           "url": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/colors"
         }
       ]
     },
@@ -4807,6 +6191,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/colorspace"
+        }
       ]
     },
     {
@@ -4826,6 +6216,12 @@
           "url": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/combined-stream"
         }
       ]
     },
@@ -4847,6 +6243,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/commander"
+        }
       ]
     },
     {
@@ -4866,6 +6268,12 @@
           "url": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/component-emitter"
         }
       ]
     },
@@ -4887,6 +6295,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/component-type"
+        }
       ]
     },
     {
@@ -4907,6 +6321,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/compress-commons"
+        }
       ]
     },
     {
@@ -4926,6 +6346,12 @@
           "url": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/compressible"
         }
       ]
     },
@@ -4948,6 +6374,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/compression"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4966,6 +6398,12 @@
               "url": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/compression\\node_modules\\bytes"
             }
           ]
         }
@@ -4989,6 +6427,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/concat-map"
+        }
       ]
     },
     {
@@ -5008,6 +6452,12 @@
           "url": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/concat-stream"
         }
       ]
     },
@@ -5030,6 +6480,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/concurrently"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5048,6 +6504,12 @@
               "url": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/concurrently\\node_modules\\supports-color"
             }
           ]
         }
@@ -5071,6 +6533,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/config"
+        }
       ]
     },
     {
@@ -5091,6 +6559,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/console-control-strings"
+        }
       ]
     },
     {
@@ -5110,6 +6584,12 @@
           "url": "https://registry.npmjs.org/constantinople/-/constantinople-4.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/constantinople"
         }
       ]
     },
@@ -5132,6 +6612,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/content-disposition"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5150,6 +6636,12 @@
               "url": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/content-disposition\\node_modules\\safe-buffer"
             }
           ]
         }
@@ -5173,6 +6665,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/content-type"
+        }
       ]
     },
     {
@@ -5192,6 +6690,12 @@
           "url": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cookie-parser"
         }
       ]
     },
@@ -5213,6 +6717,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cookie-signature"
+        }
       ]
     },
     {
@@ -5232,6 +6742,12 @@
           "url": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cookie"
         }
       ]
     },
@@ -5253,6 +6769,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/copy-descriptor"
+        }
       ]
     },
     {
@@ -5272,6 +6794,12 @@
           "url": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/core-util-is"
         }
       ]
     },
@@ -5293,6 +6821,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cors"
+        }
       ]
     },
     {
@@ -5312,6 +6846,12 @@
           "url": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/crc"
         }
       ]
     },
@@ -5333,6 +6873,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/crc32-stream"
+        }
       ]
     },
     {
@@ -5352,6 +6898,12 @@
           "url": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/create-require"
         }
       ]
     },
@@ -5373,6 +6925,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/crypto-js"
+        }
       ]
     },
     {
@@ -5392,6 +6950,12 @@
           "url": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dashdash"
         }
       ]
     },
@@ -5413,6 +6977,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/date-fns"
+        }
       ]
     },
     {
@@ -5432,6 +7002,12 @@
           "url": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dateformat"
         }
       ]
     },
@@ -5453,6 +7029,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/debug"
+        }
       ]
     },
     {
@@ -5472,6 +7054,12 @@
           "url": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decamelize"
         }
       ]
     },
@@ -5493,6 +7081,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decode-uri-component"
+        }
       ]
     },
     {
@@ -5512,6 +7106,12 @@
           "url": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-response"
         }
       ]
     },
@@ -5534,6 +7134,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-tar"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5552,6 +7158,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-tar\\node_modules\\file-type"
             }
           ]
         }
@@ -5576,6 +7188,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-tarbz2"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5594,6 +7212,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-6.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-tarbz2\\node_modules\\file-type"
             }
           ]
         }
@@ -5618,6 +7242,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-targz"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5636,6 +7266,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-targz\\node_modules\\file-type"
             }
           ]
         }
@@ -5660,6 +7296,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-unzip"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5678,6 +7320,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-unzip\\node_modules\\file-type"
             }
           ]
         },
@@ -5699,6 +7347,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-unzip\\node_modules\\get-stream"
+            }
           ]
         },
         {
@@ -5718,6 +7372,12 @@
               "url": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-unzip\\node_modules\\pify"
             }
           ]
         }
@@ -5742,6 +7402,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5762,6 +7428,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress\\node_modules\\make-dir"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -5780,6 +7452,12 @@
                   "url": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/decompress\\node_modules\\make-dir\\node_modules\\pify"
                 }
               ]
             }
@@ -5803,6 +7481,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress\\node_modules\\pify"
+            }
           ]
         }
       ]
@@ -5825,6 +7509,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/deep-equal"
+        }
       ]
     },
     {
@@ -5844,6 +7534,12 @@
           "url": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/deep-extend"
         }
       ]
     },
@@ -5865,6 +7561,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/deep-is"
+        }
       ]
     },
     {
@@ -5884,6 +7586,12 @@
           "url": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/define-properties"
         }
       ]
     },
@@ -5905,6 +7613,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/define-property"
+        }
       ]
     },
     {
@@ -5924,6 +7638,12 @@
           "url": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/delayed-stream"
         }
       ]
     },
@@ -5945,6 +7665,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/delegates"
+        }
       ]
     },
     {
@@ -5964,6 +7690,12 @@
           "url": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/depd"
         }
       ]
     },
@@ -5985,6 +7717,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/destroy"
+        }
       ]
     },
     {
@@ -6004,6 +7742,12 @@
           "url": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/detect-file"
         }
       ]
     },
@@ -6025,6 +7769,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/detect-libc"
+        }
       ]
     },
     {
@@ -6044,6 +7794,12 @@
           "url": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dfa"
         }
       ]
     },
@@ -6066,6 +7822,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dicer"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -6084,6 +7846,12 @@
               "url": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/dicer\\node_modules\\isarray"
             }
           ]
         },
@@ -6105,6 +7873,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/dicer\\node_modules\\readable-stream"
+            }
           ]
         },
         {
@@ -6124,6 +7898,12 @@
               "url": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/dicer\\node_modules\\string_decoder"
             }
           ]
         }
@@ -6147,6 +7927,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/diff"
+        }
       ]
     },
     {
@@ -6166,6 +7952,12 @@
           "url": "https://registry.npmjs.org/doctypes/-/doctypes-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/doctypes"
         }
       ]
     },
@@ -6187,6 +7979,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/domelementtype"
+        }
       ]
     },
     {
@@ -6206,6 +8004,12 @@
           "url": "https://registry.npmjs.org/domhandler/-/domhandler-2.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/domhandler"
         }
       ]
     },
@@ -6227,6 +8031,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/domutils"
+        }
       ]
     },
     {
@@ -6246,6 +8056,12 @@
           "url": "https://registry.npmjs.org/dottie/-/dottie-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dottie"
         }
       ]
     },
@@ -6267,6 +8083,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/double-ended-queue"
+        }
       ]
     },
     {
@@ -6286,6 +8108,12 @@
           "url": "https://registry.npmjs.org/doublearray/-/doublearray-0.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/doublearray"
         }
       ]
     },
@@ -6308,6 +8136,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/download"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -6326,6 +8160,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-11.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/download\\node_modules\\file-type"
             }
           ]
         }
@@ -6349,6 +8189,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/duplexer2"
+        }
       ]
     },
     {
@@ -6368,6 +8214,12 @@
           "url": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/duplexer3"
         }
       ]
     },
@@ -6389,6 +8241,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dynamic-dedupe"
+        }
       ]
     },
     {
@@ -6408,6 +8266,12 @@
           "url": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ecc-jsbn"
         }
       ]
     },
@@ -6429,6 +8293,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ee-first"
+        }
       ]
     },
     {
@@ -6448,6 +8318,12 @@
           "url": "https://registry.npmjs.org/eivindfjeldstad-dot/-/eivindfjeldstad-dot-0.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/eivindfjeldstad-dot"
         }
       ]
     },
@@ -6469,6 +8345,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/emoji-regex"
+        }
       ]
     },
     {
@@ -6489,6 +8371,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/enabled"
+        }
       ]
     },
     {
@@ -6508,6 +8396,12 @@
           "url": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/encodeurl"
         }
       ]
     },
@@ -6530,6 +8424,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/encoding"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -6548,6 +8448,12 @@
               "url": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/encoding\\node_modules\\iconv-lite"
             }
           ]
         }
@@ -6571,6 +8477,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/end-of-stream"
+        }
       ]
     },
     {
@@ -6590,6 +8502,12 @@
           "url": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-4.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/engine.io-parser"
         }
       ]
     },
@@ -6612,6 +8530,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/engine.io"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -6630,6 +8554,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/engine.io\\node_modules\\debug"
             }
           ]
         },
@@ -6650,6 +8580,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/engine.io\\node_modules\\ms"
             }
           ]
         }
@@ -6673,6 +8609,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/env-paths"
+        }
       ]
     },
     {
@@ -6692,6 +8634,12 @@
           "url": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/err-code"
         }
       ]
     },
@@ -6713,6 +8661,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/error-ex"
+        }
       ]
     },
     {
@@ -6732,6 +8686,12 @@
           "url": "https://registry.npmjs.org/errorhandler/-/errorhandler-1.5.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/errorhandler"
         }
       ]
     },
@@ -6753,6 +8713,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/es-abstract"
+        }
       ]
     },
     {
@@ -6772,6 +8738,12 @@
           "url": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/es-get-iterator"
         }
       ]
     },
@@ -6793,6 +8765,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/es-to-primitive"
+        }
       ]
     },
     {
@@ -6812,6 +8790,12 @@
           "url": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/escape-html"
         }
       ]
     },
@@ -6833,6 +8817,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/escape-string-regexp"
+        }
       ]
     },
     {
@@ -6852,6 +8842,12 @@
           "url": "https://registry.npmjs.org/escodegen/-/escodegen-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/escodegen"
         }
       ]
     },
@@ -6873,6 +8869,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/esprima"
+        }
       ]
     },
     {
@@ -6892,6 +8894,12 @@
           "url": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/estraverse"
         }
       ]
     },
@@ -6913,6 +8921,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/esutils"
+        }
       ]
     },
     {
@@ -6932,6 +8946,12 @@
           "url": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/etag"
         }
       ]
     },
@@ -6953,6 +8973,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/eventemitter2"
+        }
       ]
     },
     {
@@ -6972,6 +8998,12 @@
           "url": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/eventemitter3"
         }
       ]
     },
@@ -6993,6 +9025,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/exif"
+        }
       ]
     },
     {
@@ -7012,6 +9050,12 @@
           "url": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/exit"
         }
       ]
     },
@@ -7034,6 +9078,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/expand-brackets"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7052,6 +9102,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets\\node_modules\\define-property"
             }
           ]
         },
@@ -7072,6 +9128,12 @@
               "url": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets\\node_modules\\extend-shallow"
             }
           ]
         },
@@ -7094,6 +9156,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets\\node_modules\\is-accessor-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -7112,6 +9180,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/expand-brackets\\node_modules\\is-accessor-descriptor\\node_modules\\kind-of"
                 }
               ]
             }
@@ -7136,6 +9210,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets\\node_modules\\is-data-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -7154,6 +9234,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/expand-brackets\\node_modules\\is-data-descriptor\\node_modules\\kind-of"
                 }
               ]
             }
@@ -7177,6 +9263,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets\\node_modules\\is-descriptor"
+            }
           ]
         },
         {
@@ -7197,6 +9289,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets\\node_modules\\is-extendable"
+            }
           ]
         },
         {
@@ -7216,6 +9314,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets\\node_modules\\kind-of"
             }
           ]
         }
@@ -7239,6 +9343,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/expand-template"
+        }
       ]
     },
     {
@@ -7259,6 +9369,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/expand-tilde"
+        }
       ]
     },
     {
@@ -7278,6 +9394,12 @@
           "url": "https://registry.npmjs.org/express-ipfilter/-/express-ipfilter-1.3.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-ipfilter"
         }
       ]
     },
@@ -7300,6 +9422,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-jwt"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7318,6 +9446,12 @@
               "url": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-0.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/express-jwt\\node_modules\\jsonwebtoken"
             }
           ]
         },
@@ -7338,6 +9472,12 @@
               "url": "https://registry.npmjs.org/moment/-/moment-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/express-jwt\\node_modules\\moment"
             }
           ]
         }
@@ -7361,6 +9501,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-rate-limit"
+        }
       ]
     },
     {
@@ -7381,6 +9527,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-robots-txt"
+        }
       ]
     },
     {
@@ -7400,6 +9552,12 @@
           "url": "https://registry.npmjs.org/express-security.txt/-/express-security.txt-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-security.txt"
         }
       ]
     },
@@ -7422,6 +9580,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7440,6 +9604,12 @@
               "url": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/express\\node_modules\\cookie"
             }
           ]
         },
@@ -7460,6 +9630,12 @@
               "url": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/express\\node_modules\\safe-buffer"
             }
           ]
         }
@@ -7483,6 +9659,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ext-list"
+        }
       ]
     },
     {
@@ -7502,6 +9684,12 @@
           "url": "https://registry.npmjs.org/ext-name/-/ext-name-5.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ext-name"
         }
       ]
     },
@@ -7523,6 +9711,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/extend-shallow"
+        }
       ]
     },
     {
@@ -7542,6 +9736,12 @@
           "url": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/extend"
         }
       ]
     },
@@ -7564,6 +9764,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/extglob"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7582,6 +9788,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/extglob\\node_modules\\define-property"
             }
           ]
         },
@@ -7603,6 +9815,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/extglob\\node_modules\\extend-shallow"
+            }
           ]
         },
         {
@@ -7622,6 +9840,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/extglob\\node_modules\\is-extendable"
             }
           ]
         }
@@ -7645,6 +9869,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/extsprintf"
+        }
       ]
     },
     {
@@ -7664,6 +9894,12 @@
           "url": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fast-deep-equal"
         }
       ]
     },
@@ -7685,6 +9921,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fast-json-stable-stringify"
+        }
       ]
     },
     {
@@ -7704,6 +9946,12 @@
           "url": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fast-levenshtein"
         }
       ]
     },
@@ -7725,6 +9973,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fast.js"
+        }
       ]
     },
     {
@@ -7744,6 +9998,12 @@
           "url": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fd-slicer"
         }
       ]
     },
@@ -7765,6 +10025,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/feature-policy"
+        }
       ]
     },
     {
@@ -7784,6 +10050,12 @@
           "url": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fecha"
         }
       ]
     },
@@ -7806,6 +10078,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/file-js"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7824,6 +10102,12 @@
               "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/file-js\\node_modules\\brace-expansion"
             }
           ]
         },
@@ -7844,6 +10128,12 @@
               "url": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/file-js\\node_modules\\minimatch"
             }
           ]
         }
@@ -7867,6 +10157,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/file-stream-rotator"
+        }
       ]
     },
     {
@@ -7886,6 +10182,12 @@
           "url": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/file-type"
         }
       ]
     },
@@ -7907,6 +10209,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/file-uri-to-path"
+        }
       ]
     },
     {
@@ -7926,6 +10234,12 @@
           "url": "https://registry.npmjs.org/filehound/-/filehound-1.17.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/filehound"
         }
       ]
     },
@@ -7947,6 +10261,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/filename-reserved-regex"
+        }
       ]
     },
     {
@@ -7967,6 +10287,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/filenamify"
+        }
       ]
     },
     {
@@ -7986,6 +10312,12 @@
           "url": "https://registry.npmjs.org/filesniffer/-/filesniffer-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/filesniffer"
         }
       ]
     },
@@ -8008,6 +10340,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fill-range"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -8026,6 +10364,12 @@
               "url": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/fill-range\\node_modules\\extend-shallow"
             }
           ]
         },
@@ -8046,6 +10390,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/fill-range\\node_modules\\is-extendable"
             }
           ]
         }
@@ -8069,6 +10419,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/finale-rest"
+        }
       ]
     },
     {
@@ -8088,6 +10444,12 @@
           "url": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/finalhandler"
         }
       ]
     },
@@ -8109,6 +10471,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/find-up"
+        }
       ]
     },
     {
@@ -8128,6 +10496,12 @@
           "url": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/findup-sync"
         }
       ]
     },
@@ -8149,6 +10523,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fined"
+        }
       ]
     },
     {
@@ -8168,6 +10548,12 @@
           "url": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/flagged-respawn"
         }
       ]
     },
@@ -8189,6 +10575,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fn.name"
+        }
       ]
     },
     {
@@ -8208,6 +10600,12 @@
           "url": "https://registry.npmjs.org/fontkit/-/fontkit-1.9.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fontkit"
         }
       ]
     },
@@ -8229,6 +10627,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/for-each"
+        }
       ]
     },
     {
@@ -8248,6 +10652,12 @@
           "url": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/for-in"
         }
       ]
     },
@@ -8269,6 +10679,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/for-own"
+        }
       ]
     },
     {
@@ -8288,6 +10704,12 @@
           "url": "https://registry.npmjs.org/foreachasync/-/foreachasync-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/foreachasync"
         }
       ]
     },
@@ -8309,6 +10731,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/forever-agent"
+        }
       ]
     },
     {
@@ -8328,6 +10756,12 @@
           "url": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/form-data"
         }
       ]
     },
@@ -8349,6 +10783,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/formatio"
+        }
       ]
     },
     {
@@ -8368,6 +10808,12 @@
           "url": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/forwarded"
         }
       ]
     },
@@ -8389,6 +10835,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fragment-cache"
+        }
       ]
     },
     {
@@ -8408,6 +10860,12 @@
           "url": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fresh"
         }
       ]
     },
@@ -8429,6 +10887,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/from2"
+        }
       ]
     },
     {
@@ -8448,6 +10912,12 @@
           "url": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fs-constants"
         }
       ]
     },
@@ -8469,6 +10939,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fs-extra"
+        }
       ]
     },
     {
@@ -8489,6 +10965,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fs-minipass"
+        }
       ]
     },
     {
@@ -8508,6 +10990,12 @@
           "url": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fs.realpath"
         }
       ]
     },
@@ -8530,6 +11018,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fstream"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -8548,6 +11042,12 @@
               "url": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/fstream\\node_modules\\mkdirp"
             }
           ]
         },
@@ -8568,6 +11068,12 @@
               "url": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/fstream\\node_modules\\rimraf"
             }
           ]
         }
@@ -8591,6 +11097,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/function-bind"
+        }
       ]
     },
     {
@@ -8610,6 +11122,12 @@
           "url": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/function.prototype.name"
         }
       ]
     },
@@ -8631,6 +11149,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/functions-have-names"
+        }
       ]
     },
     {
@@ -8650,6 +11174,12 @@
           "url": "https://registry.npmjs.org/fuzzball/-/fuzzball-1.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fuzzball"
         }
       ]
     },
@@ -8671,6 +11201,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/gauge"
+        }
       ]
     },
     {
@@ -8690,6 +11226,12 @@
           "url": "https://registry.npmjs.org/geojson-utils/-/geojson-utils-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/geojson-utils"
         }
       ]
     },
@@ -8711,6 +11253,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-caller-file"
+        }
       ]
     },
     {
@@ -8730,6 +11278,12 @@
           "url": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-intrinsic"
         }
       ]
     },
@@ -8751,6 +11305,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-stream"
+        }
       ]
     },
     {
@@ -8770,6 +11330,12 @@
           "url": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-symbol-description"
         }
       ]
     },
@@ -8791,6 +11357,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-value"
+        }
       ]
     },
     {
@@ -8810,6 +11382,12 @@
           "url": "https://registry.npmjs.org/getobject/-/getobject-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/getobject"
         }
       ]
     },
@@ -8831,6 +11409,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/getpass"
+        }
       ]
     },
     {
@@ -8850,6 +11434,12 @@
           "url": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/github-from-package"
         }
       ]
     },
@@ -8872,6 +11462,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/glob-parent"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -8890,6 +11486,12 @@
               "url": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/glob-parent\\node_modules\\is-glob"
             }
           ]
         }
@@ -8914,6 +11516,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/glob"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -8932,6 +11540,12 @@
               "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/glob\\node_modules\\brace-expansion"
             }
           ]
         },
@@ -8952,6 +11566,12 @@
               "url": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/glob\\node_modules\\minimatch"
             }
           ]
         }
@@ -8975,6 +11595,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/global-modules"
+        }
       ]
     },
     {
@@ -8996,6 +11622,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/global-prefix"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9014,6 +11646,12 @@
               "url": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/global-prefix\\node_modules\\which"
             }
           ]
         }
@@ -9038,6 +11676,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/got"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9056,6 +11700,12 @@
               "url": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/got\\node_modules\\get-stream"
             }
           ]
         },
@@ -9076,6 +11726,12 @@
               "url": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/got\\node_modules\\pify"
             }
           ]
         }
@@ -9099,6 +11755,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/graceful-fs"
+        }
       ]
     },
     {
@@ -9120,6 +11782,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-cli"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9138,6 +11806,12 @@
               "url": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-cli\\node_modules\\nopt"
             }
           ]
         }
@@ -9162,6 +11836,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-contrib-compress"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9180,6 +11860,12 @@
               "url": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-contrib-compress\\node_modules\\ansi-styles"
             }
           ]
         },
@@ -9201,6 +11887,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-contrib-compress\\node_modules\\chalk"
+            }
           ]
         },
         {
@@ -9220,6 +11912,12 @@
               "url": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-contrib-compress\\node_modules\\supports-color"
             }
           ]
         }
@@ -9243,6 +11941,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-known-options"
+        }
       ]
     },
     {
@@ -9264,6 +11968,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-legacy-log-utils"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9282,6 +11992,12 @@
               "url": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils\\node_modules\\ansi-styles"
             }
           ]
         },
@@ -9303,6 +12019,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils\\node_modules\\chalk"
+            }
           ]
         },
         {
@@ -9322,6 +12044,12 @@
               "url": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils\\node_modules\\color-convert"
             }
           ]
         },
@@ -9343,6 +12071,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils\\node_modules\\color-name"
+            }
           ]
         },
         {
@@ -9363,6 +12097,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils\\node_modules\\has-flag"
+            }
           ]
         },
         {
@@ -9382,6 +12122,12 @@
               "url": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils\\node_modules\\supports-color"
             }
           ]
         }
@@ -9406,6 +12152,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-legacy-log"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9424,6 +12176,12 @@
               "url": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log\\node_modules\\colors"
             }
           ]
         }
@@ -9448,6 +12206,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-legacy-util"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9466,6 +12230,12 @@
               "url": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-util\\node_modules\\async"
             }
           ]
         }
@@ -9489,6 +12259,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-replace-json"
+        }
       ]
     },
     {
@@ -9510,6 +12286,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9528,6 +12310,12 @@
               "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt\\node_modules\\brace-expansion"
             }
           ]
         },
@@ -9550,6 +12338,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt\\node_modules\\findup-sync"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -9568,6 +12362,12 @@
                   "url": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/grunt\\node_modules\\findup-sync\\node_modules\\glob"
                 }
               ]
             }
@@ -9591,6 +12391,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt\\node_modules\\glob"
+            }
           ]
         },
         {
@@ -9610,6 +12416,12 @@
               "url": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.8.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt\\node_modules\\minimatch"
             }
           ]
         }
@@ -9634,6 +12446,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/handlebars"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9652,6 +12470,12 @@
               "url": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/handlebars\\node_modules\\wordwrap"
             }
           ]
         }
@@ -9675,6 +12499,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/har-schema"
+        }
       ]
     },
     {
@@ -9694,6 +12524,12 @@
           "url": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/har-validator"
         }
       ]
     },
@@ -9715,6 +12551,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-ansi"
+        }
       ]
     },
     {
@@ -9734,6 +12576,12 @@
           "url": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-bigints"
         }
       ]
     },
@@ -9755,6 +12603,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-flag"
+        }
       ]
     },
     {
@@ -9774,6 +12628,12 @@
           "url": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-property-descriptors"
         }
       ]
     },
@@ -9795,6 +12655,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-symbol-support-x"
+        }
       ]
     },
     {
@@ -9814,6 +12680,12 @@
           "url": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-symbols"
         }
       ]
     },
@@ -9835,6 +12707,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-to-string-tag-x"
+        }
       ]
     },
     {
@@ -9854,6 +12732,12 @@
           "url": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-tostringtag"
         }
       ]
     },
@@ -9875,6 +12759,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-unicode"
+        }
       ]
     },
     {
@@ -9894,6 +12784,12 @@
           "url": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-value"
         }
       ]
     },
@@ -9916,6 +12812,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-values"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9934,6 +12836,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/has-values\\node_modules\\kind-of"
             }
           ]
         }
@@ -9957,6 +12865,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has"
+        }
       ]
     },
     {
@@ -9976,6 +12890,12 @@
           "url": "https://registry.npmjs.org/hashids/-/hashids-2.2.10.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hashids"
         }
       ]
     },
@@ -9997,6 +12917,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hbs"
+        }
       ]
     },
     {
@@ -10016,6 +12942,12 @@
           "url": "https://registry.npmjs.org/he/-/he-0.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/he"
         }
       ]
     },
@@ -10037,6 +12969,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/heap"
+        }
       ]
     },
     {
@@ -10056,6 +12994,12 @@
           "url": "https://registry.npmjs.org/helmet/-/helmet-4.6.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/helmet"
         }
       ]
     },
@@ -10077,6 +13021,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hoister"
+        }
       ]
     },
     {
@@ -10096,6 +13046,12 @@
           "url": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/homedir-polyfill"
         }
       ]
     },
@@ -10117,6 +13073,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hooker"
+        }
       ]
     },
     {
@@ -10137,6 +13099,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hosted-git-info"
+        }
       ]
     },
     {
@@ -10156,6 +13124,12 @@
           "url": "https://registry.npmjs.org/html-entities/-/html-entities-1.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/html-entities"
         }
       ]
     },
@@ -10178,6 +13152,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/htmlparser2"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -10196,6 +13176,12 @@
               "url": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/htmlparser2\\node_modules\\isarray"
             }
           ]
         },
@@ -10217,6 +13203,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/htmlparser2\\node_modules\\readable-stream"
+            }
           ]
         },
         {
@@ -10236,6 +13228,12 @@
               "url": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/htmlparser2\\node_modules\\string_decoder"
             }
           ]
         }
@@ -10259,6 +13257,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/http-cache-semantics"
+        }
       ]
     },
     {
@@ -10278,6 +13282,12 @@
           "url": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/http-errors"
         }
       ]
     },
@@ -10300,6 +13310,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/http-proxy-agent"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -10318,6 +13334,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/http-proxy-agent\\node_modules\\debug"
             }
           ]
         },
@@ -10338,6 +13360,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/http-proxy-agent\\node_modules\\ms"
             }
           ]
         }
@@ -10361,6 +13389,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/http-signature"
+        }
       ]
     },
     {
@@ -10382,6 +13416,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/https-proxy-agent"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -10400,6 +13440,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/https-proxy-agent\\node_modules\\debug"
             }
           ]
         },
@@ -10420,6 +13466,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/https-proxy-agent\\node_modules\\ms"
             }
           ]
         }
@@ -10443,6 +13495,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/humanize-ms"
+        }
       ]
     },
     {
@@ -10462,6 +13520,12 @@
           "url": "https://registry.npmjs.org/i18n/-/i18n-0.11.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/i18n"
         }
       ]
     },
@@ -10483,6 +13547,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/iconv-lite"
+        }
       ]
     },
     {
@@ -10502,6 +13572,12 @@
           "url": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ieee754"
         }
       ]
     },
@@ -10524,6 +13600,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ignore-walk"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -10542,6 +13624,12 @@
               "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/ignore-walk\\node_modules\\brace-expansion"
             }
           ]
         },
@@ -10562,6 +13650,12 @@
               "url": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/ignore-walk\\node_modules\\minimatch"
             }
           ]
         }
@@ -10585,6 +13679,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/iltorb"
+        }
       ]
     },
     {
@@ -10604,6 +13704,12 @@
           "url": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/imurmurhash"
         }
       ]
     },
@@ -10625,6 +13731,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/indent-string"
+        }
       ]
     },
     {
@@ -10644,6 +13756,12 @@
           "url": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/infer-owner"
         }
       ]
     },
@@ -10665,6 +13783,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/inflection"
+        }
       ]
     },
     {
@@ -10684,6 +13808,12 @@
           "url": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/inflight"
         }
       ]
     },
@@ -10705,6 +13835,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/inherits"
+        }
       ]
     },
     {
@@ -10724,6 +13860,12 @@
           "url": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ini"
         }
       ]
     },
@@ -10745,6 +13887,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/internal-slot"
+        }
       ]
     },
     {
@@ -10764,6 +13912,12 @@
           "url": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/interpret"
         }
       ]
     },
@@ -10785,6 +13939,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/into-stream"
+        }
       ]
     },
     {
@@ -10804,6 +13964,12 @@
           "url": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/invariant"
         }
       ]
     },
@@ -10825,6 +13991,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ip"
+        }
       ]
     },
     {
@@ -10844,6 +14016,12 @@
           "url": "https://registry.npmjs.org/ip6/-/ip6-0.2.10.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ip6"
         }
       ]
     },
@@ -10865,6 +14043,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ipaddr.js"
+        }
       ]
     },
     {
@@ -10884,6 +14068,12 @@
           "url": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-absolute"
         }
       ]
     },
@@ -10905,6 +14095,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-accessor-descriptor"
+        }
       ]
     },
     {
@@ -10924,6 +14120,12 @@
           "url": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-arguments"
         }
       ]
     },
@@ -10945,6 +14147,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-arrayish"
+        }
       ]
     },
     {
@@ -10964,6 +14172,12 @@
           "url": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-bigint"
         }
       ]
     },
@@ -10985,6 +14199,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-binary-path"
+        }
       ]
     },
     {
@@ -11004,6 +14224,12 @@
           "url": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-boolean-object"
         }
       ]
     },
@@ -11025,6 +14251,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-buffer"
+        }
       ]
     },
     {
@@ -11044,6 +14276,12 @@
           "url": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-callable"
         }
       ]
     },
@@ -11065,6 +14303,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-core-module"
+        }
       ]
     },
     {
@@ -11084,6 +14328,12 @@
           "url": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-data-descriptor"
         }
       ]
     },
@@ -11105,6 +14355,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-date-object"
+        }
       ]
     },
     {
@@ -11124,6 +14380,12 @@
           "url": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-descriptor"
         }
       ]
     },
@@ -11145,6 +14407,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-docker"
+        }
       ]
     },
     {
@@ -11164,6 +14432,12 @@
           "url": "https://registry.npmjs.org/is-expression/-/is-expression-4.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-expression"
         }
       ]
     },
@@ -11185,6 +14459,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-extendable"
+        }
       ]
     },
     {
@@ -11204,6 +14484,12 @@
           "url": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-extglob"
         }
       ]
     },
@@ -11225,6 +14511,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-fullwidth-code-point"
+        }
       ]
     },
     {
@@ -11244,6 +14536,12 @@
           "url": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-generator-function"
         }
       ]
     },
@@ -11265,6 +14563,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-glob"
+        }
       ]
     },
     {
@@ -11284,6 +14588,12 @@
           "url": "https://registry.npmjs.org/is-heroku/-/is-heroku-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-heroku"
         }
       ]
     },
@@ -11305,6 +14615,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-lambda"
+        }
       ]
     },
     {
@@ -11324,6 +14640,12 @@
           "url": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-map"
         }
       ]
     },
@@ -11345,6 +14667,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-natural-number"
+        }
       ]
     },
     {
@@ -11364,6 +14692,12 @@
           "url": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-negative-zero"
         }
       ]
     },
@@ -11385,6 +14719,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-number-like"
+        }
       ]
     },
     {
@@ -11404,6 +14744,12 @@
           "url": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-number-object"
         }
       ]
     },
@@ -11426,6 +14772,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-number"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -11444,6 +14796,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/is-number\\node_modules\\kind-of"
             }
           ]
         }
@@ -11467,6 +14825,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-object"
+        }
       ]
     },
     {
@@ -11486,6 +14850,12 @@
           "url": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-plain-obj"
         }
       ]
     },
@@ -11507,6 +14877,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-plain-object"
+        }
       ]
     },
     {
@@ -11526,6 +14902,12 @@
           "url": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-promise"
         }
       ]
     },
@@ -11547,6 +14929,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-regex"
+        }
       ]
     },
     {
@@ -11566,6 +14954,12 @@
           "url": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-relative"
         }
       ]
     },
@@ -11587,6 +14981,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-retry-allowed"
+        }
       ]
     },
     {
@@ -11606,6 +15006,12 @@
           "url": "https://registry.npmjs.org/is-set/-/is-set-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-set"
         }
       ]
     },
@@ -11627,6 +15033,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-shared-array-buffer"
+        }
       ]
     },
     {
@@ -11646,6 +15058,12 @@
           "url": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-stream"
         }
       ]
     },
@@ -11667,6 +15085,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-string"
+        }
       ]
     },
     {
@@ -11686,6 +15110,12 @@
           "url": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-symbol"
         }
       ]
     },
@@ -11707,6 +15137,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-typed-array"
+        }
       ]
     },
     {
@@ -11726,6 +15162,12 @@
           "url": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-typedarray"
         }
       ]
     },
@@ -11747,6 +15189,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-unc-path"
+        }
       ]
     },
     {
@@ -11766,6 +15214,12 @@
           "url": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-weakmap"
         }
       ]
     },
@@ -11787,6 +15241,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-weakref"
+        }
       ]
     },
     {
@@ -11806,6 +15266,12 @@
           "url": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-weakset"
         }
       ]
     },
@@ -11827,6 +15293,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-windows"
+        }
       ]
     },
     {
@@ -11846,6 +15318,12 @@
           "url": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isarray"
         }
       ]
     },
@@ -11867,6 +15345,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isexe"
+        }
       ]
     },
     {
@@ -11886,6 +15370,12 @@
           "url": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isobject"
         }
       ]
     },
@@ -11907,6 +15397,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isstream"
+        }
       ]
     },
     {
@@ -11926,6 +15422,12 @@
           "url": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isurl"
         }
       ]
     },
@@ -11947,6 +15449,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/js-stringify"
+        }
       ]
     },
     {
@@ -11966,6 +15474,12 @@
           "url": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/js-tokens"
         }
       ]
     },
@@ -11987,6 +15501,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/js-yaml"
+        }
       ]
     },
     {
@@ -12006,6 +15526,12 @@
           "url": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jsbn"
         }
       ]
     },
@@ -12027,6 +15553,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-buffer"
+        }
       ]
     },
     {
@@ -12046,6 +15578,12 @@
           "url": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-parse-better-errors"
         }
       ]
     },
@@ -12067,6 +15605,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-schema-traverse"
+        }
       ]
     },
     {
@@ -12086,6 +15630,12 @@
           "url": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-schema"
         }
       ]
     },
@@ -12107,6 +15657,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-stringify-safe"
+        }
       ]
     },
     {
@@ -12126,6 +15682,12 @@
           "url": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json5"
         }
       ]
     },
@@ -12147,6 +15709,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jsonfile"
+        }
       ]
     },
     {
@@ -12166,6 +15734,12 @@
           "url": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-0.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jsonwebtoken"
         }
       ]
     },
@@ -12187,6 +15761,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jsprim"
+        }
       ]
     },
     {
@@ -12206,6 +15786,12 @@
           "url": "https://registry.npmjs.org/jssha/-/jssha-3.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jssha"
         }
       ]
     },
@@ -12227,6 +15813,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jstransformer"
+        }
       ]
     },
     {
@@ -12246,6 +15838,12 @@
           "url": "https://registry.npmjs.org/juicy-chat-bot/-/juicy-chat-bot-0.6.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/juicy-chat-bot"
         }
       ]
     },
@@ -12267,6 +15865,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jwa"
+        }
       ]
     },
     {
@@ -12286,6 +15890,12 @@
           "url": "https://registry.npmjs.org/jws/-/jws-0.2.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jws"
         }
       ]
     },
@@ -12307,6 +15917,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/keyv"
+        }
       ]
     },
     {
@@ -12326,6 +15942,12 @@
           "url": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/kind-of"
         }
       ]
     },
@@ -12347,6 +15969,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/kuler"
+        }
       ]
     },
     {
@@ -12366,6 +15994,12 @@
           "url": "https://registry.npmjs.org/kuromoji/-/kuromoji-0.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/kuromoji"
         }
       ]
     },
@@ -12387,6 +16021,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lazystream"
+        }
       ]
     },
     {
@@ -12406,6 +16046,12 @@
           "url": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/levn"
         }
       ]
     },
@@ -12428,6 +16074,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/libxmljs2"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12446,6 +16098,12 @@
               "url": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/libxmljs2\\node_modules\\nan"
             }
           ]
         }
@@ -12470,6 +16128,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/liftup"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12488,6 +16152,12 @@
               "url": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup\\node_modules\\braces"
             }
           ]
         },
@@ -12509,6 +16179,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup\\node_modules\\fill-range"
+            }
           ]
         },
         {
@@ -12528,6 +16204,12 @@
               "url": "https://registry.npmjs.org/findup-sync/-/findup-sync-4.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup\\node_modules\\findup-sync"
             }
           ]
         },
@@ -12549,6 +16231,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup\\node_modules\\is-glob"
+            }
           ]
         },
         {
@@ -12568,6 +16256,12 @@
               "url": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup\\node_modules\\is-number"
             }
           ]
         },
@@ -12589,6 +16283,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup\\node_modules\\micromatch"
+            }
           ]
         },
         {
@@ -12608,6 +16308,12 @@
               "url": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup\\node_modules\\to-regex-range"
             }
           ]
         }
@@ -12632,6 +16338,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/linebreak"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12650,6 +16362,12 @@
               "url": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/linebreak\\node_modules\\base64-js"
             }
           ]
         }
@@ -12673,6 +16391,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/listenercount"
+        }
       ]
     },
     {
@@ -12692,6 +16416,12 @@
           "url": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/locate-path"
         }
       ]
     },
@@ -12713,6 +16443,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lodash.camelcase"
+        }
       ]
     },
     {
@@ -12732,6 +16468,12 @@
           "url": "https://registry.npmjs.org/lodash.isfinite/-/lodash.isfinite-3.3.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lodash.isfinite"
         }
       ]
     },
@@ -12753,6 +16495,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lodash.set"
+        }
       ]
     },
     {
@@ -12772,6 +16520,12 @@
           "url": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lodash"
         }
       ]
     },
@@ -12794,6 +16548,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/logform"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12812,6 +16572,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/logform\\node_modules\\ms"
             }
           ]
         }
@@ -12835,6 +16601,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lolex"
+        }
       ]
     },
     {
@@ -12854,6 +16626,12 @@
           "url": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/loose-envify"
         }
       ]
     },
@@ -12875,6 +16653,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lowercase-keys"
+        }
       ]
     },
     {
@@ -12894,6 +16678,12 @@
           "url": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lru-cache"
         }
       ]
     },
@@ -12916,6 +16706,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-dir"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12934,6 +16730,12 @@
               "url": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-dir\\node_modules\\semver"
             }
           ]
         }
@@ -12957,6 +16759,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-error"
+        }
       ]
     },
     {
@@ -12976,6 +16784,12 @@
           "url": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-9.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-fetch-happen"
         }
       ],
       "components": [
@@ -12998,6 +16812,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen\\node_modules\\@tootallnate\\once"
+            }
           ]
         },
         {
@@ -13017,6 +16837,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen\\node_modules\\debug"
             }
           ]
         },
@@ -13038,6 +16864,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen\\node_modules\\http-cache-semantics"
+            }
           ]
         },
         {
@@ -13058,6 +16890,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen\\node_modules\\http-proxy-agent"
+            }
           ]
         },
         {
@@ -13077,6 +16915,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen\\node_modules\\ms"
             }
           ]
         }
@@ -13100,6 +16944,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-iterator"
+        }
       ]
     },
     {
@@ -13119,6 +16969,12 @@
           "url": "https://registry.npmjs.org/make-plural/-/make-plural-6.2.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-plural"
         }
       ]
     },
@@ -13140,6 +16996,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/map-cache"
+        }
       ]
     },
     {
@@ -13159,6 +17021,12 @@
           "url": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/map-visit"
         }
       ]
     },
@@ -13180,6 +17048,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/marsdb"
+        }
       ]
     },
     {
@@ -13199,6 +17073,12 @@
           "url": "https://registry.npmjs.org/math-interval-parser/-/math-interval-parser-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/math-interval-parser"
         }
       ]
     },
@@ -13220,6 +17100,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/media-typer"
+        }
       ]
     },
     {
@@ -13239,6 +17125,12 @@
           "url": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/merge-descriptors"
         }
       ]
     },
@@ -13260,6 +17152,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/messageformat-formatters"
+        }
       ]
     },
     {
@@ -13279,6 +17177,12 @@
           "url": "https://registry.npmjs.org/messageformat-parser/-/messageformat-parser-4.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/messageformat-parser"
         }
       ]
     },
@@ -13301,6 +17205,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/messageformat"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -13319,6 +17229,12 @@
               "url": "https://registry.npmjs.org/make-plural/-/make-plural-4.3.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/messageformat\\node_modules\\make-plural"
             }
           ]
         }
@@ -13342,6 +17258,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/methods"
+        }
       ]
     },
     {
@@ -13361,6 +17283,12 @@
           "url": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/micromatch"
         }
       ]
     },
@@ -13382,6 +17310,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mime-db"
+        }
       ]
     },
     {
@@ -13401,6 +17335,12 @@
           "url": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mime-types"
         }
       ]
     },
@@ -13422,6 +17362,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mime"
+        }
       ]
     },
     {
@@ -13441,6 +17387,12 @@
           "url": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mimic-response"
         }
       ]
     },
@@ -13462,6 +17414,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minimatch"
+        }
       ]
     },
     {
@@ -13481,6 +17439,12 @@
           "url": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minimist"
         }
       ]
     },
@@ -13502,6 +17466,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-collect"
+        }
       ]
     },
     {
@@ -13521,6 +17491,12 @@
           "url": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-1.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-fetch"
         }
       ]
     },
@@ -13542,6 +17518,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-flush"
+        }
       ]
     },
     {
@@ -13561,6 +17543,12 @@
           "url": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-pipeline"
         }
       ]
     },
@@ -13582,6 +17570,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-sized"
+        }
       ]
     },
     {
@@ -13601,6 +17595,12 @@
           "url": "https://registry.npmjs.org/minipass/-/minipass-3.3.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass"
         }
       ]
     },
@@ -13622,6 +17622,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minizlib"
+        }
       ]
     },
     {
@@ -13641,6 +17647,12 @@
           "url": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mixin-deep"
         }
       ]
     },
@@ -13662,6 +17674,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mkdirp-classic"
+        }
       ]
     },
     {
@@ -13681,6 +17699,12 @@
           "url": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mkdirp"
         }
       ]
     },
@@ -13702,6 +17726,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/moment-timezone"
+        }
       ]
     },
     {
@@ -13721,6 +17751,12 @@
           "url": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/moment"
         }
       ]
     },
@@ -13743,6 +17779,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/morgan"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -13761,6 +17803,12 @@
               "url": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/morgan\\node_modules\\on-finished"
             }
           ]
         }
@@ -13784,6 +17832,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mout"
+        }
       ]
     },
     {
@@ -13803,6 +17857,12 @@
           "url": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ms"
         }
       ]
     },
@@ -13825,6 +17885,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/multer"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -13843,6 +17909,12 @@
               "url": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/multer\\node_modules\\mkdirp"
             }
           ]
         }
@@ -13866,6 +17938,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mustache"
+        }
       ]
     },
     {
@@ -13885,6 +17963,12 @@
           "url": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/nan"
         }
       ]
     },
@@ -13906,6 +17990,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/nanomatch"
+        }
       ]
     },
     {
@@ -13925,6 +18015,12 @@
           "url": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/napi-build-utils"
         }
       ]
     },
@@ -13947,6 +18043,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/needle"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -13965,6 +18067,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/needle\\node_modules\\debug"
             }
           ]
         },
@@ -13985,6 +18093,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/needle\\node_modules\\ms"
             }
           ]
         }
@@ -14008,6 +18122,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/negotiator"
+        }
       ]
     },
     {
@@ -14027,6 +18147,12 @@
           "url": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/neo-async"
         }
       ]
     },
@@ -14049,6 +18175,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-abi"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14067,6 +18199,12 @@
               "url": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-abi\\node_modules\\semver"
             }
           ]
         }
@@ -14090,6 +18228,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-addon-api"
+        }
       ]
     },
     {
@@ -14109,6 +18253,12 @@
           "url": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-fetch"
         }
       ]
     },
@@ -14131,6 +18281,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-gyp"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14149,6 +18305,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp\\node_modules\\ansi-regex"
             }
           ]
         },
@@ -14170,6 +18332,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp\\node_modules\\are-we-there-yet"
+            }
           ]
         },
         {
@@ -14189,6 +18357,12 @@
               "url": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp\\node_modules\\gauge"
             }
           ]
         },
@@ -14210,6 +18384,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp\\node_modules\\is-fullwidth-code-point"
+            }
           ]
         },
         {
@@ -14229,6 +18409,12 @@
               "url": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp\\node_modules\\nopt"
             }
           ]
         },
@@ -14250,6 +18436,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp\\node_modules\\npmlog"
+            }
           ]
         },
         {
@@ -14269,6 +18461,12 @@
               "url": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp\\node_modules\\readable-stream"
             }
           ]
         },
@@ -14290,6 +18488,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp\\node_modules\\string-width"
+            }
           ]
         },
         {
@@ -14309,6 +18513,12 @@
               "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp\\node_modules\\strip-ansi"
             }
           ]
         }
@@ -14333,6 +18543,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-pre-gyp"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14351,6 +18567,12 @@
               "url": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp\\node_modules\\chownr"
             }
           ]
         },
@@ -14372,6 +18594,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp\\node_modules\\fs-minipass"
+            }
           ]
         },
         {
@@ -14391,6 +18619,12 @@
               "url": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp\\node_modules\\minipass"
             }
           ]
         },
@@ -14412,6 +18646,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp\\node_modules\\minizlib"
+            }
           ]
         },
         {
@@ -14431,6 +18671,12 @@
               "url": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp\\node_modules\\mkdirp"
             }
           ]
         },
@@ -14452,6 +18698,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp\\node_modules\\nopt"
+            }
           ]
         },
         {
@@ -14471,6 +18723,12 @@
               "url": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp\\node_modules\\rimraf"
             }
           ]
         },
@@ -14492,6 +18750,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp\\node_modules\\safe-buffer"
+            }
           ]
         },
         {
@@ -14511,6 +18775,12 @@
               "url": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp\\node_modules\\semver"
             }
           ]
         },
@@ -14532,6 +18802,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp\\node_modules\\tar"
+            }
           ]
         },
         {
@@ -14551,6 +18827,12 @@
               "url": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp\\node_modules\\yallist"
             }
           ]
         }
@@ -14574,6 +18856,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/noop-logger"
+        }
       ]
     },
     {
@@ -14593,6 +18881,12 @@
           "url": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/nopt"
         }
       ]
     },
@@ -14615,6 +18909,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/normalize-package-data"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14633,6 +18933,12 @@
               "url": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/normalize-package-data\\node_modules\\semver"
             }
           ]
         }
@@ -14656,6 +18962,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/normalize-path"
+        }
       ]
     },
     {
@@ -14675,6 +18987,12 @@
           "url": "https://registry.npmjs.org/normalize-url/-/normalize-url-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/normalize-url"
         }
       ]
     },
@@ -14697,6 +19015,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/notevil"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14715,6 +19039,12 @@
               "url": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/notevil\\node_modules\\esprima"
             }
           ]
         }
@@ -14738,6 +19068,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/npm-bundled"
+        }
       ]
     },
     {
@@ -14757,6 +19093,12 @@
           "url": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/npm-normalize-package-bin"
         }
       ]
     },
@@ -14778,6 +19120,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/npm-packlist"
+        }
       ]
     },
     {
@@ -14797,6 +19145,12 @@
           "url": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/npmlog"
         }
       ]
     },
@@ -14818,6 +19172,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/number-is-nan"
+        }
       ]
     },
     {
@@ -14838,6 +19198,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/oauth-sign"
+        }
       ]
     },
     {
@@ -14857,6 +19223,12 @@
           "url": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-assign"
         }
       ]
     },
@@ -14879,6 +19251,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-copy"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14897,6 +19275,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy\\node_modules\\define-property"
             }
           ]
         },
@@ -14918,6 +19302,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy\\node_modules\\is-accessor-descriptor"
+            }
           ]
         },
         {
@@ -14937,6 +19327,12 @@
               "url": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy\\node_modules\\is-data-descriptor"
             }
           ]
         },
@@ -14959,6 +19355,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy\\node_modules\\is-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -14977,6 +19379,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/object-copy\\node_modules\\is-descriptor\\node_modules\\kind-of"
                 }
               ]
             }
@@ -15000,6 +19408,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy\\node_modules\\kind-of"
+            }
           ]
         }
       ]
@@ -15022,6 +19436,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-inspect"
+        }
       ]
     },
     {
@@ -15041,6 +19461,12 @@
           "url": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-is"
         }
       ]
     },
@@ -15062,6 +19488,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-keys"
+        }
       ]
     },
     {
@@ -15081,6 +19513,12 @@
           "url": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-visit"
         }
       ]
     },
@@ -15102,6 +19540,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object.assign"
+        }
       ]
     },
     {
@@ -15121,6 +19565,12 @@
           "url": "https://registry.npmjs.org/object.defaults/-/object.defaults-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object.defaults"
         }
       ]
     },
@@ -15142,6 +19592,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object.map"
+        }
       ]
     },
     {
@@ -15161,6 +19617,12 @@
           "url": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object.pick"
         }
       ]
     },
@@ -15182,6 +19644,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/on-finished"
+        }
       ]
     },
     {
@@ -15201,6 +19669,12 @@
           "url": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/on-headers"
         }
       ]
     },
@@ -15222,6 +19696,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/once"
+        }
       ]
     },
     {
@@ -15241,6 +19721,12 @@
           "url": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/one-time"
         }
       ]
     },
@@ -15262,6 +19748,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/opentype.js"
+        }
       ]
     },
     {
@@ -15281,6 +19773,12 @@
           "url": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/optionator"
         }
       ]
     },
@@ -15302,6 +19800,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/os-homedir"
+        }
       ]
     },
     {
@@ -15321,6 +19825,12 @@
           "url": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/os-tmpdir"
         }
       ]
     },
@@ -15342,6 +19852,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/osenv"
+        }
       ]
     },
     {
@@ -15361,6 +19877,12 @@
           "url": "https://registry.npmjs.org/otplib/-/otplib-12.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/otplib"
         }
       ]
     },
@@ -15382,6 +19904,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-cancelable"
+        }
       ]
     },
     {
@@ -15401,6 +19929,12 @@
           "url": "https://registry.npmjs.org/p-event/-/p-event-2.3.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-event"
         }
       ]
     },
@@ -15422,6 +19956,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-finally"
+        }
       ]
     },
     {
@@ -15441,6 +19981,12 @@
           "url": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-is-promise"
         }
       ]
     },
@@ -15462,6 +20008,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-limit"
+        }
       ]
     },
     {
@@ -15481,6 +20033,12 @@
           "url": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-locate"
         }
       ]
     },
@@ -15502,6 +20060,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-map"
+        }
       ]
     },
     {
@@ -15521,6 +20085,12 @@
           "url": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-timeout"
         }
       ]
     },
@@ -15542,6 +20112,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-try"
+        }
       ]
     },
     {
@@ -15561,6 +20137,12 @@
           "url": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pako"
         }
       ]
     },
@@ -15582,6 +20164,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/parse-filepath"
+        }
       ]
     },
     {
@@ -15601,6 +20189,12 @@
           "url": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/parse-json"
         }
       ]
     },
@@ -15622,6 +20216,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/parse-passwd"
+        }
       ]
     },
     {
@@ -15641,6 +20241,12 @@
           "url": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/parseurl"
         }
       ]
     },
@@ -15662,6 +20268,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pascalcase"
+        }
       ]
     },
     {
@@ -15681,6 +20293,12 @@
           "url": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-exists"
         }
       ]
     },
@@ -15702,6 +20320,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-is-absolute"
+        }
       ]
     },
     {
@@ -15721,6 +20345,12 @@
           "url": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-parse"
         }
       ]
     },
@@ -15742,6 +20372,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-root-regex"
+        }
       ]
     },
     {
@@ -15761,6 +20397,12 @@
           "url": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-root"
         }
       ]
     },
@@ -15782,6 +20424,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-to-regexp"
+        }
       ]
     },
     {
@@ -15801,6 +20449,12 @@
           "url": "https://registry.npmjs.org/pdfkit/-/pdfkit-0.11.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pdfkit"
         }
       ]
     },
@@ -15822,6 +20476,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/peek-readable"
+        }
       ]
     },
     {
@@ -15841,6 +20501,12 @@
           "url": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pend"
         }
       ]
     },
@@ -15862,6 +20528,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/performance-now"
+        }
       ]
     },
     {
@@ -15881,6 +20553,12 @@
           "url": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.5.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pg-connection-string"
         }
       ]
     },
@@ -15902,6 +20580,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/picomatch"
+        }
       ]
     },
     {
@@ -15921,6 +20605,12 @@
           "url": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pify"
         }
       ]
     },
@@ -15942,6 +20632,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pinkie-promise"
+        }
       ]
     },
     {
@@ -15961,6 +20657,12 @@
           "url": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pinkie"
         }
       ]
     },
@@ -15982,6 +20684,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/png-js"
+        }
       ]
     },
     {
@@ -16001,6 +20709,12 @@
           "url": "https://registry.npmjs.org/portscanner/-/portscanner-2.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/portscanner"
         }
       ]
     },
@@ -16022,6 +20736,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/posix-character-classes"
+        }
       ]
     },
     {
@@ -16041,6 +20761,12 @@
           "url": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.3.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/prebuild-install"
         }
       ]
     },
@@ -16062,6 +20788,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/prelude-ls"
+        }
       ]
     },
     {
@@ -16081,6 +20813,12 @@
           "url": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/prepend-http"
         }
       ]
     },
@@ -16102,6 +20840,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pretty-bytes"
+        }
       ]
     },
     {
@@ -16121,6 +20865,12 @@
           "url": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/process-nextick-args"
         }
       ]
     },
@@ -16142,6 +20892,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/prom-client"
+        }
       ]
     },
     {
@@ -16161,6 +20917,12 @@
           "url": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/promise-inflight"
         }
       ]
     },
@@ -16183,6 +20945,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/promise-retry"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -16201,6 +20969,12 @@
               "url": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/promise-retry\\node_modules\\err-code"
             }
           ]
         },
@@ -16221,6 +20995,12 @@
               "url": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/promise-retry\\node_modules\\retry"
             }
           ]
         }
@@ -16244,6 +21024,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/promise"
+        }
       ]
     },
     {
@@ -16263,6 +21049,12 @@
           "url": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/proper-lockfile"
         }
       ]
     },
@@ -16284,6 +21076,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/proxy-addr"
+        }
       ]
     },
     {
@@ -16303,6 +21101,12 @@
           "url": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/psl"
         }
       ]
     },
@@ -16324,6 +21128,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-attrs"
+        }
       ]
     },
     {
@@ -16343,6 +21153,12 @@
           "url": "https://registry.npmjs.org/pug-code-gen/-/pug-code-gen-3.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-code-gen"
         }
       ]
     },
@@ -16364,6 +21180,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-error"
+        }
       ]
     },
     {
@@ -16383,6 +21205,12 @@
           "url": "https://registry.npmjs.org/pug-filters/-/pug-filters-4.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-filters"
         }
       ]
     },
@@ -16404,6 +21232,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-lexer"
+        }
       ]
     },
     {
@@ -16423,6 +21257,12 @@
           "url": "https://registry.npmjs.org/pug-linker/-/pug-linker-4.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-linker"
         }
       ]
     },
@@ -16444,6 +21284,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-load"
+        }
       ]
     },
     {
@@ -16463,6 +21309,12 @@
           "url": "https://registry.npmjs.org/pug-parser/-/pug-parser-6.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-parser"
         }
       ]
     },
@@ -16484,6 +21336,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-runtime"
+        }
       ]
     },
     {
@@ -16503,6 +21361,12 @@
           "url": "https://registry.npmjs.org/pug-strip-comments/-/pug-strip-comments-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-strip-comments"
         }
       ]
     },
@@ -16524,6 +21388,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-walk"
+        }
       ]
     },
     {
@@ -16543,6 +21413,12 @@
           "url": "https://registry.npmjs.org/pug/-/pug-3.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug"
         }
       ]
     },
@@ -16564,6 +21440,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pump"
+        }
       ]
     },
     {
@@ -16583,6 +21465,12 @@
           "url": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/punycode"
         }
       ]
     },
@@ -16604,6 +21492,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/qs"
+        }
       ]
     },
     {
@@ -16623,6 +21517,12 @@
           "url": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/query-string"
         }
       ]
     },
@@ -16644,6 +21544,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/range_check"
+        }
       ]
     },
     {
@@ -16663,6 +21569,12 @@
           "url": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/range-parser"
         }
       ]
     },
@@ -16684,6 +21596,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/raw-body"
+        }
       ]
     },
     {
@@ -16703,6 +21621,12 @@
           "url": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/rc"
         }
       ]
     },
@@ -16725,6 +21649,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/read-pkg"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -16743,6 +21673,12 @@
               "url": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/read-pkg\\node_modules\\pify"
             }
           ]
         }
@@ -16767,6 +21703,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/readable-stream"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -16785,6 +21727,12 @@
               "url": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/readable-stream\\node_modules\\isarray"
             }
           ]
         }
@@ -16809,6 +21757,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/readable-web-to-node-stream"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -16827,6 +21781,12 @@
               "url": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/readable-web-to-node-stream\\node_modules\\readable-stream"
             }
           ]
         }
@@ -16850,6 +21810,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/readdirp"
+        }
       ]
     },
     {
@@ -16869,6 +21835,12 @@
           "url": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/rechoir"
         }
       ]
     },
@@ -16890,6 +21862,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/regex-not"
+        }
       ]
     },
     {
@@ -16909,6 +21887,12 @@
           "url": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/regexp.prototype.flags"
         }
       ]
     },
@@ -16930,6 +21914,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/remove-trailing-separator"
+        }
       ]
     },
     {
@@ -16950,6 +21940,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/repeat-element"
+        }
       ]
     },
     {
@@ -16969,6 +21965,12 @@
           "url": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/repeat-string"
         }
       ]
     },
@@ -16991,6 +21993,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/replace"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17009,6 +22017,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\ansi-regex"
             }
           ]
         },
@@ -17030,6 +22044,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\ansi-styles"
+            }
           ]
         },
         {
@@ -17049,6 +22069,12 @@
               "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\brace-expansion"
             }
           ]
         },
@@ -17070,6 +22096,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\cliui"
+            }
           ]
         },
         {
@@ -17089,6 +22121,12 @@
               "url": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\color-convert"
             }
           ]
         },
@@ -17110,6 +22148,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\color-name"
+            }
           ]
         },
         {
@@ -17129,6 +22173,12 @@
               "url": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\find-up"
             }
           ]
         },
@@ -17150,6 +22200,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\is-fullwidth-code-point"
+            }
           ]
         },
         {
@@ -17169,6 +22225,12 @@
               "url": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\locate-path"
             }
           ]
         },
@@ -17190,6 +22252,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\minimatch"
+            }
           ]
         },
         {
@@ -17209,6 +22277,12 @@
               "url": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\p-locate"
             }
           ]
         },
@@ -17230,6 +22304,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\path-exists"
+            }
           ]
         },
         {
@@ -17249,6 +22329,12 @@
               "url": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\string-width"
             }
           ]
         },
@@ -17270,6 +22356,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\strip-ansi"
+            }
           ]
         },
         {
@@ -17289,6 +22381,12 @@
               "url": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\wrap-ansi"
             }
           ]
         },
@@ -17310,6 +22408,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\yargs-parser"
+            }
           ]
         },
         {
@@ -17329,6 +22433,12 @@
               "url": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\yargs"
             }
           ]
         }
@@ -17353,6 +22463,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/request"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17371,6 +22487,12 @@
               "url": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/request\\node_modules\\qs"
             }
           ]
         }
@@ -17394,6 +22516,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/require-directory"
+        }
       ]
     },
     {
@@ -17413,6 +22541,12 @@
           "url": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/require-main-filename"
         }
       ]
     },
@@ -17434,6 +22568,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/resolve-dir"
+        }
       ]
     },
     {
@@ -17453,6 +22593,12 @@
           "url": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/resolve-url"
         }
       ]
     },
@@ -17474,6 +22620,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/resolve"
+        }
       ]
     },
     {
@@ -17493,6 +22645,12 @@
           "url": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/responselike"
         }
       ]
     },
@@ -17514,6 +22672,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/restructure"
+        }
       ]
     },
     {
@@ -17533,6 +22697,12 @@
           "url": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ret"
         }
       ]
     },
@@ -17554,6 +22724,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/retry-as-promised"
+        }
       ]
     },
     {
@@ -17574,6 +22750,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/retry"
+        }
       ]
     },
     {
@@ -17593,6 +22775,12 @@
           "url": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/rimraf"
         }
       ]
     },
@@ -17615,6 +22803,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/rxjs"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17633,6 +22827,12 @@
               "url": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/rxjs\\node_modules\\tslib"
             }
           ]
         }
@@ -17656,6 +22856,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safe-buffer"
+        }
       ]
     },
     {
@@ -17675,6 +22881,12 @@
           "url": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safe-regex-test"
         }
       ]
     },
@@ -17696,6 +22908,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safe-regex"
+        }
       ]
     },
     {
@@ -17715,6 +22933,12 @@
           "url": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safe-stable-stringify"
         }
       ]
     },
@@ -17736,6 +22960,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safer-buffer"
+        }
       ]
     },
     {
@@ -17756,6 +22986,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/samsam"
+        }
       ]
     },
     {
@@ -17775,6 +23011,12 @@
           "url": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sanitize-filename"
         }
       ]
     },
@@ -17797,6 +23039,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sanitize-html"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17815,6 +23063,12 @@
               "url": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sanitize-html\\node_modules\\lodash"
             }
           ]
         }
@@ -17838,6 +23092,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sax"
+        }
       ]
     },
     {
@@ -17858,6 +23118,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/seek-bzip"
+        }
       ]
     },
     {
@@ -17877,6 +23143,12 @@
           "url": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/semver"
         }
       ]
     },
@@ -17899,6 +23171,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/send"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17917,6 +23195,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/send\\node_modules\\ms"
             }
           ]
         }
@@ -17940,6 +23224,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sequelize-pool"
+        }
       ]
     },
     {
@@ -17961,6 +23251,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sequelize"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17979,6 +23275,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sequelize\\node_modules\\debug"
             }
           ]
         },
@@ -18000,6 +23302,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sequelize\\node_modules\\ms"
+            }
           ]
         },
         {
@@ -18019,6 +23327,12 @@
               "url": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sequelize\\node_modules\\uuid"
             }
           ]
         }
@@ -18043,6 +23357,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/serve-index"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18061,6 +23381,12 @@
               "url": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index\\node_modules\\depd"
             }
           ]
         },
@@ -18082,6 +23408,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index\\node_modules\\http-errors"
+            }
           ]
         },
         {
@@ -18101,6 +23433,12 @@
               "url": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index\\node_modules\\inherits"
             }
           ]
         },
@@ -18122,6 +23460,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index\\node_modules\\setprototypeof"
+            }
           ]
         },
         {
@@ -18141,6 +23485,12 @@
               "url": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index\\node_modules\\statuses"
             }
           ]
         }
@@ -18164,6 +23514,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/serve-static"
+        }
       ]
     },
     {
@@ -18183,6 +23539,12 @@
           "url": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/set-blocking"
         }
       ]
     },
@@ -18205,6 +23567,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/set-value"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18223,6 +23591,12 @@
               "url": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/set-value\\node_modules\\extend-shallow"
             }
           ]
         },
@@ -18243,6 +23617,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/set-value\\node_modules\\is-extendable"
             }
           ]
         }
@@ -18266,6 +23646,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/setimmediate"
+        }
       ]
     },
     {
@@ -18285,6 +23671,12 @@
           "url": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/setprototypeof"
         }
       ]
     },
@@ -18306,6 +23698,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/side-channel"
+        }
       ]
     },
     {
@@ -18326,6 +23724,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/signal-exit"
+        }
       ]
     },
     {
@@ -18345,6 +23749,12 @@
           "url": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/simple-concat"
         }
       ]
     },
@@ -18367,6 +23777,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/simple-get"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18385,6 +23801,12 @@
               "url": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/simple-get\\node_modules\\decompress-response"
             }
           ]
         },
@@ -18405,6 +23827,12 @@
               "url": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/simple-get\\node_modules\\mimic-response"
             }
           ]
         }
@@ -18429,6 +23857,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/simple-swizzle"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18447,6 +23881,12 @@
               "url": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/simple-swizzle\\node_modules\\is-arrayish"
             }
           ]
         }
@@ -18470,6 +23910,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sinon"
+        }
       ]
     },
     {
@@ -18489,6 +23935,12 @@
           "url": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/smart-buffer"
         }
       ]
     },
@@ -18511,6 +23963,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/snapdragon-node"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18529,6 +23987,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon-node\\node_modules\\define-property"
             }
           ]
         }
@@ -18553,6 +24017,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/snapdragon-util"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18571,6 +24041,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon-util\\node_modules\\kind-of"
             }
           ]
         }
@@ -18595,6 +24071,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/snapdragon"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18613,6 +24095,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon\\node_modules\\define-property"
             }
           ]
         },
@@ -18633,6 +24121,12 @@
               "url": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon\\node_modules\\extend-shallow"
             }
           ]
         },
@@ -18655,6 +24149,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon\\node_modules\\is-accessor-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -18673,6 +24173,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/snapdragon\\node_modules\\is-accessor-descriptor\\node_modules\\kind-of"
                 }
               ]
             }
@@ -18697,6 +24203,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon\\node_modules\\is-data-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -18715,6 +24227,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/snapdragon\\node_modules\\is-data-descriptor\\node_modules\\kind-of"
                 }
               ]
             }
@@ -18738,6 +24256,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon\\node_modules\\is-descriptor"
+            }
           ]
         },
         {
@@ -18757,6 +24281,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon\\node_modules\\is-extendable"
             }
           ]
         },
@@ -18778,6 +24308,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon\\node_modules\\kind-of"
+            }
           ]
         },
         {
@@ -18797,6 +24333,12 @@
               "url": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon\\node_modules\\source-map"
             }
           ]
         }
@@ -18820,6 +24362,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socket.io-adapter"
+        }
       ]
     },
     {
@@ -18841,6 +24389,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socket.io-parser"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18859,6 +24413,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socket.io-parser\\node_modules\\debug"
             }
           ]
         },
@@ -18879,6 +24439,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socket.io-parser\\node_modules\\ms"
             }
           ]
         }
@@ -18903,6 +24469,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socket.io"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18921,6 +24493,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socket.io\\node_modules\\debug"
             }
           ]
         },
@@ -18941,6 +24519,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socket.io\\node_modules\\ms"
             }
           ]
         }
@@ -18965,6 +24549,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socks-proxy-agent"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18983,6 +24573,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socks-proxy-agent\\node_modules\\debug"
             }
           ]
         },
@@ -19003,6 +24599,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socks-proxy-agent\\node_modules\\ms"
             }
           ]
         }
@@ -19027,6 +24629,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socks"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -19045,6 +24653,12 @@
               "url": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socks\\node_modules\\ip"
             }
           ]
         }
@@ -19069,6 +24683,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sort-keys-length"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -19087,6 +24707,12 @@
               "url": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sort-keys-length\\node_modules\\sort-keys"
             }
           ]
         }
@@ -19110,6 +24736,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sort-keys"
+        }
       ]
     },
     {
@@ -19129,6 +24761,12 @@
           "url": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/source-map-resolve"
         }
       ]
     },
@@ -19150,6 +24788,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/source-map-support"
+        }
       ]
     },
     {
@@ -19169,6 +24813,12 @@
           "url": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/source-map-url"
         }
       ]
     },
@@ -19190,6 +24840,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/source-map"
+        }
       ]
     },
     {
@@ -19209,6 +24865,12 @@
           "url": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2-1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spawn-command"
         }
       ]
     },
@@ -19230,6 +24892,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spdx-correct"
+        }
       ]
     },
     {
@@ -19249,6 +24917,12 @@
           "url": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spdx-exceptions"
         }
       ]
     },
@@ -19270,6 +24944,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spdx-expression-parse"
+        }
       ]
     },
     {
@@ -19289,6 +24969,12 @@
           "url": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.12.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spdx-license-ids"
         }
       ]
     },
@@ -19310,6 +24996,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/split-string"
+        }
       ]
     },
     {
@@ -19329,6 +25021,12 @@
           "url": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sprintf-js"
         }
       ]
     },
@@ -19350,6 +25048,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sqlite3"
+        }
       ]
     },
     {
@@ -19369,6 +25073,12 @@
           "url": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sshpk"
         }
       ]
     },
@@ -19390,6 +25100,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ssri"
+        }
       ]
     },
     {
@@ -19409,6 +25125,12 @@
           "url": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/stack-trace"
         }
       ]
     },
@@ -19431,6 +25153,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/static-extend"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -19449,6 +25177,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend\\node_modules\\define-property"
             }
           ]
         },
@@ -19471,6 +25205,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend\\node_modules\\is-accessor-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -19489,6 +25229,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/static-extend\\node_modules\\is-accessor-descriptor\\node_modules\\kind-of"
                 }
               ]
             }
@@ -19513,6 +25259,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend\\node_modules\\is-data-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -19531,6 +25283,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/static-extend\\node_modules\\is-data-descriptor\\node_modules\\kind-of"
                 }
               ]
             }
@@ -19554,6 +25312,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend\\node_modules\\is-descriptor"
+            }
           ]
         },
         {
@@ -19573,6 +25337,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend\\node_modules\\kind-of"
             }
           ]
         }
@@ -19596,6 +25366,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/statuses"
+        }
       ]
     },
     {
@@ -19615,6 +25391,12 @@
           "url": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-2.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/stream-buffers"
         }
       ]
     },
@@ -19636,6 +25418,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/streamsearch"
+        }
       ]
     },
     {
@@ -19655,6 +25443,12 @@
           "url": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strict-uri-encode"
         }
       ]
     },
@@ -19676,6 +25470,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string_decoder"
+        }
       ]
     },
     {
@@ -19695,6 +25495,12 @@
           "url": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string-width"
         }
       ]
     },
@@ -19716,6 +25522,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string.fromcodepoint"
+        }
       ]
     },
     {
@@ -19735,6 +25547,12 @@
           "url": "https://registry.npmjs.org/string.prototype.codepointat/-/string.prototype.codepointat-0.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string.prototype.codepointat"
         }
       ]
     },
@@ -19756,6 +25574,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string.prototype.trimend"
+        }
       ]
     },
     {
@@ -19775,6 +25599,12 @@
           "url": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string.prototype.trimstart"
         }
       ]
     },
@@ -19796,6 +25626,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-ansi"
+        }
       ]
     },
     {
@@ -19815,6 +25651,12 @@
           "url": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-bom"
         }
       ]
     },
@@ -19836,6 +25678,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-dirs"
+        }
       ]
     },
     {
@@ -19855,6 +25703,12 @@
           "url": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-json-comments"
         }
       ]
     },
@@ -19876,6 +25730,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-outer"
+        }
       ]
     },
     {
@@ -19895,6 +25755,12 @@
           "url": "https://registry.npmjs.org/strtok3/-/strtok3-6.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strtok3"
         }
       ]
     },
@@ -19916,6 +25782,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/supports-color"
+        }
       ]
     },
     {
@@ -19935,6 +25807,12 @@
           "url": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/supports-preserve-symlinks-flag"
         }
       ]
     },
@@ -19956,6 +25834,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/svg-captcha"
+        }
       ]
     },
     {
@@ -19976,6 +25860,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/swagger-ui-dist"
+        }
       ]
     },
     {
@@ -19995,6 +25885,12 @@
           "url": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-4.5.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/swagger-ui-express"
         }
       ]
     },
@@ -20017,6 +25913,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tar-fs"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -20035,6 +25937,12 @@
               "url": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/tar-fs\\node_modules\\bl"
             }
           ]
         },
@@ -20056,6 +25964,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/tar-fs\\node_modules\\chownr"
+            }
           ]
         },
         {
@@ -20076,6 +25990,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/tar-fs\\node_modules\\readable-stream"
+            }
           ]
         },
         {
@@ -20095,6 +26015,12 @@
               "url": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/tar-fs\\node_modules\\tar-stream"
             }
           ]
         }
@@ -20118,6 +26044,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tar-stream"
+        }
       ]
     },
     {
@@ -20137,6 +26069,12 @@
           "url": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tar"
         }
       ]
     },
@@ -20158,6 +26096,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tdigest"
+        }
       ]
     },
     {
@@ -20177,6 +26121,12 @@
           "url": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/text-hex"
         }
       ]
     },
@@ -20198,6 +26148,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/thirty-two"
+        }
       ]
     },
     {
@@ -20217,6 +26173,12 @@
           "url": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/through"
         }
       ]
     },
@@ -20238,6 +26200,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/timed-out"
+        }
       ]
     },
     {
@@ -20257,6 +26225,12 @@
           "url": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tiny-inflate"
         }
       ]
     },
@@ -20278,6 +26252,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-buffer"
+        }
       ]
     },
     {
@@ -20297,6 +26277,12 @@
           "url": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-fast-properties"
         }
       ]
     },
@@ -20319,6 +26305,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-object-path"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -20337,6 +26329,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/to-object-path\\node_modules\\kind-of"
             }
           ]
         }
@@ -20360,6 +26358,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-regex-range"
+        }
       ]
     },
     {
@@ -20379,6 +26383,12 @@
           "url": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-regex"
         }
       ]
     },
@@ -20400,6 +26410,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/toidentifier"
+        }
       ]
     },
     {
@@ -20419,6 +26435,12 @@
           "url": "https://registry.npmjs.org/token-stream/-/token-stream-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/token-stream"
         }
       ]
     },
@@ -20440,6 +26462,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/token-types"
+        }
       ]
     },
     {
@@ -20459,6 +26487,12 @@
           "url": "https://registry.npmjs.org/toposort-class/-/toposort-class-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/toposort-class"
         }
       ]
     },
@@ -20480,6 +26514,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tough-cookie"
+        }
       ]
     },
     {
@@ -20499,6 +26539,12 @@
           "url": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tr46"
         }
       ]
     },
@@ -20520,6 +26566,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/traverse"
+        }
       ]
     },
     {
@@ -20539,6 +26591,12 @@
           "url": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tree-kill"
         }
       ]
     },
@@ -20560,6 +26618,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/trim-repeated"
+        }
       ]
     },
     {
@@ -20580,6 +26644,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/triple-beam"
+        }
       ]
     },
     {
@@ -20599,6 +26669,12 @@
           "url": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/truncate-utf8-bytes"
         }
       ]
     },
@@ -20621,6 +26697,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ts-node-dev"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -20639,6 +26721,12 @@
               "url": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/ts-node-dev\\node_modules\\rimraf"
             }
           ]
         }
@@ -20662,6 +26750,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ts-node"
+        }
       ]
     },
     {
@@ -20681,6 +26775,12 @@
           "url": "https://registry.npmjs.org/tsconfig/-/tsconfig-7.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tsconfig"
         }
       ]
     },
@@ -20702,6 +26802,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tslib"
+        }
       ]
     },
     {
@@ -20721,6 +26827,12 @@
           "url": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tunnel-agent"
         }
       ]
     },
@@ -20742,6 +26854,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tweetnacl"
+        }
       ]
     },
     {
@@ -20761,6 +26879,12 @@
           "url": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/type-check"
         }
       ]
     },
@@ -20782,6 +26906,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/type-is"
+        }
       ]
     },
     {
@@ -20801,6 +26931,12 @@
           "url": "https://registry.npmjs.org/typecast/-/typecast-0.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/typecast"
         }
       ]
     },
@@ -20822,6 +26958,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/typedarray"
+        }
       ]
     },
     {
@@ -20841,6 +26983,12 @@
           "url": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/typescript"
         }
       ]
     },
@@ -20862,6 +27010,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/uglify-js"
+        }
       ]
     },
     {
@@ -20881,6 +27035,12 @@
           "url": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unbox-primitive"
         }
       ]
     },
@@ -20902,6 +27062,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unbzip2-stream"
+        }
       ]
     },
     {
@@ -20921,6 +27087,12 @@
           "url": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unc-path-regex"
         }
       ]
     },
@@ -20942,6 +27114,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/underscore.string"
+        }
       ]
     },
     {
@@ -20962,6 +27140,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unicode-properties"
+        }
       ]
     },
     {
@@ -20981,6 +27165,12 @@
           "url": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unicode-trie"
         }
       ]
     },
@@ -21003,6 +27193,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/union-value"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21021,6 +27217,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/union-value\\node_modules\\is-extendable"
             }
           ]
         }
@@ -21044,6 +27246,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unique-filename"
+        }
       ]
     },
     {
@@ -21063,6 +27271,12 @@
           "url": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unique-slug"
         }
       ]
     },
@@ -21084,6 +27298,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unit-compare"
+        }
       ]
     },
     {
@@ -21104,6 +27324,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/universalify"
+        }
       ]
     },
     {
@@ -21123,6 +27349,12 @@
           "url": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unpipe"
         }
       ]
     },
@@ -21145,6 +27377,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unset-value"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21165,6 +27403,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/unset-value\\node_modules\\has-value"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -21183,6 +27427,12 @@
                   "url": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/unset-value\\node_modules\\has-value\\node_modules\\isobject"
                 }
               ]
             }
@@ -21206,6 +27456,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/unset-value\\node_modules\\has-values"
+            }
           ]
         },
         {
@@ -21225,6 +27481,12 @@
               "url": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/unset-value\\node_modules\\isarray"
             }
           ]
         }
@@ -21248,6 +27510,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/untildify"
+        }
       ]
     },
     {
@@ -21269,6 +27537,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unzipper"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21287,6 +27561,12 @@
               "url": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/unzipper\\node_modules\\bluebird"
             }
           ]
         }
@@ -21310,6 +27590,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/uri-js"
+        }
       ]
     },
     {
@@ -21329,6 +27615,12 @@
           "url": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/urix"
         }
       ]
     },
@@ -21350,6 +27642,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/url-parse-lax"
+        }
       ]
     },
     {
@@ -21369,6 +27667,12 @@
           "url": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/url-to-options"
         }
       ]
     },
@@ -21390,6 +27694,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/use"
+        }
       ]
     },
     {
@@ -21409,6 +27719,12 @@
           "url": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/utf8-byte-length"
         }
       ]
     },
@@ -21430,6 +27746,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/util-deprecate"
+        }
       ]
     },
     {
@@ -21449,6 +27771,12 @@
           "url": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/util"
         }
       ]
     },
@@ -21470,6 +27798,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/utils-merge"
+        }
       ]
     },
     {
@@ -21489,6 +27823,12 @@
           "url": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/uuid"
         }
       ]
     },
@@ -21510,6 +27850,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/v8flags"
+        }
       ]
     },
     {
@@ -21529,6 +27875,12 @@
           "url": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/validate-npm-package-license"
         }
       ]
     },
@@ -21550,6 +27902,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/validate"
+        }
       ]
     },
     {
@@ -21570,6 +27928,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/validator"
+        }
       ]
     },
     {
@@ -21589,6 +27953,12 @@
           "url": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/vary"
         }
       ]
     },
@@ -21611,6 +27981,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/verror"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21629,6 +28005,12 @@
               "url": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/verror\\node_modules\\core-util-is"
             }
           ]
         }
@@ -21653,6 +28035,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/vm2"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21671,6 +28059,12 @@
               "url": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/vm2\\node_modules\\acorn"
             }
           ]
         }
@@ -21694,6 +28088,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/void-elements"
+        }
       ]
     },
     {
@@ -21713,6 +28113,12 @@
           "url": "https://registry.npmjs.org/walk/-/walk-2.3.15.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/walk"
         }
       ]
     },
@@ -21734,6 +28140,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/walkdir"
+        }
       ]
     },
     {
@@ -21753,6 +28165,12 @@
           "url": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/webidl-conversions"
         }
       ]
     },
@@ -21774,6 +28192,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/whatwg-url"
+        }
       ]
     },
     {
@@ -21793,6 +28217,12 @@
           "url": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-boxed-primitive"
         }
       ]
     },
@@ -21814,6 +28244,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-collection"
+        }
       ]
     },
     {
@@ -21833,6 +28269,12 @@
           "url": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-module"
         }
       ]
     },
@@ -21854,6 +28296,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-pm-runs"
+        }
       ]
     },
     {
@@ -21873,6 +28321,12 @@
           "url": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-typed-array"
         }
       ]
     },
@@ -21894,6 +28348,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which"
+        }
       ]
     },
     {
@@ -21913,6 +28373,12 @@
           "url": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wide-align"
         }
       ]
     },
@@ -21935,6 +28401,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/winston-transport"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21953,6 +28425,12 @@
               "url": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/winston-transport\\node_modules\\readable-stream"
             }
           ]
         }
@@ -21977,6 +28455,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/winston"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21995,6 +28479,12 @@
               "url": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/winston\\node_modules\\async"
             }
           ]
         },
@@ -22016,6 +28506,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/winston\\node_modules\\is-stream"
+            }
           ]
         },
         {
@@ -22035,6 +28531,12 @@
               "url": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/winston\\node_modules\\readable-stream"
             }
           ]
         }
@@ -22058,6 +28560,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/with"
+        }
       ]
     },
     {
@@ -22077,6 +28585,12 @@
           "url": "https://registry.npmjs.org/wkx/-/wkx-0.5.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wkx"
         }
       ]
     },
@@ -22098,6 +28612,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/word-wrap"
+        }
       ]
     },
     {
@@ -22117,6 +28637,12 @@
           "url": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wordwrap"
         }
       ]
     },
@@ -22139,6 +28665,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wrap-ansi"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -22157,6 +28689,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi\\node_modules\\ansi-regex"
             }
           ]
         },
@@ -22178,6 +28716,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi\\node_modules\\emoji-regex"
+            }
           ]
         },
         {
@@ -22197,6 +28741,12 @@
               "url": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi\\node_modules\\is-fullwidth-code-point"
             }
           ]
         },
@@ -22218,6 +28768,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi\\node_modules\\string-width"
+            }
           ]
         },
         {
@@ -22237,6 +28793,12 @@
               "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi\\node_modules\\strip-ansi"
             }
           ]
         }
@@ -22260,6 +28822,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wrappy"
+        }
       ]
     },
     {
@@ -22279,6 +28847,12 @@
           "url": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ws"
         }
       ]
     },
@@ -22300,6 +28874,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/xtend"
+        }
       ]
     },
     {
@@ -22319,6 +28899,12 @@
           "url": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/y18n"
         }
       ]
     },
@@ -22340,6 +28926,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yallist"
+        }
       ]
     },
     {
@@ -22360,6 +28952,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yaml-schema-validator"
+        }
       ]
     },
     {
@@ -22379,6 +28977,12 @@
           "url": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yargs-parser"
         }
       ]
     },
@@ -22401,6 +29005,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yargs"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -22419,6 +29029,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs\\node_modules\\ansi-regex"
             }
           ]
         },
@@ -22440,6 +29056,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs\\node_modules\\emoji-regex"
+            }
           ]
         },
         {
@@ -22459,6 +29081,12 @@
               "url": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs\\node_modules\\is-fullwidth-code-point"
             }
           ]
         },
@@ -22480,6 +29108,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs\\node_modules\\string-width"
+            }
           ]
         },
         {
@@ -22499,6 +29133,12 @@
               "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs\\node_modules\\strip-ansi"
             }
           ]
         }
@@ -22522,6 +29162,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yauzl"
+        }
       ]
     },
     {
@@ -22541,6 +29187,12 @@
           "url": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yn"
         }
       ]
     },
@@ -22562,6 +29214,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/z85"
+        }
       ]
     },
     {
@@ -22582,6 +29240,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/zip-stream"
+        }
       ]
     },
     {
@@ -22601,6 +29265,12 @@
           "url": "https://registry.npmjs.org/zlibjs/-/zlibjs-0.3.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/zlibjs"
         }
       ]
     }

--- a/tests/_data/sbom_demo-results/juice-shop_npm8_node16_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/juice-shop_npm8_node16_windows-latest.snap.json
@@ -62,7 +62,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -95,7 +95,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@babel\\helper-string-parser"
         }
       ]
@@ -122,7 +122,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@babel\\helper-validator-identifier"
         }
       ]
@@ -149,7 +149,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@babel\\parser"
         }
       ]
@@ -176,7 +176,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@babel\\types"
         }
       ]
@@ -203,7 +203,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@colors\\colors"
         }
       ]
@@ -230,7 +230,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@dabh\\diagnostics"
         }
       ]
@@ -257,7 +257,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@gar\\promisify"
         }
       ]
@@ -284,7 +284,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@mapbox\\node-pre-gyp"
         }
       ],
@@ -310,7 +310,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\ansi-regex"
             }
           ]
@@ -336,7 +336,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\are-we-there-yet"
             }
           ]
@@ -362,7 +362,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\detect-libc"
             }
           ]
@@ -388,7 +388,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\gauge"
             }
           ]
@@ -414,7 +414,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\is-fullwidth-code-point"
             }
           ]
@@ -440,7 +440,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\make-dir"
             }
           ],
@@ -466,7 +466,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\make-dir\\node_modules\\semver"
                 }
               ]
@@ -494,7 +494,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\nopt"
             }
           ]
@@ -520,7 +520,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\npmlog"
             }
           ]
@@ -546,7 +546,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\readable-stream"
             }
           ]
@@ -572,7 +572,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\string-width"
             }
           ]
@@ -598,7 +598,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\strip-ansi"
             }
           ]
@@ -627,7 +627,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\core-loader"
         }
       ]
@@ -654,7 +654,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\core"
         }
       ]
@@ -681,7 +681,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\evaluator"
         }
       ]
@@ -708,7 +708,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-all"
         }
       ]
@@ -735,7 +735,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-ar"
         }
       ]
@@ -762,7 +762,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-bn"
         }
       ]
@@ -789,7 +789,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-ca"
         }
       ]
@@ -816,7 +816,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-cs"
         }
       ]
@@ -843,7 +843,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-da"
         }
       ]
@@ -870,7 +870,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-de"
         }
       ]
@@ -897,7 +897,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-el"
         }
       ]
@@ -924,7 +924,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-en-min"
         }
       ]
@@ -951,7 +951,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-en"
         }
       ]
@@ -978,7 +978,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-es"
         }
       ]
@@ -1005,7 +1005,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-eu"
         }
       ]
@@ -1032,7 +1032,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-fa"
         }
       ]
@@ -1059,7 +1059,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-fi"
         }
       ]
@@ -1086,7 +1086,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-fr"
         }
       ]
@@ -1113,7 +1113,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-ga"
         }
       ]
@@ -1140,7 +1140,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-gl"
         }
       ]
@@ -1167,7 +1167,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-hi"
         }
       ]
@@ -1194,7 +1194,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-hu"
         }
       ]
@@ -1221,7 +1221,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-hy"
         }
       ]
@@ -1248,7 +1248,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-id"
         }
       ]
@@ -1275,7 +1275,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-it"
         }
       ]
@@ -1302,7 +1302,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-ja"
         }
       ]
@@ -1329,7 +1329,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-ko"
         }
       ]
@@ -1356,7 +1356,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-lt"
         }
       ]
@@ -1383,7 +1383,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-ms"
         }
       ]
@@ -1410,7 +1410,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-ne"
         }
       ]
@@ -1437,7 +1437,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-nl"
         }
       ]
@@ -1464,7 +1464,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-no"
         }
       ]
@@ -1491,7 +1491,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-pl"
         }
       ]
@@ -1518,7 +1518,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-pt"
         }
       ]
@@ -1545,7 +1545,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-ro"
         }
       ]
@@ -1572,7 +1572,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-ru"
         }
       ]
@@ -1599,7 +1599,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-sl"
         }
       ]
@@ -1626,7 +1626,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-sr"
         }
       ]
@@ -1653,7 +1653,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-sv"
         }
       ]
@@ -1680,7 +1680,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-ta"
         }
       ]
@@ -1707,7 +1707,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-th"
         }
       ]
@@ -1734,7 +1734,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-tl"
         }
       ]
@@ -1761,7 +1761,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-tr"
         }
       ]
@@ -1788,7 +1788,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-uk"
         }
       ]
@@ -1815,7 +1815,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-zh"
         }
       ]
@@ -1842,7 +1842,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\language-min"
         }
       ]
@@ -1869,7 +1869,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\language"
         }
       ]
@@ -1896,7 +1896,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\ner"
         }
       ]
@@ -1923,7 +1923,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\neural"
         }
       ]
@@ -1950,7 +1950,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\nlg"
         }
       ]
@@ -1977,7 +1977,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\nlp"
         }
       ]
@@ -2004,7 +2004,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\nlu"
         }
       ]
@@ -2031,7 +2031,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\request"
         }
       ]
@@ -2058,7 +2058,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\sentiment"
         }
       ]
@@ -2085,7 +2085,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\similarity"
         }
       ]
@@ -2112,7 +2112,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\slot"
         }
       ]
@@ -2139,7 +2139,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@npmcli\\fs"
         }
       ]
@@ -2166,7 +2166,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@npmcli\\move-file"
         }
       ]
@@ -2193,7 +2193,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib\\core"
         }
       ]
@@ -2220,7 +2220,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib\\plugin-crypto"
         }
       ]
@@ -2247,7 +2247,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib\\plugin-thirty-two"
         }
       ]
@@ -2274,7 +2274,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib\\preset-default"
         }
       ]
@@ -2301,7 +2301,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib\\preset-v11"
         }
       ]
@@ -2328,7 +2328,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@sindresorhus\\is"
         }
       ]
@@ -2355,7 +2355,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@swc\\helpers"
         }
       ]
@@ -2382,7 +2382,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@tokenizer\\token"
         }
       ]
@@ -2409,7 +2409,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@tootallnate\\once"
         }
       ]
@@ -2436,7 +2436,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types\\component-emitter"
         }
       ]
@@ -2463,7 +2463,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types\\cookie"
         }
       ]
@@ -2490,7 +2490,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types\\cors"
         }
       ]
@@ -2517,7 +2517,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types\\debug"
         }
       ]
@@ -2544,7 +2544,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types\\ms"
         }
       ]
@@ -2571,7 +2571,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types\\node"
         }
       ]
@@ -2598,7 +2598,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types\\strip-bom"
         }
       ]
@@ -2625,7 +2625,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types\\strip-json-comments"
         }
       ]
@@ -2652,7 +2652,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types\\validator"
         }
       ]
@@ -2678,7 +2678,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/abbrev"
         }
       ]
@@ -2704,7 +2704,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/accepts"
         }
       ]
@@ -2730,7 +2730,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/acorn-walk"
         }
       ]
@@ -2756,7 +2756,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/acorn"
         }
       ]
@@ -2782,7 +2782,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/agent-base"
         }
       ],
@@ -2808,7 +2808,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agent-base\\node_modules\\debug"
             }
           ]
@@ -2834,7 +2834,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agent-base\\node_modules\\ms"
             }
           ]
@@ -2862,7 +2862,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/agentkeepalive"
         }
       ],
@@ -2888,7 +2888,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agentkeepalive\\node_modules\\debug"
             }
           ]
@@ -2914,7 +2914,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agentkeepalive\\node_modules\\depd"
             }
           ]
@@ -2940,7 +2940,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agentkeepalive\\node_modules\\ms"
             }
           ]
@@ -2968,7 +2968,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/aggregate-error"
         }
       ]
@@ -2994,7 +2994,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ajv"
         }
       ]
@@ -3020,7 +3020,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ansi-regex"
         }
       ]
@@ -3046,7 +3046,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ansi-styles"
         }
       ]
@@ -3072,7 +3072,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/anymatch"
         }
       ],
@@ -3098,7 +3098,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/anymatch\\node_modules\\normalize-path"
             }
           ]
@@ -3126,7 +3126,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/append-field"
         }
       ]
@@ -3152,7 +3152,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/aproba"
         }
       ]
@@ -3178,7 +3178,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/archive-type"
         }
       ],
@@ -3204,7 +3204,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/archive-type\\node_modules\\file-type"
             }
           ]
@@ -3232,7 +3232,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/archiver-utils"
         }
       ]
@@ -3258,7 +3258,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/archiver"
         }
       ]
@@ -3284,7 +3284,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/are-we-there-yet"
         }
       ]
@@ -3310,7 +3310,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/arg"
         }
       ]
@@ -3336,7 +3336,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/argparse"
         }
       ],
@@ -3362,7 +3362,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/argparse\\node_modules\\sprintf-js"
             }
           ]
@@ -3390,7 +3390,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/arr-diff"
         }
       ]
@@ -3416,7 +3416,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/arr-flatten"
         }
       ]
@@ -3442,7 +3442,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/arr-union"
         }
       ]
@@ -3468,7 +3468,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/array-each"
         }
       ]
@@ -3494,7 +3494,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/array-flatten"
         }
       ]
@@ -3520,7 +3520,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/array-slice"
         }
       ]
@@ -3546,7 +3546,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/array-unique"
         }
       ]
@@ -3572,7 +3572,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/asap"
         }
       ]
@@ -3598,7 +3598,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/asn1"
         }
       ]
@@ -3624,7 +3624,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/assert-never"
         }
       ]
@@ -3650,7 +3650,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/assert-plus"
         }
       ]
@@ -3676,7 +3676,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/assign-symbols"
         }
       ]
@@ -3702,7 +3702,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/async"
         }
       ]
@@ -3728,7 +3728,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/asynckit"
         }
       ]
@@ -3754,7 +3754,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/at-least-node"
         }
       ]
@@ -3780,7 +3780,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/atob"
         }
       ]
@@ -3806,7 +3806,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/available-typed-arrays"
         }
       ]
@@ -3832,7 +3832,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/aws-sign2"
         }
       ]
@@ -3858,7 +3858,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/aws4"
         }
       ]
@@ -3884,7 +3884,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/babel-walk"
         }
       ]
@@ -3910,7 +3910,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/balanced-match"
         }
       ]
@@ -3936,7 +3936,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base"
         }
       ],
@@ -3962,7 +3962,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/base\\node_modules\\define-property"
             }
           ]
@@ -3990,7 +3990,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base64-arraybuffer"
         }
       ]
@@ -4016,7 +4016,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base64-js"
         }
       ]
@@ -4042,7 +4042,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base64id"
         }
       ]
@@ -4068,7 +4068,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base64url"
         }
       ]
@@ -4094,7 +4094,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/basic-auth"
         }
       ]
@@ -4120,7 +4120,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/batch"
         }
       ]
@@ -4146,7 +4146,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bcrypt-pbkdf"
         }
       ]
@@ -4172,7 +4172,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/big-integer"
         }
       ]
@@ -4198,7 +4198,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/binary-extensions"
         }
       ]
@@ -4224,7 +4224,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/binary"
         }
       ]
@@ -4250,7 +4250,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bindings"
         }
       ]
@@ -4276,7 +4276,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bintrees"
         }
       ]
@@ -4302,7 +4302,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bl"
         }
       ]
@@ -4328,7 +4328,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bluebird"
         }
       ]
@@ -4354,7 +4354,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/body-parser"
         }
       ]
@@ -4380,7 +4380,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bower-config"
         }
       ],
@@ -4406,7 +4406,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bower-config\\node_modules\\minimist"
             }
           ]
@@ -4434,7 +4434,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/brace-expansion"
         }
       ]
@@ -4460,7 +4460,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/braces"
         }
       ],
@@ -4486,7 +4486,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/braces\\node_modules\\extend-shallow"
             }
           ]
@@ -4512,7 +4512,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/braces\\node_modules\\is-extendable"
             }
           ]
@@ -4540,7 +4540,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/brotli"
         }
       ]
@@ -4566,7 +4566,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-alloc-unsafe"
         }
       ]
@@ -4592,7 +4592,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-alloc"
         }
       ]
@@ -4618,7 +4618,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-crc32"
         }
       ]
@@ -4644,7 +4644,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-fill"
         }
       ]
@@ -4670,7 +4670,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-from"
         }
       ]
@@ -4696,7 +4696,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-indexof-polyfill"
         }
       ]
@@ -4722,7 +4722,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer"
         }
       ]
@@ -4748,7 +4748,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffers"
         }
       ]
@@ -4774,7 +4774,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/busboy"
         }
       ],
@@ -4800,7 +4800,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/busboy\\node_modules\\isarray"
             }
           ]
@@ -4826,7 +4826,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/busboy\\node_modules\\readable-stream"
             }
           ]
@@ -4852,7 +4852,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/busboy\\node_modules\\string_decoder"
             }
           ]
@@ -4880,7 +4880,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/byline"
         }
       ]
@@ -4906,7 +4906,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bytes"
         }
       ]
@@ -4932,7 +4932,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cacache"
         }
       ]
@@ -4958,7 +4958,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cache-base"
         }
       ]
@@ -4984,7 +4984,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cacheable-request"
         }
       ],
@@ -5010,7 +5010,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cacheable-request\\node_modules\\get-stream"
             }
           ]
@@ -5036,7 +5036,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cacheable-request\\node_modules\\lowercase-keys"
             }
           ]
@@ -5064,7 +5064,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/call-bind"
         }
       ]
@@ -5090,7 +5090,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/camelcase"
         }
       ]
@@ -5116,7 +5116,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/caseless"
         }
       ]
@@ -5142,7 +5142,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/chainsaw"
         }
       ]
@@ -5168,7 +5168,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/chalk"
         }
       ]
@@ -5194,7 +5194,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/character-parser"
         }
       ]
@@ -5220,7 +5220,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/check-dependencies"
         }
       ],
@@ -5246,7 +5246,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/check-dependencies\\node_modules\\semver"
             }
           ]
@@ -5274,7 +5274,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/check-types"
         }
       ]
@@ -5300,7 +5300,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/chokidar"
         }
       ],
@@ -5326,7 +5326,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar\\node_modules\\braces"
             }
           ]
@@ -5352,7 +5352,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar\\node_modules\\fill-range"
             }
           ]
@@ -5378,7 +5378,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar\\node_modules\\is-glob"
             }
           ]
@@ -5404,7 +5404,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar\\node_modules\\is-number"
             }
           ]
@@ -5430,7 +5430,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar\\node_modules\\normalize-path"
             }
           ]
@@ -5456,7 +5456,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar\\node_modules\\to-regex-range"
             }
           ]
@@ -5484,7 +5484,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/chownr"
         }
       ]
@@ -5510,7 +5510,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/clarinet"
         }
       ]
@@ -5536,7 +5536,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/class-utils"
         }
       ],
@@ -5562,7 +5562,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils\\node_modules\\define-property"
             }
           ]
@@ -5588,7 +5588,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils\\node_modules\\is-accessor-descriptor"
             }
           ],
@@ -5614,7 +5614,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/class-utils\\node_modules\\is-accessor-descriptor\\node_modules\\kind-of"
                 }
               ]
@@ -5642,7 +5642,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils\\node_modules\\is-data-descriptor"
             }
           ],
@@ -5668,7 +5668,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/class-utils\\node_modules\\is-data-descriptor\\node_modules\\kind-of"
                 }
               ]
@@ -5696,7 +5696,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils\\node_modules\\is-descriptor"
             }
           ]
@@ -5722,7 +5722,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils\\node_modules\\kind-of"
             }
           ]
@@ -5750,7 +5750,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/clean-stack"
         }
       ]
@@ -5776,7 +5776,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cliui"
         }
       ],
@@ -5802,7 +5802,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui\\node_modules\\ansi-regex"
             }
           ]
@@ -5828,7 +5828,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui\\node_modules\\emoji-regex"
             }
           ]
@@ -5854,7 +5854,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui\\node_modules\\is-fullwidth-code-point"
             }
           ]
@@ -5880,7 +5880,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui\\node_modules\\string-width"
             }
           ]
@@ -5906,7 +5906,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui\\node_modules\\strip-ansi"
             }
           ]
@@ -5934,7 +5934,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/clone-response"
         }
       ]
@@ -5960,7 +5960,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/clone"
         }
       ]
@@ -5986,7 +5986,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/code-point-at"
         }
       ]
@@ -6012,7 +6012,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/collection-visit"
         }
       ]
@@ -6038,7 +6038,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color-convert"
         }
       ]
@@ -6064,7 +6064,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color-name"
         }
       ]
@@ -6090,7 +6090,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color-string"
         }
       ]
@@ -6116,7 +6116,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color-support"
         }
       ]
@@ -6142,7 +6142,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color"
         }
       ]
@@ -6168,7 +6168,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/colors"
         }
       ]
@@ -6194,7 +6194,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/colorspace"
         }
       ]
@@ -6220,7 +6220,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/combined-stream"
         }
       ]
@@ -6246,7 +6246,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/commander"
         }
       ]
@@ -6272,7 +6272,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/component-emitter"
         }
       ]
@@ -6298,7 +6298,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/component-type"
         }
       ]
@@ -6324,7 +6324,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/compress-commons"
         }
       ]
@@ -6350,7 +6350,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/compressible"
         }
       ]
@@ -6376,7 +6376,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/compression"
         }
       ],
@@ -6402,7 +6402,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/compression\\node_modules\\bytes"
             }
           ]
@@ -6430,7 +6430,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/concat-map"
         }
       ]
@@ -6456,7 +6456,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/concat-stream"
         }
       ]
@@ -6482,7 +6482,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/concurrently"
         }
       ],
@@ -6508,7 +6508,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/concurrently\\node_modules\\supports-color"
             }
           ]
@@ -6536,7 +6536,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/config"
         }
       ]
@@ -6562,7 +6562,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/console-control-strings"
         }
       ]
@@ -6588,7 +6588,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/constantinople"
         }
       ]
@@ -6614,7 +6614,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/content-disposition"
         }
       ],
@@ -6640,7 +6640,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/content-disposition\\node_modules\\safe-buffer"
             }
           ]
@@ -6668,7 +6668,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/content-type"
         }
       ]
@@ -6694,7 +6694,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cookie-parser"
         }
       ]
@@ -6720,7 +6720,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cookie-signature"
         }
       ]
@@ -6746,7 +6746,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cookie"
         }
       ]
@@ -6772,7 +6772,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/copy-descriptor"
         }
       ]
@@ -6798,7 +6798,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/core-util-is"
         }
       ]
@@ -6824,7 +6824,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cors"
         }
       ]
@@ -6850,7 +6850,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/crc"
         }
       ]
@@ -6876,7 +6876,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/crc32-stream"
         }
       ]
@@ -6902,7 +6902,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/create-require"
         }
       ]
@@ -6928,7 +6928,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/crypto-js"
         }
       ]
@@ -6954,7 +6954,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dashdash"
         }
       ]
@@ -6980,7 +6980,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/date-fns"
         }
       ]
@@ -7006,7 +7006,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dateformat"
         }
       ]
@@ -7032,7 +7032,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/debug"
         }
       ]
@@ -7058,7 +7058,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decamelize"
         }
       ]
@@ -7084,7 +7084,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decode-uri-component"
         }
       ]
@@ -7110,7 +7110,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-response"
         }
       ]
@@ -7136,7 +7136,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-tar"
         }
       ],
@@ -7162,7 +7162,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-tar\\node_modules\\file-type"
             }
           ]
@@ -7190,7 +7190,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-tarbz2"
         }
       ],
@@ -7216,7 +7216,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-tarbz2\\node_modules\\file-type"
             }
           ]
@@ -7244,7 +7244,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-targz"
         }
       ],
@@ -7270,7 +7270,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-targz\\node_modules\\file-type"
             }
           ]
@@ -7298,7 +7298,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-unzip"
         }
       ],
@@ -7324,7 +7324,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-unzip\\node_modules\\file-type"
             }
           ]
@@ -7350,7 +7350,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-unzip\\node_modules\\get-stream"
             }
           ]
@@ -7376,7 +7376,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-unzip\\node_modules\\pify"
             }
           ]
@@ -7404,7 +7404,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress"
         }
       ],
@@ -7430,7 +7430,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress\\node_modules\\make-dir"
             }
           ],
@@ -7456,7 +7456,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/decompress\\node_modules\\make-dir\\node_modules\\pify"
                 }
               ]
@@ -7484,7 +7484,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress\\node_modules\\pify"
             }
           ]
@@ -7512,7 +7512,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/deep-equal"
         }
       ]
@@ -7538,7 +7538,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/deep-extend"
         }
       ]
@@ -7564,7 +7564,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/deep-is"
         }
       ]
@@ -7590,7 +7590,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/define-properties"
         }
       ]
@@ -7616,7 +7616,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/define-property"
         }
       ]
@@ -7642,7 +7642,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/delayed-stream"
         }
       ]
@@ -7668,7 +7668,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/delegates"
         }
       ]
@@ -7694,7 +7694,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/depd"
         }
       ]
@@ -7720,7 +7720,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/destroy"
         }
       ]
@@ -7746,7 +7746,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/detect-file"
         }
       ]
@@ -7772,7 +7772,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/detect-libc"
         }
       ]
@@ -7798,7 +7798,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dfa"
         }
       ]
@@ -7824,7 +7824,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dicer"
         }
       ],
@@ -7850,7 +7850,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/dicer\\node_modules\\isarray"
             }
           ]
@@ -7876,7 +7876,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/dicer\\node_modules\\readable-stream"
             }
           ]
@@ -7902,7 +7902,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/dicer\\node_modules\\string_decoder"
             }
           ]
@@ -7930,7 +7930,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/diff"
         }
       ]
@@ -7956,7 +7956,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/doctypes"
         }
       ]
@@ -7982,7 +7982,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/domelementtype"
         }
       ]
@@ -8008,7 +8008,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/domhandler"
         }
       ]
@@ -8034,7 +8034,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/domutils"
         }
       ]
@@ -8060,7 +8060,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dottie"
         }
       ]
@@ -8086,7 +8086,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/double-ended-queue"
         }
       ]
@@ -8112,7 +8112,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/doublearray"
         }
       ]
@@ -8138,7 +8138,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/download"
         }
       ],
@@ -8164,7 +8164,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/download\\node_modules\\file-type"
             }
           ]
@@ -8192,7 +8192,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/duplexer2"
         }
       ]
@@ -8218,7 +8218,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/duplexer3"
         }
       ]
@@ -8244,7 +8244,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dynamic-dedupe"
         }
       ]
@@ -8270,7 +8270,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ecc-jsbn"
         }
       ]
@@ -8296,7 +8296,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ee-first"
         }
       ]
@@ -8322,7 +8322,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/eivindfjeldstad-dot"
         }
       ]
@@ -8348,7 +8348,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/emoji-regex"
         }
       ]
@@ -8374,7 +8374,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/enabled"
         }
       ]
@@ -8400,7 +8400,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/encodeurl"
         }
       ]
@@ -8426,7 +8426,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/encoding"
         }
       ],
@@ -8452,7 +8452,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/encoding\\node_modules\\iconv-lite"
             }
           ]
@@ -8480,7 +8480,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/end-of-stream"
         }
       ]
@@ -8506,7 +8506,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/engine.io-parser"
         }
       ]
@@ -8532,7 +8532,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/engine.io"
         }
       ],
@@ -8558,7 +8558,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/engine.io\\node_modules\\debug"
             }
           ]
@@ -8584,7 +8584,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/engine.io\\node_modules\\ms"
             }
           ]
@@ -8612,7 +8612,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/env-paths"
         }
       ]
@@ -8638,7 +8638,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/err-code"
         }
       ]
@@ -8664,7 +8664,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/error-ex"
         }
       ]
@@ -8690,7 +8690,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/errorhandler"
         }
       ]
@@ -8716,7 +8716,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/es-abstract"
         }
       ]
@@ -8742,7 +8742,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/es-get-iterator"
         }
       ]
@@ -8768,7 +8768,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/es-to-primitive"
         }
       ]
@@ -8794,7 +8794,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/escape-html"
         }
       ]
@@ -8820,7 +8820,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/escape-string-regexp"
         }
       ]
@@ -8846,7 +8846,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/escodegen"
         }
       ]
@@ -8872,7 +8872,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/esprima"
         }
       ]
@@ -8898,7 +8898,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/estraverse"
         }
       ]
@@ -8924,7 +8924,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/esutils"
         }
       ]
@@ -8950,7 +8950,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/etag"
         }
       ]
@@ -8976,7 +8976,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/eventemitter2"
         }
       ]
@@ -9002,7 +9002,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/eventemitter3"
         }
       ]
@@ -9028,7 +9028,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/exif"
         }
       ]
@@ -9054,7 +9054,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/exit"
         }
       ]
@@ -9080,7 +9080,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/expand-brackets"
         }
       ],
@@ -9106,7 +9106,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets\\node_modules\\define-property"
             }
           ]
@@ -9132,7 +9132,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets\\node_modules\\extend-shallow"
             }
           ]
@@ -9158,7 +9158,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets\\node_modules\\is-accessor-descriptor"
             }
           ],
@@ -9184,7 +9184,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/expand-brackets\\node_modules\\is-accessor-descriptor\\node_modules\\kind-of"
                 }
               ]
@@ -9212,7 +9212,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets\\node_modules\\is-data-descriptor"
             }
           ],
@@ -9238,7 +9238,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/expand-brackets\\node_modules\\is-data-descriptor\\node_modules\\kind-of"
                 }
               ]
@@ -9266,7 +9266,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets\\node_modules\\is-descriptor"
             }
           ]
@@ -9292,7 +9292,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets\\node_modules\\is-extendable"
             }
           ]
@@ -9318,7 +9318,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets\\node_modules\\kind-of"
             }
           ]
@@ -9346,7 +9346,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/expand-template"
         }
       ]
@@ -9372,7 +9372,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/expand-tilde"
         }
       ]
@@ -9398,7 +9398,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-ipfilter"
         }
       ]
@@ -9424,7 +9424,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-jwt"
         }
       ],
@@ -9450,7 +9450,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/express-jwt\\node_modules\\jsonwebtoken"
             }
           ]
@@ -9476,7 +9476,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/express-jwt\\node_modules\\moment"
             }
           ]
@@ -9504,7 +9504,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-rate-limit"
         }
       ]
@@ -9530,7 +9530,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-robots-txt"
         }
       ]
@@ -9556,7 +9556,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-security.txt"
         }
       ]
@@ -9582,7 +9582,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express"
         }
       ],
@@ -9608,7 +9608,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/express\\node_modules\\cookie"
             }
           ]
@@ -9634,7 +9634,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/express\\node_modules\\safe-buffer"
             }
           ]
@@ -9662,7 +9662,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ext-list"
         }
       ]
@@ -9688,7 +9688,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ext-name"
         }
       ]
@@ -9714,7 +9714,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/extend-shallow"
         }
       ]
@@ -9740,7 +9740,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/extend"
         }
       ]
@@ -9766,7 +9766,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/extglob"
         }
       ],
@@ -9792,7 +9792,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/extglob\\node_modules\\define-property"
             }
           ]
@@ -9818,7 +9818,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/extglob\\node_modules\\extend-shallow"
             }
           ]
@@ -9844,7 +9844,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/extglob\\node_modules\\is-extendable"
             }
           ]
@@ -9872,7 +9872,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/extsprintf"
         }
       ]
@@ -9898,7 +9898,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fast-deep-equal"
         }
       ]
@@ -9924,7 +9924,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fast-json-stable-stringify"
         }
       ]
@@ -9950,7 +9950,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fast-levenshtein"
         }
       ]
@@ -9976,7 +9976,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fast.js"
         }
       ]
@@ -10002,7 +10002,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fd-slicer"
         }
       ]
@@ -10028,7 +10028,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/feature-policy"
         }
       ]
@@ -10054,7 +10054,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fecha"
         }
       ]
@@ -10080,7 +10080,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/file-js"
         }
       ],
@@ -10106,7 +10106,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/file-js\\node_modules\\brace-expansion"
             }
           ]
@@ -10132,7 +10132,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/file-js\\node_modules\\minimatch"
             }
           ]
@@ -10160,7 +10160,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/file-stream-rotator"
         }
       ]
@@ -10186,7 +10186,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/file-type"
         }
       ]
@@ -10212,7 +10212,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/file-uri-to-path"
         }
       ]
@@ -10238,7 +10238,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/filehound"
         }
       ]
@@ -10264,7 +10264,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/filename-reserved-regex"
         }
       ]
@@ -10290,7 +10290,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/filenamify"
         }
       ]
@@ -10316,7 +10316,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/filesniffer"
         }
       ]
@@ -10342,7 +10342,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fill-range"
         }
       ],
@@ -10368,7 +10368,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/fill-range\\node_modules\\extend-shallow"
             }
           ]
@@ -10394,7 +10394,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/fill-range\\node_modules\\is-extendable"
             }
           ]
@@ -10422,7 +10422,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/finale-rest"
         }
       ]
@@ -10448,7 +10448,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/finalhandler"
         }
       ]
@@ -10474,7 +10474,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/find-up"
         }
       ]
@@ -10500,7 +10500,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/findup-sync"
         }
       ]
@@ -10526,7 +10526,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fined"
         }
       ]
@@ -10552,7 +10552,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/flagged-respawn"
         }
       ]
@@ -10578,7 +10578,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fn.name"
         }
       ]
@@ -10604,7 +10604,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fontkit"
         }
       ]
@@ -10630,7 +10630,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/for-each"
         }
       ]
@@ -10656,7 +10656,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/for-in"
         }
       ]
@@ -10682,7 +10682,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/for-own"
         }
       ]
@@ -10708,7 +10708,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/foreachasync"
         }
       ]
@@ -10734,7 +10734,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/forever-agent"
         }
       ]
@@ -10760,7 +10760,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/form-data"
         }
       ]
@@ -10786,7 +10786,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/formatio"
         }
       ]
@@ -10812,7 +10812,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/forwarded"
         }
       ]
@@ -10838,7 +10838,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fragment-cache"
         }
       ]
@@ -10864,7 +10864,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fresh"
         }
       ]
@@ -10890,7 +10890,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/from2"
         }
       ]
@@ -10916,7 +10916,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fs-constants"
         }
       ]
@@ -10942,7 +10942,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fs-extra"
         }
       ]
@@ -10968,7 +10968,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fs-minipass"
         }
       ]
@@ -10994,7 +10994,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fs.realpath"
         }
       ]
@@ -11020,7 +11020,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fstream"
         }
       ],
@@ -11046,7 +11046,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/fstream\\node_modules\\mkdirp"
             }
           ]
@@ -11072,7 +11072,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/fstream\\node_modules\\rimraf"
             }
           ]
@@ -11100,7 +11100,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/function-bind"
         }
       ]
@@ -11126,7 +11126,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/function.prototype.name"
         }
       ]
@@ -11152,7 +11152,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/functions-have-names"
         }
       ]
@@ -11178,7 +11178,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fuzzball"
         }
       ]
@@ -11204,7 +11204,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/gauge"
         }
       ]
@@ -11230,7 +11230,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/geojson-utils"
         }
       ]
@@ -11256,7 +11256,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-caller-file"
         }
       ]
@@ -11282,7 +11282,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-intrinsic"
         }
       ]
@@ -11308,7 +11308,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-stream"
         }
       ]
@@ -11334,7 +11334,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-symbol-description"
         }
       ]
@@ -11360,7 +11360,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-value"
         }
       ]
@@ -11386,7 +11386,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/getobject"
         }
       ]
@@ -11412,7 +11412,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/getpass"
         }
       ]
@@ -11438,7 +11438,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/github-from-package"
         }
       ]
@@ -11464,7 +11464,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/glob-parent"
         }
       ],
@@ -11490,7 +11490,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/glob-parent\\node_modules\\is-glob"
             }
           ]
@@ -11518,7 +11518,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/glob"
         }
       ],
@@ -11544,7 +11544,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/glob\\node_modules\\brace-expansion"
             }
           ]
@@ -11570,7 +11570,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/glob\\node_modules\\minimatch"
             }
           ]
@@ -11598,7 +11598,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/global-modules"
         }
       ]
@@ -11624,7 +11624,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/global-prefix"
         }
       ],
@@ -11650,7 +11650,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/global-prefix\\node_modules\\which"
             }
           ]
@@ -11678,7 +11678,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/got"
         }
       ],
@@ -11704,7 +11704,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/got\\node_modules\\get-stream"
             }
           ]
@@ -11730,7 +11730,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/got\\node_modules\\pify"
             }
           ]
@@ -11758,7 +11758,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/graceful-fs"
         }
       ]
@@ -11784,7 +11784,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-cli"
         }
       ],
@@ -11810,7 +11810,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-cli\\node_modules\\nopt"
             }
           ]
@@ -11838,7 +11838,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-contrib-compress"
         }
       ],
@@ -11864,7 +11864,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-contrib-compress\\node_modules\\ansi-styles"
             }
           ]
@@ -11890,7 +11890,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-contrib-compress\\node_modules\\chalk"
             }
           ]
@@ -11916,7 +11916,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-contrib-compress\\node_modules\\supports-color"
             }
           ]
@@ -11944,7 +11944,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-known-options"
         }
       ]
@@ -11970,7 +11970,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-legacy-log-utils"
         }
       ],
@@ -11996,7 +11996,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils\\node_modules\\ansi-styles"
             }
           ]
@@ -12022,7 +12022,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils\\node_modules\\chalk"
             }
           ]
@@ -12048,7 +12048,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils\\node_modules\\color-convert"
             }
           ]
@@ -12074,7 +12074,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils\\node_modules\\color-name"
             }
           ]
@@ -12100,7 +12100,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils\\node_modules\\has-flag"
             }
           ]
@@ -12126,7 +12126,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils\\node_modules\\supports-color"
             }
           ]
@@ -12154,7 +12154,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-legacy-log"
         }
       ],
@@ -12180,7 +12180,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log\\node_modules\\colors"
             }
           ]
@@ -12208,7 +12208,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-legacy-util"
         }
       ],
@@ -12234,7 +12234,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-util\\node_modules\\async"
             }
           ]
@@ -12262,7 +12262,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-replace-json"
         }
       ]
@@ -12288,7 +12288,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt"
         }
       ],
@@ -12314,7 +12314,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt\\node_modules\\brace-expansion"
             }
           ]
@@ -12340,7 +12340,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt\\node_modules\\findup-sync"
             }
           ],
@@ -12366,7 +12366,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/grunt\\node_modules\\findup-sync\\node_modules\\glob"
                 }
               ]
@@ -12394,7 +12394,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt\\node_modules\\glob"
             }
           ]
@@ -12420,7 +12420,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt\\node_modules\\minimatch"
             }
           ]
@@ -12448,7 +12448,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/handlebars"
         }
       ],
@@ -12474,7 +12474,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/handlebars\\node_modules\\wordwrap"
             }
           ]
@@ -12502,7 +12502,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/har-schema"
         }
       ]
@@ -12528,7 +12528,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/har-validator"
         }
       ]
@@ -12554,7 +12554,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-ansi"
         }
       ]
@@ -12580,7 +12580,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-bigints"
         }
       ]
@@ -12606,7 +12606,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-flag"
         }
       ]
@@ -12632,7 +12632,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-property-descriptors"
         }
       ]
@@ -12658,7 +12658,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-symbol-support-x"
         }
       ]
@@ -12684,7 +12684,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-symbols"
         }
       ]
@@ -12710,7 +12710,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-to-string-tag-x"
         }
       ]
@@ -12736,7 +12736,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-tostringtag"
         }
       ]
@@ -12762,7 +12762,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-unicode"
         }
       ]
@@ -12788,7 +12788,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-value"
         }
       ]
@@ -12814,7 +12814,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-values"
         }
       ],
@@ -12840,7 +12840,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/has-values\\node_modules\\kind-of"
             }
           ]
@@ -12868,7 +12868,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has"
         }
       ]
@@ -12894,7 +12894,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hashids"
         }
       ]
@@ -12920,7 +12920,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hbs"
         }
       ]
@@ -12946,7 +12946,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/he"
         }
       ]
@@ -12972,7 +12972,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/heap"
         }
       ]
@@ -12998,7 +12998,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/helmet"
         }
       ]
@@ -13024,7 +13024,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hoister"
         }
       ]
@@ -13050,7 +13050,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/homedir-polyfill"
         }
       ]
@@ -13076,7 +13076,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hooker"
         }
       ]
@@ -13102,7 +13102,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hosted-git-info"
         }
       ]
@@ -13128,7 +13128,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/html-entities"
         }
       ]
@@ -13154,7 +13154,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/htmlparser2"
         }
       ],
@@ -13180,7 +13180,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/htmlparser2\\node_modules\\isarray"
             }
           ]
@@ -13206,7 +13206,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/htmlparser2\\node_modules\\readable-stream"
             }
           ]
@@ -13232,7 +13232,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/htmlparser2\\node_modules\\string_decoder"
             }
           ]
@@ -13260,7 +13260,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/http-cache-semantics"
         }
       ]
@@ -13286,7 +13286,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/http-errors"
         }
       ]
@@ -13312,7 +13312,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/http-proxy-agent"
         }
       ],
@@ -13338,7 +13338,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/http-proxy-agent\\node_modules\\debug"
             }
           ]
@@ -13364,7 +13364,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/http-proxy-agent\\node_modules\\ms"
             }
           ]
@@ -13392,7 +13392,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/http-signature"
         }
       ]
@@ -13418,7 +13418,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/https-proxy-agent"
         }
       ],
@@ -13444,7 +13444,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/https-proxy-agent\\node_modules\\debug"
             }
           ]
@@ -13470,7 +13470,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/https-proxy-agent\\node_modules\\ms"
             }
           ]
@@ -13498,7 +13498,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/humanize-ms"
         }
       ]
@@ -13524,7 +13524,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/i18n"
         }
       ]
@@ -13550,7 +13550,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/iconv-lite"
         }
       ]
@@ -13576,7 +13576,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ieee754"
         }
       ]
@@ -13602,7 +13602,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ignore-walk"
         }
       ],
@@ -13628,7 +13628,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/ignore-walk\\node_modules\\brace-expansion"
             }
           ]
@@ -13654,7 +13654,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/ignore-walk\\node_modules\\minimatch"
             }
           ]
@@ -13682,7 +13682,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/iltorb"
         }
       ]
@@ -13708,7 +13708,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/imurmurhash"
         }
       ]
@@ -13734,7 +13734,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/indent-string"
         }
       ]
@@ -13760,7 +13760,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/infer-owner"
         }
       ]
@@ -13786,7 +13786,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/inflection"
         }
       ]
@@ -13812,7 +13812,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/inflight"
         }
       ]
@@ -13838,7 +13838,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/inherits"
         }
       ]
@@ -13864,7 +13864,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ini"
         }
       ]
@@ -13890,7 +13890,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/internal-slot"
         }
       ]
@@ -13916,7 +13916,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/interpret"
         }
       ]
@@ -13942,7 +13942,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/into-stream"
         }
       ]
@@ -13968,7 +13968,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/invariant"
         }
       ]
@@ -13994,7 +13994,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ip"
         }
       ]
@@ -14020,7 +14020,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ip6"
         }
       ]
@@ -14046,7 +14046,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ipaddr.js"
         }
       ]
@@ -14072,7 +14072,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-absolute"
         }
       ]
@@ -14098,7 +14098,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-accessor-descriptor"
         }
       ]
@@ -14124,7 +14124,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-arguments"
         }
       ]
@@ -14150,7 +14150,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-arrayish"
         }
       ]
@@ -14176,7 +14176,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-bigint"
         }
       ]
@@ -14202,7 +14202,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-binary-path"
         }
       ]
@@ -14228,7 +14228,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-boolean-object"
         }
       ]
@@ -14254,7 +14254,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-buffer"
         }
       ]
@@ -14280,7 +14280,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-callable"
         }
       ]
@@ -14306,7 +14306,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-core-module"
         }
       ]
@@ -14332,7 +14332,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-data-descriptor"
         }
       ]
@@ -14358,7 +14358,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-date-object"
         }
       ]
@@ -14384,7 +14384,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-descriptor"
         }
       ]
@@ -14410,7 +14410,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-docker"
         }
       ]
@@ -14436,7 +14436,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-expression"
         }
       ]
@@ -14462,7 +14462,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-extendable"
         }
       ]
@@ -14488,7 +14488,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-extglob"
         }
       ]
@@ -14514,7 +14514,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-fullwidth-code-point"
         }
       ]
@@ -14540,7 +14540,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-generator-function"
         }
       ]
@@ -14566,7 +14566,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-glob"
         }
       ]
@@ -14592,7 +14592,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-heroku"
         }
       ]
@@ -14618,7 +14618,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-lambda"
         }
       ]
@@ -14644,7 +14644,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-map"
         }
       ]
@@ -14670,7 +14670,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-natural-number"
         }
       ]
@@ -14696,7 +14696,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-negative-zero"
         }
       ]
@@ -14722,7 +14722,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-number-like"
         }
       ]
@@ -14748,7 +14748,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-number-object"
         }
       ]
@@ -14774,7 +14774,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-number"
         }
       ],
@@ -14800,7 +14800,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/is-number\\node_modules\\kind-of"
             }
           ]
@@ -14828,7 +14828,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-object"
         }
       ]
@@ -14854,7 +14854,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-plain-obj"
         }
       ]
@@ -14880,7 +14880,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-plain-object"
         }
       ]
@@ -14906,7 +14906,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-promise"
         }
       ]
@@ -14932,7 +14932,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-regex"
         }
       ]
@@ -14958,7 +14958,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-relative"
         }
       ]
@@ -14984,7 +14984,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-retry-allowed"
         }
       ]
@@ -15010,7 +15010,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-set"
         }
       ]
@@ -15036,7 +15036,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-shared-array-buffer"
         }
       ]
@@ -15062,7 +15062,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-stream"
         }
       ]
@@ -15088,7 +15088,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-string"
         }
       ]
@@ -15114,7 +15114,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-symbol"
         }
       ]
@@ -15140,7 +15140,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-typed-array"
         }
       ]
@@ -15166,7 +15166,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-typedarray"
         }
       ]
@@ -15192,7 +15192,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-unc-path"
         }
       ]
@@ -15218,7 +15218,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-weakmap"
         }
       ]
@@ -15244,7 +15244,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-weakref"
         }
       ]
@@ -15270,7 +15270,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-weakset"
         }
       ]
@@ -15296,7 +15296,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-windows"
         }
       ]
@@ -15322,7 +15322,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isarray"
         }
       ]
@@ -15348,7 +15348,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isexe"
         }
       ]
@@ -15374,7 +15374,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isobject"
         }
       ]
@@ -15400,7 +15400,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isstream"
         }
       ]
@@ -15426,7 +15426,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isurl"
         }
       ]
@@ -15452,7 +15452,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/js-stringify"
         }
       ]
@@ -15478,7 +15478,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/js-tokens"
         }
       ]
@@ -15504,7 +15504,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/js-yaml"
         }
       ]
@@ -15530,7 +15530,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jsbn"
         }
       ]
@@ -15556,7 +15556,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-buffer"
         }
       ]
@@ -15582,7 +15582,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-parse-better-errors"
         }
       ]
@@ -15608,7 +15608,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-schema-traverse"
         }
       ]
@@ -15634,7 +15634,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-schema"
         }
       ]
@@ -15660,7 +15660,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-stringify-safe"
         }
       ]
@@ -15686,7 +15686,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json5"
         }
       ]
@@ -15712,7 +15712,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jsonfile"
         }
       ]
@@ -15738,7 +15738,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jsonwebtoken"
         }
       ]
@@ -15764,7 +15764,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jsprim"
         }
       ]
@@ -15790,7 +15790,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jssha"
         }
       ]
@@ -15816,7 +15816,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jstransformer"
         }
       ]
@@ -15842,7 +15842,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/juicy-chat-bot"
         }
       ]
@@ -15868,7 +15868,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jwa"
         }
       ]
@@ -15894,7 +15894,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jws"
         }
       ]
@@ -15920,7 +15920,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/keyv"
         }
       ]
@@ -15946,7 +15946,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/kind-of"
         }
       ]
@@ -15972,7 +15972,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/kuler"
         }
       ]
@@ -15998,7 +15998,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/kuromoji"
         }
       ]
@@ -16024,7 +16024,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lazystream"
         }
       ]
@@ -16050,7 +16050,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/levn"
         }
       ]
@@ -16076,7 +16076,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/libxmljs2"
         }
       ],
@@ -16102,7 +16102,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/libxmljs2\\node_modules\\nan"
             }
           ]
@@ -16130,7 +16130,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/liftup"
         }
       ],
@@ -16156,7 +16156,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup\\node_modules\\braces"
             }
           ]
@@ -16182,7 +16182,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup\\node_modules\\fill-range"
             }
           ]
@@ -16208,7 +16208,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup\\node_modules\\findup-sync"
             }
           ]
@@ -16234,7 +16234,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup\\node_modules\\is-glob"
             }
           ]
@@ -16260,7 +16260,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup\\node_modules\\is-number"
             }
           ]
@@ -16286,7 +16286,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup\\node_modules\\micromatch"
             }
           ]
@@ -16312,7 +16312,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup\\node_modules\\to-regex-range"
             }
           ]
@@ -16340,7 +16340,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/linebreak"
         }
       ],
@@ -16366,7 +16366,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/linebreak\\node_modules\\base64-js"
             }
           ]
@@ -16394,7 +16394,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/listenercount"
         }
       ]
@@ -16420,7 +16420,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/locate-path"
         }
       ]
@@ -16446,7 +16446,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lodash.camelcase"
         }
       ]
@@ -16472,7 +16472,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lodash.isfinite"
         }
       ]
@@ -16498,7 +16498,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lodash.set"
         }
       ]
@@ -16524,7 +16524,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lodash"
         }
       ]
@@ -16550,7 +16550,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/logform"
         }
       ],
@@ -16576,7 +16576,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/logform\\node_modules\\ms"
             }
           ]
@@ -16604,7 +16604,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lolex"
         }
       ]
@@ -16630,7 +16630,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/loose-envify"
         }
       ]
@@ -16656,7 +16656,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lowercase-keys"
         }
       ]
@@ -16682,7 +16682,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lru-cache"
         }
       ]
@@ -16708,7 +16708,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-dir"
         }
       ],
@@ -16734,7 +16734,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-dir\\node_modules\\semver"
             }
           ]
@@ -16762,7 +16762,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-error"
         }
       ]
@@ -16788,7 +16788,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-fetch-happen"
         }
       ],
@@ -16815,7 +16815,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen\\node_modules\\@tootallnate\\once"
             }
           ]
@@ -16841,7 +16841,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen\\node_modules\\debug"
             }
           ]
@@ -16867,7 +16867,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen\\node_modules\\http-cache-semantics"
             }
           ]
@@ -16893,7 +16893,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen\\node_modules\\http-proxy-agent"
             }
           ]
@@ -16919,7 +16919,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen\\node_modules\\ms"
             }
           ]
@@ -16947,7 +16947,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-iterator"
         }
       ]
@@ -16973,7 +16973,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-plural"
         }
       ]
@@ -16999,7 +16999,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/map-cache"
         }
       ]
@@ -17025,7 +17025,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/map-visit"
         }
       ]
@@ -17051,7 +17051,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/marsdb"
         }
       ]
@@ -17077,7 +17077,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/math-interval-parser"
         }
       ]
@@ -17103,7 +17103,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/media-typer"
         }
       ]
@@ -17129,7 +17129,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/merge-descriptors"
         }
       ]
@@ -17155,7 +17155,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/messageformat-formatters"
         }
       ]
@@ -17181,7 +17181,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/messageformat-parser"
         }
       ]
@@ -17207,7 +17207,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/messageformat"
         }
       ],
@@ -17233,7 +17233,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/messageformat\\node_modules\\make-plural"
             }
           ]
@@ -17261,7 +17261,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/methods"
         }
       ]
@@ -17287,7 +17287,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/micromatch"
         }
       ]
@@ -17313,7 +17313,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mime-db"
         }
       ]
@@ -17339,7 +17339,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mime-types"
         }
       ]
@@ -17365,7 +17365,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mime"
         }
       ]
@@ -17391,7 +17391,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mimic-response"
         }
       ]
@@ -17417,7 +17417,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minimatch"
         }
       ]
@@ -17443,7 +17443,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minimist"
         }
       ]
@@ -17469,7 +17469,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-collect"
         }
       ]
@@ -17495,7 +17495,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-fetch"
         }
       ]
@@ -17521,7 +17521,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-flush"
         }
       ]
@@ -17547,7 +17547,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-pipeline"
         }
       ]
@@ -17573,7 +17573,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-sized"
         }
       ]
@@ -17599,7 +17599,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass"
         }
       ]
@@ -17625,7 +17625,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minizlib"
         }
       ]
@@ -17651,7 +17651,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mixin-deep"
         }
       ]
@@ -17677,7 +17677,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mkdirp-classic"
         }
       ]
@@ -17703,7 +17703,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mkdirp"
         }
       ]
@@ -17729,7 +17729,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/moment-timezone"
         }
       ]
@@ -17755,7 +17755,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/moment"
         }
       ]
@@ -17781,7 +17781,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/morgan"
         }
       ],
@@ -17807,7 +17807,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/morgan\\node_modules\\on-finished"
             }
           ]
@@ -17835,7 +17835,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mout"
         }
       ]
@@ -17861,7 +17861,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ms"
         }
       ]
@@ -17887,7 +17887,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/multer"
         }
       ],
@@ -17913,7 +17913,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/multer\\node_modules\\mkdirp"
             }
           ]
@@ -17941,7 +17941,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mustache"
         }
       ]
@@ -17967,7 +17967,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/nan"
         }
       ]
@@ -17993,7 +17993,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/nanomatch"
         }
       ]
@@ -18019,7 +18019,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/napi-build-utils"
         }
       ]
@@ -18045,7 +18045,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/needle"
         }
       ],
@@ -18071,7 +18071,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/needle\\node_modules\\debug"
             }
           ]
@@ -18097,7 +18097,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/needle\\node_modules\\ms"
             }
           ]
@@ -18125,7 +18125,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/negotiator"
         }
       ]
@@ -18151,7 +18151,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/neo-async"
         }
       ]
@@ -18177,7 +18177,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-abi"
         }
       ],
@@ -18203,7 +18203,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-abi\\node_modules\\semver"
             }
           ]
@@ -18231,7 +18231,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-addon-api"
         }
       ]
@@ -18257,7 +18257,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-fetch"
         }
       ]
@@ -18283,7 +18283,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-gyp"
         }
       ],
@@ -18309,7 +18309,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp\\node_modules\\ansi-regex"
             }
           ]
@@ -18335,7 +18335,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp\\node_modules\\are-we-there-yet"
             }
           ]
@@ -18361,7 +18361,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp\\node_modules\\gauge"
             }
           ]
@@ -18387,7 +18387,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp\\node_modules\\is-fullwidth-code-point"
             }
           ]
@@ -18413,7 +18413,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp\\node_modules\\nopt"
             }
           ]
@@ -18439,7 +18439,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp\\node_modules\\npmlog"
             }
           ]
@@ -18465,7 +18465,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp\\node_modules\\readable-stream"
             }
           ]
@@ -18491,7 +18491,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp\\node_modules\\string-width"
             }
           ]
@@ -18517,7 +18517,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp\\node_modules\\strip-ansi"
             }
           ]
@@ -18545,7 +18545,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-pre-gyp"
         }
       ],
@@ -18571,7 +18571,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp\\node_modules\\chownr"
             }
           ]
@@ -18597,7 +18597,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp\\node_modules\\fs-minipass"
             }
           ]
@@ -18623,7 +18623,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp\\node_modules\\minipass"
             }
           ]
@@ -18649,7 +18649,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp\\node_modules\\minizlib"
             }
           ]
@@ -18675,7 +18675,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp\\node_modules\\mkdirp"
             }
           ]
@@ -18701,7 +18701,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp\\node_modules\\nopt"
             }
           ]
@@ -18727,7 +18727,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp\\node_modules\\rimraf"
             }
           ]
@@ -18753,7 +18753,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp\\node_modules\\safe-buffer"
             }
           ]
@@ -18779,7 +18779,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp\\node_modules\\semver"
             }
           ]
@@ -18805,7 +18805,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp\\node_modules\\tar"
             }
           ]
@@ -18831,7 +18831,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp\\node_modules\\yallist"
             }
           ]
@@ -18859,7 +18859,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/noop-logger"
         }
       ]
@@ -18885,7 +18885,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/nopt"
         }
       ]
@@ -18911,7 +18911,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/normalize-package-data"
         }
       ],
@@ -18937,7 +18937,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/normalize-package-data\\node_modules\\semver"
             }
           ]
@@ -18965,7 +18965,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/normalize-path"
         }
       ]
@@ -18991,7 +18991,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/normalize-url"
         }
       ]
@@ -19017,7 +19017,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/notevil"
         }
       ],
@@ -19043,7 +19043,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/notevil\\node_modules\\esprima"
             }
           ]
@@ -19071,7 +19071,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/npm-bundled"
         }
       ]
@@ -19097,7 +19097,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/npm-normalize-package-bin"
         }
       ]
@@ -19123,7 +19123,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/npm-packlist"
         }
       ]
@@ -19149,7 +19149,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/npmlog"
         }
       ]
@@ -19175,7 +19175,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/number-is-nan"
         }
       ]
@@ -19201,7 +19201,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/oauth-sign"
         }
       ]
@@ -19227,7 +19227,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-assign"
         }
       ]
@@ -19253,7 +19253,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-copy"
         }
       ],
@@ -19279,7 +19279,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy\\node_modules\\define-property"
             }
           ]
@@ -19305,7 +19305,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy\\node_modules\\is-accessor-descriptor"
             }
           ]
@@ -19331,7 +19331,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy\\node_modules\\is-data-descriptor"
             }
           ]
@@ -19357,7 +19357,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy\\node_modules\\is-descriptor"
             }
           ],
@@ -19383,7 +19383,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/object-copy\\node_modules\\is-descriptor\\node_modules\\kind-of"
                 }
               ]
@@ -19411,7 +19411,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy\\node_modules\\kind-of"
             }
           ]
@@ -19439,7 +19439,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-inspect"
         }
       ]
@@ -19465,7 +19465,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-is"
         }
       ]
@@ -19491,7 +19491,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-keys"
         }
       ]
@@ -19517,7 +19517,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-visit"
         }
       ]
@@ -19543,7 +19543,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object.assign"
         }
       ]
@@ -19569,7 +19569,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object.defaults"
         }
       ]
@@ -19595,7 +19595,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object.map"
         }
       ]
@@ -19621,7 +19621,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object.pick"
         }
       ]
@@ -19647,7 +19647,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/on-finished"
         }
       ]
@@ -19673,7 +19673,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/on-headers"
         }
       ]
@@ -19699,7 +19699,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/once"
         }
       ]
@@ -19725,7 +19725,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/one-time"
         }
       ]
@@ -19751,7 +19751,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/opentype.js"
         }
       ]
@@ -19777,7 +19777,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/optionator"
         }
       ]
@@ -19803,7 +19803,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/os-homedir"
         }
       ]
@@ -19829,7 +19829,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/os-tmpdir"
         }
       ]
@@ -19855,7 +19855,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/osenv"
         }
       ]
@@ -19881,7 +19881,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/otplib"
         }
       ]
@@ -19907,7 +19907,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-cancelable"
         }
       ]
@@ -19933,7 +19933,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-event"
         }
       ]
@@ -19959,7 +19959,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-finally"
         }
       ]
@@ -19985,7 +19985,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-is-promise"
         }
       ]
@@ -20011,7 +20011,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-limit"
         }
       ]
@@ -20037,7 +20037,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-locate"
         }
       ]
@@ -20063,7 +20063,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-map"
         }
       ]
@@ -20089,7 +20089,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-timeout"
         }
       ]
@@ -20115,7 +20115,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-try"
         }
       ]
@@ -20141,7 +20141,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pako"
         }
       ]
@@ -20167,7 +20167,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/parse-filepath"
         }
       ]
@@ -20193,7 +20193,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/parse-json"
         }
       ]
@@ -20219,7 +20219,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/parse-passwd"
         }
       ]
@@ -20245,7 +20245,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/parseurl"
         }
       ]
@@ -20271,7 +20271,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pascalcase"
         }
       ]
@@ -20297,7 +20297,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-exists"
         }
       ]
@@ -20323,7 +20323,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-is-absolute"
         }
       ]
@@ -20349,7 +20349,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-parse"
         }
       ]
@@ -20375,7 +20375,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-root-regex"
         }
       ]
@@ -20401,7 +20401,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-root"
         }
       ]
@@ -20427,7 +20427,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-to-regexp"
         }
       ]
@@ -20453,7 +20453,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pdfkit"
         }
       ]
@@ -20479,7 +20479,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/peek-readable"
         }
       ]
@@ -20505,7 +20505,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pend"
         }
       ]
@@ -20531,7 +20531,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/performance-now"
         }
       ]
@@ -20557,7 +20557,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pg-connection-string"
         }
       ]
@@ -20583,7 +20583,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/picomatch"
         }
       ]
@@ -20609,7 +20609,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pify"
         }
       ]
@@ -20635,7 +20635,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pinkie-promise"
         }
       ]
@@ -20661,7 +20661,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pinkie"
         }
       ]
@@ -20687,7 +20687,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/png-js"
         }
       ]
@@ -20713,7 +20713,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/portscanner"
         }
       ]
@@ -20739,7 +20739,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/posix-character-classes"
         }
       ]
@@ -20765,7 +20765,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/prebuild-install"
         }
       ]
@@ -20791,7 +20791,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/prelude-ls"
         }
       ]
@@ -20817,7 +20817,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/prepend-http"
         }
       ]
@@ -20843,7 +20843,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pretty-bytes"
         }
       ]
@@ -20869,7 +20869,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/process-nextick-args"
         }
       ]
@@ -20895,7 +20895,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/prom-client"
         }
       ]
@@ -20921,7 +20921,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/promise-inflight"
         }
       ]
@@ -20947,7 +20947,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/promise-retry"
         }
       ],
@@ -20973,7 +20973,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/promise-retry\\node_modules\\err-code"
             }
           ]
@@ -20999,7 +20999,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/promise-retry\\node_modules\\retry"
             }
           ]
@@ -21027,7 +21027,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/promise"
         }
       ]
@@ -21053,7 +21053,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/proper-lockfile"
         }
       ]
@@ -21079,7 +21079,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/proxy-addr"
         }
       ]
@@ -21105,7 +21105,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/psl"
         }
       ]
@@ -21131,7 +21131,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-attrs"
         }
       ]
@@ -21157,7 +21157,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-code-gen"
         }
       ]
@@ -21183,7 +21183,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-error"
         }
       ]
@@ -21209,7 +21209,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-filters"
         }
       ]
@@ -21235,7 +21235,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-lexer"
         }
       ]
@@ -21261,7 +21261,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-linker"
         }
       ]
@@ -21287,7 +21287,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-load"
         }
       ]
@@ -21313,7 +21313,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-parser"
         }
       ]
@@ -21339,7 +21339,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-runtime"
         }
       ]
@@ -21365,7 +21365,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-strip-comments"
         }
       ]
@@ -21391,7 +21391,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-walk"
         }
       ]
@@ -21417,7 +21417,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug"
         }
       ]
@@ -21443,7 +21443,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pump"
         }
       ]
@@ -21469,7 +21469,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/punycode"
         }
       ]
@@ -21495,7 +21495,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/qs"
         }
       ]
@@ -21521,7 +21521,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/query-string"
         }
       ]
@@ -21547,7 +21547,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/range_check"
         }
       ]
@@ -21573,7 +21573,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/range-parser"
         }
       ]
@@ -21599,7 +21599,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/raw-body"
         }
       ]
@@ -21625,7 +21625,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/rc"
         }
       ]
@@ -21651,7 +21651,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/read-pkg"
         }
       ],
@@ -21677,7 +21677,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/read-pkg\\node_modules\\pify"
             }
           ]
@@ -21705,7 +21705,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/readable-stream"
         }
       ],
@@ -21731,7 +21731,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/readable-stream\\node_modules\\isarray"
             }
           ]
@@ -21759,7 +21759,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/readable-web-to-node-stream"
         }
       ],
@@ -21785,7 +21785,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/readable-web-to-node-stream\\node_modules\\readable-stream"
             }
           ]
@@ -21813,7 +21813,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/readdirp"
         }
       ]
@@ -21839,7 +21839,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/rechoir"
         }
       ]
@@ -21865,7 +21865,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/regex-not"
         }
       ]
@@ -21891,7 +21891,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/regexp.prototype.flags"
         }
       ]
@@ -21917,7 +21917,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/remove-trailing-separator"
         }
       ]
@@ -21943,7 +21943,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/repeat-element"
         }
       ]
@@ -21969,7 +21969,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/repeat-string"
         }
       ]
@@ -21995,7 +21995,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/replace"
         }
       ],
@@ -22021,7 +22021,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\ansi-regex"
             }
           ]
@@ -22047,7 +22047,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\ansi-styles"
             }
           ]
@@ -22073,7 +22073,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\brace-expansion"
             }
           ]
@@ -22099,7 +22099,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\cliui"
             }
           ]
@@ -22125,7 +22125,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\color-convert"
             }
           ]
@@ -22151,7 +22151,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\color-name"
             }
           ]
@@ -22177,7 +22177,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\find-up"
             }
           ]
@@ -22203,7 +22203,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\is-fullwidth-code-point"
             }
           ]
@@ -22229,7 +22229,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\locate-path"
             }
           ]
@@ -22255,7 +22255,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\minimatch"
             }
           ]
@@ -22281,7 +22281,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\p-locate"
             }
           ]
@@ -22307,7 +22307,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\path-exists"
             }
           ]
@@ -22333,7 +22333,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\string-width"
             }
           ]
@@ -22359,7 +22359,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\strip-ansi"
             }
           ]
@@ -22385,7 +22385,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\wrap-ansi"
             }
           ]
@@ -22411,7 +22411,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\yargs-parser"
             }
           ]
@@ -22437,7 +22437,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\yargs"
             }
           ]
@@ -22465,7 +22465,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/request"
         }
       ],
@@ -22491,7 +22491,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/request\\node_modules\\qs"
             }
           ]
@@ -22519,7 +22519,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/require-directory"
         }
       ]
@@ -22545,7 +22545,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/require-main-filename"
         }
       ]
@@ -22571,7 +22571,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/resolve-dir"
         }
       ]
@@ -22597,7 +22597,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/resolve-url"
         }
       ]
@@ -22623,7 +22623,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/resolve"
         }
       ]
@@ -22649,7 +22649,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/responselike"
         }
       ]
@@ -22675,7 +22675,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/restructure"
         }
       ]
@@ -22701,7 +22701,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ret"
         }
       ]
@@ -22727,7 +22727,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/retry-as-promised"
         }
       ]
@@ -22753,7 +22753,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/retry"
         }
       ]
@@ -22779,7 +22779,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/rimraf"
         }
       ]
@@ -22805,7 +22805,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/rxjs"
         }
       ],
@@ -22831,7 +22831,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/rxjs\\node_modules\\tslib"
             }
           ]
@@ -22859,7 +22859,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safe-buffer"
         }
       ]
@@ -22885,7 +22885,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safe-regex-test"
         }
       ]
@@ -22911,7 +22911,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safe-regex"
         }
       ]
@@ -22937,7 +22937,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safe-stable-stringify"
         }
       ]
@@ -22963,7 +22963,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safer-buffer"
         }
       ]
@@ -22989,7 +22989,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/samsam"
         }
       ]
@@ -23015,7 +23015,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sanitize-filename"
         }
       ]
@@ -23041,7 +23041,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sanitize-html"
         }
       ],
@@ -23067,7 +23067,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sanitize-html\\node_modules\\lodash"
             }
           ]
@@ -23095,7 +23095,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sax"
         }
       ]
@@ -23121,7 +23121,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/seek-bzip"
         }
       ]
@@ -23147,7 +23147,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/semver"
         }
       ]
@@ -23173,7 +23173,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/send"
         }
       ],
@@ -23199,7 +23199,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/send\\node_modules\\ms"
             }
           ]
@@ -23227,7 +23227,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sequelize-pool"
         }
       ]
@@ -23253,7 +23253,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sequelize"
         }
       ],
@@ -23279,7 +23279,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sequelize\\node_modules\\debug"
             }
           ]
@@ -23305,7 +23305,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sequelize\\node_modules\\ms"
             }
           ]
@@ -23331,7 +23331,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sequelize\\node_modules\\uuid"
             }
           ]
@@ -23359,7 +23359,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/serve-index"
         }
       ],
@@ -23385,7 +23385,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index\\node_modules\\depd"
             }
           ]
@@ -23411,7 +23411,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index\\node_modules\\http-errors"
             }
           ]
@@ -23437,7 +23437,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index\\node_modules\\inherits"
             }
           ]
@@ -23463,7 +23463,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index\\node_modules\\setprototypeof"
             }
           ]
@@ -23489,7 +23489,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index\\node_modules\\statuses"
             }
           ]
@@ -23517,7 +23517,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/serve-static"
         }
       ]
@@ -23543,7 +23543,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/set-blocking"
         }
       ]
@@ -23569,7 +23569,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/set-value"
         }
       ],
@@ -23595,7 +23595,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/set-value\\node_modules\\extend-shallow"
             }
           ]
@@ -23621,7 +23621,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/set-value\\node_modules\\is-extendable"
             }
           ]
@@ -23649,7 +23649,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/setimmediate"
         }
       ]
@@ -23675,7 +23675,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/setprototypeof"
         }
       ]
@@ -23701,7 +23701,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/side-channel"
         }
       ]
@@ -23727,7 +23727,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/signal-exit"
         }
       ]
@@ -23753,7 +23753,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/simple-concat"
         }
       ]
@@ -23779,7 +23779,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/simple-get"
         }
       ],
@@ -23805,7 +23805,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/simple-get\\node_modules\\decompress-response"
             }
           ]
@@ -23831,7 +23831,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/simple-get\\node_modules\\mimic-response"
             }
           ]
@@ -23859,7 +23859,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/simple-swizzle"
         }
       ],
@@ -23885,7 +23885,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/simple-swizzle\\node_modules\\is-arrayish"
             }
           ]
@@ -23913,7 +23913,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sinon"
         }
       ]
@@ -23939,7 +23939,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/smart-buffer"
         }
       ]
@@ -23965,7 +23965,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/snapdragon-node"
         }
       ],
@@ -23991,7 +23991,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon-node\\node_modules\\define-property"
             }
           ]
@@ -24019,7 +24019,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/snapdragon-util"
         }
       ],
@@ -24045,7 +24045,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon-util\\node_modules\\kind-of"
             }
           ]
@@ -24073,7 +24073,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/snapdragon"
         }
       ],
@@ -24099,7 +24099,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon\\node_modules\\define-property"
             }
           ]
@@ -24125,7 +24125,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon\\node_modules\\extend-shallow"
             }
           ]
@@ -24151,7 +24151,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon\\node_modules\\is-accessor-descriptor"
             }
           ],
@@ -24177,7 +24177,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/snapdragon\\node_modules\\is-accessor-descriptor\\node_modules\\kind-of"
                 }
               ]
@@ -24205,7 +24205,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon\\node_modules\\is-data-descriptor"
             }
           ],
@@ -24231,7 +24231,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/snapdragon\\node_modules\\is-data-descriptor\\node_modules\\kind-of"
                 }
               ]
@@ -24259,7 +24259,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon\\node_modules\\is-descriptor"
             }
           ]
@@ -24285,7 +24285,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon\\node_modules\\is-extendable"
             }
           ]
@@ -24311,7 +24311,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon\\node_modules\\kind-of"
             }
           ]
@@ -24337,7 +24337,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon\\node_modules\\source-map"
             }
           ]
@@ -24365,7 +24365,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socket.io-adapter"
         }
       ]
@@ -24391,7 +24391,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socket.io-parser"
         }
       ],
@@ -24417,7 +24417,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socket.io-parser\\node_modules\\debug"
             }
           ]
@@ -24443,7 +24443,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socket.io-parser\\node_modules\\ms"
             }
           ]
@@ -24471,7 +24471,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socket.io"
         }
       ],
@@ -24497,7 +24497,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socket.io\\node_modules\\debug"
             }
           ]
@@ -24523,7 +24523,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socket.io\\node_modules\\ms"
             }
           ]
@@ -24551,7 +24551,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socks-proxy-agent"
         }
       ],
@@ -24577,7 +24577,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socks-proxy-agent\\node_modules\\debug"
             }
           ]
@@ -24603,7 +24603,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socks-proxy-agent\\node_modules\\ms"
             }
           ]
@@ -24631,7 +24631,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socks"
         }
       ],
@@ -24657,7 +24657,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socks\\node_modules\\ip"
             }
           ]
@@ -24685,7 +24685,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sort-keys-length"
         }
       ],
@@ -24711,7 +24711,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sort-keys-length\\node_modules\\sort-keys"
             }
           ]
@@ -24739,7 +24739,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sort-keys"
         }
       ]
@@ -24765,7 +24765,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/source-map-resolve"
         }
       ]
@@ -24791,7 +24791,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/source-map-support"
         }
       ]
@@ -24817,7 +24817,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/source-map-url"
         }
       ]
@@ -24843,7 +24843,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/source-map"
         }
       ]
@@ -24869,7 +24869,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spawn-command"
         }
       ]
@@ -24895,7 +24895,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spdx-correct"
         }
       ]
@@ -24921,7 +24921,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spdx-exceptions"
         }
       ]
@@ -24947,7 +24947,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spdx-expression-parse"
         }
       ]
@@ -24973,7 +24973,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spdx-license-ids"
         }
       ]
@@ -24999,7 +24999,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/split-string"
         }
       ]
@@ -25025,7 +25025,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sprintf-js"
         }
       ]
@@ -25051,7 +25051,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sqlite3"
         }
       ]
@@ -25077,7 +25077,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sshpk"
         }
       ]
@@ -25103,7 +25103,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ssri"
         }
       ]
@@ -25129,7 +25129,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/stack-trace"
         }
       ]
@@ -25155,7 +25155,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/static-extend"
         }
       ],
@@ -25181,7 +25181,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend\\node_modules\\define-property"
             }
           ]
@@ -25207,7 +25207,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend\\node_modules\\is-accessor-descriptor"
             }
           ],
@@ -25233,7 +25233,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/static-extend\\node_modules\\is-accessor-descriptor\\node_modules\\kind-of"
                 }
               ]
@@ -25261,7 +25261,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend\\node_modules\\is-data-descriptor"
             }
           ],
@@ -25287,7 +25287,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/static-extend\\node_modules\\is-data-descriptor\\node_modules\\kind-of"
                 }
               ]
@@ -25315,7 +25315,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend\\node_modules\\is-descriptor"
             }
           ]
@@ -25341,7 +25341,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend\\node_modules\\kind-of"
             }
           ]
@@ -25369,7 +25369,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/statuses"
         }
       ]
@@ -25395,7 +25395,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/stream-buffers"
         }
       ]
@@ -25421,7 +25421,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/streamsearch"
         }
       ]
@@ -25447,7 +25447,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strict-uri-encode"
         }
       ]
@@ -25473,7 +25473,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string_decoder"
         }
       ]
@@ -25499,7 +25499,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string-width"
         }
       ]
@@ -25525,7 +25525,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string.fromcodepoint"
         }
       ]
@@ -25551,7 +25551,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string.prototype.codepointat"
         }
       ]
@@ -25577,7 +25577,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string.prototype.trimend"
         }
       ]
@@ -25603,7 +25603,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string.prototype.trimstart"
         }
       ]
@@ -25629,7 +25629,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-ansi"
         }
       ]
@@ -25655,7 +25655,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-bom"
         }
       ]
@@ -25681,7 +25681,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-dirs"
         }
       ]
@@ -25707,7 +25707,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-json-comments"
         }
       ]
@@ -25733,7 +25733,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-outer"
         }
       ]
@@ -25759,7 +25759,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strtok3"
         }
       ]
@@ -25785,7 +25785,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/supports-color"
         }
       ]
@@ -25811,7 +25811,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/supports-preserve-symlinks-flag"
         }
       ]
@@ -25837,7 +25837,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/svg-captcha"
         }
       ]
@@ -25863,7 +25863,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/swagger-ui-dist"
         }
       ]
@@ -25889,7 +25889,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/swagger-ui-express"
         }
       ]
@@ -25915,7 +25915,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tar-fs"
         }
       ],
@@ -25941,7 +25941,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/tar-fs\\node_modules\\bl"
             }
           ]
@@ -25967,7 +25967,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/tar-fs\\node_modules\\chownr"
             }
           ]
@@ -25993,7 +25993,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/tar-fs\\node_modules\\readable-stream"
             }
           ]
@@ -26019,7 +26019,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/tar-fs\\node_modules\\tar-stream"
             }
           ]
@@ -26047,7 +26047,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tar-stream"
         }
       ]
@@ -26073,7 +26073,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tar"
         }
       ]
@@ -26099,7 +26099,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tdigest"
         }
       ]
@@ -26125,7 +26125,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/text-hex"
         }
       ]
@@ -26151,7 +26151,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/thirty-two"
         }
       ]
@@ -26177,7 +26177,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/through"
         }
       ]
@@ -26203,7 +26203,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/timed-out"
         }
       ]
@@ -26229,7 +26229,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tiny-inflate"
         }
       ]
@@ -26255,7 +26255,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-buffer"
         }
       ]
@@ -26281,7 +26281,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-fast-properties"
         }
       ]
@@ -26307,7 +26307,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-object-path"
         }
       ],
@@ -26333,7 +26333,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/to-object-path\\node_modules\\kind-of"
             }
           ]
@@ -26361,7 +26361,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-regex-range"
         }
       ]
@@ -26387,7 +26387,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-regex"
         }
       ]
@@ -26413,7 +26413,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/toidentifier"
         }
       ]
@@ -26439,7 +26439,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/token-stream"
         }
       ]
@@ -26465,7 +26465,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/token-types"
         }
       ]
@@ -26491,7 +26491,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/toposort-class"
         }
       ]
@@ -26517,7 +26517,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tough-cookie"
         }
       ]
@@ -26543,7 +26543,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tr46"
         }
       ]
@@ -26569,7 +26569,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/traverse"
         }
       ]
@@ -26595,7 +26595,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tree-kill"
         }
       ]
@@ -26621,7 +26621,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/trim-repeated"
         }
       ]
@@ -26647,7 +26647,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/triple-beam"
         }
       ]
@@ -26673,7 +26673,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/truncate-utf8-bytes"
         }
       ]
@@ -26699,7 +26699,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ts-node-dev"
         }
       ],
@@ -26725,7 +26725,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/ts-node-dev\\node_modules\\rimraf"
             }
           ]
@@ -26753,7 +26753,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ts-node"
         }
       ]
@@ -26779,7 +26779,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tsconfig"
         }
       ]
@@ -26805,7 +26805,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tslib"
         }
       ]
@@ -26831,7 +26831,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tunnel-agent"
         }
       ]
@@ -26857,7 +26857,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tweetnacl"
         }
       ]
@@ -26883,7 +26883,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/type-check"
         }
       ]
@@ -26909,7 +26909,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/type-is"
         }
       ]
@@ -26935,7 +26935,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/typecast"
         }
       ]
@@ -26961,7 +26961,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/typedarray"
         }
       ]
@@ -26987,7 +26987,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/typescript"
         }
       ]
@@ -27013,7 +27013,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/uglify-js"
         }
       ]
@@ -27039,7 +27039,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unbox-primitive"
         }
       ]
@@ -27065,7 +27065,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unbzip2-stream"
         }
       ]
@@ -27091,7 +27091,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unc-path-regex"
         }
       ]
@@ -27117,7 +27117,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/underscore.string"
         }
       ]
@@ -27143,7 +27143,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unicode-properties"
         }
       ]
@@ -27169,7 +27169,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unicode-trie"
         }
       ]
@@ -27195,7 +27195,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/union-value"
         }
       ],
@@ -27221,7 +27221,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/union-value\\node_modules\\is-extendable"
             }
           ]
@@ -27249,7 +27249,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unique-filename"
         }
       ]
@@ -27275,7 +27275,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unique-slug"
         }
       ]
@@ -27301,7 +27301,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unit-compare"
         }
       ]
@@ -27327,7 +27327,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/universalify"
         }
       ]
@@ -27353,7 +27353,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unpipe"
         }
       ]
@@ -27379,7 +27379,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unset-value"
         }
       ],
@@ -27405,7 +27405,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/unset-value\\node_modules\\has-value"
             }
           ],
@@ -27431,7 +27431,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/unset-value\\node_modules\\has-value\\node_modules\\isobject"
                 }
               ]
@@ -27459,7 +27459,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/unset-value\\node_modules\\has-values"
             }
           ]
@@ -27485,7 +27485,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/unset-value\\node_modules\\isarray"
             }
           ]
@@ -27513,7 +27513,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/untildify"
         }
       ]
@@ -27539,7 +27539,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unzipper"
         }
       ],
@@ -27565,7 +27565,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/unzipper\\node_modules\\bluebird"
             }
           ]
@@ -27593,7 +27593,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/uri-js"
         }
       ]
@@ -27619,7 +27619,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/urix"
         }
       ]
@@ -27645,7 +27645,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/url-parse-lax"
         }
       ]
@@ -27671,7 +27671,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/url-to-options"
         }
       ]
@@ -27697,7 +27697,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/use"
         }
       ]
@@ -27723,7 +27723,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/utf8-byte-length"
         }
       ]
@@ -27749,7 +27749,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/util-deprecate"
         }
       ]
@@ -27775,7 +27775,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/util"
         }
       ]
@@ -27801,7 +27801,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/utils-merge"
         }
       ]
@@ -27827,7 +27827,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/uuid"
         }
       ]
@@ -27853,7 +27853,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/v8flags"
         }
       ]
@@ -27879,7 +27879,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/validate-npm-package-license"
         }
       ]
@@ -27905,7 +27905,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/validate"
         }
       ]
@@ -27931,7 +27931,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/validator"
         }
       ]
@@ -27957,7 +27957,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/vary"
         }
       ]
@@ -27983,7 +27983,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/verror"
         }
       ],
@@ -28009,7 +28009,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/verror\\node_modules\\core-util-is"
             }
           ]
@@ -28037,7 +28037,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/vm2"
         }
       ],
@@ -28063,7 +28063,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/vm2\\node_modules\\acorn"
             }
           ]
@@ -28091,7 +28091,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/void-elements"
         }
       ]
@@ -28117,7 +28117,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/walk"
         }
       ]
@@ -28143,7 +28143,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/walkdir"
         }
       ]
@@ -28169,7 +28169,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/webidl-conversions"
         }
       ]
@@ -28195,7 +28195,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/whatwg-url"
         }
       ]
@@ -28221,7 +28221,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-boxed-primitive"
         }
       ]
@@ -28247,7 +28247,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-collection"
         }
       ]
@@ -28273,7 +28273,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-module"
         }
       ]
@@ -28299,7 +28299,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-pm-runs"
         }
       ]
@@ -28325,7 +28325,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-typed-array"
         }
       ]
@@ -28351,7 +28351,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which"
         }
       ]
@@ -28377,7 +28377,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wide-align"
         }
       ]
@@ -28403,7 +28403,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/winston-transport"
         }
       ],
@@ -28429,7 +28429,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/winston-transport\\node_modules\\readable-stream"
             }
           ]
@@ -28457,7 +28457,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/winston"
         }
       ],
@@ -28483,7 +28483,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/winston\\node_modules\\async"
             }
           ]
@@ -28509,7 +28509,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/winston\\node_modules\\is-stream"
             }
           ]
@@ -28535,7 +28535,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/winston\\node_modules\\readable-stream"
             }
           ]
@@ -28563,7 +28563,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/with"
         }
       ]
@@ -28589,7 +28589,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wkx"
         }
       ]
@@ -28615,7 +28615,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/word-wrap"
         }
       ]
@@ -28641,7 +28641,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wordwrap"
         }
       ]
@@ -28667,7 +28667,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wrap-ansi"
         }
       ],
@@ -28693,7 +28693,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi\\node_modules\\ansi-regex"
             }
           ]
@@ -28719,7 +28719,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi\\node_modules\\emoji-regex"
             }
           ]
@@ -28745,7 +28745,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi\\node_modules\\is-fullwidth-code-point"
             }
           ]
@@ -28771,7 +28771,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi\\node_modules\\string-width"
             }
           ]
@@ -28797,7 +28797,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi\\node_modules\\strip-ansi"
             }
           ]
@@ -28825,7 +28825,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wrappy"
         }
       ]
@@ -28851,7 +28851,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ws"
         }
       ]
@@ -28877,7 +28877,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/xtend"
         }
       ]
@@ -28903,7 +28903,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/y18n"
         }
       ]
@@ -28929,7 +28929,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yallist"
         }
       ]
@@ -28955,7 +28955,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yaml-schema-validator"
         }
       ]
@@ -28981,7 +28981,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yargs-parser"
         }
       ]
@@ -29007,7 +29007,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yargs"
         }
       ],
@@ -29033,7 +29033,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs\\node_modules\\ansi-regex"
             }
           ]
@@ -29059,7 +29059,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs\\node_modules\\emoji-regex"
             }
           ]
@@ -29085,7 +29085,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs\\node_modules\\is-fullwidth-code-point"
             }
           ]
@@ -29111,7 +29111,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs\\node_modules\\string-width"
             }
           ]
@@ -29137,7 +29137,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs\\node_modules\\strip-ansi"
             }
           ]
@@ -29165,7 +29165,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yauzl"
         }
       ]
@@ -29191,7 +29191,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yn"
         }
       ]
@@ -29217,7 +29217,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/z85"
         }
       ]
@@ -29243,7 +29243,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/zip-stream"
         }
       ]
@@ -29269,7 +29269,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/zlibjs"
         }
       ]

--- a/tests/_data/sbom_demo-results/juice-shop_npm8_node18_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/juice-shop_npm8_node18_macos-latest.snap.json
@@ -62,7 +62,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -95,7 +95,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@babel/helper-string-parser"
         }
       ]
@@ -122,7 +122,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@babel/helper-validator-identifier"
         }
       ]
@@ -149,7 +149,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@babel/parser"
         }
       ]
@@ -176,7 +176,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@babel/types"
         }
       ]
@@ -203,7 +203,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@colors/colors"
         }
       ]
@@ -230,7 +230,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@dabh/diagnostics"
         }
       ]
@@ -257,7 +257,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@gar/promisify"
         }
       ]
@@ -284,7 +284,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@mapbox/node-pre-gyp"
         }
       ],
@@ -310,7 +310,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/ansi-regex"
             }
           ]
@@ -336,7 +336,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/are-we-there-yet"
             }
           ]
@@ -362,7 +362,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/detect-libc"
             }
           ]
@@ -388,7 +388,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/gauge"
             }
           ]
@@ -414,7 +414,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -440,7 +440,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/make-dir"
             }
           ],
@@ -466,7 +466,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/@mapbox/node-pre-gyp/node_modules/make-dir/node_modules/semver"
                 }
               ]
@@ -494,7 +494,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/nopt"
             }
           ]
@@ -520,7 +520,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/npmlog"
             }
           ]
@@ -546,7 +546,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/readable-stream"
             }
           ]
@@ -572,7 +572,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/string-width"
             }
           ]
@@ -598,7 +598,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/strip-ansi"
             }
           ]
@@ -627,7 +627,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/core-loader"
         }
       ]
@@ -654,7 +654,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/core"
         }
       ]
@@ -681,7 +681,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/evaluator"
         }
       ]
@@ -708,7 +708,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-all"
         }
       ]
@@ -735,7 +735,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ar"
         }
       ]
@@ -762,7 +762,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-bn"
         }
       ]
@@ -789,7 +789,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ca"
         }
       ]
@@ -816,7 +816,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-cs"
         }
       ]
@@ -843,7 +843,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-da"
         }
       ]
@@ -870,7 +870,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-de"
         }
       ]
@@ -897,7 +897,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-el"
         }
       ]
@@ -924,7 +924,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-en-min"
         }
       ]
@@ -951,7 +951,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-en"
         }
       ]
@@ -978,7 +978,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-es"
         }
       ]
@@ -1005,7 +1005,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-eu"
         }
       ]
@@ -1032,7 +1032,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-fa"
         }
       ]
@@ -1059,7 +1059,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-fi"
         }
       ]
@@ -1086,7 +1086,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-fr"
         }
       ]
@@ -1113,7 +1113,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ga"
         }
       ]
@@ -1140,7 +1140,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-gl"
         }
       ]
@@ -1167,7 +1167,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-hi"
         }
       ]
@@ -1194,7 +1194,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-hu"
         }
       ]
@@ -1221,7 +1221,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-hy"
         }
       ]
@@ -1248,7 +1248,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-id"
         }
       ]
@@ -1275,7 +1275,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-it"
         }
       ]
@@ -1302,7 +1302,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ja"
         }
       ]
@@ -1329,7 +1329,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ko"
         }
       ]
@@ -1356,7 +1356,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-lt"
         }
       ]
@@ -1383,7 +1383,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ms"
         }
       ]
@@ -1410,7 +1410,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ne"
         }
       ]
@@ -1437,7 +1437,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-nl"
         }
       ]
@@ -1464,7 +1464,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-no"
         }
       ]
@@ -1491,7 +1491,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-pl"
         }
       ]
@@ -1518,7 +1518,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-pt"
         }
       ]
@@ -1545,7 +1545,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ro"
         }
       ]
@@ -1572,7 +1572,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ru"
         }
       ]
@@ -1599,7 +1599,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-sl"
         }
       ]
@@ -1626,7 +1626,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-sr"
         }
       ]
@@ -1653,7 +1653,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-sv"
         }
       ]
@@ -1680,7 +1680,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ta"
         }
       ]
@@ -1707,7 +1707,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-th"
         }
       ]
@@ -1734,7 +1734,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-tl"
         }
       ]
@@ -1761,7 +1761,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-tr"
         }
       ]
@@ -1788,7 +1788,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-uk"
         }
       ]
@@ -1815,7 +1815,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-zh"
         }
       ]
@@ -1842,7 +1842,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/language-min"
         }
       ]
@@ -1869,7 +1869,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/language"
         }
       ]
@@ -1896,7 +1896,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/ner"
         }
       ]
@@ -1923,7 +1923,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/neural"
         }
       ]
@@ -1950,7 +1950,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/nlg"
         }
       ]
@@ -1977,7 +1977,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/nlp"
         }
       ]
@@ -2004,7 +2004,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/nlu"
         }
       ]
@@ -2031,7 +2031,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/request"
         }
       ]
@@ -2058,7 +2058,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/sentiment"
         }
       ]
@@ -2085,7 +2085,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/similarity"
         }
       ]
@@ -2112,7 +2112,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/slot"
         }
       ]
@@ -2139,7 +2139,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@npmcli/fs"
         }
       ]
@@ -2166,7 +2166,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@npmcli/move-file"
         }
       ]
@@ -2193,7 +2193,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib/core"
         }
       ]
@@ -2220,7 +2220,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib/plugin-crypto"
         }
       ]
@@ -2247,7 +2247,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib/plugin-thirty-two"
         }
       ]
@@ -2274,7 +2274,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib/preset-default"
         }
       ]
@@ -2301,7 +2301,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib/preset-v11"
         }
       ]
@@ -2328,7 +2328,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@sindresorhus/is"
         }
       ]
@@ -2355,7 +2355,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@swc/helpers"
         }
       ]
@@ -2382,7 +2382,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@tokenizer/token"
         }
       ]
@@ -2409,7 +2409,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@tootallnate/once"
         }
       ]
@@ -2436,7 +2436,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/component-emitter"
         }
       ]
@@ -2463,7 +2463,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/cookie"
         }
       ]
@@ -2490,7 +2490,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/cors"
         }
       ]
@@ -2517,7 +2517,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/debug"
         }
       ]
@@ -2544,7 +2544,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/ms"
         }
       ]
@@ -2571,7 +2571,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/node"
         }
       ]
@@ -2598,7 +2598,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/strip-bom"
         }
       ]
@@ -2625,7 +2625,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/strip-json-comments"
         }
       ]
@@ -2652,7 +2652,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/validator"
         }
       ]
@@ -2678,7 +2678,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/abbrev"
         }
       ]
@@ -2704,7 +2704,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/accepts"
         }
       ]
@@ -2730,7 +2730,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/acorn-walk"
         }
       ]
@@ -2756,7 +2756,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/acorn"
         }
       ]
@@ -2782,7 +2782,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/agent-base"
         }
       ],
@@ -2808,7 +2808,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agent-base/node_modules/debug"
             }
           ]
@@ -2834,7 +2834,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agent-base/node_modules/ms"
             }
           ]
@@ -2862,7 +2862,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/agentkeepalive"
         }
       ],
@@ -2888,7 +2888,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agentkeepalive/node_modules/debug"
             }
           ]
@@ -2914,7 +2914,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agentkeepalive/node_modules/depd"
             }
           ]
@@ -2940,7 +2940,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agentkeepalive/node_modules/ms"
             }
           ]
@@ -2968,7 +2968,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/aggregate-error"
         }
       ]
@@ -2994,7 +2994,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ajv"
         }
       ]
@@ -3020,7 +3020,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ansi-regex"
         }
       ]
@@ -3046,7 +3046,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ansi-styles"
         }
       ]
@@ -3072,7 +3072,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/anymatch"
         }
       ],
@@ -3098,7 +3098,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/anymatch/node_modules/normalize-path"
             }
           ]
@@ -3126,7 +3126,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/append-field"
         }
       ]
@@ -3152,7 +3152,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/aproba"
         }
       ]
@@ -3178,7 +3178,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/archive-type"
         }
       ],
@@ -3204,7 +3204,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/archive-type/node_modules/file-type"
             }
           ]
@@ -3232,7 +3232,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/archiver-utils"
         }
       ]
@@ -3258,7 +3258,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/archiver"
         }
       ]
@@ -3284,7 +3284,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/are-we-there-yet"
         }
       ]
@@ -3310,7 +3310,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/arg"
         }
       ]
@@ -3336,7 +3336,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/argparse"
         }
       ],
@@ -3362,7 +3362,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/argparse/node_modules/sprintf-js"
             }
           ]
@@ -3390,7 +3390,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/arr-diff"
         }
       ]
@@ -3416,7 +3416,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/arr-flatten"
         }
       ]
@@ -3442,7 +3442,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/arr-union"
         }
       ]
@@ -3468,7 +3468,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/array-each"
         }
       ]
@@ -3494,7 +3494,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/array-flatten"
         }
       ]
@@ -3520,7 +3520,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/array-slice"
         }
       ]
@@ -3546,7 +3546,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/array-unique"
         }
       ]
@@ -3572,7 +3572,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/asap"
         }
       ]
@@ -3598,7 +3598,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/asn1"
         }
       ]
@@ -3624,7 +3624,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/assert-never"
         }
       ]
@@ -3650,7 +3650,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/assert-plus"
         }
       ]
@@ -3676,7 +3676,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/assign-symbols"
         }
       ]
@@ -3702,7 +3702,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/async"
         }
       ]
@@ -3728,7 +3728,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/asynckit"
         }
       ]
@@ -3754,7 +3754,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/at-least-node"
         }
       ]
@@ -3780,7 +3780,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/atob"
         }
       ]
@@ -3806,7 +3806,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/available-typed-arrays"
         }
       ]
@@ -3832,7 +3832,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/aws-sign2"
         }
       ]
@@ -3858,7 +3858,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/aws4"
         }
       ]
@@ -3884,7 +3884,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/babel-walk"
         }
       ]
@@ -3910,7 +3910,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/balanced-match"
         }
       ]
@@ -3936,7 +3936,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base"
         }
       ],
@@ -3962,7 +3962,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/base/node_modules/define-property"
             }
           ]
@@ -3990,7 +3990,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base64-arraybuffer"
         }
       ]
@@ -4016,7 +4016,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base64-js"
         }
       ]
@@ -4042,7 +4042,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base64id"
         }
       ]
@@ -4068,7 +4068,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base64url"
         }
       ]
@@ -4094,7 +4094,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/basic-auth"
         }
       ]
@@ -4120,7 +4120,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/batch"
         }
       ]
@@ -4146,7 +4146,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bcrypt-pbkdf"
         }
       ]
@@ -4172,7 +4172,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/big-integer"
         }
       ]
@@ -4198,7 +4198,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/binary-extensions"
         }
       ]
@@ -4224,7 +4224,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/binary"
         }
       ]
@@ -4250,7 +4250,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bindings"
         }
       ]
@@ -4276,7 +4276,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bintrees"
         }
       ]
@@ -4302,7 +4302,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bl"
         }
       ]
@@ -4328,7 +4328,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bluebird"
         }
       ]
@@ -4354,7 +4354,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/body-parser"
         }
       ]
@@ -4380,7 +4380,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bower-config"
         }
       ],
@@ -4406,7 +4406,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bower-config/node_modules/minimist"
             }
           ]
@@ -4434,7 +4434,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/brace-expansion"
         }
       ]
@@ -4460,7 +4460,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/braces"
         }
       ],
@@ -4486,7 +4486,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/braces/node_modules/extend-shallow"
             }
           ]
@@ -4512,7 +4512,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/braces/node_modules/is-extendable"
             }
           ]
@@ -4540,7 +4540,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/brotli"
         }
       ]
@@ -4566,7 +4566,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-alloc-unsafe"
         }
       ]
@@ -4592,7 +4592,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-alloc"
         }
       ]
@@ -4618,7 +4618,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-crc32"
         }
       ]
@@ -4644,7 +4644,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-fill"
         }
       ]
@@ -4670,7 +4670,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-from"
         }
       ]
@@ -4696,7 +4696,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-indexof-polyfill"
         }
       ]
@@ -4722,7 +4722,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer"
         }
       ]
@@ -4748,7 +4748,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffers"
         }
       ]
@@ -4774,7 +4774,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/busboy"
         }
       ],
@@ -4800,7 +4800,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/busboy/node_modules/isarray"
             }
           ]
@@ -4826,7 +4826,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/busboy/node_modules/readable-stream"
             }
           ]
@@ -4852,7 +4852,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/busboy/node_modules/string_decoder"
             }
           ]
@@ -4880,7 +4880,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/byline"
         }
       ]
@@ -4906,7 +4906,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bytes"
         }
       ]
@@ -4932,7 +4932,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cacache"
         }
       ]
@@ -4958,7 +4958,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cache-base"
         }
       ]
@@ -4984,7 +4984,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cacheable-request"
         }
       ],
@@ -5010,7 +5010,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cacheable-request/node_modules/get-stream"
             }
           ]
@@ -5036,7 +5036,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cacheable-request/node_modules/lowercase-keys"
             }
           ]
@@ -5064,7 +5064,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/call-bind"
         }
       ]
@@ -5090,7 +5090,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/camelcase"
         }
       ]
@@ -5116,7 +5116,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/caseless"
         }
       ]
@@ -5142,7 +5142,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/chainsaw"
         }
       ]
@@ -5168,7 +5168,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/chalk"
         }
       ]
@@ -5194,7 +5194,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/character-parser"
         }
       ]
@@ -5220,7 +5220,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/check-dependencies"
         }
       ],
@@ -5246,7 +5246,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/check-dependencies/node_modules/semver"
             }
           ]
@@ -5274,7 +5274,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/check-types"
         }
       ]
@@ -5300,7 +5300,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/chokidar"
         }
       ],
@@ -5326,7 +5326,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar/node_modules/braces"
             }
           ]
@@ -5352,7 +5352,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar/node_modules/fill-range"
             }
           ]
@@ -5378,7 +5378,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar/node_modules/is-glob"
             }
           ]
@@ -5404,7 +5404,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar/node_modules/is-number"
             }
           ]
@@ -5430,7 +5430,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar/node_modules/normalize-path"
             }
           ]
@@ -5456,7 +5456,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar/node_modules/to-regex-range"
             }
           ]
@@ -5484,7 +5484,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/chownr"
         }
       ]
@@ -5510,7 +5510,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/clarinet"
         }
       ]
@@ -5536,7 +5536,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/class-utils"
         }
       ],
@@ -5562,7 +5562,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils/node_modules/define-property"
             }
           ]
@@ -5588,7 +5588,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils/node_modules/is-accessor-descriptor"
             }
           ],
@@ -5614,7 +5614,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/class-utils/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
@@ -5642,7 +5642,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils/node_modules/is-data-descriptor"
             }
           ],
@@ -5668,7 +5668,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/class-utils/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
@@ -5696,7 +5696,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils/node_modules/is-descriptor"
             }
           ]
@@ -5722,7 +5722,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils/node_modules/kind-of"
             }
           ]
@@ -5750,7 +5750,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/clean-stack"
         }
       ]
@@ -5776,7 +5776,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cliui"
         }
       ],
@@ -5802,7 +5802,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui/node_modules/ansi-regex"
             }
           ]
@@ -5828,7 +5828,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui/node_modules/emoji-regex"
             }
           ]
@@ -5854,7 +5854,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -5880,7 +5880,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui/node_modules/string-width"
             }
           ]
@@ -5906,7 +5906,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui/node_modules/strip-ansi"
             }
           ]
@@ -5934,7 +5934,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/clone-response"
         }
       ]
@@ -5960,7 +5960,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/clone"
         }
       ]
@@ -5986,7 +5986,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/code-point-at"
         }
       ]
@@ -6012,7 +6012,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/collection-visit"
         }
       ]
@@ -6038,7 +6038,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color-convert"
         }
       ]
@@ -6064,7 +6064,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color-name"
         }
       ]
@@ -6090,7 +6090,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color-string"
         }
       ]
@@ -6116,7 +6116,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color-support"
         }
       ]
@@ -6142,7 +6142,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color"
         }
       ]
@@ -6168,7 +6168,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/colors"
         }
       ]
@@ -6194,7 +6194,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/colorspace"
         }
       ]
@@ -6220,7 +6220,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/combined-stream"
         }
       ]
@@ -6246,7 +6246,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/commander"
         }
       ]
@@ -6272,7 +6272,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/component-emitter"
         }
       ]
@@ -6298,7 +6298,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/component-type"
         }
       ]
@@ -6324,7 +6324,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/compress-commons"
         }
       ]
@@ -6350,7 +6350,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/compressible"
         }
       ]
@@ -6376,7 +6376,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/compression"
         }
       ],
@@ -6402,7 +6402,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/compression/node_modules/bytes"
             }
           ]
@@ -6430,7 +6430,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/concat-map"
         }
       ]
@@ -6456,7 +6456,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/concat-stream"
         }
       ]
@@ -6482,7 +6482,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/concurrently"
         }
       ],
@@ -6508,7 +6508,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/concurrently/node_modules/supports-color"
             }
           ]
@@ -6536,7 +6536,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/config"
         }
       ]
@@ -6562,7 +6562,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/console-control-strings"
         }
       ]
@@ -6588,7 +6588,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/constantinople"
         }
       ]
@@ -6614,7 +6614,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/content-disposition"
         }
       ],
@@ -6640,7 +6640,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/content-disposition/node_modules/safe-buffer"
             }
           ]
@@ -6668,7 +6668,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/content-type"
         }
       ]
@@ -6694,7 +6694,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cookie-parser"
         }
       ]
@@ -6720,7 +6720,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cookie-signature"
         }
       ]
@@ -6746,7 +6746,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cookie"
         }
       ]
@@ -6772,7 +6772,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/copy-descriptor"
         }
       ]
@@ -6798,7 +6798,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/core-util-is"
         }
       ]
@@ -6824,7 +6824,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cors"
         }
       ]
@@ -6850,7 +6850,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/crc"
         }
       ]
@@ -6876,7 +6876,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/crc32-stream"
         }
       ]
@@ -6902,7 +6902,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/create-require"
         }
       ]
@@ -6928,7 +6928,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/crypto-js"
         }
       ]
@@ -6954,7 +6954,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dashdash"
         }
       ]
@@ -6980,7 +6980,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/date-fns"
         }
       ]
@@ -7006,7 +7006,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dateformat"
         }
       ]
@@ -7032,7 +7032,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/debug"
         }
       ]
@@ -7058,7 +7058,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decamelize"
         }
       ]
@@ -7084,7 +7084,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decode-uri-component"
         }
       ]
@@ -7110,7 +7110,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-response"
         }
       ]
@@ -7136,7 +7136,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-tar"
         }
       ],
@@ -7162,7 +7162,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-tar/node_modules/file-type"
             }
           ]
@@ -7190,7 +7190,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-tarbz2"
         }
       ],
@@ -7216,7 +7216,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-tarbz2/node_modules/file-type"
             }
           ]
@@ -7244,7 +7244,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-targz"
         }
       ],
@@ -7270,7 +7270,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-targz/node_modules/file-type"
             }
           ]
@@ -7298,7 +7298,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-unzip"
         }
       ],
@@ -7324,7 +7324,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-unzip/node_modules/file-type"
             }
           ]
@@ -7350,7 +7350,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-unzip/node_modules/get-stream"
             }
           ]
@@ -7376,7 +7376,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-unzip/node_modules/pify"
             }
           ]
@@ -7404,7 +7404,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress"
         }
       ],
@@ -7430,7 +7430,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress/node_modules/make-dir"
             }
           ],
@@ -7456,7 +7456,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/decompress/node_modules/make-dir/node_modules/pify"
                 }
               ]
@@ -7484,7 +7484,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress/node_modules/pify"
             }
           ]
@@ -7512,7 +7512,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/deep-equal"
         }
       ]
@@ -7538,7 +7538,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/deep-extend"
         }
       ]
@@ -7564,7 +7564,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/deep-is"
         }
       ]
@@ -7590,7 +7590,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/define-properties"
         }
       ]
@@ -7616,7 +7616,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/define-property"
         }
       ]
@@ -7642,7 +7642,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/delayed-stream"
         }
       ]
@@ -7668,7 +7668,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/delegates"
         }
       ]
@@ -7694,7 +7694,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/depd"
         }
       ]
@@ -7720,7 +7720,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/destroy"
         }
       ]
@@ -7746,7 +7746,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/detect-file"
         }
       ]
@@ -7772,7 +7772,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/detect-libc"
         }
       ]
@@ -7798,7 +7798,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dfa"
         }
       ]
@@ -7824,7 +7824,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dicer"
         }
       ],
@@ -7850,7 +7850,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/dicer/node_modules/isarray"
             }
           ]
@@ -7876,7 +7876,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/dicer/node_modules/readable-stream"
             }
           ]
@@ -7902,7 +7902,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/dicer/node_modules/string_decoder"
             }
           ]
@@ -7930,7 +7930,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/diff"
         }
       ]
@@ -7956,7 +7956,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/doctypes"
         }
       ]
@@ -7982,7 +7982,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/domelementtype"
         }
       ]
@@ -8008,7 +8008,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/domhandler"
         }
       ]
@@ -8034,7 +8034,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/domutils"
         }
       ]
@@ -8060,7 +8060,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dottie"
         }
       ]
@@ -8086,7 +8086,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/double-ended-queue"
         }
       ]
@@ -8112,7 +8112,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/doublearray"
         }
       ]
@@ -8138,7 +8138,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/download"
         }
       ],
@@ -8164,7 +8164,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/download/node_modules/file-type"
             }
           ]
@@ -8192,7 +8192,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/duplexer2"
         }
       ]
@@ -8218,7 +8218,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/duplexer3"
         }
       ]
@@ -8244,7 +8244,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dynamic-dedupe"
         }
       ]
@@ -8270,7 +8270,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ecc-jsbn"
         }
       ]
@@ -8296,7 +8296,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ee-first"
         }
       ]
@@ -8322,7 +8322,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/eivindfjeldstad-dot"
         }
       ]
@@ -8348,7 +8348,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/emoji-regex"
         }
       ]
@@ -8374,7 +8374,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/enabled"
         }
       ]
@@ -8400,7 +8400,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/encodeurl"
         }
       ]
@@ -8426,7 +8426,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/encoding"
         }
       ],
@@ -8452,7 +8452,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/encoding/node_modules/iconv-lite"
             }
           ]
@@ -8480,7 +8480,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/end-of-stream"
         }
       ]
@@ -8506,7 +8506,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/engine.io-parser"
         }
       ]
@@ -8532,7 +8532,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/engine.io"
         }
       ],
@@ -8558,7 +8558,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/engine.io/node_modules/debug"
             }
           ]
@@ -8584,7 +8584,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/engine.io/node_modules/ms"
             }
           ]
@@ -8612,7 +8612,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/env-paths"
         }
       ]
@@ -8638,7 +8638,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/err-code"
         }
       ]
@@ -8664,7 +8664,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/error-ex"
         }
       ]
@@ -8690,7 +8690,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/errorhandler"
         }
       ]
@@ -8716,7 +8716,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/es-abstract"
         }
       ]
@@ -8742,7 +8742,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/es-get-iterator"
         }
       ]
@@ -8768,7 +8768,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/es-to-primitive"
         }
       ]
@@ -8794,7 +8794,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/escape-html"
         }
       ]
@@ -8820,7 +8820,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/escape-string-regexp"
         }
       ]
@@ -8846,7 +8846,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/escodegen"
         }
       ]
@@ -8872,7 +8872,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/esprima"
         }
       ]
@@ -8898,7 +8898,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/estraverse"
         }
       ]
@@ -8924,7 +8924,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/esutils"
         }
       ]
@@ -8950,7 +8950,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/etag"
         }
       ]
@@ -8976,7 +8976,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/eventemitter2"
         }
       ]
@@ -9002,7 +9002,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/eventemitter3"
         }
       ]
@@ -9028,7 +9028,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/exif"
         }
       ]
@@ -9054,7 +9054,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/exit"
         }
       ]
@@ -9080,7 +9080,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/expand-brackets"
         }
       ],
@@ -9106,7 +9106,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/define-property"
             }
           ]
@@ -9132,7 +9132,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/extend-shallow"
             }
           ]
@@ -9158,7 +9158,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/is-accessor-descriptor"
             }
           ],
@@ -9184,7 +9184,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/expand-brackets/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
@@ -9212,7 +9212,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/is-data-descriptor"
             }
           ],
@@ -9238,7 +9238,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/expand-brackets/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
@@ -9266,7 +9266,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/is-descriptor"
             }
           ]
@@ -9292,7 +9292,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/is-extendable"
             }
           ]
@@ -9318,7 +9318,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/kind-of"
             }
           ]
@@ -9346,7 +9346,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/expand-template"
         }
       ]
@@ -9372,7 +9372,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/expand-tilde"
         }
       ]
@@ -9398,7 +9398,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-ipfilter"
         }
       ]
@@ -9424,7 +9424,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-jwt"
         }
       ],
@@ -9450,7 +9450,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/express-jwt/node_modules/jsonwebtoken"
             }
           ]
@@ -9476,7 +9476,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/express-jwt/node_modules/moment"
             }
           ]
@@ -9504,7 +9504,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-rate-limit"
         }
       ]
@@ -9530,7 +9530,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-robots-txt"
         }
       ]
@@ -9556,7 +9556,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-security.txt"
         }
       ]
@@ -9582,7 +9582,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express"
         }
       ],
@@ -9608,7 +9608,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/express/node_modules/cookie"
             }
           ]
@@ -9634,7 +9634,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/express/node_modules/safe-buffer"
             }
           ]
@@ -9662,7 +9662,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ext-list"
         }
       ]
@@ -9688,7 +9688,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ext-name"
         }
       ]
@@ -9714,7 +9714,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/extend-shallow"
         }
       ]
@@ -9740,7 +9740,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/extend"
         }
       ]
@@ -9766,7 +9766,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/extglob"
         }
       ],
@@ -9792,7 +9792,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/extglob/node_modules/define-property"
             }
           ]
@@ -9818,7 +9818,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/extglob/node_modules/extend-shallow"
             }
           ]
@@ -9844,7 +9844,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/extglob/node_modules/is-extendable"
             }
           ]
@@ -9872,7 +9872,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/extsprintf"
         }
       ]
@@ -9898,7 +9898,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fast-deep-equal"
         }
       ]
@@ -9924,7 +9924,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fast-json-stable-stringify"
         }
       ]
@@ -9950,7 +9950,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fast-levenshtein"
         }
       ]
@@ -9976,7 +9976,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fast.js"
         }
       ]
@@ -10002,7 +10002,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fd-slicer"
         }
       ]
@@ -10028,7 +10028,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/feature-policy"
         }
       ]
@@ -10054,7 +10054,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fecha"
         }
       ]
@@ -10080,7 +10080,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/file-js"
         }
       ],
@@ -10106,7 +10106,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/file-js/node_modules/brace-expansion"
             }
           ]
@@ -10132,7 +10132,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/file-js/node_modules/minimatch"
             }
           ]
@@ -10160,7 +10160,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/file-stream-rotator"
         }
       ]
@@ -10186,7 +10186,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/file-type"
         }
       ]
@@ -10212,7 +10212,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/file-uri-to-path"
         }
       ]
@@ -10238,7 +10238,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/filehound"
         }
       ]
@@ -10264,7 +10264,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/filename-reserved-regex"
         }
       ]
@@ -10290,7 +10290,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/filenamify"
         }
       ]
@@ -10316,7 +10316,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/filesniffer"
         }
       ]
@@ -10342,7 +10342,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fill-range"
         }
       ],
@@ -10368,7 +10368,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/fill-range/node_modules/extend-shallow"
             }
           ]
@@ -10394,7 +10394,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/fill-range/node_modules/is-extendable"
             }
           ]
@@ -10422,7 +10422,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/finale-rest"
         }
       ]
@@ -10448,7 +10448,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/finalhandler"
         }
       ]
@@ -10474,7 +10474,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/find-up"
         }
       ]
@@ -10500,7 +10500,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/findup-sync"
         }
       ]
@@ -10526,7 +10526,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fined"
         }
       ]
@@ -10552,7 +10552,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/flagged-respawn"
         }
       ]
@@ -10578,7 +10578,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fn.name"
         }
       ]
@@ -10604,7 +10604,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fontkit"
         }
       ]
@@ -10630,7 +10630,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/for-each"
         }
       ]
@@ -10656,7 +10656,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/for-in"
         }
       ]
@@ -10682,7 +10682,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/for-own"
         }
       ]
@@ -10708,7 +10708,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/foreachasync"
         }
       ]
@@ -10734,7 +10734,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/forever-agent"
         }
       ]
@@ -10760,7 +10760,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/form-data"
         }
       ]
@@ -10786,7 +10786,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/formatio"
         }
       ]
@@ -10812,7 +10812,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/forwarded"
         }
       ]
@@ -10838,7 +10838,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fragment-cache"
         }
       ]
@@ -10864,7 +10864,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fresh"
         }
       ]
@@ -10890,7 +10890,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/from2"
         }
       ]
@@ -10916,7 +10916,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fs-constants"
         }
       ]
@@ -10942,7 +10942,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fs-extra"
         }
       ]
@@ -10968,7 +10968,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fs-minipass"
         }
       ]
@@ -10994,7 +10994,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fs.realpath"
         }
       ]
@@ -11020,7 +11020,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fsevents"
         }
       ]
@@ -11046,7 +11046,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fstream"
         }
       ],
@@ -11072,7 +11072,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/fstream/node_modules/mkdirp"
             }
           ]
@@ -11098,7 +11098,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/fstream/node_modules/rimraf"
             }
           ]
@@ -11126,7 +11126,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/function-bind"
         }
       ]
@@ -11152,7 +11152,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/function.prototype.name"
         }
       ]
@@ -11178,7 +11178,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/functions-have-names"
         }
       ]
@@ -11204,7 +11204,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fuzzball"
         }
       ]
@@ -11230,7 +11230,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/gauge"
         }
       ]
@@ -11256,7 +11256,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/geojson-utils"
         }
       ]
@@ -11282,7 +11282,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-caller-file"
         }
       ]
@@ -11308,7 +11308,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-intrinsic"
         }
       ]
@@ -11334,7 +11334,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-stream"
         }
       ]
@@ -11360,7 +11360,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-symbol-description"
         }
       ]
@@ -11386,7 +11386,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-value"
         }
       ]
@@ -11412,7 +11412,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/getobject"
         }
       ]
@@ -11438,7 +11438,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/getpass"
         }
       ]
@@ -11464,7 +11464,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/github-from-package"
         }
       ]
@@ -11490,7 +11490,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/glob-parent"
         }
       ],
@@ -11516,7 +11516,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/glob-parent/node_modules/is-glob"
             }
           ]
@@ -11544,7 +11544,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/glob"
         }
       ],
@@ -11570,7 +11570,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/glob/node_modules/brace-expansion"
             }
           ]
@@ -11596,7 +11596,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/glob/node_modules/minimatch"
             }
           ]
@@ -11624,7 +11624,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/global-modules"
         }
       ]
@@ -11650,7 +11650,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/global-prefix"
         }
       ],
@@ -11676,7 +11676,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/global-prefix/node_modules/which"
             }
           ]
@@ -11704,7 +11704,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/got"
         }
       ],
@@ -11730,7 +11730,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/got/node_modules/get-stream"
             }
           ]
@@ -11756,7 +11756,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/got/node_modules/pify"
             }
           ]
@@ -11784,7 +11784,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/graceful-fs"
         }
       ]
@@ -11810,7 +11810,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-cli"
         }
       ],
@@ -11836,7 +11836,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-cli/node_modules/nopt"
             }
           ]
@@ -11864,7 +11864,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-contrib-compress"
         }
       ],
@@ -11890,7 +11890,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-contrib-compress/node_modules/ansi-styles"
             }
           ]
@@ -11916,7 +11916,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-contrib-compress/node_modules/chalk"
             }
           ]
@@ -11942,7 +11942,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-contrib-compress/node_modules/supports-color"
             }
           ]
@@ -11970,7 +11970,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-known-options"
         }
       ]
@@ -11996,7 +11996,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-legacy-log-utils"
         }
       ],
@@ -12022,7 +12022,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils/node_modules/ansi-styles"
             }
           ]
@@ -12048,7 +12048,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils/node_modules/chalk"
             }
           ]
@@ -12074,7 +12074,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils/node_modules/color-convert"
             }
           ]
@@ -12100,7 +12100,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils/node_modules/color-name"
             }
           ]
@@ -12126,7 +12126,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils/node_modules/has-flag"
             }
           ]
@@ -12152,7 +12152,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils/node_modules/supports-color"
             }
           ]
@@ -12180,7 +12180,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-legacy-log"
         }
       ],
@@ -12206,7 +12206,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log/node_modules/colors"
             }
           ]
@@ -12234,7 +12234,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-legacy-util"
         }
       ],
@@ -12260,7 +12260,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-util/node_modules/async"
             }
           ]
@@ -12288,7 +12288,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-replace-json"
         }
       ]
@@ -12314,7 +12314,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt"
         }
       ],
@@ -12340,7 +12340,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt/node_modules/brace-expansion"
             }
           ]
@@ -12366,7 +12366,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt/node_modules/findup-sync"
             }
           ],
@@ -12392,7 +12392,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/grunt/node_modules/findup-sync/node_modules/glob"
                 }
               ]
@@ -12420,7 +12420,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt/node_modules/glob"
             }
           ]
@@ -12446,7 +12446,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt/node_modules/minimatch"
             }
           ]
@@ -12474,7 +12474,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/handlebars"
         }
       ],
@@ -12500,7 +12500,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/handlebars/node_modules/wordwrap"
             }
           ]
@@ -12528,7 +12528,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/har-schema"
         }
       ]
@@ -12554,7 +12554,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/har-validator"
         }
       ]
@@ -12580,7 +12580,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-ansi"
         }
       ]
@@ -12606,7 +12606,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-bigints"
         }
       ]
@@ -12632,7 +12632,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-flag"
         }
       ]
@@ -12658,7 +12658,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-property-descriptors"
         }
       ]
@@ -12684,7 +12684,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-symbol-support-x"
         }
       ]
@@ -12710,7 +12710,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-symbols"
         }
       ]
@@ -12736,7 +12736,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-to-string-tag-x"
         }
       ]
@@ -12762,7 +12762,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-tostringtag"
         }
       ]
@@ -12788,7 +12788,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-unicode"
         }
       ]
@@ -12814,7 +12814,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-value"
         }
       ]
@@ -12840,7 +12840,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-values"
         }
       ],
@@ -12866,7 +12866,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/has-values/node_modules/kind-of"
             }
           ]
@@ -12894,7 +12894,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has"
         }
       ]
@@ -12920,7 +12920,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hashids"
         }
       ]
@@ -12946,7 +12946,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hbs"
         }
       ]
@@ -12972,7 +12972,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/he"
         }
       ]
@@ -12998,7 +12998,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/heap"
         }
       ]
@@ -13024,7 +13024,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/helmet"
         }
       ]
@@ -13050,7 +13050,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hoister"
         }
       ]
@@ -13076,7 +13076,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/homedir-polyfill"
         }
       ]
@@ -13102,7 +13102,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hooker"
         }
       ]
@@ -13128,7 +13128,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hosted-git-info"
         }
       ]
@@ -13154,7 +13154,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/html-entities"
         }
       ]
@@ -13180,7 +13180,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/htmlparser2"
         }
       ],
@@ -13206,7 +13206,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/htmlparser2/node_modules/isarray"
             }
           ]
@@ -13232,7 +13232,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/htmlparser2/node_modules/readable-stream"
             }
           ]
@@ -13258,7 +13258,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/htmlparser2/node_modules/string_decoder"
             }
           ]
@@ -13286,7 +13286,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/http-cache-semantics"
         }
       ]
@@ -13312,7 +13312,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/http-errors"
         }
       ]
@@ -13338,7 +13338,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/http-proxy-agent"
         }
       ],
@@ -13364,7 +13364,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/http-proxy-agent/node_modules/debug"
             }
           ]
@@ -13390,7 +13390,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/http-proxy-agent/node_modules/ms"
             }
           ]
@@ -13418,7 +13418,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/http-signature"
         }
       ]
@@ -13444,7 +13444,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/https-proxy-agent"
         }
       ],
@@ -13470,7 +13470,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/https-proxy-agent/node_modules/debug"
             }
           ]
@@ -13496,7 +13496,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/https-proxy-agent/node_modules/ms"
             }
           ]
@@ -13524,7 +13524,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/humanize-ms"
         }
       ]
@@ -13550,7 +13550,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/i18n"
         }
       ]
@@ -13576,7 +13576,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/iconv-lite"
         }
       ]
@@ -13602,7 +13602,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ieee754"
         }
       ]
@@ -13628,7 +13628,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ignore-walk"
         }
       ],
@@ -13654,7 +13654,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/ignore-walk/node_modules/brace-expansion"
             }
           ]
@@ -13680,7 +13680,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/ignore-walk/node_modules/minimatch"
             }
           ]
@@ -13708,7 +13708,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/iltorb"
         }
       ]
@@ -13734,7 +13734,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/imurmurhash"
         }
       ]
@@ -13760,7 +13760,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/indent-string"
         }
       ]
@@ -13786,7 +13786,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/infer-owner"
         }
       ]
@@ -13812,7 +13812,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/inflection"
         }
       ]
@@ -13838,7 +13838,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/inflight"
         }
       ]
@@ -13864,7 +13864,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/inherits"
         }
       ]
@@ -13890,7 +13890,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ini"
         }
       ]
@@ -13916,7 +13916,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/internal-slot"
         }
       ]
@@ -13942,7 +13942,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/interpret"
         }
       ]
@@ -13968,7 +13968,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/into-stream"
         }
       ]
@@ -13994,7 +13994,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/invariant"
         }
       ]
@@ -14020,7 +14020,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ip"
         }
       ]
@@ -14046,7 +14046,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ip6"
         }
       ]
@@ -14072,7 +14072,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ipaddr.js"
         }
       ]
@@ -14098,7 +14098,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-absolute"
         }
       ]
@@ -14124,7 +14124,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-accessor-descriptor"
         }
       ]
@@ -14150,7 +14150,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-arguments"
         }
       ]
@@ -14176,7 +14176,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-arrayish"
         }
       ]
@@ -14202,7 +14202,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-bigint"
         }
       ]
@@ -14228,7 +14228,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-binary-path"
         }
       ]
@@ -14254,7 +14254,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-boolean-object"
         }
       ]
@@ -14280,7 +14280,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-buffer"
         }
       ]
@@ -14306,7 +14306,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-callable"
         }
       ]
@@ -14332,7 +14332,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-core-module"
         }
       ]
@@ -14358,7 +14358,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-data-descriptor"
         }
       ]
@@ -14384,7 +14384,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-date-object"
         }
       ]
@@ -14410,7 +14410,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-descriptor"
         }
       ]
@@ -14436,7 +14436,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-docker"
         }
       ]
@@ -14462,7 +14462,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-expression"
         }
       ]
@@ -14488,7 +14488,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-extendable"
         }
       ]
@@ -14514,7 +14514,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-extglob"
         }
       ]
@@ -14540,7 +14540,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-fullwidth-code-point"
         }
       ]
@@ -14566,7 +14566,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-generator-function"
         }
       ]
@@ -14592,7 +14592,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-glob"
         }
       ]
@@ -14618,7 +14618,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-heroku"
         }
       ]
@@ -14644,7 +14644,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-lambda"
         }
       ]
@@ -14670,7 +14670,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-map"
         }
       ]
@@ -14696,7 +14696,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-natural-number"
         }
       ]
@@ -14722,7 +14722,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-negative-zero"
         }
       ]
@@ -14748,7 +14748,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-number-like"
         }
       ]
@@ -14774,7 +14774,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-number-object"
         }
       ]
@@ -14800,7 +14800,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-number"
         }
       ],
@@ -14826,7 +14826,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/is-number/node_modules/kind-of"
             }
           ]
@@ -14854,7 +14854,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-object"
         }
       ]
@@ -14880,7 +14880,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-plain-obj"
         }
       ]
@@ -14906,7 +14906,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-plain-object"
         }
       ]
@@ -14932,7 +14932,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-promise"
         }
       ]
@@ -14958,7 +14958,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-regex"
         }
       ]
@@ -14984,7 +14984,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-relative"
         }
       ]
@@ -15010,7 +15010,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-retry-allowed"
         }
       ]
@@ -15036,7 +15036,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-set"
         }
       ]
@@ -15062,7 +15062,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-shared-array-buffer"
         }
       ]
@@ -15088,7 +15088,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-stream"
         }
       ]
@@ -15114,7 +15114,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-string"
         }
       ]
@@ -15140,7 +15140,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-symbol"
         }
       ]
@@ -15166,7 +15166,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-typed-array"
         }
       ]
@@ -15192,7 +15192,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-typedarray"
         }
       ]
@@ -15218,7 +15218,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-unc-path"
         }
       ]
@@ -15244,7 +15244,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-weakmap"
         }
       ]
@@ -15270,7 +15270,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-weakref"
         }
       ]
@@ -15296,7 +15296,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-weakset"
         }
       ]
@@ -15322,7 +15322,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-windows"
         }
       ]
@@ -15348,7 +15348,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isarray"
         }
       ]
@@ -15374,7 +15374,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isexe"
         }
       ]
@@ -15400,7 +15400,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isobject"
         }
       ]
@@ -15426,7 +15426,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isstream"
         }
       ]
@@ -15452,7 +15452,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isurl"
         }
       ]
@@ -15478,7 +15478,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/js-stringify"
         }
       ]
@@ -15504,7 +15504,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/js-tokens"
         }
       ]
@@ -15530,7 +15530,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/js-yaml"
         }
       ]
@@ -15556,7 +15556,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jsbn"
         }
       ]
@@ -15582,7 +15582,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-buffer"
         }
       ]
@@ -15608,7 +15608,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-parse-better-errors"
         }
       ]
@@ -15634,7 +15634,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-schema-traverse"
         }
       ]
@@ -15660,7 +15660,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-schema"
         }
       ]
@@ -15686,7 +15686,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-stringify-safe"
         }
       ]
@@ -15712,7 +15712,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json5"
         }
       ]
@@ -15738,7 +15738,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jsonfile"
         }
       ]
@@ -15764,7 +15764,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jsonwebtoken"
         }
       ]
@@ -15790,7 +15790,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jsprim"
         }
       ]
@@ -15816,7 +15816,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jssha"
         }
       ]
@@ -15842,7 +15842,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jstransformer"
         }
       ]
@@ -15868,7 +15868,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/juicy-chat-bot"
         }
       ]
@@ -15894,7 +15894,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jwa"
         }
       ]
@@ -15920,7 +15920,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jws"
         }
       ]
@@ -15946,7 +15946,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/keyv"
         }
       ]
@@ -15972,7 +15972,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/kind-of"
         }
       ]
@@ -15998,7 +15998,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/kuler"
         }
       ]
@@ -16024,7 +16024,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/kuromoji"
         }
       ]
@@ -16050,7 +16050,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lazystream"
         }
       ]
@@ -16076,7 +16076,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/levn"
         }
       ]
@@ -16102,7 +16102,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/libxmljs2"
         }
       ],
@@ -16128,7 +16128,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/libxmljs2/node_modules/nan"
             }
           ]
@@ -16156,7 +16156,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/liftup"
         }
       ],
@@ -16182,7 +16182,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/braces"
             }
           ]
@@ -16208,7 +16208,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/fill-range"
             }
           ]
@@ -16234,7 +16234,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/findup-sync"
             }
           ]
@@ -16260,7 +16260,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/is-glob"
             }
           ]
@@ -16286,7 +16286,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/is-number"
             }
           ]
@@ -16312,7 +16312,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/micromatch"
             }
           ]
@@ -16338,7 +16338,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/to-regex-range"
             }
           ]
@@ -16366,7 +16366,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/linebreak"
         }
       ],
@@ -16392,7 +16392,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/linebreak/node_modules/base64-js"
             }
           ]
@@ -16420,7 +16420,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/listenercount"
         }
       ]
@@ -16446,7 +16446,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/locate-path"
         }
       ]
@@ -16472,7 +16472,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lodash.camelcase"
         }
       ]
@@ -16498,7 +16498,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lodash.isfinite"
         }
       ]
@@ -16524,7 +16524,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lodash.set"
         }
       ]
@@ -16550,7 +16550,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lodash"
         }
       ]
@@ -16576,7 +16576,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/logform"
         }
       ],
@@ -16602,7 +16602,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/logform/node_modules/ms"
             }
           ]
@@ -16630,7 +16630,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lolex"
         }
       ]
@@ -16656,7 +16656,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/loose-envify"
         }
       ]
@@ -16682,7 +16682,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lowercase-keys"
         }
       ]
@@ -16708,7 +16708,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lru-cache"
         }
       ]
@@ -16734,7 +16734,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-dir"
         }
       ],
@@ -16760,7 +16760,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-dir/node_modules/semver"
             }
           ]
@@ -16788,7 +16788,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-error"
         }
       ]
@@ -16814,7 +16814,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-fetch-happen"
         }
       ],
@@ -16841,7 +16841,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen/node_modules/@tootallnate/once"
             }
           ]
@@ -16867,7 +16867,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen/node_modules/debug"
             }
           ]
@@ -16893,7 +16893,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen/node_modules/http-cache-semantics"
             }
           ]
@@ -16919,7 +16919,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen/node_modules/http-proxy-agent"
             }
           ]
@@ -16945,7 +16945,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen/node_modules/ms"
             }
           ]
@@ -16973,7 +16973,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-iterator"
         }
       ]
@@ -16999,7 +16999,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-plural"
         }
       ]
@@ -17025,7 +17025,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/map-cache"
         }
       ]
@@ -17051,7 +17051,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/map-visit"
         }
       ]
@@ -17077,7 +17077,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/marsdb"
         }
       ]
@@ -17103,7 +17103,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/math-interval-parser"
         }
       ]
@@ -17129,7 +17129,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/media-typer"
         }
       ]
@@ -17155,7 +17155,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/merge-descriptors"
         }
       ]
@@ -17181,7 +17181,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/messageformat-formatters"
         }
       ]
@@ -17207,7 +17207,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/messageformat-parser"
         }
       ]
@@ -17233,7 +17233,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/messageformat"
         }
       ],
@@ -17259,7 +17259,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/messageformat/node_modules/make-plural"
             }
           ]
@@ -17287,7 +17287,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/methods"
         }
       ]
@@ -17313,7 +17313,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/micromatch"
         }
       ]
@@ -17339,7 +17339,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mime-db"
         }
       ]
@@ -17365,7 +17365,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mime-types"
         }
       ]
@@ -17391,7 +17391,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mime"
         }
       ]
@@ -17417,7 +17417,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mimic-response"
         }
       ]
@@ -17443,7 +17443,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minimatch"
         }
       ]
@@ -17469,7 +17469,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minimist"
         }
       ]
@@ -17495,7 +17495,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-collect"
         }
       ]
@@ -17521,7 +17521,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-fetch"
         }
       ]
@@ -17547,7 +17547,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-flush"
         }
       ]
@@ -17573,7 +17573,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-pipeline"
         }
       ]
@@ -17599,7 +17599,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-sized"
         }
       ]
@@ -17625,7 +17625,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass"
         }
       ]
@@ -17651,7 +17651,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minizlib"
         }
       ]
@@ -17677,7 +17677,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mixin-deep"
         }
       ]
@@ -17703,7 +17703,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mkdirp-classic"
         }
       ]
@@ -17729,7 +17729,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mkdirp"
         }
       ]
@@ -17755,7 +17755,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/moment-timezone"
         }
       ]
@@ -17781,7 +17781,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/moment"
         }
       ]
@@ -17807,7 +17807,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/morgan"
         }
       ],
@@ -17833,7 +17833,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/morgan/node_modules/on-finished"
             }
           ]
@@ -17861,7 +17861,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mout"
         }
       ]
@@ -17887,7 +17887,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ms"
         }
       ]
@@ -17913,7 +17913,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/multer"
         }
       ],
@@ -17939,7 +17939,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/multer/node_modules/mkdirp"
             }
           ]
@@ -17967,7 +17967,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mustache"
         }
       ]
@@ -17993,7 +17993,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/nan"
         }
       ]
@@ -18019,7 +18019,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/nanomatch"
         }
       ]
@@ -18045,7 +18045,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/napi-build-utils"
         }
       ]
@@ -18071,7 +18071,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/needle"
         }
       ],
@@ -18097,7 +18097,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/needle/node_modules/debug"
             }
           ]
@@ -18123,7 +18123,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/needle/node_modules/ms"
             }
           ]
@@ -18151,7 +18151,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/negotiator"
         }
       ]
@@ -18177,7 +18177,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/neo-async"
         }
       ]
@@ -18203,7 +18203,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-abi"
         }
       ],
@@ -18229,7 +18229,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-abi/node_modules/semver"
             }
           ]
@@ -18257,7 +18257,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-addon-api"
         }
       ]
@@ -18283,7 +18283,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-fetch"
         }
       ]
@@ -18309,7 +18309,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-gyp"
         }
       ],
@@ -18335,7 +18335,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/ansi-regex"
             }
           ]
@@ -18361,7 +18361,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/are-we-there-yet"
             }
           ]
@@ -18387,7 +18387,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/gauge"
             }
           ]
@@ -18413,7 +18413,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -18439,7 +18439,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/nopt"
             }
           ]
@@ -18465,7 +18465,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/npmlog"
             }
           ]
@@ -18491,7 +18491,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/readable-stream"
             }
           ]
@@ -18517,7 +18517,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/string-width"
             }
           ]
@@ -18543,7 +18543,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/strip-ansi"
             }
           ]
@@ -18571,7 +18571,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-pre-gyp"
         }
       ],
@@ -18597,7 +18597,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/chownr"
             }
           ]
@@ -18623,7 +18623,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/fs-minipass"
             }
           ]
@@ -18649,7 +18649,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/minipass"
             }
           ]
@@ -18675,7 +18675,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/minizlib"
             }
           ]
@@ -18701,7 +18701,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/mkdirp"
             }
           ]
@@ -18727,7 +18727,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/nopt"
             }
           ]
@@ -18753,7 +18753,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/rimraf"
             }
           ]
@@ -18779,7 +18779,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/safe-buffer"
             }
           ]
@@ -18805,7 +18805,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/semver"
             }
           ]
@@ -18831,7 +18831,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/tar"
             }
           ]
@@ -18857,7 +18857,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/yallist"
             }
           ]
@@ -18885,7 +18885,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/noop-logger"
         }
       ]
@@ -18911,7 +18911,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/nopt"
         }
       ]
@@ -18937,7 +18937,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/normalize-package-data"
         }
       ],
@@ -18963,7 +18963,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/normalize-package-data/node_modules/semver"
             }
           ]
@@ -18991,7 +18991,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/normalize-path"
         }
       ]
@@ -19017,7 +19017,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/normalize-url"
         }
       ]
@@ -19043,7 +19043,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/notevil"
         }
       ],
@@ -19069,7 +19069,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/notevil/node_modules/esprima"
             }
           ]
@@ -19097,7 +19097,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/npm-bundled"
         }
       ]
@@ -19123,7 +19123,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/npm-normalize-package-bin"
         }
       ]
@@ -19149,7 +19149,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/npm-packlist"
         }
       ]
@@ -19175,7 +19175,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/npmlog"
         }
       ]
@@ -19201,7 +19201,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/number-is-nan"
         }
       ]
@@ -19227,7 +19227,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/oauth-sign"
         }
       ]
@@ -19253,7 +19253,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-assign"
         }
       ]
@@ -19279,7 +19279,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-copy"
         }
       ],
@@ -19305,7 +19305,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy/node_modules/define-property"
             }
           ]
@@ -19331,7 +19331,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy/node_modules/is-accessor-descriptor"
             }
           ]
@@ -19357,7 +19357,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy/node_modules/is-data-descriptor"
             }
           ]
@@ -19383,7 +19383,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy/node_modules/is-descriptor"
             }
           ],
@@ -19409,7 +19409,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/object-copy/node_modules/is-descriptor/node_modules/kind-of"
                 }
               ]
@@ -19437,7 +19437,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy/node_modules/kind-of"
             }
           ]
@@ -19465,7 +19465,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-inspect"
         }
       ]
@@ -19491,7 +19491,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-is"
         }
       ]
@@ -19517,7 +19517,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-keys"
         }
       ]
@@ -19543,7 +19543,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-visit"
         }
       ]
@@ -19569,7 +19569,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object.assign"
         }
       ]
@@ -19595,7 +19595,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object.defaults"
         }
       ]
@@ -19621,7 +19621,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object.map"
         }
       ]
@@ -19647,7 +19647,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object.pick"
         }
       ]
@@ -19673,7 +19673,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/on-finished"
         }
       ]
@@ -19699,7 +19699,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/on-headers"
         }
       ]
@@ -19725,7 +19725,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/once"
         }
       ]
@@ -19751,7 +19751,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/one-time"
         }
       ]
@@ -19777,7 +19777,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/opentype.js"
         }
       ]
@@ -19803,7 +19803,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/optionator"
         }
       ]
@@ -19829,7 +19829,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/os-homedir"
         }
       ]
@@ -19855,7 +19855,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/os-tmpdir"
         }
       ]
@@ -19881,7 +19881,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/osenv"
         }
       ]
@@ -19907,7 +19907,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/otplib"
         }
       ]
@@ -19933,7 +19933,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-cancelable"
         }
       ]
@@ -19959,7 +19959,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-event"
         }
       ]
@@ -19985,7 +19985,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-finally"
         }
       ]
@@ -20011,7 +20011,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-is-promise"
         }
       ]
@@ -20037,7 +20037,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-limit"
         }
       ]
@@ -20063,7 +20063,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-locate"
         }
       ]
@@ -20089,7 +20089,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-map"
         }
       ]
@@ -20115,7 +20115,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-timeout"
         }
       ]
@@ -20141,7 +20141,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-try"
         }
       ]
@@ -20167,7 +20167,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pako"
         }
       ]
@@ -20193,7 +20193,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/parse-filepath"
         }
       ]
@@ -20219,7 +20219,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/parse-json"
         }
       ]
@@ -20245,7 +20245,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/parse-passwd"
         }
       ]
@@ -20271,7 +20271,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/parseurl"
         }
       ]
@@ -20297,7 +20297,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pascalcase"
         }
       ]
@@ -20323,7 +20323,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-exists"
         }
       ]
@@ -20349,7 +20349,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-is-absolute"
         }
       ]
@@ -20375,7 +20375,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-parse"
         }
       ]
@@ -20401,7 +20401,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-root-regex"
         }
       ]
@@ -20427,7 +20427,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-root"
         }
       ]
@@ -20453,7 +20453,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-to-regexp"
         }
       ]
@@ -20479,7 +20479,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pdfkit"
         }
       ]
@@ -20505,7 +20505,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/peek-readable"
         }
       ]
@@ -20531,7 +20531,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pend"
         }
       ]
@@ -20557,7 +20557,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/performance-now"
         }
       ]
@@ -20583,7 +20583,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pg-connection-string"
         }
       ]
@@ -20609,7 +20609,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/picomatch"
         }
       ]
@@ -20635,7 +20635,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pify"
         }
       ]
@@ -20661,7 +20661,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pinkie-promise"
         }
       ]
@@ -20687,7 +20687,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pinkie"
         }
       ]
@@ -20713,7 +20713,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/png-js"
         }
       ]
@@ -20739,7 +20739,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/portscanner"
         }
       ]
@@ -20765,7 +20765,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/posix-character-classes"
         }
       ]
@@ -20791,7 +20791,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/prebuild-install"
         }
       ]
@@ -20817,7 +20817,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/prelude-ls"
         }
       ]
@@ -20843,7 +20843,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/prepend-http"
         }
       ]
@@ -20869,7 +20869,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pretty-bytes"
         }
       ]
@@ -20895,7 +20895,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/process-nextick-args"
         }
       ]
@@ -20921,7 +20921,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/prom-client"
         }
       ]
@@ -20947,7 +20947,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/promise-inflight"
         }
       ]
@@ -20973,7 +20973,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/promise-retry"
         }
       ],
@@ -20999,7 +20999,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/promise-retry/node_modules/err-code"
             }
           ]
@@ -21025,7 +21025,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/promise-retry/node_modules/retry"
             }
           ]
@@ -21053,7 +21053,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/promise"
         }
       ]
@@ -21079,7 +21079,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/proper-lockfile"
         }
       ]
@@ -21105,7 +21105,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/proxy-addr"
         }
       ]
@@ -21131,7 +21131,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/psl"
         }
       ]
@@ -21157,7 +21157,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-attrs"
         }
       ]
@@ -21183,7 +21183,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-code-gen"
         }
       ]
@@ -21209,7 +21209,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-error"
         }
       ]
@@ -21235,7 +21235,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-filters"
         }
       ]
@@ -21261,7 +21261,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-lexer"
         }
       ]
@@ -21287,7 +21287,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-linker"
         }
       ]
@@ -21313,7 +21313,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-load"
         }
       ]
@@ -21339,7 +21339,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-parser"
         }
       ]
@@ -21365,7 +21365,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-runtime"
         }
       ]
@@ -21391,7 +21391,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-strip-comments"
         }
       ]
@@ -21417,7 +21417,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-walk"
         }
       ]
@@ -21443,7 +21443,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug"
         }
       ]
@@ -21469,7 +21469,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pump"
         }
       ]
@@ -21495,7 +21495,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/punycode"
         }
       ]
@@ -21521,7 +21521,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/qs"
         }
       ]
@@ -21547,7 +21547,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/query-string"
         }
       ]
@@ -21573,7 +21573,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/range_check"
         }
       ]
@@ -21599,7 +21599,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/range-parser"
         }
       ]
@@ -21625,7 +21625,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/raw-body"
         }
       ]
@@ -21651,7 +21651,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/rc"
         }
       ]
@@ -21677,7 +21677,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/read-pkg"
         }
       ],
@@ -21703,7 +21703,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/read-pkg/node_modules/pify"
             }
           ]
@@ -21731,7 +21731,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/readable-stream"
         }
       ],
@@ -21757,7 +21757,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/readable-stream/node_modules/isarray"
             }
           ]
@@ -21785,7 +21785,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/readable-web-to-node-stream"
         }
       ],
@@ -21811,7 +21811,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/readable-web-to-node-stream/node_modules/readable-stream"
             }
           ]
@@ -21839,7 +21839,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/readdirp"
         }
       ]
@@ -21865,7 +21865,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/rechoir"
         }
       ]
@@ -21891,7 +21891,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/regex-not"
         }
       ]
@@ -21917,7 +21917,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/regexp.prototype.flags"
         }
       ]
@@ -21943,7 +21943,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/remove-trailing-separator"
         }
       ]
@@ -21969,7 +21969,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/repeat-element"
         }
       ]
@@ -21995,7 +21995,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/repeat-string"
         }
       ]
@@ -22021,7 +22021,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/replace"
         }
       ],
@@ -22047,7 +22047,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/ansi-regex"
             }
           ]
@@ -22073,7 +22073,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/ansi-styles"
             }
           ]
@@ -22099,7 +22099,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/brace-expansion"
             }
           ]
@@ -22125,7 +22125,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/cliui"
             }
           ]
@@ -22151,7 +22151,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/color-convert"
             }
           ]
@@ -22177,7 +22177,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/color-name"
             }
           ]
@@ -22203,7 +22203,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/find-up"
             }
           ]
@@ -22229,7 +22229,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -22255,7 +22255,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/locate-path"
             }
           ]
@@ -22281,7 +22281,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/minimatch"
             }
           ]
@@ -22307,7 +22307,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/p-locate"
             }
           ]
@@ -22333,7 +22333,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/path-exists"
             }
           ]
@@ -22359,7 +22359,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/string-width"
             }
           ]
@@ -22385,7 +22385,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/strip-ansi"
             }
           ]
@@ -22411,7 +22411,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/wrap-ansi"
             }
           ]
@@ -22437,7 +22437,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/yargs-parser"
             }
           ]
@@ -22463,7 +22463,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/yargs"
             }
           ]
@@ -22491,7 +22491,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/request"
         }
       ],
@@ -22517,7 +22517,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/request/node_modules/qs"
             }
           ]
@@ -22545,7 +22545,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/require-directory"
         }
       ]
@@ -22571,7 +22571,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/require-main-filename"
         }
       ]
@@ -22597,7 +22597,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/resolve-dir"
         }
       ]
@@ -22623,7 +22623,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/resolve-url"
         }
       ]
@@ -22649,7 +22649,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/resolve"
         }
       ]
@@ -22675,7 +22675,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/responselike"
         }
       ]
@@ -22701,7 +22701,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/restructure"
         }
       ]
@@ -22727,7 +22727,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ret"
         }
       ]
@@ -22753,7 +22753,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/retry-as-promised"
         }
       ]
@@ -22779,7 +22779,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/retry"
         }
       ]
@@ -22805,7 +22805,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/rimraf"
         }
       ]
@@ -22831,7 +22831,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/rxjs"
         }
       ],
@@ -22857,7 +22857,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/rxjs/node_modules/tslib"
             }
           ]
@@ -22885,7 +22885,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safe-buffer"
         }
       ]
@@ -22911,7 +22911,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safe-regex-test"
         }
       ]
@@ -22937,7 +22937,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safe-regex"
         }
       ]
@@ -22963,7 +22963,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safe-stable-stringify"
         }
       ]
@@ -22989,7 +22989,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safer-buffer"
         }
       ]
@@ -23015,7 +23015,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/samsam"
         }
       ]
@@ -23041,7 +23041,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sanitize-filename"
         }
       ]
@@ -23067,7 +23067,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sanitize-html"
         }
       ],
@@ -23093,7 +23093,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sanitize-html/node_modules/lodash"
             }
           ]
@@ -23121,7 +23121,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sax"
         }
       ]
@@ -23147,7 +23147,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/seek-bzip"
         }
       ]
@@ -23173,7 +23173,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/semver"
         }
       ]
@@ -23199,7 +23199,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/send"
         }
       ],
@@ -23225,7 +23225,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/send/node_modules/ms"
             }
           ]
@@ -23253,7 +23253,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sequelize-pool"
         }
       ]
@@ -23279,7 +23279,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sequelize"
         }
       ],
@@ -23305,7 +23305,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sequelize/node_modules/debug"
             }
           ]
@@ -23331,7 +23331,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sequelize/node_modules/ms"
             }
           ]
@@ -23357,7 +23357,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sequelize/node_modules/uuid"
             }
           ]
@@ -23385,7 +23385,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/serve-index"
         }
       ],
@@ -23411,7 +23411,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index/node_modules/depd"
             }
           ]
@@ -23437,7 +23437,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index/node_modules/http-errors"
             }
           ]
@@ -23463,7 +23463,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index/node_modules/inherits"
             }
           ]
@@ -23489,7 +23489,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index/node_modules/setprototypeof"
             }
           ]
@@ -23515,7 +23515,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index/node_modules/statuses"
             }
           ]
@@ -23543,7 +23543,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/serve-static"
         }
       ]
@@ -23569,7 +23569,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/set-blocking"
         }
       ]
@@ -23595,7 +23595,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/set-value"
         }
       ],
@@ -23621,7 +23621,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/set-value/node_modules/extend-shallow"
             }
           ]
@@ -23647,7 +23647,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/set-value/node_modules/is-extendable"
             }
           ]
@@ -23675,7 +23675,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/setimmediate"
         }
       ]
@@ -23701,7 +23701,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/setprototypeof"
         }
       ]
@@ -23727,7 +23727,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/side-channel"
         }
       ]
@@ -23753,7 +23753,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/signal-exit"
         }
       ]
@@ -23779,7 +23779,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/simple-concat"
         }
       ]
@@ -23805,7 +23805,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/simple-get"
         }
       ],
@@ -23831,7 +23831,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/simple-get/node_modules/decompress-response"
             }
           ]
@@ -23857,7 +23857,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/simple-get/node_modules/mimic-response"
             }
           ]
@@ -23885,7 +23885,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/simple-swizzle"
         }
       ],
@@ -23911,7 +23911,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/simple-swizzle/node_modules/is-arrayish"
             }
           ]
@@ -23939,7 +23939,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sinon"
         }
       ]
@@ -23965,7 +23965,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/smart-buffer"
         }
       ]
@@ -23991,7 +23991,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/snapdragon-node"
         }
       ],
@@ -24017,7 +24017,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon-node/node_modules/define-property"
             }
           ]
@@ -24045,7 +24045,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/snapdragon-util"
         }
       ],
@@ -24071,7 +24071,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon-util/node_modules/kind-of"
             }
           ]
@@ -24099,7 +24099,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/snapdragon"
         }
       ],
@@ -24125,7 +24125,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/define-property"
             }
           ]
@@ -24151,7 +24151,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/extend-shallow"
             }
           ]
@@ -24177,7 +24177,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/is-accessor-descriptor"
             }
           ],
@@ -24203,7 +24203,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/snapdragon/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
@@ -24231,7 +24231,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/is-data-descriptor"
             }
           ],
@@ -24257,7 +24257,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/snapdragon/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
@@ -24285,7 +24285,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/is-descriptor"
             }
           ]
@@ -24311,7 +24311,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/is-extendable"
             }
           ]
@@ -24337,7 +24337,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/kind-of"
             }
           ]
@@ -24363,7 +24363,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/source-map"
             }
           ]
@@ -24391,7 +24391,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socket.io-adapter"
         }
       ]
@@ -24417,7 +24417,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socket.io-parser"
         }
       ],
@@ -24443,7 +24443,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socket.io-parser/node_modules/debug"
             }
           ]
@@ -24469,7 +24469,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socket.io-parser/node_modules/ms"
             }
           ]
@@ -24497,7 +24497,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socket.io"
         }
       ],
@@ -24523,7 +24523,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socket.io/node_modules/debug"
             }
           ]
@@ -24549,7 +24549,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socket.io/node_modules/ms"
             }
           ]
@@ -24577,7 +24577,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socks-proxy-agent"
         }
       ],
@@ -24603,7 +24603,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socks-proxy-agent/node_modules/debug"
             }
           ]
@@ -24629,7 +24629,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socks-proxy-agent/node_modules/ms"
             }
           ]
@@ -24657,7 +24657,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socks"
         }
       ],
@@ -24683,7 +24683,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socks/node_modules/ip"
             }
           ]
@@ -24711,7 +24711,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sort-keys-length"
         }
       ],
@@ -24737,7 +24737,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sort-keys-length/node_modules/sort-keys"
             }
           ]
@@ -24765,7 +24765,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sort-keys"
         }
       ]
@@ -24791,7 +24791,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/source-map-resolve"
         }
       ]
@@ -24817,7 +24817,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/source-map-support"
         }
       ]
@@ -24843,7 +24843,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/source-map-url"
         }
       ]
@@ -24869,7 +24869,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/source-map"
         }
       ]
@@ -24895,7 +24895,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spawn-command"
         }
       ]
@@ -24921,7 +24921,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spdx-correct"
         }
       ]
@@ -24947,7 +24947,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spdx-exceptions"
         }
       ]
@@ -24973,7 +24973,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spdx-expression-parse"
         }
       ]
@@ -24999,7 +24999,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spdx-license-ids"
         }
       ]
@@ -25025,7 +25025,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/split-string"
         }
       ]
@@ -25051,7 +25051,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sprintf-js"
         }
       ]
@@ -25077,7 +25077,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sqlite3"
         }
       ]
@@ -25103,7 +25103,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sshpk"
         }
       ]
@@ -25129,7 +25129,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ssri"
         }
       ]
@@ -25155,7 +25155,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/stack-trace"
         }
       ]
@@ -25181,7 +25181,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/static-extend"
         }
       ],
@@ -25207,7 +25207,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend/node_modules/define-property"
             }
           ]
@@ -25233,7 +25233,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend/node_modules/is-accessor-descriptor"
             }
           ],
@@ -25259,7 +25259,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/static-extend/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
@@ -25287,7 +25287,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend/node_modules/is-data-descriptor"
             }
           ],
@@ -25313,7 +25313,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/static-extend/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
@@ -25341,7 +25341,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend/node_modules/is-descriptor"
             }
           ]
@@ -25367,7 +25367,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend/node_modules/kind-of"
             }
           ]
@@ -25395,7 +25395,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/statuses"
         }
       ]
@@ -25421,7 +25421,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/stream-buffers"
         }
       ]
@@ -25447,7 +25447,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/streamsearch"
         }
       ]
@@ -25473,7 +25473,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strict-uri-encode"
         }
       ]
@@ -25499,7 +25499,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string_decoder"
         }
       ]
@@ -25525,7 +25525,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string-width"
         }
       ]
@@ -25551,7 +25551,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string.fromcodepoint"
         }
       ]
@@ -25577,7 +25577,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string.prototype.codepointat"
         }
       ]
@@ -25603,7 +25603,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string.prototype.trimend"
         }
       ]
@@ -25629,7 +25629,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string.prototype.trimstart"
         }
       ]
@@ -25655,7 +25655,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-ansi"
         }
       ]
@@ -25681,7 +25681,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-bom"
         }
       ]
@@ -25707,7 +25707,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-dirs"
         }
       ]
@@ -25733,7 +25733,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-json-comments"
         }
       ]
@@ -25759,7 +25759,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-outer"
         }
       ]
@@ -25785,7 +25785,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strtok3"
         }
       ]
@@ -25811,7 +25811,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/supports-color"
         }
       ]
@@ -25837,7 +25837,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/supports-preserve-symlinks-flag"
         }
       ]
@@ -25863,7 +25863,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/svg-captcha"
         }
       ]
@@ -25889,7 +25889,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/swagger-ui-dist"
         }
       ]
@@ -25915,7 +25915,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/swagger-ui-express"
         }
       ]
@@ -25941,7 +25941,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tar-fs"
         }
       ],
@@ -25967,7 +25967,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/tar-fs/node_modules/bl"
             }
           ]
@@ -25993,7 +25993,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/tar-fs/node_modules/chownr"
             }
           ]
@@ -26019,7 +26019,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/tar-fs/node_modules/readable-stream"
             }
           ]
@@ -26045,7 +26045,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/tar-fs/node_modules/tar-stream"
             }
           ]
@@ -26073,7 +26073,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tar-stream"
         }
       ]
@@ -26099,7 +26099,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tar"
         }
       ]
@@ -26125,7 +26125,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tdigest"
         }
       ]
@@ -26151,7 +26151,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/text-hex"
         }
       ]
@@ -26177,7 +26177,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/thirty-two"
         }
       ]
@@ -26203,7 +26203,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/through"
         }
       ]
@@ -26229,7 +26229,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/timed-out"
         }
       ]
@@ -26255,7 +26255,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tiny-inflate"
         }
       ]
@@ -26281,7 +26281,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-buffer"
         }
       ]
@@ -26307,7 +26307,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-fast-properties"
         }
       ]
@@ -26333,7 +26333,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-object-path"
         }
       ],
@@ -26359,7 +26359,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/to-object-path/node_modules/kind-of"
             }
           ]
@@ -26387,7 +26387,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-regex-range"
         }
       ]
@@ -26413,7 +26413,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-regex"
         }
       ]
@@ -26439,7 +26439,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/toidentifier"
         }
       ]
@@ -26465,7 +26465,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/token-stream"
         }
       ]
@@ -26491,7 +26491,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/token-types"
         }
       ]
@@ -26517,7 +26517,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/toposort-class"
         }
       ]
@@ -26543,7 +26543,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tough-cookie"
         }
       ]
@@ -26569,7 +26569,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tr46"
         }
       ]
@@ -26595,7 +26595,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/traverse"
         }
       ]
@@ -26621,7 +26621,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tree-kill"
         }
       ]
@@ -26647,7 +26647,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/trim-repeated"
         }
       ]
@@ -26673,7 +26673,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/triple-beam"
         }
       ]
@@ -26699,7 +26699,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/truncate-utf8-bytes"
         }
       ]
@@ -26725,7 +26725,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ts-node-dev"
         }
       ],
@@ -26751,7 +26751,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/ts-node-dev/node_modules/rimraf"
             }
           ]
@@ -26779,7 +26779,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ts-node"
         }
       ]
@@ -26805,7 +26805,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tsconfig"
         }
       ]
@@ -26831,7 +26831,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tslib"
         }
       ]
@@ -26857,7 +26857,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tunnel-agent"
         }
       ]
@@ -26883,7 +26883,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tweetnacl"
         }
       ]
@@ -26909,7 +26909,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/type-check"
         }
       ]
@@ -26935,7 +26935,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/type-is"
         }
       ]
@@ -26961,7 +26961,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/typecast"
         }
       ]
@@ -26987,7 +26987,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/typedarray"
         }
       ]
@@ -27013,7 +27013,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/typescript"
         }
       ]
@@ -27039,7 +27039,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/uglify-js"
         }
       ]
@@ -27065,7 +27065,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unbox-primitive"
         }
       ]
@@ -27091,7 +27091,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unbzip2-stream"
         }
       ]
@@ -27117,7 +27117,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unc-path-regex"
         }
       ]
@@ -27143,7 +27143,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/underscore.string"
         }
       ]
@@ -27169,7 +27169,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unicode-properties"
         }
       ]
@@ -27195,7 +27195,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unicode-trie"
         }
       ]
@@ -27221,7 +27221,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/union-value"
         }
       ],
@@ -27247,7 +27247,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/union-value/node_modules/is-extendable"
             }
           ]
@@ -27275,7 +27275,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unique-filename"
         }
       ]
@@ -27301,7 +27301,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unique-slug"
         }
       ]
@@ -27327,7 +27327,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unit-compare"
         }
       ]
@@ -27353,7 +27353,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/universalify"
         }
       ]
@@ -27379,7 +27379,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unpipe"
         }
       ]
@@ -27405,7 +27405,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unset-value"
         }
       ],
@@ -27431,7 +27431,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/unset-value/node_modules/has-value"
             }
           ],
@@ -27457,7 +27457,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/unset-value/node_modules/has-value/node_modules/isobject"
                 }
               ]
@@ -27485,7 +27485,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/unset-value/node_modules/has-values"
             }
           ]
@@ -27511,7 +27511,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/unset-value/node_modules/isarray"
             }
           ]
@@ -27539,7 +27539,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/untildify"
         }
       ]
@@ -27565,7 +27565,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unzipper"
         }
       ],
@@ -27591,7 +27591,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/unzipper/node_modules/bluebird"
             }
           ]
@@ -27619,7 +27619,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/uri-js"
         }
       ]
@@ -27645,7 +27645,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/urix"
         }
       ]
@@ -27671,7 +27671,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/url-parse-lax"
         }
       ]
@@ -27697,7 +27697,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/url-to-options"
         }
       ]
@@ -27723,7 +27723,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/use"
         }
       ]
@@ -27749,7 +27749,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/utf8-byte-length"
         }
       ]
@@ -27775,7 +27775,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/util-deprecate"
         }
       ]
@@ -27801,7 +27801,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/util"
         }
       ]
@@ -27827,7 +27827,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/utils-merge"
         }
       ]
@@ -27853,7 +27853,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/uuid"
         }
       ]
@@ -27879,7 +27879,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/v8flags"
         }
       ]
@@ -27905,7 +27905,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/validate-npm-package-license"
         }
       ]
@@ -27931,7 +27931,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/validate"
         }
       ]
@@ -27957,7 +27957,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/validator"
         }
       ]
@@ -27983,7 +27983,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/vary"
         }
       ]
@@ -28009,7 +28009,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/verror"
         }
       ],
@@ -28035,7 +28035,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/verror/node_modules/core-util-is"
             }
           ]
@@ -28063,7 +28063,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/vm2"
         }
       ],
@@ -28089,7 +28089,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/vm2/node_modules/acorn"
             }
           ]
@@ -28117,7 +28117,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/void-elements"
         }
       ]
@@ -28143,7 +28143,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/walk"
         }
       ]
@@ -28169,7 +28169,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/walkdir"
         }
       ]
@@ -28195,7 +28195,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/webidl-conversions"
         }
       ]
@@ -28221,7 +28221,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/whatwg-url"
         }
       ]
@@ -28247,7 +28247,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-boxed-primitive"
         }
       ]
@@ -28273,7 +28273,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-collection"
         }
       ]
@@ -28299,7 +28299,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-module"
         }
       ]
@@ -28325,7 +28325,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-pm-runs"
         }
       ]
@@ -28351,7 +28351,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-typed-array"
         }
       ]
@@ -28377,7 +28377,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which"
         }
       ]
@@ -28403,7 +28403,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wide-align"
         }
       ]
@@ -28429,7 +28429,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/winston-transport"
         }
       ],
@@ -28455,7 +28455,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/winston-transport/node_modules/readable-stream"
             }
           ]
@@ -28483,7 +28483,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/winston"
         }
       ],
@@ -28509,7 +28509,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/winston/node_modules/async"
             }
           ]
@@ -28535,7 +28535,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/winston/node_modules/is-stream"
             }
           ]
@@ -28561,7 +28561,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/winston/node_modules/readable-stream"
             }
           ]
@@ -28589,7 +28589,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/with"
         }
       ]
@@ -28615,7 +28615,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wkx"
         }
       ]
@@ -28641,7 +28641,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/word-wrap"
         }
       ]
@@ -28667,7 +28667,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wordwrap"
         }
       ]
@@ -28693,7 +28693,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wrap-ansi"
         }
       ],
@@ -28719,7 +28719,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi/node_modules/ansi-regex"
             }
           ]
@@ -28745,7 +28745,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi/node_modules/emoji-regex"
             }
           ]
@@ -28771,7 +28771,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -28797,7 +28797,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi/node_modules/string-width"
             }
           ]
@@ -28823,7 +28823,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi/node_modules/strip-ansi"
             }
           ]
@@ -28851,7 +28851,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wrappy"
         }
       ]
@@ -28877,7 +28877,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ws"
         }
       ]
@@ -28903,7 +28903,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/xtend"
         }
       ]
@@ -28929,7 +28929,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/y18n"
         }
       ]
@@ -28955,7 +28955,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yallist"
         }
       ]
@@ -28981,7 +28981,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yaml-schema-validator"
         }
       ]
@@ -29007,7 +29007,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yargs-parser"
         }
       ]
@@ -29033,7 +29033,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yargs"
         }
       ],
@@ -29059,7 +29059,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs/node_modules/ansi-regex"
             }
           ]
@@ -29085,7 +29085,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs/node_modules/emoji-regex"
             }
           ]
@@ -29111,7 +29111,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -29137,7 +29137,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs/node_modules/string-width"
             }
           ]
@@ -29163,7 +29163,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs/node_modules/strip-ansi"
             }
           ]
@@ -29191,7 +29191,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yauzl"
         }
       ]
@@ -29217,7 +29217,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yn"
         }
       ]
@@ -29243,7 +29243,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/z85"
         }
       ]
@@ -29269,7 +29269,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/zip-stream"
         }
       ]
@@ -29295,7 +29295,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/zlibjs"
         }
       ]

--- a/tests/_data/sbom_demo-results/juice-shop_npm8_node18_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/juice-shop_npm8_node18_macos-latest.snap.json
@@ -62,6 +62,10 @@
       ],
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -88,6 +92,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@babel/helper-string-parser"
+        }
       ]
     },
     {
@@ -108,6 +118,12 @@
           "url": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@babel/helper-validator-identifier"
         }
       ]
     },
@@ -130,6 +146,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@babel/parser"
+        }
       ]
     },
     {
@@ -150,6 +172,12 @@
           "url": "https://registry.npmjs.org/@babel/types/-/types-7.20.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@babel/types"
         }
       ]
     },
@@ -172,6 +200,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@colors/colors"
+        }
       ]
     },
     {
@@ -193,6 +227,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@dabh/diagnostics"
+        }
       ]
     },
     {
@@ -213,6 +253,12 @@
           "url": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@gar/promisify"
         }
       ]
     },
@@ -236,6 +282,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@mapbox/node-pre-gyp"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -254,6 +306,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/ansi-regex"
             }
           ]
         },
@@ -275,6 +333,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/are-we-there-yet"
+            }
           ]
         },
         {
@@ -294,6 +358,12 @@
               "url": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/detect-libc"
             }
           ]
         },
@@ -315,6 +385,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/gauge"
+            }
           ]
         },
         {
@@ -334,6 +410,12 @@
               "url": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/is-fullwidth-code-point"
             }
           ]
         },
@@ -356,6 +438,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/make-dir"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -374,6 +462,12 @@
                   "url": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/@mapbox/node-pre-gyp/node_modules/make-dir/node_modules/semver"
                 }
               ]
             }
@@ -397,6 +491,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/nopt"
+            }
           ]
         },
         {
@@ -416,6 +516,12 @@
               "url": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/npmlog"
             }
           ]
         },
@@ -437,6 +543,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/readable-stream"
+            }
           ]
         },
         {
@@ -457,6 +569,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/string-width"
+            }
           ]
         },
         {
@@ -476,6 +594,12 @@
               "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/strip-ansi"
             }
           ]
         }
@@ -500,6 +624,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/core-loader"
+        }
       ]
     },
     {
@@ -520,6 +650,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/core/-/core-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/core"
         }
       ]
     },
@@ -542,6 +678,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/evaluator"
+        }
       ]
     },
     {
@@ -562,6 +704,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-all/-/lang-all-4.24.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-all"
         }
       ]
     },
@@ -584,6 +732,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ar"
+        }
       ]
     },
     {
@@ -604,6 +758,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-bn/-/lang-bn-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-bn"
         }
       ]
     },
@@ -626,6 +786,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ca"
+        }
       ]
     },
     {
@@ -646,6 +812,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-cs/-/lang-cs-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-cs"
         }
       ]
     },
@@ -668,6 +840,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-da"
+        }
       ]
     },
     {
@@ -688,6 +866,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-de/-/lang-de-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-de"
         }
       ]
     },
@@ -710,6 +894,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-el"
+        }
       ]
     },
     {
@@ -730,6 +920,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-en-min/-/lang-en-min-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-en-min"
         }
       ]
     },
@@ -752,6 +948,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-en"
+        }
       ]
     },
     {
@@ -772,6 +974,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-es/-/lang-es-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-es"
         }
       ]
     },
@@ -794,6 +1002,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-eu"
+        }
       ]
     },
     {
@@ -814,6 +1028,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-fa/-/lang-fa-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-fa"
         }
       ]
     },
@@ -836,6 +1056,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-fi"
+        }
       ]
     },
     {
@@ -856,6 +1082,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-fr/-/lang-fr-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-fr"
         }
       ]
     },
@@ -878,6 +1110,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ga"
+        }
       ]
     },
     {
@@ -898,6 +1136,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-gl/-/lang-gl-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-gl"
         }
       ]
     },
@@ -920,6 +1164,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-hi"
+        }
       ]
     },
     {
@@ -940,6 +1190,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-hu/-/lang-hu-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-hu"
         }
       ]
     },
@@ -962,6 +1218,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-hy"
+        }
       ]
     },
     {
@@ -982,6 +1244,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-id/-/lang-id-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-id"
         }
       ]
     },
@@ -1004,6 +1272,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-it"
+        }
       ]
     },
     {
@@ -1024,6 +1298,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-ja/-/lang-ja-4.24.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ja"
         }
       ]
     },
@@ -1046,6 +1326,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ko"
+        }
       ]
     },
     {
@@ -1066,6 +1352,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-lt/-/lang-lt-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-lt"
         }
       ]
     },
@@ -1088,6 +1380,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ms"
+        }
       ]
     },
     {
@@ -1108,6 +1406,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-ne/-/lang-ne-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ne"
         }
       ]
     },
@@ -1130,6 +1434,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-nl"
+        }
       ]
     },
     {
@@ -1150,6 +1460,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-no/-/lang-no-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-no"
         }
       ]
     },
@@ -1172,6 +1488,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-pl"
+        }
       ]
     },
     {
@@ -1192,6 +1514,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-pt/-/lang-pt-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-pt"
         }
       ]
     },
@@ -1214,6 +1542,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ro"
+        }
       ]
     },
     {
@@ -1234,6 +1568,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-ru/-/lang-ru-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ru"
         }
       ]
     },
@@ -1256,6 +1596,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-sl"
+        }
       ]
     },
     {
@@ -1276,6 +1622,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-sr/-/lang-sr-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-sr"
         }
       ]
     },
@@ -1298,6 +1650,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-sv"
+        }
       ]
     },
     {
@@ -1318,6 +1676,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-ta/-/lang-ta-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ta"
         }
       ]
     },
@@ -1340,6 +1704,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-th"
+        }
       ]
     },
     {
@@ -1360,6 +1730,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-tl/-/lang-tl-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-tl"
         }
       ]
     },
@@ -1382,6 +1758,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-tr"
+        }
       ]
     },
     {
@@ -1402,6 +1784,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-uk/-/lang-uk-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-uk"
         }
       ]
     },
@@ -1424,6 +1812,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-zh"
+        }
       ]
     },
     {
@@ -1444,6 +1838,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/language-min/-/language-min-4.22.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/language-min"
         }
       ]
     },
@@ -1466,6 +1866,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/language"
+        }
       ]
     },
     {
@@ -1486,6 +1892,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/ner/-/ner-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/ner"
         }
       ]
     },
@@ -1508,6 +1920,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/neural"
+        }
       ]
     },
     {
@@ -1528,6 +1946,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/nlg/-/nlg-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/nlg"
         }
       ]
     },
@@ -1550,6 +1974,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/nlp"
+        }
       ]
     },
     {
@@ -1570,6 +2000,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/nlu/-/nlu-4.23.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/nlu"
         }
       ]
     },
@@ -1592,6 +2028,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/request"
+        }
       ]
     },
     {
@@ -1612,6 +2054,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/sentiment/-/sentiment-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/sentiment"
         }
       ]
     },
@@ -1634,6 +2082,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/similarity"
+        }
       ]
     },
     {
@@ -1654,6 +2108,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/slot/-/slot-4.22.17.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/slot"
         }
       ]
     },
@@ -1676,6 +2136,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@npmcli/fs"
+        }
       ]
     },
     {
@@ -1696,6 +2162,12 @@
           "url": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@npmcli/move-file"
         }
       ]
     },
@@ -1718,6 +2190,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib/core"
+        }
       ]
     },
     {
@@ -1738,6 +2216,12 @@
           "url": "https://registry.npmjs.org/@otplib/plugin-crypto/-/plugin-crypto-12.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib/plugin-crypto"
         }
       ]
     },
@@ -1760,6 +2244,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib/plugin-thirty-two"
+        }
       ]
     },
     {
@@ -1780,6 +2270,12 @@
           "url": "https://registry.npmjs.org/@otplib/preset-default/-/preset-default-12.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib/preset-default"
         }
       ]
     },
@@ -1802,6 +2298,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib/preset-v11"
+        }
       ]
     },
     {
@@ -1822,6 +2324,12 @@
           "url": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@sindresorhus/is"
         }
       ]
     },
@@ -1844,6 +2352,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@swc/helpers"
+        }
       ]
     },
     {
@@ -1864,6 +2378,12 @@
           "url": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@tokenizer/token"
         }
       ]
     },
@@ -1886,6 +2406,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@tootallnate/once"
+        }
       ]
     },
     {
@@ -1906,6 +2432,12 @@
           "url": "https://registry.npmjs.org/@types/component-emitter/-/component-emitter-1.2.11.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/component-emitter"
         }
       ]
     },
@@ -1928,6 +2460,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/cookie"
+        }
       ]
     },
     {
@@ -1948,6 +2486,12 @@
           "url": "https://registry.npmjs.org/@types/cors/-/cors-2.8.12.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/cors"
         }
       ]
     },
@@ -1970,6 +2514,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/debug"
+        }
       ]
     },
     {
@@ -1990,6 +2540,12 @@
           "url": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/ms"
         }
       ]
     },
@@ -2012,6 +2568,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/node"
+        }
       ]
     },
     {
@@ -2032,6 +2594,12 @@
           "url": "https://registry.npmjs.org/@types/strip-bom/-/strip-bom-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/strip-bom"
         }
       ]
     },
@@ -2054,6 +2622,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/strip-json-comments"
+        }
       ]
     },
     {
@@ -2075,6 +2649,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/validator"
+        }
       ]
     },
     {
@@ -2094,6 +2674,12 @@
           "url": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/abbrev"
         }
       ]
     },
@@ -2115,6 +2701,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/accepts"
+        }
       ]
     },
     {
@@ -2135,6 +2727,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/acorn-walk"
+        }
       ]
     },
     {
@@ -2154,6 +2752,12 @@
           "url": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/acorn"
         }
       ]
     },
@@ -2176,6 +2780,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/agent-base"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -2194,6 +2804,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agent-base/node_modules/debug"
             }
           ]
         },
@@ -2214,6 +2830,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agent-base/node_modules/ms"
             }
           ]
         }
@@ -2238,6 +2860,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/agentkeepalive"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -2256,6 +2884,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agentkeepalive/node_modules/debug"
             }
           ]
         },
@@ -2277,6 +2911,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agentkeepalive/node_modules/depd"
+            }
           ]
         },
         {
@@ -2296,6 +2936,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agentkeepalive/node_modules/ms"
             }
           ]
         }
@@ -2319,6 +2965,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/aggregate-error"
+        }
       ]
     },
     {
@@ -2338,6 +2990,12 @@
           "url": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ajv"
         }
       ]
     },
@@ -2359,6 +3017,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ansi-regex"
+        }
       ]
     },
     {
@@ -2378,6 +3042,12 @@
           "url": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ansi-styles"
         }
       ]
     },
@@ -2400,6 +3070,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/anymatch"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -2418,6 +3094,12 @@
               "url": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/anymatch/node_modules/normalize-path"
             }
           ]
         }
@@ -2441,6 +3123,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/append-field"
+        }
       ]
     },
     {
@@ -2460,6 +3148,12 @@
           "url": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/aproba"
         }
       ]
     },
@@ -2482,6 +3176,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/archive-type"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -2500,6 +3200,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-4.4.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/archive-type/node_modules/file-type"
             }
           ]
         }
@@ -2523,6 +3229,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/archiver-utils"
+        }
       ]
     },
     {
@@ -2542,6 +3254,12 @@
           "url": "https://registry.npmjs.org/archiver/-/archiver-1.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/archiver"
         }
       ]
     },
@@ -2563,6 +3281,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/are-we-there-yet"
+        }
       ]
     },
     {
@@ -2582,6 +3306,12 @@
           "url": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/arg"
         }
       ]
     },
@@ -2604,6 +3334,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/argparse"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -2622,6 +3358,12 @@
               "url": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/argparse/node_modules/sprintf-js"
             }
           ]
         }
@@ -2645,6 +3387,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/arr-diff"
+        }
       ]
     },
     {
@@ -2664,6 +3412,12 @@
           "url": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/arr-flatten"
         }
       ]
     },
@@ -2685,6 +3439,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/arr-union"
+        }
       ]
     },
     {
@@ -2704,6 +3464,12 @@
           "url": "https://registry.npmjs.org/array-each/-/array-each-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/array-each"
         }
       ]
     },
@@ -2725,6 +3491,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/array-flatten"
+        }
       ]
     },
     {
@@ -2744,6 +3516,12 @@
           "url": "https://registry.npmjs.org/array-slice/-/array-slice-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/array-slice"
         }
       ]
     },
@@ -2765,6 +3543,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/array-unique"
+        }
       ]
     },
     {
@@ -2784,6 +3568,12 @@
           "url": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/asap"
         }
       ]
     },
@@ -2805,6 +3595,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/asn1"
+        }
       ]
     },
     {
@@ -2824,6 +3620,12 @@
           "url": "https://registry.npmjs.org/assert-never/-/assert-never-1.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/assert-never"
         }
       ]
     },
@@ -2845,6 +3647,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/assert-plus"
+        }
       ]
     },
     {
@@ -2864,6 +3672,12 @@
           "url": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/assign-symbols"
         }
       ]
     },
@@ -2885,6 +3699,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/async"
+        }
       ]
     },
     {
@@ -2904,6 +3724,12 @@
           "url": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/asynckit"
         }
       ]
     },
@@ -2925,6 +3751,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/at-least-node"
+        }
       ]
     },
     {
@@ -2944,6 +3776,12 @@
           "url": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/atob"
         }
       ]
     },
@@ -2965,6 +3803,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/available-typed-arrays"
+        }
       ]
     },
     {
@@ -2984,6 +3828,12 @@
           "url": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/aws-sign2"
         }
       ]
     },
@@ -3005,6 +3855,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/aws4"
+        }
       ]
     },
     {
@@ -3025,6 +3881,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/babel-walk"
+        }
       ]
     },
     {
@@ -3044,6 +3906,12 @@
           "url": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/balanced-match"
         }
       ]
     },
@@ -3066,6 +3934,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -3084,6 +3958,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/base/node_modules/define-property"
             }
           ]
         }
@@ -3107,6 +3987,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base64-arraybuffer"
+        }
       ]
     },
     {
@@ -3126,6 +4012,12 @@
           "url": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base64-js"
         }
       ]
     },
@@ -3147,6 +4039,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base64id"
+        }
       ]
     },
     {
@@ -3166,6 +4064,12 @@
           "url": "https://registry.npmjs.org/base64url/-/base64url-0.0.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base64url"
         }
       ]
     },
@@ -3187,6 +4091,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/basic-auth"
+        }
       ]
     },
     {
@@ -3206,6 +4116,12 @@
           "url": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/batch"
         }
       ]
     },
@@ -3227,6 +4143,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bcrypt-pbkdf"
+        }
       ]
     },
     {
@@ -3246,6 +4168,12 @@
           "url": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/big-integer"
         }
       ]
     },
@@ -3267,6 +4195,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/binary-extensions"
+        }
       ]
     },
     {
@@ -3286,6 +4220,12 @@
           "url": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/binary"
         }
       ]
     },
@@ -3307,6 +4247,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bindings"
+        }
       ]
     },
     {
@@ -3326,6 +4272,12 @@
           "url": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bintrees"
         }
       ]
     },
@@ -3347,6 +4299,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bl"
+        }
       ]
     },
     {
@@ -3367,6 +4325,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bluebird"
+        }
       ]
     },
     {
@@ -3386,6 +4350,12 @@
           "url": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/body-parser"
         }
       ]
     },
@@ -3408,6 +4378,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bower-config"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -3426,6 +4402,12 @@
               "url": "https://registry.npmjs.org/minimist/-/minimist-0.2.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bower-config/node_modules/minimist"
             }
           ]
         }
@@ -3449,6 +4431,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/brace-expansion"
+        }
       ]
     },
     {
@@ -3470,6 +4458,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/braces"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -3488,6 +4482,12 @@
               "url": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/braces/node_modules/extend-shallow"
             }
           ]
         },
@@ -3508,6 +4508,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/braces/node_modules/is-extendable"
             }
           ]
         }
@@ -3531,6 +4537,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/brotli"
+        }
       ]
     },
     {
@@ -3550,6 +4562,12 @@
           "url": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-alloc-unsafe"
         }
       ]
     },
@@ -3571,6 +4589,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-alloc"
+        }
       ]
     },
     {
@@ -3590,6 +4614,12 @@
           "url": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-crc32"
         }
       ]
     },
@@ -3611,6 +4641,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-fill"
+        }
       ]
     },
     {
@@ -3630,6 +4666,12 @@
           "url": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-from"
         }
       ]
     },
@@ -3651,6 +4693,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-indexof-polyfill"
+        }
       ]
     },
     {
@@ -3671,6 +4719,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer"
+        }
       ]
     },
     {
@@ -3690,6 +4744,12 @@
           "url": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffers"
         }
       ]
     },
@@ -3712,6 +4772,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/busboy"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -3730,6 +4796,12 @@
               "url": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/busboy/node_modules/isarray"
             }
           ]
         },
@@ -3751,6 +4823,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/busboy/node_modules/readable-stream"
+            }
           ]
         },
         {
@@ -3770,6 +4848,12 @@
               "url": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/busboy/node_modules/string_decoder"
             }
           ]
         }
@@ -3793,6 +4877,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/byline"
+        }
       ]
     },
     {
@@ -3812,6 +4902,12 @@
           "url": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bytes"
         }
       ]
     },
@@ -3833,6 +4929,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cacache"
+        }
       ]
     },
     {
@@ -3852,6 +4954,12 @@
           "url": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cache-base"
         }
       ]
     },
@@ -3874,6 +4982,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cacheable-request"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -3892,6 +5006,12 @@
               "url": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cacheable-request/node_modules/get-stream"
             }
           ]
         },
@@ -3912,6 +5032,12 @@
               "url": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cacheable-request/node_modules/lowercase-keys"
             }
           ]
         }
@@ -3935,6 +5061,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/call-bind"
+        }
       ]
     },
     {
@@ -3954,6 +5086,12 @@
           "url": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/camelcase"
         }
       ]
     },
@@ -3975,6 +5113,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/caseless"
+        }
       ]
     },
     {
@@ -3994,6 +5138,12 @@
           "url": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/chainsaw"
         }
       ]
     },
@@ -4015,6 +5165,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/chalk"
+        }
       ]
     },
     {
@@ -4034,6 +5190,12 @@
           "url": "https://registry.npmjs.org/character-parser/-/character-parser-2.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/character-parser"
         }
       ]
     },
@@ -4056,6 +5218,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/check-dependencies"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4074,6 +5242,12 @@
               "url": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/check-dependencies/node_modules/semver"
             }
           ]
         }
@@ -4097,6 +5271,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/check-types"
+        }
       ]
     },
     {
@@ -4118,6 +5298,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/chokidar"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4136,6 +5322,12 @@
               "url": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar/node_modules/braces"
             }
           ]
         },
@@ -4157,6 +5349,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar/node_modules/fill-range"
+            }
           ]
         },
         {
@@ -4176,6 +5374,12 @@
               "url": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar/node_modules/is-glob"
             }
           ]
         },
@@ -4197,6 +5401,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar/node_modules/is-number"
+            }
           ]
         },
         {
@@ -4217,6 +5427,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar/node_modules/normalize-path"
+            }
           ]
         },
         {
@@ -4236,6 +5452,12 @@
               "url": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar/node_modules/to-regex-range"
             }
           ]
         }
@@ -4259,6 +5481,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/chownr"
+        }
       ]
     },
     {
@@ -4278,6 +5506,12 @@
           "url": "https://registry.npmjs.org/clarinet/-/clarinet-0.12.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/clarinet"
         }
       ]
     },
@@ -4300,6 +5534,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/class-utils"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4318,6 +5558,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils/node_modules/define-property"
             }
           ]
         },
@@ -4340,6 +5586,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils/node_modules/is-accessor-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -4358,6 +5610,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/class-utils/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -4382,6 +5640,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils/node_modules/is-data-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -4400,6 +5664,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/class-utils/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -4423,6 +5693,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils/node_modules/is-descriptor"
+            }
           ]
         },
         {
@@ -4442,6 +5718,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils/node_modules/kind-of"
             }
           ]
         }
@@ -4465,6 +5747,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/clean-stack"
+        }
       ]
     },
     {
@@ -4486,6 +5774,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cliui"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4504,6 +5798,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui/node_modules/ansi-regex"
             }
           ]
         },
@@ -4525,6 +5825,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui/node_modules/emoji-regex"
+            }
           ]
         },
         {
@@ -4544,6 +5850,12 @@
               "url": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui/node_modules/is-fullwidth-code-point"
             }
           ]
         },
@@ -4565,6 +5877,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui/node_modules/string-width"
+            }
           ]
         },
         {
@@ -4584,6 +5902,12 @@
               "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui/node_modules/strip-ansi"
             }
           ]
         }
@@ -4607,6 +5931,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/clone-response"
+        }
       ]
     },
     {
@@ -4626,6 +5956,12 @@
           "url": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/clone"
         }
       ]
     },
@@ -4647,6 +5983,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/code-point-at"
+        }
       ]
     },
     {
@@ -4666,6 +6008,12 @@
           "url": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/collection-visit"
         }
       ]
     },
@@ -4687,6 +6035,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color-convert"
+        }
       ]
     },
     {
@@ -4706,6 +6060,12 @@
           "url": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color-name"
         }
       ]
     },
@@ -4727,6 +6087,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color-string"
+        }
       ]
     },
     {
@@ -4746,6 +6112,12 @@
           "url": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color-support"
         }
       ]
     },
@@ -4767,6 +6139,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color"
+        }
       ]
     },
     {
@@ -4786,6 +6164,12 @@
           "url": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/colors"
         }
       ]
     },
@@ -4807,6 +6191,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/colorspace"
+        }
       ]
     },
     {
@@ -4826,6 +6216,12 @@
           "url": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/combined-stream"
         }
       ]
     },
@@ -4847,6 +6243,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/commander"
+        }
       ]
     },
     {
@@ -4866,6 +6268,12 @@
           "url": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/component-emitter"
         }
       ]
     },
@@ -4887,6 +6295,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/component-type"
+        }
       ]
     },
     {
@@ -4907,6 +6321,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/compress-commons"
+        }
       ]
     },
     {
@@ -4926,6 +6346,12 @@
           "url": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/compressible"
         }
       ]
     },
@@ -4948,6 +6374,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/compression"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4966,6 +6398,12 @@
               "url": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/compression/node_modules/bytes"
             }
           ]
         }
@@ -4989,6 +6427,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/concat-map"
+        }
       ]
     },
     {
@@ -5008,6 +6452,12 @@
           "url": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/concat-stream"
         }
       ]
     },
@@ -5030,6 +6480,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/concurrently"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5048,6 +6504,12 @@
               "url": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/concurrently/node_modules/supports-color"
             }
           ]
         }
@@ -5071,6 +6533,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/config"
+        }
       ]
     },
     {
@@ -5091,6 +6559,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/console-control-strings"
+        }
       ]
     },
     {
@@ -5110,6 +6584,12 @@
           "url": "https://registry.npmjs.org/constantinople/-/constantinople-4.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/constantinople"
         }
       ]
     },
@@ -5132,6 +6612,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/content-disposition"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5150,6 +6636,12 @@
               "url": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/content-disposition/node_modules/safe-buffer"
             }
           ]
         }
@@ -5173,6 +6665,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/content-type"
+        }
       ]
     },
     {
@@ -5192,6 +6690,12 @@
           "url": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cookie-parser"
         }
       ]
     },
@@ -5213,6 +6717,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cookie-signature"
+        }
       ]
     },
     {
@@ -5232,6 +6742,12 @@
           "url": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cookie"
         }
       ]
     },
@@ -5253,6 +6769,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/copy-descriptor"
+        }
       ]
     },
     {
@@ -5272,6 +6794,12 @@
           "url": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/core-util-is"
         }
       ]
     },
@@ -5293,6 +6821,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cors"
+        }
       ]
     },
     {
@@ -5312,6 +6846,12 @@
           "url": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/crc"
         }
       ]
     },
@@ -5333,6 +6873,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/crc32-stream"
+        }
       ]
     },
     {
@@ -5352,6 +6898,12 @@
           "url": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/create-require"
         }
       ]
     },
@@ -5373,6 +6925,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/crypto-js"
+        }
       ]
     },
     {
@@ -5392,6 +6950,12 @@
           "url": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dashdash"
         }
       ]
     },
@@ -5413,6 +6977,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/date-fns"
+        }
       ]
     },
     {
@@ -5432,6 +7002,12 @@
           "url": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dateformat"
         }
       ]
     },
@@ -5453,6 +7029,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/debug"
+        }
       ]
     },
     {
@@ -5472,6 +7054,12 @@
           "url": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decamelize"
         }
       ]
     },
@@ -5493,6 +7081,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decode-uri-component"
+        }
       ]
     },
     {
@@ -5512,6 +7106,12 @@
           "url": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-response"
         }
       ]
     },
@@ -5534,6 +7134,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-tar"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5552,6 +7158,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-tar/node_modules/file-type"
             }
           ]
         }
@@ -5576,6 +7188,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-tarbz2"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5594,6 +7212,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-6.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-tarbz2/node_modules/file-type"
             }
           ]
         }
@@ -5618,6 +7242,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-targz"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5636,6 +7266,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-targz/node_modules/file-type"
             }
           ]
         }
@@ -5660,6 +7296,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-unzip"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5678,6 +7320,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-unzip/node_modules/file-type"
             }
           ]
         },
@@ -5699,6 +7347,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-unzip/node_modules/get-stream"
+            }
           ]
         },
         {
@@ -5718,6 +7372,12 @@
               "url": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-unzip/node_modules/pify"
             }
           ]
         }
@@ -5742,6 +7402,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5762,6 +7428,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress/node_modules/make-dir"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -5780,6 +7452,12 @@
                   "url": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/decompress/node_modules/make-dir/node_modules/pify"
                 }
               ]
             }
@@ -5803,6 +7481,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress/node_modules/pify"
+            }
           ]
         }
       ]
@@ -5825,6 +7509,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/deep-equal"
+        }
       ]
     },
     {
@@ -5844,6 +7534,12 @@
           "url": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/deep-extend"
         }
       ]
     },
@@ -5865,6 +7561,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/deep-is"
+        }
       ]
     },
     {
@@ -5884,6 +7586,12 @@
           "url": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/define-properties"
         }
       ]
     },
@@ -5905,6 +7613,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/define-property"
+        }
       ]
     },
     {
@@ -5924,6 +7638,12 @@
           "url": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/delayed-stream"
         }
       ]
     },
@@ -5945,6 +7665,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/delegates"
+        }
       ]
     },
     {
@@ -5964,6 +7690,12 @@
           "url": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/depd"
         }
       ]
     },
@@ -5985,6 +7717,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/destroy"
+        }
       ]
     },
     {
@@ -6004,6 +7742,12 @@
           "url": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/detect-file"
         }
       ]
     },
@@ -6025,6 +7769,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/detect-libc"
+        }
       ]
     },
     {
@@ -6044,6 +7794,12 @@
           "url": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dfa"
         }
       ]
     },
@@ -6066,6 +7822,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dicer"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -6084,6 +7846,12 @@
               "url": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/dicer/node_modules/isarray"
             }
           ]
         },
@@ -6105,6 +7873,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/dicer/node_modules/readable-stream"
+            }
           ]
         },
         {
@@ -6124,6 +7898,12 @@
               "url": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/dicer/node_modules/string_decoder"
             }
           ]
         }
@@ -6147,6 +7927,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/diff"
+        }
       ]
     },
     {
@@ -6166,6 +7952,12 @@
           "url": "https://registry.npmjs.org/doctypes/-/doctypes-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/doctypes"
         }
       ]
     },
@@ -6187,6 +7979,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/domelementtype"
+        }
       ]
     },
     {
@@ -6206,6 +8004,12 @@
           "url": "https://registry.npmjs.org/domhandler/-/domhandler-2.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/domhandler"
         }
       ]
     },
@@ -6227,6 +8031,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/domutils"
+        }
       ]
     },
     {
@@ -6246,6 +8056,12 @@
           "url": "https://registry.npmjs.org/dottie/-/dottie-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dottie"
         }
       ]
     },
@@ -6267,6 +8083,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/double-ended-queue"
+        }
       ]
     },
     {
@@ -6286,6 +8108,12 @@
           "url": "https://registry.npmjs.org/doublearray/-/doublearray-0.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/doublearray"
         }
       ]
     },
@@ -6308,6 +8136,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/download"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -6326,6 +8160,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-11.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/download/node_modules/file-type"
             }
           ]
         }
@@ -6349,6 +8189,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/duplexer2"
+        }
       ]
     },
     {
@@ -6368,6 +8214,12 @@
           "url": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/duplexer3"
         }
       ]
     },
@@ -6389,6 +8241,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dynamic-dedupe"
+        }
       ]
     },
     {
@@ -6408,6 +8266,12 @@
           "url": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ecc-jsbn"
         }
       ]
     },
@@ -6429,6 +8293,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ee-first"
+        }
       ]
     },
     {
@@ -6448,6 +8318,12 @@
           "url": "https://registry.npmjs.org/eivindfjeldstad-dot/-/eivindfjeldstad-dot-0.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/eivindfjeldstad-dot"
         }
       ]
     },
@@ -6469,6 +8345,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/emoji-regex"
+        }
       ]
     },
     {
@@ -6489,6 +8371,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/enabled"
+        }
       ]
     },
     {
@@ -6508,6 +8396,12 @@
           "url": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/encodeurl"
         }
       ]
     },
@@ -6530,6 +8424,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/encoding"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -6548,6 +8448,12 @@
               "url": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/encoding/node_modules/iconv-lite"
             }
           ]
         }
@@ -6571,6 +8477,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/end-of-stream"
+        }
       ]
     },
     {
@@ -6590,6 +8502,12 @@
           "url": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-4.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/engine.io-parser"
         }
       ]
     },
@@ -6612,6 +8530,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/engine.io"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -6630,6 +8554,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/engine.io/node_modules/debug"
             }
           ]
         },
@@ -6650,6 +8580,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/engine.io/node_modules/ms"
             }
           ]
         }
@@ -6673,6 +8609,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/env-paths"
+        }
       ]
     },
     {
@@ -6692,6 +8634,12 @@
           "url": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/err-code"
         }
       ]
     },
@@ -6713,6 +8661,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/error-ex"
+        }
       ]
     },
     {
@@ -6732,6 +8686,12 @@
           "url": "https://registry.npmjs.org/errorhandler/-/errorhandler-1.5.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/errorhandler"
         }
       ]
     },
@@ -6753,6 +8713,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/es-abstract"
+        }
       ]
     },
     {
@@ -6772,6 +8738,12 @@
           "url": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/es-get-iterator"
         }
       ]
     },
@@ -6793,6 +8765,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/es-to-primitive"
+        }
       ]
     },
     {
@@ -6812,6 +8790,12 @@
           "url": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/escape-html"
         }
       ]
     },
@@ -6833,6 +8817,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/escape-string-regexp"
+        }
       ]
     },
     {
@@ -6852,6 +8842,12 @@
           "url": "https://registry.npmjs.org/escodegen/-/escodegen-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/escodegen"
         }
       ]
     },
@@ -6873,6 +8869,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/esprima"
+        }
       ]
     },
     {
@@ -6892,6 +8894,12 @@
           "url": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/estraverse"
         }
       ]
     },
@@ -6913,6 +8921,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/esutils"
+        }
       ]
     },
     {
@@ -6932,6 +8946,12 @@
           "url": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/etag"
         }
       ]
     },
@@ -6953,6 +8973,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/eventemitter2"
+        }
       ]
     },
     {
@@ -6972,6 +8998,12 @@
           "url": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/eventemitter3"
         }
       ]
     },
@@ -6993,6 +9025,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/exif"
+        }
       ]
     },
     {
@@ -7012,6 +9050,12 @@
           "url": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/exit"
         }
       ]
     },
@@ -7034,6 +9078,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/expand-brackets"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7052,6 +9102,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/define-property"
             }
           ]
         },
@@ -7072,6 +9128,12 @@
               "url": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/extend-shallow"
             }
           ]
         },
@@ -7094,6 +9156,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/is-accessor-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -7112,6 +9180,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/expand-brackets/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -7136,6 +9210,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/is-data-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -7154,6 +9234,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/expand-brackets/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -7177,6 +9263,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/is-descriptor"
+            }
           ]
         },
         {
@@ -7197,6 +9289,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/is-extendable"
+            }
           ]
         },
         {
@@ -7216,6 +9314,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/kind-of"
             }
           ]
         }
@@ -7239,6 +9343,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/expand-template"
+        }
       ]
     },
     {
@@ -7259,6 +9369,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/expand-tilde"
+        }
       ]
     },
     {
@@ -7278,6 +9394,12 @@
           "url": "https://registry.npmjs.org/express-ipfilter/-/express-ipfilter-1.3.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-ipfilter"
         }
       ]
     },
@@ -7300,6 +9422,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-jwt"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7318,6 +9446,12 @@
               "url": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-0.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/express-jwt/node_modules/jsonwebtoken"
             }
           ]
         },
@@ -7338,6 +9472,12 @@
               "url": "https://registry.npmjs.org/moment/-/moment-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/express-jwt/node_modules/moment"
             }
           ]
         }
@@ -7361,6 +9501,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-rate-limit"
+        }
       ]
     },
     {
@@ -7381,6 +9527,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-robots-txt"
+        }
       ]
     },
     {
@@ -7400,6 +9552,12 @@
           "url": "https://registry.npmjs.org/express-security.txt/-/express-security.txt-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-security.txt"
         }
       ]
     },
@@ -7422,6 +9580,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7440,6 +9604,12 @@
               "url": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/express/node_modules/cookie"
             }
           ]
         },
@@ -7460,6 +9630,12 @@
               "url": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/express/node_modules/safe-buffer"
             }
           ]
         }
@@ -7483,6 +9659,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ext-list"
+        }
       ]
     },
     {
@@ -7502,6 +9684,12 @@
           "url": "https://registry.npmjs.org/ext-name/-/ext-name-5.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ext-name"
         }
       ]
     },
@@ -7523,6 +9711,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/extend-shallow"
+        }
       ]
     },
     {
@@ -7542,6 +9736,12 @@
           "url": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/extend"
         }
       ]
     },
@@ -7564,6 +9764,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/extglob"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7582,6 +9788,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/extglob/node_modules/define-property"
             }
           ]
         },
@@ -7603,6 +9815,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/extglob/node_modules/extend-shallow"
+            }
           ]
         },
         {
@@ -7622,6 +9840,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/extglob/node_modules/is-extendable"
             }
           ]
         }
@@ -7645,6 +9869,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/extsprintf"
+        }
       ]
     },
     {
@@ -7664,6 +9894,12 @@
           "url": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fast-deep-equal"
         }
       ]
     },
@@ -7685,6 +9921,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fast-json-stable-stringify"
+        }
       ]
     },
     {
@@ -7704,6 +9946,12 @@
           "url": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fast-levenshtein"
         }
       ]
     },
@@ -7725,6 +9973,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fast.js"
+        }
       ]
     },
     {
@@ -7744,6 +9998,12 @@
           "url": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fd-slicer"
         }
       ]
     },
@@ -7765,6 +10025,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/feature-policy"
+        }
       ]
     },
     {
@@ -7784,6 +10050,12 @@
           "url": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fecha"
         }
       ]
     },
@@ -7806,6 +10078,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/file-js"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7824,6 +10102,12 @@
               "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/file-js/node_modules/brace-expansion"
             }
           ]
         },
@@ -7844,6 +10128,12 @@
               "url": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/file-js/node_modules/minimatch"
             }
           ]
         }
@@ -7867,6 +10157,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/file-stream-rotator"
+        }
       ]
     },
     {
@@ -7886,6 +10182,12 @@
           "url": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/file-type"
         }
       ]
     },
@@ -7907,6 +10209,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/file-uri-to-path"
+        }
       ]
     },
     {
@@ -7926,6 +10234,12 @@
           "url": "https://registry.npmjs.org/filehound/-/filehound-1.17.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/filehound"
         }
       ]
     },
@@ -7947,6 +10261,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/filename-reserved-regex"
+        }
       ]
     },
     {
@@ -7967,6 +10287,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/filenamify"
+        }
       ]
     },
     {
@@ -7986,6 +10312,12 @@
           "url": "https://registry.npmjs.org/filesniffer/-/filesniffer-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/filesniffer"
         }
       ]
     },
@@ -8008,6 +10340,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fill-range"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -8026,6 +10364,12 @@
               "url": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/fill-range/node_modules/extend-shallow"
             }
           ]
         },
@@ -8046,6 +10390,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/fill-range/node_modules/is-extendable"
             }
           ]
         }
@@ -8069,6 +10419,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/finale-rest"
+        }
       ]
     },
     {
@@ -8088,6 +10444,12 @@
           "url": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/finalhandler"
         }
       ]
     },
@@ -8109,6 +10471,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/find-up"
+        }
       ]
     },
     {
@@ -8128,6 +10496,12 @@
           "url": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/findup-sync"
         }
       ]
     },
@@ -8149,6 +10523,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fined"
+        }
       ]
     },
     {
@@ -8168,6 +10548,12 @@
           "url": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/flagged-respawn"
         }
       ]
     },
@@ -8189,6 +10575,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fn.name"
+        }
       ]
     },
     {
@@ -8208,6 +10600,12 @@
           "url": "https://registry.npmjs.org/fontkit/-/fontkit-1.9.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fontkit"
         }
       ]
     },
@@ -8229,6 +10627,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/for-each"
+        }
       ]
     },
     {
@@ -8248,6 +10652,12 @@
           "url": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/for-in"
         }
       ]
     },
@@ -8269,6 +10679,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/for-own"
+        }
       ]
     },
     {
@@ -8288,6 +10704,12 @@
           "url": "https://registry.npmjs.org/foreachasync/-/foreachasync-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/foreachasync"
         }
       ]
     },
@@ -8309,6 +10731,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/forever-agent"
+        }
       ]
     },
     {
@@ -8328,6 +10756,12 @@
           "url": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/form-data"
         }
       ]
     },
@@ -8349,6 +10783,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/formatio"
+        }
       ]
     },
     {
@@ -8368,6 +10808,12 @@
           "url": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/forwarded"
         }
       ]
     },
@@ -8389,6 +10835,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fragment-cache"
+        }
       ]
     },
     {
@@ -8408,6 +10860,12 @@
           "url": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fresh"
         }
       ]
     },
@@ -8429,6 +10887,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/from2"
+        }
       ]
     },
     {
@@ -8448,6 +10912,12 @@
           "url": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fs-constants"
         }
       ]
     },
@@ -8469,6 +10939,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fs-extra"
+        }
       ]
     },
     {
@@ -8488,6 +10964,12 @@
           "url": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fs-minipass"
         }
       ]
     },
@@ -8509,6 +10991,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fs.realpath"
+        }
       ]
     },
     {
@@ -8528,6 +11016,12 @@
           "url": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fsevents"
         }
       ]
     },
@@ -8550,6 +11044,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fstream"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -8568,6 +11068,12 @@
               "url": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/fstream/node_modules/mkdirp"
             }
           ]
         },
@@ -8588,6 +11094,12 @@
               "url": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/fstream/node_modules/rimraf"
             }
           ]
         }
@@ -8611,6 +11123,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/function-bind"
+        }
       ]
     },
     {
@@ -8630,6 +11148,12 @@
           "url": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/function.prototype.name"
         }
       ]
     },
@@ -8651,6 +11175,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/functions-have-names"
+        }
       ]
     },
     {
@@ -8670,6 +11200,12 @@
           "url": "https://registry.npmjs.org/fuzzball/-/fuzzball-1.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fuzzball"
         }
       ]
     },
@@ -8691,6 +11227,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/gauge"
+        }
       ]
     },
     {
@@ -8710,6 +11252,12 @@
           "url": "https://registry.npmjs.org/geojson-utils/-/geojson-utils-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/geojson-utils"
         }
       ]
     },
@@ -8731,6 +11279,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-caller-file"
+        }
       ]
     },
     {
@@ -8750,6 +11304,12 @@
           "url": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-intrinsic"
         }
       ]
     },
@@ -8771,6 +11331,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-stream"
+        }
       ]
     },
     {
@@ -8790,6 +11356,12 @@
           "url": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-symbol-description"
         }
       ]
     },
@@ -8811,6 +11383,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-value"
+        }
       ]
     },
     {
@@ -8830,6 +11408,12 @@
           "url": "https://registry.npmjs.org/getobject/-/getobject-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/getobject"
         }
       ]
     },
@@ -8851,6 +11435,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/getpass"
+        }
       ]
     },
     {
@@ -8870,6 +11460,12 @@
           "url": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/github-from-package"
         }
       ]
     },
@@ -8892,6 +11488,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/glob-parent"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -8910,6 +11512,12 @@
               "url": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/glob-parent/node_modules/is-glob"
             }
           ]
         }
@@ -8934,6 +11542,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/glob"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -8952,6 +11566,12 @@
               "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/glob/node_modules/brace-expansion"
             }
           ]
         },
@@ -8972,6 +11592,12 @@
               "url": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/glob/node_modules/minimatch"
             }
           ]
         }
@@ -8995,6 +11621,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/global-modules"
+        }
       ]
     },
     {
@@ -9016,6 +11648,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/global-prefix"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9034,6 +11672,12 @@
               "url": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/global-prefix/node_modules/which"
             }
           ]
         }
@@ -9058,6 +11702,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/got"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9076,6 +11726,12 @@
               "url": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/got/node_modules/get-stream"
             }
           ]
         },
@@ -9096,6 +11752,12 @@
               "url": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/got/node_modules/pify"
             }
           ]
         }
@@ -9119,6 +11781,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/graceful-fs"
+        }
       ]
     },
     {
@@ -9140,6 +11808,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-cli"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9158,6 +11832,12 @@
               "url": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-cli/node_modules/nopt"
             }
           ]
         }
@@ -9182,6 +11862,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-contrib-compress"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9200,6 +11886,12 @@
               "url": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-contrib-compress/node_modules/ansi-styles"
             }
           ]
         },
@@ -9221,6 +11913,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-contrib-compress/node_modules/chalk"
+            }
           ]
         },
         {
@@ -9240,6 +11938,12 @@
               "url": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-contrib-compress/node_modules/supports-color"
             }
           ]
         }
@@ -9263,6 +11967,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-known-options"
+        }
       ]
     },
     {
@@ -9284,6 +11994,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-legacy-log-utils"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9302,6 +12018,12 @@
               "url": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils/node_modules/ansi-styles"
             }
           ]
         },
@@ -9323,6 +12045,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils/node_modules/chalk"
+            }
           ]
         },
         {
@@ -9342,6 +12070,12 @@
               "url": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils/node_modules/color-convert"
             }
           ]
         },
@@ -9363,6 +12097,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils/node_modules/color-name"
+            }
           ]
         },
         {
@@ -9383,6 +12123,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils/node_modules/has-flag"
+            }
           ]
         },
         {
@@ -9402,6 +12148,12 @@
               "url": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils/node_modules/supports-color"
             }
           ]
         }
@@ -9426,6 +12178,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-legacy-log"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9444,6 +12202,12 @@
               "url": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log/node_modules/colors"
             }
           ]
         }
@@ -9468,6 +12232,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-legacy-util"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9486,6 +12256,12 @@
               "url": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-util/node_modules/async"
             }
           ]
         }
@@ -9509,6 +12285,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-replace-json"
+        }
       ]
     },
     {
@@ -9530,6 +12312,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9548,6 +12336,12 @@
               "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt/node_modules/brace-expansion"
             }
           ]
         },
@@ -9570,6 +12364,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt/node_modules/findup-sync"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -9588,6 +12388,12 @@
                   "url": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/grunt/node_modules/findup-sync/node_modules/glob"
                 }
               ]
             }
@@ -9611,6 +12417,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt/node_modules/glob"
+            }
           ]
         },
         {
@@ -9630,6 +12442,12 @@
               "url": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.8.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt/node_modules/minimatch"
             }
           ]
         }
@@ -9654,6 +12472,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/handlebars"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9672,6 +12496,12 @@
               "url": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/handlebars/node_modules/wordwrap"
             }
           ]
         }
@@ -9695,6 +12525,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/har-schema"
+        }
       ]
     },
     {
@@ -9714,6 +12550,12 @@
           "url": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/har-validator"
         }
       ]
     },
@@ -9735,6 +12577,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-ansi"
+        }
       ]
     },
     {
@@ -9754,6 +12602,12 @@
           "url": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-bigints"
         }
       ]
     },
@@ -9775,6 +12629,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-flag"
+        }
       ]
     },
     {
@@ -9794,6 +12654,12 @@
           "url": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-property-descriptors"
         }
       ]
     },
@@ -9815,6 +12681,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-symbol-support-x"
+        }
       ]
     },
     {
@@ -9834,6 +12706,12 @@
           "url": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-symbols"
         }
       ]
     },
@@ -9855,6 +12733,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-to-string-tag-x"
+        }
       ]
     },
     {
@@ -9874,6 +12758,12 @@
           "url": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-tostringtag"
         }
       ]
     },
@@ -9895,6 +12785,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-unicode"
+        }
       ]
     },
     {
@@ -9914,6 +12810,12 @@
           "url": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-value"
         }
       ]
     },
@@ -9936,6 +12838,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-values"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9954,6 +12862,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/has-values/node_modules/kind-of"
             }
           ]
         }
@@ -9977,6 +12891,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has"
+        }
       ]
     },
     {
@@ -9996,6 +12916,12 @@
           "url": "https://registry.npmjs.org/hashids/-/hashids-2.2.10.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hashids"
         }
       ]
     },
@@ -10017,6 +12943,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hbs"
+        }
       ]
     },
     {
@@ -10036,6 +12968,12 @@
           "url": "https://registry.npmjs.org/he/-/he-0.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/he"
         }
       ]
     },
@@ -10057,6 +12995,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/heap"
+        }
       ]
     },
     {
@@ -10076,6 +13020,12 @@
           "url": "https://registry.npmjs.org/helmet/-/helmet-4.6.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/helmet"
         }
       ]
     },
@@ -10097,6 +13047,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hoister"
+        }
       ]
     },
     {
@@ -10116,6 +13072,12 @@
           "url": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/homedir-polyfill"
         }
       ]
     },
@@ -10137,6 +13099,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hooker"
+        }
       ]
     },
     {
@@ -10157,6 +13125,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hosted-git-info"
+        }
       ]
     },
     {
@@ -10176,6 +13150,12 @@
           "url": "https://registry.npmjs.org/html-entities/-/html-entities-1.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/html-entities"
         }
       ]
     },
@@ -10198,6 +13178,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/htmlparser2"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -10216,6 +13202,12 @@
               "url": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/htmlparser2/node_modules/isarray"
             }
           ]
         },
@@ -10237,6 +13229,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/htmlparser2/node_modules/readable-stream"
+            }
           ]
         },
         {
@@ -10256,6 +13254,12 @@
               "url": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/htmlparser2/node_modules/string_decoder"
             }
           ]
         }
@@ -10279,6 +13283,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/http-cache-semantics"
+        }
       ]
     },
     {
@@ -10298,6 +13308,12 @@
           "url": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/http-errors"
         }
       ]
     },
@@ -10320,6 +13336,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/http-proxy-agent"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -10338,6 +13360,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/http-proxy-agent/node_modules/debug"
             }
           ]
         },
@@ -10358,6 +13386,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/http-proxy-agent/node_modules/ms"
             }
           ]
         }
@@ -10381,6 +13415,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/http-signature"
+        }
       ]
     },
     {
@@ -10402,6 +13442,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/https-proxy-agent"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -10420,6 +13466,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/https-proxy-agent/node_modules/debug"
             }
           ]
         },
@@ -10440,6 +13492,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/https-proxy-agent/node_modules/ms"
             }
           ]
         }
@@ -10463,6 +13521,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/humanize-ms"
+        }
       ]
     },
     {
@@ -10482,6 +13546,12 @@
           "url": "https://registry.npmjs.org/i18n/-/i18n-0.11.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/i18n"
         }
       ]
     },
@@ -10503,6 +13573,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/iconv-lite"
+        }
       ]
     },
     {
@@ -10522,6 +13598,12 @@
           "url": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ieee754"
         }
       ]
     },
@@ -10544,6 +13626,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ignore-walk"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -10562,6 +13650,12 @@
               "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/ignore-walk/node_modules/brace-expansion"
             }
           ]
         },
@@ -10582,6 +13676,12 @@
               "url": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/ignore-walk/node_modules/minimatch"
             }
           ]
         }
@@ -10605,6 +13705,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/iltorb"
+        }
       ]
     },
     {
@@ -10624,6 +13730,12 @@
           "url": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/imurmurhash"
         }
       ]
     },
@@ -10645,6 +13757,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/indent-string"
+        }
       ]
     },
     {
@@ -10664,6 +13782,12 @@
           "url": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/infer-owner"
         }
       ]
     },
@@ -10685,6 +13809,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/inflection"
+        }
       ]
     },
     {
@@ -10704,6 +13834,12 @@
           "url": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/inflight"
         }
       ]
     },
@@ -10725,6 +13861,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/inherits"
+        }
       ]
     },
     {
@@ -10744,6 +13886,12 @@
           "url": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ini"
         }
       ]
     },
@@ -10765,6 +13913,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/internal-slot"
+        }
       ]
     },
     {
@@ -10784,6 +13938,12 @@
           "url": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/interpret"
         }
       ]
     },
@@ -10805,6 +13965,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/into-stream"
+        }
       ]
     },
     {
@@ -10824,6 +13990,12 @@
           "url": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/invariant"
         }
       ]
     },
@@ -10845,6 +14017,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ip"
+        }
       ]
     },
     {
@@ -10864,6 +14042,12 @@
           "url": "https://registry.npmjs.org/ip6/-/ip6-0.2.10.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ip6"
         }
       ]
     },
@@ -10885,6 +14069,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ipaddr.js"
+        }
       ]
     },
     {
@@ -10904,6 +14094,12 @@
           "url": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-absolute"
         }
       ]
     },
@@ -10925,6 +14121,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-accessor-descriptor"
+        }
       ]
     },
     {
@@ -10944,6 +14146,12 @@
           "url": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-arguments"
         }
       ]
     },
@@ -10965,6 +14173,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-arrayish"
+        }
       ]
     },
     {
@@ -10984,6 +14198,12 @@
           "url": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-bigint"
         }
       ]
     },
@@ -11005,6 +14225,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-binary-path"
+        }
       ]
     },
     {
@@ -11024,6 +14250,12 @@
           "url": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-boolean-object"
         }
       ]
     },
@@ -11045,6 +14277,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-buffer"
+        }
       ]
     },
     {
@@ -11064,6 +14302,12 @@
           "url": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-callable"
         }
       ]
     },
@@ -11085,6 +14329,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-core-module"
+        }
       ]
     },
     {
@@ -11104,6 +14354,12 @@
           "url": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-data-descriptor"
         }
       ]
     },
@@ -11125,6 +14381,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-date-object"
+        }
       ]
     },
     {
@@ -11144,6 +14406,12 @@
           "url": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-descriptor"
         }
       ]
     },
@@ -11165,6 +14433,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-docker"
+        }
       ]
     },
     {
@@ -11184,6 +14458,12 @@
           "url": "https://registry.npmjs.org/is-expression/-/is-expression-4.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-expression"
         }
       ]
     },
@@ -11205,6 +14485,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-extendable"
+        }
       ]
     },
     {
@@ -11224,6 +14510,12 @@
           "url": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-extglob"
         }
       ]
     },
@@ -11245,6 +14537,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-fullwidth-code-point"
+        }
       ]
     },
     {
@@ -11264,6 +14562,12 @@
           "url": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-generator-function"
         }
       ]
     },
@@ -11285,6 +14589,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-glob"
+        }
       ]
     },
     {
@@ -11304,6 +14614,12 @@
           "url": "https://registry.npmjs.org/is-heroku/-/is-heroku-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-heroku"
         }
       ]
     },
@@ -11325,6 +14641,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-lambda"
+        }
       ]
     },
     {
@@ -11344,6 +14666,12 @@
           "url": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-map"
         }
       ]
     },
@@ -11365,6 +14693,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-natural-number"
+        }
       ]
     },
     {
@@ -11384,6 +14718,12 @@
           "url": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-negative-zero"
         }
       ]
     },
@@ -11405,6 +14745,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-number-like"
+        }
       ]
     },
     {
@@ -11424,6 +14770,12 @@
           "url": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-number-object"
         }
       ]
     },
@@ -11446,6 +14798,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-number"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -11464,6 +14822,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/is-number/node_modules/kind-of"
             }
           ]
         }
@@ -11487,6 +14851,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-object"
+        }
       ]
     },
     {
@@ -11506,6 +14876,12 @@
           "url": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-plain-obj"
         }
       ]
     },
@@ -11527,6 +14903,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-plain-object"
+        }
       ]
     },
     {
@@ -11546,6 +14928,12 @@
           "url": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-promise"
         }
       ]
     },
@@ -11567,6 +14955,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-regex"
+        }
       ]
     },
     {
@@ -11586,6 +14980,12 @@
           "url": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-relative"
         }
       ]
     },
@@ -11607,6 +15007,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-retry-allowed"
+        }
       ]
     },
     {
@@ -11626,6 +15032,12 @@
           "url": "https://registry.npmjs.org/is-set/-/is-set-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-set"
         }
       ]
     },
@@ -11647,6 +15059,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-shared-array-buffer"
+        }
       ]
     },
     {
@@ -11666,6 +15084,12 @@
           "url": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-stream"
         }
       ]
     },
@@ -11687,6 +15111,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-string"
+        }
       ]
     },
     {
@@ -11706,6 +15136,12 @@
           "url": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-symbol"
         }
       ]
     },
@@ -11727,6 +15163,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-typed-array"
+        }
       ]
     },
     {
@@ -11746,6 +15188,12 @@
           "url": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-typedarray"
         }
       ]
     },
@@ -11767,6 +15215,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-unc-path"
+        }
       ]
     },
     {
@@ -11786,6 +15240,12 @@
           "url": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-weakmap"
         }
       ]
     },
@@ -11807,6 +15267,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-weakref"
+        }
       ]
     },
     {
@@ -11826,6 +15292,12 @@
           "url": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-weakset"
         }
       ]
     },
@@ -11847,6 +15319,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-windows"
+        }
       ]
     },
     {
@@ -11866,6 +15344,12 @@
           "url": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isarray"
         }
       ]
     },
@@ -11887,6 +15371,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isexe"
+        }
       ]
     },
     {
@@ -11906,6 +15396,12 @@
           "url": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isobject"
         }
       ]
     },
@@ -11927,6 +15423,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isstream"
+        }
       ]
     },
     {
@@ -11946,6 +15448,12 @@
           "url": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isurl"
         }
       ]
     },
@@ -11967,6 +15475,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/js-stringify"
+        }
       ]
     },
     {
@@ -11986,6 +15500,12 @@
           "url": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/js-tokens"
         }
       ]
     },
@@ -12007,6 +15527,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/js-yaml"
+        }
       ]
     },
     {
@@ -12026,6 +15552,12 @@
           "url": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jsbn"
         }
       ]
     },
@@ -12047,6 +15579,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-buffer"
+        }
       ]
     },
     {
@@ -12066,6 +15604,12 @@
           "url": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-parse-better-errors"
         }
       ]
     },
@@ -12087,6 +15631,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-schema-traverse"
+        }
       ]
     },
     {
@@ -12106,6 +15656,12 @@
           "url": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-schema"
         }
       ]
     },
@@ -12127,6 +15683,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-stringify-safe"
+        }
       ]
     },
     {
@@ -12146,6 +15708,12 @@
           "url": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json5"
         }
       ]
     },
@@ -12167,6 +15735,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jsonfile"
+        }
       ]
     },
     {
@@ -12186,6 +15760,12 @@
           "url": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-0.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jsonwebtoken"
         }
       ]
     },
@@ -12207,6 +15787,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jsprim"
+        }
       ]
     },
     {
@@ -12226,6 +15812,12 @@
           "url": "https://registry.npmjs.org/jssha/-/jssha-3.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jssha"
         }
       ]
     },
@@ -12247,6 +15839,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jstransformer"
+        }
       ]
     },
     {
@@ -12266,6 +15864,12 @@
           "url": "https://registry.npmjs.org/juicy-chat-bot/-/juicy-chat-bot-0.6.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/juicy-chat-bot"
         }
       ]
     },
@@ -12287,6 +15891,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jwa"
+        }
       ]
     },
     {
@@ -12306,6 +15916,12 @@
           "url": "https://registry.npmjs.org/jws/-/jws-0.2.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jws"
         }
       ]
     },
@@ -12327,6 +15943,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/keyv"
+        }
       ]
     },
     {
@@ -12346,6 +15968,12 @@
           "url": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/kind-of"
         }
       ]
     },
@@ -12367,6 +15995,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/kuler"
+        }
       ]
     },
     {
@@ -12386,6 +16020,12 @@
           "url": "https://registry.npmjs.org/kuromoji/-/kuromoji-0.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/kuromoji"
         }
       ]
     },
@@ -12407,6 +16047,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lazystream"
+        }
       ]
     },
     {
@@ -12426,6 +16072,12 @@
           "url": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/levn"
         }
       ]
     },
@@ -12448,6 +16100,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/libxmljs2"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12466,6 +16124,12 @@
               "url": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/libxmljs2/node_modules/nan"
             }
           ]
         }
@@ -12490,6 +16154,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/liftup"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12508,6 +16178,12 @@
               "url": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/braces"
             }
           ]
         },
@@ -12529,6 +16205,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/fill-range"
+            }
           ]
         },
         {
@@ -12548,6 +16230,12 @@
               "url": "https://registry.npmjs.org/findup-sync/-/findup-sync-4.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/findup-sync"
             }
           ]
         },
@@ -12569,6 +16257,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/is-glob"
+            }
           ]
         },
         {
@@ -12588,6 +16282,12 @@
               "url": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/is-number"
             }
           ]
         },
@@ -12609,6 +16309,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/micromatch"
+            }
           ]
         },
         {
@@ -12628,6 +16334,12 @@
               "url": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/to-regex-range"
             }
           ]
         }
@@ -12652,6 +16364,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/linebreak"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12670,6 +16388,12 @@
               "url": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/linebreak/node_modules/base64-js"
             }
           ]
         }
@@ -12693,6 +16417,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/listenercount"
+        }
       ]
     },
     {
@@ -12712,6 +16442,12 @@
           "url": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/locate-path"
         }
       ]
     },
@@ -12733,6 +16469,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lodash.camelcase"
+        }
       ]
     },
     {
@@ -12752,6 +16494,12 @@
           "url": "https://registry.npmjs.org/lodash.isfinite/-/lodash.isfinite-3.3.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lodash.isfinite"
         }
       ]
     },
@@ -12773,6 +16521,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lodash.set"
+        }
       ]
     },
     {
@@ -12792,6 +16546,12 @@
           "url": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lodash"
         }
       ]
     },
@@ -12814,6 +16574,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/logform"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12832,6 +16598,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/logform/node_modules/ms"
             }
           ]
         }
@@ -12855,6 +16627,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lolex"
+        }
       ]
     },
     {
@@ -12874,6 +16652,12 @@
           "url": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/loose-envify"
         }
       ]
     },
@@ -12895,6 +16679,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lowercase-keys"
+        }
       ]
     },
     {
@@ -12914,6 +16704,12 @@
           "url": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lru-cache"
         }
       ]
     },
@@ -12936,6 +16732,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-dir"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12954,6 +16756,12 @@
               "url": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-dir/node_modules/semver"
             }
           ]
         }
@@ -12977,6 +16785,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-error"
+        }
       ]
     },
     {
@@ -12996,6 +16810,12 @@
           "url": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-9.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-fetch-happen"
         }
       ],
       "components": [
@@ -13018,6 +16838,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen/node_modules/@tootallnate/once"
+            }
           ]
         },
         {
@@ -13037,6 +16863,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen/node_modules/debug"
             }
           ]
         },
@@ -13058,6 +16890,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen/node_modules/http-cache-semantics"
+            }
           ]
         },
         {
@@ -13078,6 +16916,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen/node_modules/http-proxy-agent"
+            }
           ]
         },
         {
@@ -13097,6 +16941,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen/node_modules/ms"
             }
           ]
         }
@@ -13120,6 +16970,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-iterator"
+        }
       ]
     },
     {
@@ -13139,6 +16995,12 @@
           "url": "https://registry.npmjs.org/make-plural/-/make-plural-6.2.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-plural"
         }
       ]
     },
@@ -13160,6 +17022,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/map-cache"
+        }
       ]
     },
     {
@@ -13179,6 +17047,12 @@
           "url": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/map-visit"
         }
       ]
     },
@@ -13200,6 +17074,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/marsdb"
+        }
       ]
     },
     {
@@ -13219,6 +17099,12 @@
           "url": "https://registry.npmjs.org/math-interval-parser/-/math-interval-parser-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/math-interval-parser"
         }
       ]
     },
@@ -13240,6 +17126,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/media-typer"
+        }
       ]
     },
     {
@@ -13259,6 +17151,12 @@
           "url": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/merge-descriptors"
         }
       ]
     },
@@ -13280,6 +17178,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/messageformat-formatters"
+        }
       ]
     },
     {
@@ -13299,6 +17203,12 @@
           "url": "https://registry.npmjs.org/messageformat-parser/-/messageformat-parser-4.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/messageformat-parser"
         }
       ]
     },
@@ -13321,6 +17231,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/messageformat"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -13339,6 +17255,12 @@
               "url": "https://registry.npmjs.org/make-plural/-/make-plural-4.3.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/messageformat/node_modules/make-plural"
             }
           ]
         }
@@ -13362,6 +17284,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/methods"
+        }
       ]
     },
     {
@@ -13381,6 +17309,12 @@
           "url": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/micromatch"
         }
       ]
     },
@@ -13402,6 +17336,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mime-db"
+        }
       ]
     },
     {
@@ -13421,6 +17361,12 @@
           "url": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mime-types"
         }
       ]
     },
@@ -13442,6 +17388,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mime"
+        }
       ]
     },
     {
@@ -13461,6 +17413,12 @@
           "url": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mimic-response"
         }
       ]
     },
@@ -13482,6 +17440,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minimatch"
+        }
       ]
     },
     {
@@ -13501,6 +17465,12 @@
           "url": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minimist"
         }
       ]
     },
@@ -13522,6 +17492,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-collect"
+        }
       ]
     },
     {
@@ -13541,6 +17517,12 @@
           "url": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-1.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-fetch"
         }
       ]
     },
@@ -13562,6 +17544,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-flush"
+        }
       ]
     },
     {
@@ -13581,6 +17569,12 @@
           "url": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-pipeline"
         }
       ]
     },
@@ -13602,6 +17596,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-sized"
+        }
       ]
     },
     {
@@ -13621,6 +17621,12 @@
           "url": "https://registry.npmjs.org/minipass/-/minipass-3.3.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass"
         }
       ]
     },
@@ -13642,6 +17648,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minizlib"
+        }
       ]
     },
     {
@@ -13661,6 +17673,12 @@
           "url": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mixin-deep"
         }
       ]
     },
@@ -13682,6 +17700,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mkdirp-classic"
+        }
       ]
     },
     {
@@ -13701,6 +17725,12 @@
           "url": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mkdirp"
         }
       ]
     },
@@ -13722,6 +17752,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/moment-timezone"
+        }
       ]
     },
     {
@@ -13741,6 +17777,12 @@
           "url": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/moment"
         }
       ]
     },
@@ -13763,6 +17805,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/morgan"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -13781,6 +17829,12 @@
               "url": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/morgan/node_modules/on-finished"
             }
           ]
         }
@@ -13804,6 +17858,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mout"
+        }
       ]
     },
     {
@@ -13823,6 +17883,12 @@
           "url": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ms"
         }
       ]
     },
@@ -13845,6 +17911,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/multer"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -13863,6 +17935,12 @@
               "url": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/multer/node_modules/mkdirp"
             }
           ]
         }
@@ -13886,6 +17964,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mustache"
+        }
       ]
     },
     {
@@ -13905,6 +17989,12 @@
           "url": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/nan"
         }
       ]
     },
@@ -13926,6 +18016,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/nanomatch"
+        }
       ]
     },
     {
@@ -13945,6 +18041,12 @@
           "url": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/napi-build-utils"
         }
       ]
     },
@@ -13967,6 +18069,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/needle"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -13985,6 +18093,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/needle/node_modules/debug"
             }
           ]
         },
@@ -14005,6 +18119,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/needle/node_modules/ms"
             }
           ]
         }
@@ -14028,6 +18148,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/negotiator"
+        }
       ]
     },
     {
@@ -14047,6 +18173,12 @@
           "url": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/neo-async"
         }
       ]
     },
@@ -14069,6 +18201,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-abi"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14087,6 +18225,12 @@
               "url": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-abi/node_modules/semver"
             }
           ]
         }
@@ -14110,6 +18254,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-addon-api"
+        }
       ]
     },
     {
@@ -14129,6 +18279,12 @@
           "url": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-fetch"
         }
       ]
     },
@@ -14151,6 +18307,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-gyp"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14169,6 +18331,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/ansi-regex"
             }
           ]
         },
@@ -14190,6 +18358,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/are-we-there-yet"
+            }
           ]
         },
         {
@@ -14209,6 +18383,12 @@
               "url": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/gauge"
             }
           ]
         },
@@ -14230,6 +18410,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/is-fullwidth-code-point"
+            }
           ]
         },
         {
@@ -14249,6 +18435,12 @@
               "url": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/nopt"
             }
           ]
         },
@@ -14270,6 +18462,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/npmlog"
+            }
           ]
         },
         {
@@ -14289,6 +18487,12 @@
               "url": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/readable-stream"
             }
           ]
         },
@@ -14310,6 +18514,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/string-width"
+            }
           ]
         },
         {
@@ -14329,6 +18539,12 @@
               "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/strip-ansi"
             }
           ]
         }
@@ -14353,6 +18569,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-pre-gyp"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14371,6 +18593,12 @@
               "url": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/chownr"
             }
           ]
         },
@@ -14392,6 +18620,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/fs-minipass"
+            }
           ]
         },
         {
@@ -14411,6 +18645,12 @@
               "url": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/minipass"
             }
           ]
         },
@@ -14432,6 +18672,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/minizlib"
+            }
           ]
         },
         {
@@ -14451,6 +18697,12 @@
               "url": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/mkdirp"
             }
           ]
         },
@@ -14472,6 +18724,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/nopt"
+            }
           ]
         },
         {
@@ -14491,6 +18749,12 @@
               "url": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/rimraf"
             }
           ]
         },
@@ -14512,6 +18776,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/safe-buffer"
+            }
           ]
         },
         {
@@ -14531,6 +18801,12 @@
               "url": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/semver"
             }
           ]
         },
@@ -14552,6 +18828,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/tar"
+            }
           ]
         },
         {
@@ -14571,6 +18853,12 @@
               "url": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/yallist"
             }
           ]
         }
@@ -14594,6 +18882,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/noop-logger"
+        }
       ]
     },
     {
@@ -14613,6 +18907,12 @@
           "url": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/nopt"
         }
       ]
     },
@@ -14635,6 +18935,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/normalize-package-data"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14653,6 +18959,12 @@
               "url": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/normalize-package-data/node_modules/semver"
             }
           ]
         }
@@ -14676,6 +18988,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/normalize-path"
+        }
       ]
     },
     {
@@ -14695,6 +19013,12 @@
           "url": "https://registry.npmjs.org/normalize-url/-/normalize-url-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/normalize-url"
         }
       ]
     },
@@ -14717,6 +19041,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/notevil"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14735,6 +19065,12 @@
               "url": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/notevil/node_modules/esprima"
             }
           ]
         }
@@ -14758,6 +19094,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/npm-bundled"
+        }
       ]
     },
     {
@@ -14777,6 +19119,12 @@
           "url": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/npm-normalize-package-bin"
         }
       ]
     },
@@ -14798,6 +19146,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/npm-packlist"
+        }
       ]
     },
     {
@@ -14817,6 +19171,12 @@
           "url": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/npmlog"
         }
       ]
     },
@@ -14838,6 +19198,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/number-is-nan"
+        }
       ]
     },
     {
@@ -14858,6 +19224,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/oauth-sign"
+        }
       ]
     },
     {
@@ -14877,6 +19249,12 @@
           "url": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-assign"
         }
       ]
     },
@@ -14899,6 +19277,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-copy"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14917,6 +19301,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy/node_modules/define-property"
             }
           ]
         },
@@ -14938,6 +19328,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy/node_modules/is-accessor-descriptor"
+            }
           ]
         },
         {
@@ -14957,6 +19353,12 @@
               "url": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy/node_modules/is-data-descriptor"
             }
           ]
         },
@@ -14979,6 +19381,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy/node_modules/is-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -14997,6 +19405,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/object-copy/node_modules/is-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -15020,6 +19434,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy/node_modules/kind-of"
+            }
           ]
         }
       ]
@@ -15042,6 +19462,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-inspect"
+        }
       ]
     },
     {
@@ -15061,6 +19487,12 @@
           "url": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-is"
         }
       ]
     },
@@ -15082,6 +19514,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-keys"
+        }
       ]
     },
     {
@@ -15101,6 +19539,12 @@
           "url": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-visit"
         }
       ]
     },
@@ -15122,6 +19566,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object.assign"
+        }
       ]
     },
     {
@@ -15141,6 +19591,12 @@
           "url": "https://registry.npmjs.org/object.defaults/-/object.defaults-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object.defaults"
         }
       ]
     },
@@ -15162,6 +19618,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object.map"
+        }
       ]
     },
     {
@@ -15181,6 +19643,12 @@
           "url": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object.pick"
         }
       ]
     },
@@ -15202,6 +19670,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/on-finished"
+        }
       ]
     },
     {
@@ -15221,6 +19695,12 @@
           "url": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/on-headers"
         }
       ]
     },
@@ -15242,6 +19722,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/once"
+        }
       ]
     },
     {
@@ -15261,6 +19747,12 @@
           "url": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/one-time"
         }
       ]
     },
@@ -15282,6 +19774,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/opentype.js"
+        }
       ]
     },
     {
@@ -15301,6 +19799,12 @@
           "url": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/optionator"
         }
       ]
     },
@@ -15322,6 +19826,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/os-homedir"
+        }
       ]
     },
     {
@@ -15341,6 +19851,12 @@
           "url": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/os-tmpdir"
         }
       ]
     },
@@ -15362,6 +19878,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/osenv"
+        }
       ]
     },
     {
@@ -15381,6 +19903,12 @@
           "url": "https://registry.npmjs.org/otplib/-/otplib-12.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/otplib"
         }
       ]
     },
@@ -15402,6 +19930,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-cancelable"
+        }
       ]
     },
     {
@@ -15421,6 +19955,12 @@
           "url": "https://registry.npmjs.org/p-event/-/p-event-2.3.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-event"
         }
       ]
     },
@@ -15442,6 +19982,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-finally"
+        }
       ]
     },
     {
@@ -15461,6 +20007,12 @@
           "url": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-is-promise"
         }
       ]
     },
@@ -15482,6 +20034,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-limit"
+        }
       ]
     },
     {
@@ -15501,6 +20059,12 @@
           "url": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-locate"
         }
       ]
     },
@@ -15522,6 +20086,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-map"
+        }
       ]
     },
     {
@@ -15541,6 +20111,12 @@
           "url": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-timeout"
         }
       ]
     },
@@ -15562,6 +20138,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-try"
+        }
       ]
     },
     {
@@ -15581,6 +20163,12 @@
           "url": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pako"
         }
       ]
     },
@@ -15602,6 +20190,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/parse-filepath"
+        }
       ]
     },
     {
@@ -15621,6 +20215,12 @@
           "url": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/parse-json"
         }
       ]
     },
@@ -15642,6 +20242,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/parse-passwd"
+        }
       ]
     },
     {
@@ -15661,6 +20267,12 @@
           "url": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/parseurl"
         }
       ]
     },
@@ -15682,6 +20294,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pascalcase"
+        }
       ]
     },
     {
@@ -15701,6 +20319,12 @@
           "url": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-exists"
         }
       ]
     },
@@ -15722,6 +20346,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-is-absolute"
+        }
       ]
     },
     {
@@ -15741,6 +20371,12 @@
           "url": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-parse"
         }
       ]
     },
@@ -15762,6 +20398,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-root-regex"
+        }
       ]
     },
     {
@@ -15781,6 +20423,12 @@
           "url": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-root"
         }
       ]
     },
@@ -15802,6 +20450,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-to-regexp"
+        }
       ]
     },
     {
@@ -15821,6 +20475,12 @@
           "url": "https://registry.npmjs.org/pdfkit/-/pdfkit-0.11.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pdfkit"
         }
       ]
     },
@@ -15842,6 +20502,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/peek-readable"
+        }
       ]
     },
     {
@@ -15861,6 +20527,12 @@
           "url": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pend"
         }
       ]
     },
@@ -15882,6 +20554,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/performance-now"
+        }
       ]
     },
     {
@@ -15901,6 +20579,12 @@
           "url": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.5.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pg-connection-string"
         }
       ]
     },
@@ -15922,6 +20606,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/picomatch"
+        }
       ]
     },
     {
@@ -15941,6 +20631,12 @@
           "url": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pify"
         }
       ]
     },
@@ -15962,6 +20658,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pinkie-promise"
+        }
       ]
     },
     {
@@ -15981,6 +20683,12 @@
           "url": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pinkie"
         }
       ]
     },
@@ -16002,6 +20710,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/png-js"
+        }
       ]
     },
     {
@@ -16021,6 +20735,12 @@
           "url": "https://registry.npmjs.org/portscanner/-/portscanner-2.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/portscanner"
         }
       ]
     },
@@ -16042,6 +20762,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/posix-character-classes"
+        }
       ]
     },
     {
@@ -16061,6 +20787,12 @@
           "url": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.3.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/prebuild-install"
         }
       ]
     },
@@ -16082,6 +20814,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/prelude-ls"
+        }
       ]
     },
     {
@@ -16101,6 +20839,12 @@
           "url": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/prepend-http"
         }
       ]
     },
@@ -16122,6 +20866,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pretty-bytes"
+        }
       ]
     },
     {
@@ -16141,6 +20891,12 @@
           "url": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/process-nextick-args"
         }
       ]
     },
@@ -16162,6 +20918,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/prom-client"
+        }
       ]
     },
     {
@@ -16181,6 +20943,12 @@
           "url": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/promise-inflight"
         }
       ]
     },
@@ -16203,6 +20971,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/promise-retry"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -16221,6 +20995,12 @@
               "url": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/promise-retry/node_modules/err-code"
             }
           ]
         },
@@ -16241,6 +21021,12 @@
               "url": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/promise-retry/node_modules/retry"
             }
           ]
         }
@@ -16264,6 +21050,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/promise"
+        }
       ]
     },
     {
@@ -16283,6 +21075,12 @@
           "url": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/proper-lockfile"
         }
       ]
     },
@@ -16304,6 +21102,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/proxy-addr"
+        }
       ]
     },
     {
@@ -16323,6 +21127,12 @@
           "url": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/psl"
         }
       ]
     },
@@ -16344,6 +21154,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-attrs"
+        }
       ]
     },
     {
@@ -16363,6 +21179,12 @@
           "url": "https://registry.npmjs.org/pug-code-gen/-/pug-code-gen-3.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-code-gen"
         }
       ]
     },
@@ -16384,6 +21206,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-error"
+        }
       ]
     },
     {
@@ -16403,6 +21231,12 @@
           "url": "https://registry.npmjs.org/pug-filters/-/pug-filters-4.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-filters"
         }
       ]
     },
@@ -16424,6 +21258,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-lexer"
+        }
       ]
     },
     {
@@ -16443,6 +21283,12 @@
           "url": "https://registry.npmjs.org/pug-linker/-/pug-linker-4.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-linker"
         }
       ]
     },
@@ -16464,6 +21310,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-load"
+        }
       ]
     },
     {
@@ -16483,6 +21335,12 @@
           "url": "https://registry.npmjs.org/pug-parser/-/pug-parser-6.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-parser"
         }
       ]
     },
@@ -16504,6 +21362,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-runtime"
+        }
       ]
     },
     {
@@ -16523,6 +21387,12 @@
           "url": "https://registry.npmjs.org/pug-strip-comments/-/pug-strip-comments-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-strip-comments"
         }
       ]
     },
@@ -16544,6 +21414,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-walk"
+        }
       ]
     },
     {
@@ -16563,6 +21439,12 @@
           "url": "https://registry.npmjs.org/pug/-/pug-3.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug"
         }
       ]
     },
@@ -16584,6 +21466,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pump"
+        }
       ]
     },
     {
@@ -16603,6 +21491,12 @@
           "url": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/punycode"
         }
       ]
     },
@@ -16624,6 +21518,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/qs"
+        }
       ]
     },
     {
@@ -16643,6 +21543,12 @@
           "url": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/query-string"
         }
       ]
     },
@@ -16664,6 +21570,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/range_check"
+        }
       ]
     },
     {
@@ -16683,6 +21595,12 @@
           "url": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/range-parser"
         }
       ]
     },
@@ -16704,6 +21622,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/raw-body"
+        }
       ]
     },
     {
@@ -16723,6 +21647,12 @@
           "url": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/rc"
         }
       ]
     },
@@ -16745,6 +21675,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/read-pkg"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -16763,6 +21699,12 @@
               "url": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/read-pkg/node_modules/pify"
             }
           ]
         }
@@ -16787,6 +21729,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/readable-stream"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -16805,6 +21753,12 @@
               "url": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/readable-stream/node_modules/isarray"
             }
           ]
         }
@@ -16829,6 +21783,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/readable-web-to-node-stream"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -16847,6 +21807,12 @@
               "url": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/readable-web-to-node-stream/node_modules/readable-stream"
             }
           ]
         }
@@ -16870,6 +21836,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/readdirp"
+        }
       ]
     },
     {
@@ -16889,6 +21861,12 @@
           "url": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/rechoir"
         }
       ]
     },
@@ -16910,6 +21888,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/regex-not"
+        }
       ]
     },
     {
@@ -16929,6 +21913,12 @@
           "url": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/regexp.prototype.flags"
         }
       ]
     },
@@ -16950,6 +21940,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/remove-trailing-separator"
+        }
       ]
     },
     {
@@ -16970,6 +21966,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/repeat-element"
+        }
       ]
     },
     {
@@ -16989,6 +21991,12 @@
           "url": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/repeat-string"
         }
       ]
     },
@@ -17011,6 +22019,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/replace"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17029,6 +22043,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/ansi-regex"
             }
           ]
         },
@@ -17050,6 +22070,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/ansi-styles"
+            }
           ]
         },
         {
@@ -17069,6 +22095,12 @@
               "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/brace-expansion"
             }
           ]
         },
@@ -17090,6 +22122,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/cliui"
+            }
           ]
         },
         {
@@ -17109,6 +22147,12 @@
               "url": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/color-convert"
             }
           ]
         },
@@ -17130,6 +22174,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/color-name"
+            }
           ]
         },
         {
@@ -17149,6 +22199,12 @@
               "url": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/find-up"
             }
           ]
         },
@@ -17170,6 +22226,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/is-fullwidth-code-point"
+            }
           ]
         },
         {
@@ -17189,6 +22251,12 @@
               "url": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/locate-path"
             }
           ]
         },
@@ -17210,6 +22278,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/minimatch"
+            }
           ]
         },
         {
@@ -17229,6 +22303,12 @@
               "url": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/p-locate"
             }
           ]
         },
@@ -17250,6 +22330,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/path-exists"
+            }
           ]
         },
         {
@@ -17269,6 +22355,12 @@
               "url": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/string-width"
             }
           ]
         },
@@ -17290,6 +22382,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/strip-ansi"
+            }
           ]
         },
         {
@@ -17309,6 +22407,12 @@
               "url": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/wrap-ansi"
             }
           ]
         },
@@ -17330,6 +22434,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/yargs-parser"
+            }
           ]
         },
         {
@@ -17349,6 +22459,12 @@
               "url": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/yargs"
             }
           ]
         }
@@ -17373,6 +22489,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/request"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17391,6 +22513,12 @@
               "url": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/request/node_modules/qs"
             }
           ]
         }
@@ -17414,6 +22542,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/require-directory"
+        }
       ]
     },
     {
@@ -17433,6 +22567,12 @@
           "url": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/require-main-filename"
         }
       ]
     },
@@ -17454,6 +22594,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/resolve-dir"
+        }
       ]
     },
     {
@@ -17473,6 +22619,12 @@
           "url": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/resolve-url"
         }
       ]
     },
@@ -17494,6 +22646,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/resolve"
+        }
       ]
     },
     {
@@ -17513,6 +22671,12 @@
           "url": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/responselike"
         }
       ]
     },
@@ -17534,6 +22698,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/restructure"
+        }
       ]
     },
     {
@@ -17553,6 +22723,12 @@
           "url": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ret"
         }
       ]
     },
@@ -17574,6 +22750,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/retry-as-promised"
+        }
       ]
     },
     {
@@ -17594,6 +22776,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/retry"
+        }
       ]
     },
     {
@@ -17613,6 +22801,12 @@
           "url": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/rimraf"
         }
       ]
     },
@@ -17635,6 +22829,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/rxjs"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17653,6 +22853,12 @@
               "url": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/rxjs/node_modules/tslib"
             }
           ]
         }
@@ -17676,6 +22882,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safe-buffer"
+        }
       ]
     },
     {
@@ -17695,6 +22907,12 @@
           "url": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safe-regex-test"
         }
       ]
     },
@@ -17716,6 +22934,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safe-regex"
+        }
       ]
     },
     {
@@ -17735,6 +22959,12 @@
           "url": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safe-stable-stringify"
         }
       ]
     },
@@ -17756,6 +22986,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safer-buffer"
+        }
       ]
     },
     {
@@ -17776,6 +23012,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/samsam"
+        }
       ]
     },
     {
@@ -17795,6 +23037,12 @@
           "url": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sanitize-filename"
         }
       ]
     },
@@ -17817,6 +23065,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sanitize-html"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17835,6 +23089,12 @@
               "url": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sanitize-html/node_modules/lodash"
             }
           ]
         }
@@ -17858,6 +23118,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sax"
+        }
       ]
     },
     {
@@ -17878,6 +23144,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/seek-bzip"
+        }
       ]
     },
     {
@@ -17897,6 +23169,12 @@
           "url": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/semver"
         }
       ]
     },
@@ -17919,6 +23197,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/send"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17937,6 +23221,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/send/node_modules/ms"
             }
           ]
         }
@@ -17960,6 +23250,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sequelize-pool"
+        }
       ]
     },
     {
@@ -17981,6 +23277,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sequelize"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17999,6 +23301,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sequelize/node_modules/debug"
             }
           ]
         },
@@ -18020,6 +23328,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sequelize/node_modules/ms"
+            }
           ]
         },
         {
@@ -18039,6 +23353,12 @@
               "url": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sequelize/node_modules/uuid"
             }
           ]
         }
@@ -18063,6 +23383,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/serve-index"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18081,6 +23407,12 @@
               "url": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index/node_modules/depd"
             }
           ]
         },
@@ -18102,6 +23434,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index/node_modules/http-errors"
+            }
           ]
         },
         {
@@ -18121,6 +23459,12 @@
               "url": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index/node_modules/inherits"
             }
           ]
         },
@@ -18142,6 +23486,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index/node_modules/setprototypeof"
+            }
           ]
         },
         {
@@ -18161,6 +23511,12 @@
               "url": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index/node_modules/statuses"
             }
           ]
         }
@@ -18184,6 +23540,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/serve-static"
+        }
       ]
     },
     {
@@ -18203,6 +23565,12 @@
           "url": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/set-blocking"
         }
       ]
     },
@@ -18225,6 +23593,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/set-value"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18243,6 +23617,12 @@
               "url": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/set-value/node_modules/extend-shallow"
             }
           ]
         },
@@ -18263,6 +23643,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/set-value/node_modules/is-extendable"
             }
           ]
         }
@@ -18286,6 +23672,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/setimmediate"
+        }
       ]
     },
     {
@@ -18305,6 +23697,12 @@
           "url": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/setprototypeof"
         }
       ]
     },
@@ -18326,6 +23724,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/side-channel"
+        }
       ]
     },
     {
@@ -18346,6 +23750,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/signal-exit"
+        }
       ]
     },
     {
@@ -18365,6 +23775,12 @@
           "url": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/simple-concat"
         }
       ]
     },
@@ -18387,6 +23803,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/simple-get"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18405,6 +23827,12 @@
               "url": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/simple-get/node_modules/decompress-response"
             }
           ]
         },
@@ -18425,6 +23853,12 @@
               "url": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/simple-get/node_modules/mimic-response"
             }
           ]
         }
@@ -18449,6 +23883,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/simple-swizzle"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18467,6 +23907,12 @@
               "url": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/simple-swizzle/node_modules/is-arrayish"
             }
           ]
         }
@@ -18490,6 +23936,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sinon"
+        }
       ]
     },
     {
@@ -18509,6 +23961,12 @@
           "url": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/smart-buffer"
         }
       ]
     },
@@ -18531,6 +23989,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/snapdragon-node"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18549,6 +24013,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon-node/node_modules/define-property"
             }
           ]
         }
@@ -18573,6 +24043,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/snapdragon-util"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18591,6 +24067,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon-util/node_modules/kind-of"
             }
           ]
         }
@@ -18615,6 +24097,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/snapdragon"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18633,6 +24121,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/define-property"
             }
           ]
         },
@@ -18653,6 +24147,12 @@
               "url": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/extend-shallow"
             }
           ]
         },
@@ -18675,6 +24175,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/is-accessor-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -18693,6 +24199,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/snapdragon/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -18717,6 +24229,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/is-data-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -18735,6 +24253,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/snapdragon/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -18758,6 +24282,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/is-descriptor"
+            }
           ]
         },
         {
@@ -18777,6 +24307,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/is-extendable"
             }
           ]
         },
@@ -18798,6 +24334,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/kind-of"
+            }
           ]
         },
         {
@@ -18817,6 +24359,12 @@
               "url": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/source-map"
             }
           ]
         }
@@ -18840,6 +24388,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socket.io-adapter"
+        }
       ]
     },
     {
@@ -18861,6 +24415,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socket.io-parser"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18879,6 +24439,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socket.io-parser/node_modules/debug"
             }
           ]
         },
@@ -18899,6 +24465,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socket.io-parser/node_modules/ms"
             }
           ]
         }
@@ -18923,6 +24495,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socket.io"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18941,6 +24519,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socket.io/node_modules/debug"
             }
           ]
         },
@@ -18961,6 +24545,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socket.io/node_modules/ms"
             }
           ]
         }
@@ -18985,6 +24575,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socks-proxy-agent"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -19003,6 +24599,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socks-proxy-agent/node_modules/debug"
             }
           ]
         },
@@ -19023,6 +24625,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socks-proxy-agent/node_modules/ms"
             }
           ]
         }
@@ -19047,6 +24655,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socks"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -19065,6 +24679,12 @@
               "url": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socks/node_modules/ip"
             }
           ]
         }
@@ -19089,6 +24709,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sort-keys-length"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -19107,6 +24733,12 @@
               "url": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sort-keys-length/node_modules/sort-keys"
             }
           ]
         }
@@ -19130,6 +24762,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sort-keys"
+        }
       ]
     },
     {
@@ -19149,6 +24787,12 @@
           "url": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/source-map-resolve"
         }
       ]
     },
@@ -19170,6 +24814,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/source-map-support"
+        }
       ]
     },
     {
@@ -19189,6 +24839,12 @@
           "url": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/source-map-url"
         }
       ]
     },
@@ -19210,6 +24866,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/source-map"
+        }
       ]
     },
     {
@@ -19229,6 +24891,12 @@
           "url": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2-1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spawn-command"
         }
       ]
     },
@@ -19250,6 +24918,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spdx-correct"
+        }
       ]
     },
     {
@@ -19269,6 +24943,12 @@
           "url": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spdx-exceptions"
         }
       ]
     },
@@ -19290,6 +24970,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spdx-expression-parse"
+        }
       ]
     },
     {
@@ -19309,6 +24995,12 @@
           "url": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.12.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spdx-license-ids"
         }
       ]
     },
@@ -19330,6 +25022,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/split-string"
+        }
       ]
     },
     {
@@ -19349,6 +25047,12 @@
           "url": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sprintf-js"
         }
       ]
     },
@@ -19370,6 +25074,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sqlite3"
+        }
       ]
     },
     {
@@ -19389,6 +25099,12 @@
           "url": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sshpk"
         }
       ]
     },
@@ -19410,6 +25126,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ssri"
+        }
       ]
     },
     {
@@ -19429,6 +25151,12 @@
           "url": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/stack-trace"
         }
       ]
     },
@@ -19451,6 +25179,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/static-extend"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -19469,6 +25203,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend/node_modules/define-property"
             }
           ]
         },
@@ -19491,6 +25231,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend/node_modules/is-accessor-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -19509,6 +25255,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/static-extend/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -19533,6 +25285,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend/node_modules/is-data-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -19551,6 +25309,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/static-extend/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -19574,6 +25338,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend/node_modules/is-descriptor"
+            }
           ]
         },
         {
@@ -19593,6 +25363,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend/node_modules/kind-of"
             }
           ]
         }
@@ -19616,6 +25392,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/statuses"
+        }
       ]
     },
     {
@@ -19635,6 +25417,12 @@
           "url": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-2.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/stream-buffers"
         }
       ]
     },
@@ -19656,6 +25444,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/streamsearch"
+        }
       ]
     },
     {
@@ -19675,6 +25469,12 @@
           "url": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strict-uri-encode"
         }
       ]
     },
@@ -19696,6 +25496,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string_decoder"
+        }
       ]
     },
     {
@@ -19715,6 +25521,12 @@
           "url": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string-width"
         }
       ]
     },
@@ -19736,6 +25548,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string.fromcodepoint"
+        }
       ]
     },
     {
@@ -19755,6 +25573,12 @@
           "url": "https://registry.npmjs.org/string.prototype.codepointat/-/string.prototype.codepointat-0.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string.prototype.codepointat"
         }
       ]
     },
@@ -19776,6 +25600,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string.prototype.trimend"
+        }
       ]
     },
     {
@@ -19795,6 +25625,12 @@
           "url": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string.prototype.trimstart"
         }
       ]
     },
@@ -19816,6 +25652,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-ansi"
+        }
       ]
     },
     {
@@ -19835,6 +25677,12 @@
           "url": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-bom"
         }
       ]
     },
@@ -19856,6 +25704,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-dirs"
+        }
       ]
     },
     {
@@ -19875,6 +25729,12 @@
           "url": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-json-comments"
         }
       ]
     },
@@ -19896,6 +25756,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-outer"
+        }
       ]
     },
     {
@@ -19915,6 +25781,12 @@
           "url": "https://registry.npmjs.org/strtok3/-/strtok3-6.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strtok3"
         }
       ]
     },
@@ -19936,6 +25808,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/supports-color"
+        }
       ]
     },
     {
@@ -19955,6 +25833,12 @@
           "url": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/supports-preserve-symlinks-flag"
         }
       ]
     },
@@ -19976,6 +25860,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/svg-captcha"
+        }
       ]
     },
     {
@@ -19996,6 +25886,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/swagger-ui-dist"
+        }
       ]
     },
     {
@@ -20015,6 +25911,12 @@
           "url": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-4.5.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/swagger-ui-express"
         }
       ]
     },
@@ -20037,6 +25939,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tar-fs"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -20055,6 +25963,12 @@
               "url": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/tar-fs/node_modules/bl"
             }
           ]
         },
@@ -20076,6 +25990,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/tar-fs/node_modules/chownr"
+            }
           ]
         },
         {
@@ -20096,6 +26016,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/tar-fs/node_modules/readable-stream"
+            }
           ]
         },
         {
@@ -20115,6 +26041,12 @@
               "url": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/tar-fs/node_modules/tar-stream"
             }
           ]
         }
@@ -20138,6 +26070,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tar-stream"
+        }
       ]
     },
     {
@@ -20157,6 +26095,12 @@
           "url": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tar"
         }
       ]
     },
@@ -20178,6 +26122,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tdigest"
+        }
       ]
     },
     {
@@ -20197,6 +26147,12 @@
           "url": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/text-hex"
         }
       ]
     },
@@ -20218,6 +26174,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/thirty-two"
+        }
       ]
     },
     {
@@ -20237,6 +26199,12 @@
           "url": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/through"
         }
       ]
     },
@@ -20258,6 +26226,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/timed-out"
+        }
       ]
     },
     {
@@ -20277,6 +26251,12 @@
           "url": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tiny-inflate"
         }
       ]
     },
@@ -20298,6 +26278,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-buffer"
+        }
       ]
     },
     {
@@ -20317,6 +26303,12 @@
           "url": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-fast-properties"
         }
       ]
     },
@@ -20339,6 +26331,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-object-path"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -20357,6 +26355,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/to-object-path/node_modules/kind-of"
             }
           ]
         }
@@ -20380,6 +26384,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-regex-range"
+        }
       ]
     },
     {
@@ -20399,6 +26409,12 @@
           "url": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-regex"
         }
       ]
     },
@@ -20420,6 +26436,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/toidentifier"
+        }
       ]
     },
     {
@@ -20439,6 +26461,12 @@
           "url": "https://registry.npmjs.org/token-stream/-/token-stream-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/token-stream"
         }
       ]
     },
@@ -20460,6 +26488,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/token-types"
+        }
       ]
     },
     {
@@ -20479,6 +26513,12 @@
           "url": "https://registry.npmjs.org/toposort-class/-/toposort-class-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/toposort-class"
         }
       ]
     },
@@ -20500,6 +26540,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tough-cookie"
+        }
       ]
     },
     {
@@ -20519,6 +26565,12 @@
           "url": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tr46"
         }
       ]
     },
@@ -20540,6 +26592,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/traverse"
+        }
       ]
     },
     {
@@ -20559,6 +26617,12 @@
           "url": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tree-kill"
         }
       ]
     },
@@ -20580,6 +26644,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/trim-repeated"
+        }
       ]
     },
     {
@@ -20600,6 +26670,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/triple-beam"
+        }
       ]
     },
     {
@@ -20619,6 +26695,12 @@
           "url": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/truncate-utf8-bytes"
         }
       ]
     },
@@ -20641,6 +26723,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ts-node-dev"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -20659,6 +26747,12 @@
               "url": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/ts-node-dev/node_modules/rimraf"
             }
           ]
         }
@@ -20682,6 +26776,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ts-node"
+        }
       ]
     },
     {
@@ -20701,6 +26801,12 @@
           "url": "https://registry.npmjs.org/tsconfig/-/tsconfig-7.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tsconfig"
         }
       ]
     },
@@ -20722,6 +26828,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tslib"
+        }
       ]
     },
     {
@@ -20741,6 +26853,12 @@
           "url": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tunnel-agent"
         }
       ]
     },
@@ -20762,6 +26880,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tweetnacl"
+        }
       ]
     },
     {
@@ -20781,6 +26905,12 @@
           "url": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/type-check"
         }
       ]
     },
@@ -20802,6 +26932,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/type-is"
+        }
       ]
     },
     {
@@ -20821,6 +26957,12 @@
           "url": "https://registry.npmjs.org/typecast/-/typecast-0.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/typecast"
         }
       ]
     },
@@ -20842,6 +26984,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/typedarray"
+        }
       ]
     },
     {
@@ -20861,6 +27009,12 @@
           "url": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/typescript"
         }
       ]
     },
@@ -20882,6 +27036,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/uglify-js"
+        }
       ]
     },
     {
@@ -20901,6 +27061,12 @@
           "url": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unbox-primitive"
         }
       ]
     },
@@ -20922,6 +27088,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unbzip2-stream"
+        }
       ]
     },
     {
@@ -20941,6 +27113,12 @@
           "url": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unc-path-regex"
         }
       ]
     },
@@ -20962,6 +27140,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/underscore.string"
+        }
       ]
     },
     {
@@ -20982,6 +27166,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unicode-properties"
+        }
       ]
     },
     {
@@ -21001,6 +27191,12 @@
           "url": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unicode-trie"
         }
       ]
     },
@@ -21023,6 +27219,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/union-value"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21041,6 +27243,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/union-value/node_modules/is-extendable"
             }
           ]
         }
@@ -21064,6 +27272,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unique-filename"
+        }
       ]
     },
     {
@@ -21083,6 +27297,12 @@
           "url": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unique-slug"
         }
       ]
     },
@@ -21104,6 +27324,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unit-compare"
+        }
       ]
     },
     {
@@ -21124,6 +27350,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/universalify"
+        }
       ]
     },
     {
@@ -21143,6 +27375,12 @@
           "url": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unpipe"
         }
       ]
     },
@@ -21165,6 +27403,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unset-value"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21185,6 +27429,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/unset-value/node_modules/has-value"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -21203,6 +27453,12 @@
                   "url": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/unset-value/node_modules/has-value/node_modules/isobject"
                 }
               ]
             }
@@ -21226,6 +27482,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/unset-value/node_modules/has-values"
+            }
           ]
         },
         {
@@ -21245,6 +27507,12 @@
               "url": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/unset-value/node_modules/isarray"
             }
           ]
         }
@@ -21268,6 +27536,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/untildify"
+        }
       ]
     },
     {
@@ -21289,6 +27563,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unzipper"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21307,6 +27587,12 @@
               "url": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/unzipper/node_modules/bluebird"
             }
           ]
         }
@@ -21330,6 +27616,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/uri-js"
+        }
       ]
     },
     {
@@ -21349,6 +27641,12 @@
           "url": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/urix"
         }
       ]
     },
@@ -21370,6 +27668,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/url-parse-lax"
+        }
       ]
     },
     {
@@ -21389,6 +27693,12 @@
           "url": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/url-to-options"
         }
       ]
     },
@@ -21410,6 +27720,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/use"
+        }
       ]
     },
     {
@@ -21429,6 +27745,12 @@
           "url": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/utf8-byte-length"
         }
       ]
     },
@@ -21450,6 +27772,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/util-deprecate"
+        }
       ]
     },
     {
@@ -21469,6 +27797,12 @@
           "url": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/util"
         }
       ]
     },
@@ -21490,6 +27824,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/utils-merge"
+        }
       ]
     },
     {
@@ -21509,6 +27849,12 @@
           "url": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/uuid"
         }
       ]
     },
@@ -21530,6 +27876,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/v8flags"
+        }
       ]
     },
     {
@@ -21549,6 +27901,12 @@
           "url": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/validate-npm-package-license"
         }
       ]
     },
@@ -21570,6 +27928,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/validate"
+        }
       ]
     },
     {
@@ -21590,6 +27954,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/validator"
+        }
       ]
     },
     {
@@ -21609,6 +27979,12 @@
           "url": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/vary"
         }
       ]
     },
@@ -21631,6 +28007,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/verror"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21649,6 +28031,12 @@
               "url": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/verror/node_modules/core-util-is"
             }
           ]
         }
@@ -21673,6 +28061,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/vm2"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21691,6 +28085,12 @@
               "url": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/vm2/node_modules/acorn"
             }
           ]
         }
@@ -21714,6 +28114,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/void-elements"
+        }
       ]
     },
     {
@@ -21733,6 +28139,12 @@
           "url": "https://registry.npmjs.org/walk/-/walk-2.3.15.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/walk"
         }
       ]
     },
@@ -21754,6 +28166,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/walkdir"
+        }
       ]
     },
     {
@@ -21773,6 +28191,12 @@
           "url": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/webidl-conversions"
         }
       ]
     },
@@ -21794,6 +28218,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/whatwg-url"
+        }
       ]
     },
     {
@@ -21813,6 +28243,12 @@
           "url": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-boxed-primitive"
         }
       ]
     },
@@ -21834,6 +28270,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-collection"
+        }
       ]
     },
     {
@@ -21853,6 +28295,12 @@
           "url": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-module"
         }
       ]
     },
@@ -21874,6 +28322,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-pm-runs"
+        }
       ]
     },
     {
@@ -21893,6 +28347,12 @@
           "url": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-typed-array"
         }
       ]
     },
@@ -21914,6 +28374,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which"
+        }
       ]
     },
     {
@@ -21933,6 +28399,12 @@
           "url": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wide-align"
         }
       ]
     },
@@ -21955,6 +28427,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/winston-transport"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21973,6 +28451,12 @@
               "url": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/winston-transport/node_modules/readable-stream"
             }
           ]
         }
@@ -21997,6 +28481,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/winston"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -22015,6 +28505,12 @@
               "url": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/winston/node_modules/async"
             }
           ]
         },
@@ -22036,6 +28532,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/winston/node_modules/is-stream"
+            }
           ]
         },
         {
@@ -22055,6 +28557,12 @@
               "url": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/winston/node_modules/readable-stream"
             }
           ]
         }
@@ -22078,6 +28586,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/with"
+        }
       ]
     },
     {
@@ -22097,6 +28611,12 @@
           "url": "https://registry.npmjs.org/wkx/-/wkx-0.5.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wkx"
         }
       ]
     },
@@ -22118,6 +28638,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/word-wrap"
+        }
       ]
     },
     {
@@ -22137,6 +28663,12 @@
           "url": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wordwrap"
         }
       ]
     },
@@ -22159,6 +28691,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wrap-ansi"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -22177,6 +28715,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi/node_modules/ansi-regex"
             }
           ]
         },
@@ -22198,6 +28742,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi/node_modules/emoji-regex"
+            }
           ]
         },
         {
@@ -22217,6 +28767,12 @@
               "url": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi/node_modules/is-fullwidth-code-point"
             }
           ]
         },
@@ -22238,6 +28794,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi/node_modules/string-width"
+            }
           ]
         },
         {
@@ -22257,6 +28819,12 @@
               "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi/node_modules/strip-ansi"
             }
           ]
         }
@@ -22280,6 +28848,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wrappy"
+        }
       ]
     },
     {
@@ -22299,6 +28873,12 @@
           "url": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ws"
         }
       ]
     },
@@ -22320,6 +28900,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/xtend"
+        }
       ]
     },
     {
@@ -22339,6 +28925,12 @@
           "url": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/y18n"
         }
       ]
     },
@@ -22360,6 +28952,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yallist"
+        }
       ]
     },
     {
@@ -22380,6 +28978,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yaml-schema-validator"
+        }
       ]
     },
     {
@@ -22399,6 +29003,12 @@
           "url": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yargs-parser"
         }
       ]
     },
@@ -22421,6 +29031,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yargs"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -22439,6 +29055,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs/node_modules/ansi-regex"
             }
           ]
         },
@@ -22460,6 +29082,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs/node_modules/emoji-regex"
+            }
           ]
         },
         {
@@ -22479,6 +29107,12 @@
               "url": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs/node_modules/is-fullwidth-code-point"
             }
           ]
         },
@@ -22500,6 +29134,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs/node_modules/string-width"
+            }
           ]
         },
         {
@@ -22519,6 +29159,12 @@
               "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs/node_modules/strip-ansi"
             }
           ]
         }
@@ -22542,6 +29188,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yauzl"
+        }
       ]
     },
     {
@@ -22561,6 +29213,12 @@
           "url": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yn"
         }
       ]
     },
@@ -22582,6 +29240,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/z85"
+        }
       ]
     },
     {
@@ -22602,6 +29266,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/zip-stream"
+        }
       ]
     },
     {
@@ -22621,6 +29291,12 @@
           "url": "https://registry.npmjs.org/zlibjs/-/zlibjs-0.3.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/zlibjs"
         }
       ]
     }

--- a/tests/_data/sbom_demo-results/juice-shop_npm8_node18_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/juice-shop_npm8_node18_ubuntu-latest.snap.json
@@ -62,6 +62,10 @@
       ],
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -88,6 +92,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@babel/helper-string-parser"
+        }
       ]
     },
     {
@@ -108,6 +118,12 @@
           "url": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@babel/helper-validator-identifier"
         }
       ]
     },
@@ -130,6 +146,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@babel/parser"
+        }
       ]
     },
     {
@@ -150,6 +172,12 @@
           "url": "https://registry.npmjs.org/@babel/types/-/types-7.20.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@babel/types"
         }
       ]
     },
@@ -172,6 +200,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@colors/colors"
+        }
       ]
     },
     {
@@ -193,6 +227,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@dabh/diagnostics"
+        }
       ]
     },
     {
@@ -213,6 +253,12 @@
           "url": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@gar/promisify"
         }
       ]
     },
@@ -236,6 +282,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@mapbox/node-pre-gyp"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -254,6 +306,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/ansi-regex"
             }
           ]
         },
@@ -275,6 +333,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/are-we-there-yet"
+            }
           ]
         },
         {
@@ -294,6 +358,12 @@
               "url": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/detect-libc"
             }
           ]
         },
@@ -315,6 +385,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/gauge"
+            }
           ]
         },
         {
@@ -334,6 +410,12 @@
               "url": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/is-fullwidth-code-point"
             }
           ]
         },
@@ -356,6 +438,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/make-dir"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -374,6 +462,12 @@
                   "url": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/@mapbox/node-pre-gyp/node_modules/make-dir/node_modules/semver"
                 }
               ]
             }
@@ -397,6 +491,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/nopt"
+            }
           ]
         },
         {
@@ -416,6 +516,12 @@
               "url": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/npmlog"
             }
           ]
         },
@@ -437,6 +543,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/readable-stream"
+            }
           ]
         },
         {
@@ -457,6 +569,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/string-width"
+            }
           ]
         },
         {
@@ -476,6 +594,12 @@
               "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/strip-ansi"
             }
           ]
         }
@@ -500,6 +624,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/core-loader"
+        }
       ]
     },
     {
@@ -520,6 +650,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/core/-/core-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/core"
         }
       ]
     },
@@ -542,6 +678,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/evaluator"
+        }
       ]
     },
     {
@@ -562,6 +704,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-all/-/lang-all-4.24.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-all"
         }
       ]
     },
@@ -584,6 +732,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ar"
+        }
       ]
     },
     {
@@ -604,6 +758,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-bn/-/lang-bn-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-bn"
         }
       ]
     },
@@ -626,6 +786,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ca"
+        }
       ]
     },
     {
@@ -646,6 +812,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-cs/-/lang-cs-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-cs"
         }
       ]
     },
@@ -668,6 +840,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-da"
+        }
       ]
     },
     {
@@ -688,6 +866,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-de/-/lang-de-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-de"
         }
       ]
     },
@@ -710,6 +894,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-el"
+        }
       ]
     },
     {
@@ -730,6 +920,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-en-min/-/lang-en-min-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-en-min"
         }
       ]
     },
@@ -752,6 +948,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-en"
+        }
       ]
     },
     {
@@ -772,6 +974,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-es/-/lang-es-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-es"
         }
       ]
     },
@@ -794,6 +1002,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-eu"
+        }
       ]
     },
     {
@@ -814,6 +1028,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-fa/-/lang-fa-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-fa"
         }
       ]
     },
@@ -836,6 +1056,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-fi"
+        }
       ]
     },
     {
@@ -856,6 +1082,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-fr/-/lang-fr-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-fr"
         }
       ]
     },
@@ -878,6 +1110,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ga"
+        }
       ]
     },
     {
@@ -898,6 +1136,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-gl/-/lang-gl-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-gl"
         }
       ]
     },
@@ -920,6 +1164,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-hi"
+        }
       ]
     },
     {
@@ -940,6 +1190,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-hu/-/lang-hu-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-hu"
         }
       ]
     },
@@ -962,6 +1218,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-hy"
+        }
       ]
     },
     {
@@ -982,6 +1244,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-id/-/lang-id-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-id"
         }
       ]
     },
@@ -1004,6 +1272,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-it"
+        }
       ]
     },
     {
@@ -1024,6 +1298,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-ja/-/lang-ja-4.24.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ja"
         }
       ]
     },
@@ -1046,6 +1326,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ko"
+        }
       ]
     },
     {
@@ -1066,6 +1352,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-lt/-/lang-lt-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-lt"
         }
       ]
     },
@@ -1088,6 +1380,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ms"
+        }
       ]
     },
     {
@@ -1108,6 +1406,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-ne/-/lang-ne-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ne"
         }
       ]
     },
@@ -1130,6 +1434,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-nl"
+        }
       ]
     },
     {
@@ -1150,6 +1460,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-no/-/lang-no-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-no"
         }
       ]
     },
@@ -1172,6 +1488,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-pl"
+        }
       ]
     },
     {
@@ -1192,6 +1514,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-pt/-/lang-pt-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-pt"
         }
       ]
     },
@@ -1214,6 +1542,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ro"
+        }
       ]
     },
     {
@@ -1234,6 +1568,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-ru/-/lang-ru-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ru"
         }
       ]
     },
@@ -1256,6 +1596,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-sl"
+        }
       ]
     },
     {
@@ -1276,6 +1622,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-sr/-/lang-sr-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-sr"
         }
       ]
     },
@@ -1298,6 +1650,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-sv"
+        }
       ]
     },
     {
@@ -1318,6 +1676,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-ta/-/lang-ta-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ta"
         }
       ]
     },
@@ -1340,6 +1704,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-th"
+        }
       ]
     },
     {
@@ -1360,6 +1730,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-tl/-/lang-tl-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-tl"
         }
       ]
     },
@@ -1382,6 +1758,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-tr"
+        }
       ]
     },
     {
@@ -1402,6 +1784,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-uk/-/lang-uk-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-uk"
         }
       ]
     },
@@ -1424,6 +1812,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-zh"
+        }
       ]
     },
     {
@@ -1444,6 +1838,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/language-min/-/language-min-4.22.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/language-min"
         }
       ]
     },
@@ -1466,6 +1866,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/language"
+        }
       ]
     },
     {
@@ -1486,6 +1892,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/ner/-/ner-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/ner"
         }
       ]
     },
@@ -1508,6 +1920,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/neural"
+        }
       ]
     },
     {
@@ -1528,6 +1946,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/nlg/-/nlg-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/nlg"
         }
       ]
     },
@@ -1550,6 +1974,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/nlp"
+        }
       ]
     },
     {
@@ -1570,6 +2000,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/nlu/-/nlu-4.23.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/nlu"
         }
       ]
     },
@@ -1592,6 +2028,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/request"
+        }
       ]
     },
     {
@@ -1612,6 +2054,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/sentiment/-/sentiment-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/sentiment"
         }
       ]
     },
@@ -1634,6 +2082,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/similarity"
+        }
       ]
     },
     {
@@ -1654,6 +2108,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/slot/-/slot-4.22.17.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/slot"
         }
       ]
     },
@@ -1676,6 +2136,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@npmcli/fs"
+        }
       ]
     },
     {
@@ -1696,6 +2162,12 @@
           "url": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@npmcli/move-file"
         }
       ]
     },
@@ -1718,6 +2190,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib/core"
+        }
       ]
     },
     {
@@ -1738,6 +2216,12 @@
           "url": "https://registry.npmjs.org/@otplib/plugin-crypto/-/plugin-crypto-12.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib/plugin-crypto"
         }
       ]
     },
@@ -1760,6 +2244,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib/plugin-thirty-two"
+        }
       ]
     },
     {
@@ -1780,6 +2270,12 @@
           "url": "https://registry.npmjs.org/@otplib/preset-default/-/preset-default-12.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib/preset-default"
         }
       ]
     },
@@ -1802,6 +2298,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib/preset-v11"
+        }
       ]
     },
     {
@@ -1822,6 +2324,12 @@
           "url": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@sindresorhus/is"
         }
       ]
     },
@@ -1844,6 +2352,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@swc/helpers"
+        }
       ]
     },
     {
@@ -1864,6 +2378,12 @@
           "url": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@tokenizer/token"
         }
       ]
     },
@@ -1886,6 +2406,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@tootallnate/once"
+        }
       ]
     },
     {
@@ -1906,6 +2432,12 @@
           "url": "https://registry.npmjs.org/@types/component-emitter/-/component-emitter-1.2.11.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/component-emitter"
         }
       ]
     },
@@ -1928,6 +2460,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/cookie"
+        }
       ]
     },
     {
@@ -1948,6 +2486,12 @@
           "url": "https://registry.npmjs.org/@types/cors/-/cors-2.8.12.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/cors"
         }
       ]
     },
@@ -1970,6 +2514,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/debug"
+        }
       ]
     },
     {
@@ -1990,6 +2540,12 @@
           "url": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/ms"
         }
       ]
     },
@@ -2012,6 +2568,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/node"
+        }
       ]
     },
     {
@@ -2032,6 +2594,12 @@
           "url": "https://registry.npmjs.org/@types/strip-bom/-/strip-bom-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/strip-bom"
         }
       ]
     },
@@ -2054,6 +2622,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/strip-json-comments"
+        }
       ]
     },
     {
@@ -2075,6 +2649,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/validator"
+        }
       ]
     },
     {
@@ -2094,6 +2674,12 @@
           "url": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/abbrev"
         }
       ]
     },
@@ -2115,6 +2701,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/accepts"
+        }
       ]
     },
     {
@@ -2135,6 +2727,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/acorn-walk"
+        }
       ]
     },
     {
@@ -2154,6 +2752,12 @@
           "url": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/acorn"
         }
       ]
     },
@@ -2176,6 +2780,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/agent-base"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -2194,6 +2804,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agent-base/node_modules/debug"
             }
           ]
         },
@@ -2214,6 +2830,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agent-base/node_modules/ms"
             }
           ]
         }
@@ -2238,6 +2860,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/agentkeepalive"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -2256,6 +2884,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agentkeepalive/node_modules/debug"
             }
           ]
         },
@@ -2277,6 +2911,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agentkeepalive/node_modules/depd"
+            }
           ]
         },
         {
@@ -2296,6 +2936,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agentkeepalive/node_modules/ms"
             }
           ]
         }
@@ -2319,6 +2965,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/aggregate-error"
+        }
       ]
     },
     {
@@ -2338,6 +2990,12 @@
           "url": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ajv"
         }
       ]
     },
@@ -2359,6 +3017,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ansi-regex"
+        }
       ]
     },
     {
@@ -2378,6 +3042,12 @@
           "url": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ansi-styles"
         }
       ]
     },
@@ -2400,6 +3070,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/anymatch"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -2418,6 +3094,12 @@
               "url": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/anymatch/node_modules/normalize-path"
             }
           ]
         }
@@ -2441,6 +3123,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/append-field"
+        }
       ]
     },
     {
@@ -2460,6 +3148,12 @@
           "url": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/aproba"
         }
       ]
     },
@@ -2482,6 +3176,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/archive-type"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -2500,6 +3200,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-4.4.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/archive-type/node_modules/file-type"
             }
           ]
         }
@@ -2523,6 +3229,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/archiver-utils"
+        }
       ]
     },
     {
@@ -2542,6 +3254,12 @@
           "url": "https://registry.npmjs.org/archiver/-/archiver-1.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/archiver"
         }
       ]
     },
@@ -2563,6 +3281,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/are-we-there-yet"
+        }
       ]
     },
     {
@@ -2582,6 +3306,12 @@
           "url": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/arg"
         }
       ]
     },
@@ -2604,6 +3334,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/argparse"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -2622,6 +3358,12 @@
               "url": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/argparse/node_modules/sprintf-js"
             }
           ]
         }
@@ -2645,6 +3387,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/arr-diff"
+        }
       ]
     },
     {
@@ -2664,6 +3412,12 @@
           "url": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/arr-flatten"
         }
       ]
     },
@@ -2685,6 +3439,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/arr-union"
+        }
       ]
     },
     {
@@ -2704,6 +3464,12 @@
           "url": "https://registry.npmjs.org/array-each/-/array-each-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/array-each"
         }
       ]
     },
@@ -2725,6 +3491,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/array-flatten"
+        }
       ]
     },
     {
@@ -2744,6 +3516,12 @@
           "url": "https://registry.npmjs.org/array-slice/-/array-slice-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/array-slice"
         }
       ]
     },
@@ -2765,6 +3543,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/array-unique"
+        }
       ]
     },
     {
@@ -2784,6 +3568,12 @@
           "url": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/asap"
         }
       ]
     },
@@ -2805,6 +3595,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/asn1"
+        }
       ]
     },
     {
@@ -2824,6 +3620,12 @@
           "url": "https://registry.npmjs.org/assert-never/-/assert-never-1.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/assert-never"
         }
       ]
     },
@@ -2845,6 +3647,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/assert-plus"
+        }
       ]
     },
     {
@@ -2864,6 +3672,12 @@
           "url": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/assign-symbols"
         }
       ]
     },
@@ -2885,6 +3699,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/async"
+        }
       ]
     },
     {
@@ -2904,6 +3724,12 @@
           "url": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/asynckit"
         }
       ]
     },
@@ -2925,6 +3751,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/at-least-node"
+        }
       ]
     },
     {
@@ -2944,6 +3776,12 @@
           "url": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/atob"
         }
       ]
     },
@@ -2965,6 +3803,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/available-typed-arrays"
+        }
       ]
     },
     {
@@ -2984,6 +3828,12 @@
           "url": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/aws-sign2"
         }
       ]
     },
@@ -3005,6 +3855,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/aws4"
+        }
       ]
     },
     {
@@ -3025,6 +3881,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/babel-walk"
+        }
       ]
     },
     {
@@ -3044,6 +3906,12 @@
           "url": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/balanced-match"
         }
       ]
     },
@@ -3066,6 +3934,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -3084,6 +3958,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/base/node_modules/define-property"
             }
           ]
         }
@@ -3107,6 +3987,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base64-arraybuffer"
+        }
       ]
     },
     {
@@ -3126,6 +4012,12 @@
           "url": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base64-js"
         }
       ]
     },
@@ -3147,6 +4039,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base64id"
+        }
       ]
     },
     {
@@ -3166,6 +4064,12 @@
           "url": "https://registry.npmjs.org/base64url/-/base64url-0.0.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base64url"
         }
       ]
     },
@@ -3187,6 +4091,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/basic-auth"
+        }
       ]
     },
     {
@@ -3206,6 +4116,12 @@
           "url": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/batch"
         }
       ]
     },
@@ -3227,6 +4143,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bcrypt-pbkdf"
+        }
       ]
     },
     {
@@ -3246,6 +4168,12 @@
           "url": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/big-integer"
         }
       ]
     },
@@ -3267,6 +4195,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/binary-extensions"
+        }
       ]
     },
     {
@@ -3286,6 +4220,12 @@
           "url": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/binary"
         }
       ]
     },
@@ -3307,6 +4247,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bindings"
+        }
       ]
     },
     {
@@ -3326,6 +4272,12 @@
           "url": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bintrees"
         }
       ]
     },
@@ -3347,6 +4299,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bl"
+        }
       ]
     },
     {
@@ -3367,6 +4325,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bluebird"
+        }
       ]
     },
     {
@@ -3386,6 +4350,12 @@
           "url": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/body-parser"
         }
       ]
     },
@@ -3408,6 +4378,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bower-config"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -3426,6 +4402,12 @@
               "url": "https://registry.npmjs.org/minimist/-/minimist-0.2.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bower-config/node_modules/minimist"
             }
           ]
         }
@@ -3449,6 +4431,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/brace-expansion"
+        }
       ]
     },
     {
@@ -3470,6 +4458,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/braces"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -3488,6 +4482,12 @@
               "url": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/braces/node_modules/extend-shallow"
             }
           ]
         },
@@ -3508,6 +4508,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/braces/node_modules/is-extendable"
             }
           ]
         }
@@ -3531,6 +4537,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/brotli"
+        }
       ]
     },
     {
@@ -3550,6 +4562,12 @@
           "url": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-alloc-unsafe"
         }
       ]
     },
@@ -3571,6 +4589,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-alloc"
+        }
       ]
     },
     {
@@ -3590,6 +4614,12 @@
           "url": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-crc32"
         }
       ]
     },
@@ -3611,6 +4641,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-fill"
+        }
       ]
     },
     {
@@ -3630,6 +4666,12 @@
           "url": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-from"
         }
       ]
     },
@@ -3651,6 +4693,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-indexof-polyfill"
+        }
       ]
     },
     {
@@ -3671,6 +4719,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer"
+        }
       ]
     },
     {
@@ -3690,6 +4744,12 @@
           "url": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffers"
         }
       ]
     },
@@ -3712,6 +4772,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/busboy"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -3730,6 +4796,12 @@
               "url": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/busboy/node_modules/isarray"
             }
           ]
         },
@@ -3751,6 +4823,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/busboy/node_modules/readable-stream"
+            }
           ]
         },
         {
@@ -3770,6 +4848,12 @@
               "url": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/busboy/node_modules/string_decoder"
             }
           ]
         }
@@ -3793,6 +4877,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/byline"
+        }
       ]
     },
     {
@@ -3812,6 +4902,12 @@
           "url": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bytes"
         }
       ]
     },
@@ -3833,6 +4929,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cacache"
+        }
       ]
     },
     {
@@ -3852,6 +4954,12 @@
           "url": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cache-base"
         }
       ]
     },
@@ -3874,6 +4982,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cacheable-request"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -3892,6 +5006,12 @@
               "url": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cacheable-request/node_modules/get-stream"
             }
           ]
         },
@@ -3912,6 +5032,12 @@
               "url": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cacheable-request/node_modules/lowercase-keys"
             }
           ]
         }
@@ -3935,6 +5061,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/call-bind"
+        }
       ]
     },
     {
@@ -3954,6 +5086,12 @@
           "url": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/camelcase"
         }
       ]
     },
@@ -3975,6 +5113,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/caseless"
+        }
       ]
     },
     {
@@ -3994,6 +5138,12 @@
           "url": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/chainsaw"
         }
       ]
     },
@@ -4015,6 +5165,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/chalk"
+        }
       ]
     },
     {
@@ -4034,6 +5190,12 @@
           "url": "https://registry.npmjs.org/character-parser/-/character-parser-2.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/character-parser"
         }
       ]
     },
@@ -4056,6 +5218,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/check-dependencies"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4074,6 +5242,12 @@
               "url": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/check-dependencies/node_modules/semver"
             }
           ]
         }
@@ -4097,6 +5271,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/check-types"
+        }
       ]
     },
     {
@@ -4118,6 +5298,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/chokidar"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4136,6 +5322,12 @@
               "url": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar/node_modules/braces"
             }
           ]
         },
@@ -4157,6 +5349,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar/node_modules/fill-range"
+            }
           ]
         },
         {
@@ -4176,6 +5374,12 @@
               "url": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar/node_modules/is-glob"
             }
           ]
         },
@@ -4197,6 +5401,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar/node_modules/is-number"
+            }
           ]
         },
         {
@@ -4217,6 +5427,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar/node_modules/normalize-path"
+            }
           ]
         },
         {
@@ -4236,6 +5452,12 @@
               "url": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar/node_modules/to-regex-range"
             }
           ]
         }
@@ -4259,6 +5481,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/chownr"
+        }
       ]
     },
     {
@@ -4278,6 +5506,12 @@
           "url": "https://registry.npmjs.org/clarinet/-/clarinet-0.12.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/clarinet"
         }
       ]
     },
@@ -4300,6 +5534,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/class-utils"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4318,6 +5558,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils/node_modules/define-property"
             }
           ]
         },
@@ -4340,6 +5586,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils/node_modules/is-accessor-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -4358,6 +5610,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/class-utils/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -4382,6 +5640,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils/node_modules/is-data-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -4400,6 +5664,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/class-utils/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -4423,6 +5693,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils/node_modules/is-descriptor"
+            }
           ]
         },
         {
@@ -4442,6 +5718,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils/node_modules/kind-of"
             }
           ]
         }
@@ -4465,6 +5747,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/clean-stack"
+        }
       ]
     },
     {
@@ -4486,6 +5774,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cliui"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4504,6 +5798,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui/node_modules/ansi-regex"
             }
           ]
         },
@@ -4525,6 +5825,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui/node_modules/emoji-regex"
+            }
           ]
         },
         {
@@ -4544,6 +5850,12 @@
               "url": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui/node_modules/is-fullwidth-code-point"
             }
           ]
         },
@@ -4565,6 +5877,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui/node_modules/string-width"
+            }
           ]
         },
         {
@@ -4584,6 +5902,12 @@
               "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui/node_modules/strip-ansi"
             }
           ]
         }
@@ -4607,6 +5931,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/clone-response"
+        }
       ]
     },
     {
@@ -4626,6 +5956,12 @@
           "url": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/clone"
         }
       ]
     },
@@ -4647,6 +5983,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/code-point-at"
+        }
       ]
     },
     {
@@ -4666,6 +6008,12 @@
           "url": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/collection-visit"
         }
       ]
     },
@@ -4687,6 +6035,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color-convert"
+        }
       ]
     },
     {
@@ -4706,6 +6060,12 @@
           "url": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color-name"
         }
       ]
     },
@@ -4727,6 +6087,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color-string"
+        }
       ]
     },
     {
@@ -4746,6 +6112,12 @@
           "url": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color-support"
         }
       ]
     },
@@ -4767,6 +6139,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color"
+        }
       ]
     },
     {
@@ -4786,6 +6164,12 @@
           "url": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/colors"
         }
       ]
     },
@@ -4807,6 +6191,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/colorspace"
+        }
       ]
     },
     {
@@ -4826,6 +6216,12 @@
           "url": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/combined-stream"
         }
       ]
     },
@@ -4847,6 +6243,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/commander"
+        }
       ]
     },
     {
@@ -4866,6 +6268,12 @@
           "url": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/component-emitter"
         }
       ]
     },
@@ -4887,6 +6295,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/component-type"
+        }
       ]
     },
     {
@@ -4907,6 +6321,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/compress-commons"
+        }
       ]
     },
     {
@@ -4926,6 +6346,12 @@
           "url": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/compressible"
         }
       ]
     },
@@ -4948,6 +6374,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/compression"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4966,6 +6398,12 @@
               "url": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/compression/node_modules/bytes"
             }
           ]
         }
@@ -4989,6 +6427,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/concat-map"
+        }
       ]
     },
     {
@@ -5008,6 +6452,12 @@
           "url": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/concat-stream"
         }
       ]
     },
@@ -5030,6 +6480,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/concurrently"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5048,6 +6504,12 @@
               "url": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/concurrently/node_modules/supports-color"
             }
           ]
         }
@@ -5071,6 +6533,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/config"
+        }
       ]
     },
     {
@@ -5091,6 +6559,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/console-control-strings"
+        }
       ]
     },
     {
@@ -5110,6 +6584,12 @@
           "url": "https://registry.npmjs.org/constantinople/-/constantinople-4.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/constantinople"
         }
       ]
     },
@@ -5132,6 +6612,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/content-disposition"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5150,6 +6636,12 @@
               "url": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/content-disposition/node_modules/safe-buffer"
             }
           ]
         }
@@ -5173,6 +6665,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/content-type"
+        }
       ]
     },
     {
@@ -5192,6 +6690,12 @@
           "url": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cookie-parser"
         }
       ]
     },
@@ -5213,6 +6717,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cookie-signature"
+        }
       ]
     },
     {
@@ -5232,6 +6742,12 @@
           "url": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cookie"
         }
       ]
     },
@@ -5253,6 +6769,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/copy-descriptor"
+        }
       ]
     },
     {
@@ -5272,6 +6794,12 @@
           "url": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/core-util-is"
         }
       ]
     },
@@ -5293,6 +6821,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cors"
+        }
       ]
     },
     {
@@ -5312,6 +6846,12 @@
           "url": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/crc"
         }
       ]
     },
@@ -5333,6 +6873,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/crc32-stream"
+        }
       ]
     },
     {
@@ -5352,6 +6898,12 @@
           "url": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/create-require"
         }
       ]
     },
@@ -5373,6 +6925,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/crypto-js"
+        }
       ]
     },
     {
@@ -5392,6 +6950,12 @@
           "url": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dashdash"
         }
       ]
     },
@@ -5413,6 +6977,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/date-fns"
+        }
       ]
     },
     {
@@ -5432,6 +7002,12 @@
           "url": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dateformat"
         }
       ]
     },
@@ -5453,6 +7029,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/debug"
+        }
       ]
     },
     {
@@ -5472,6 +7054,12 @@
           "url": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decamelize"
         }
       ]
     },
@@ -5493,6 +7081,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decode-uri-component"
+        }
       ]
     },
     {
@@ -5512,6 +7106,12 @@
           "url": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-response"
         }
       ]
     },
@@ -5534,6 +7134,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-tar"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5552,6 +7158,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-tar/node_modules/file-type"
             }
           ]
         }
@@ -5576,6 +7188,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-tarbz2"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5594,6 +7212,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-6.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-tarbz2/node_modules/file-type"
             }
           ]
         }
@@ -5618,6 +7242,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-targz"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5636,6 +7266,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-targz/node_modules/file-type"
             }
           ]
         }
@@ -5660,6 +7296,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-unzip"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5678,6 +7320,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-unzip/node_modules/file-type"
             }
           ]
         },
@@ -5699,6 +7347,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-unzip/node_modules/get-stream"
+            }
           ]
         },
         {
@@ -5718,6 +7372,12 @@
               "url": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-unzip/node_modules/pify"
             }
           ]
         }
@@ -5742,6 +7402,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5762,6 +7428,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress/node_modules/make-dir"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -5780,6 +7452,12 @@
                   "url": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/decompress/node_modules/make-dir/node_modules/pify"
                 }
               ]
             }
@@ -5803,6 +7481,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress/node_modules/pify"
+            }
           ]
         }
       ]
@@ -5825,6 +7509,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/deep-equal"
+        }
       ]
     },
     {
@@ -5844,6 +7534,12 @@
           "url": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/deep-extend"
         }
       ]
     },
@@ -5865,6 +7561,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/deep-is"
+        }
       ]
     },
     {
@@ -5884,6 +7586,12 @@
           "url": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/define-properties"
         }
       ]
     },
@@ -5905,6 +7613,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/define-property"
+        }
       ]
     },
     {
@@ -5924,6 +7638,12 @@
           "url": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/delayed-stream"
         }
       ]
     },
@@ -5945,6 +7665,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/delegates"
+        }
       ]
     },
     {
@@ -5964,6 +7690,12 @@
           "url": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/depd"
         }
       ]
     },
@@ -5985,6 +7717,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/destroy"
+        }
       ]
     },
     {
@@ -6004,6 +7742,12 @@
           "url": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/detect-file"
         }
       ]
     },
@@ -6025,6 +7769,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/detect-libc"
+        }
       ]
     },
     {
@@ -6044,6 +7794,12 @@
           "url": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dfa"
         }
       ]
     },
@@ -6066,6 +7822,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dicer"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -6084,6 +7846,12 @@
               "url": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/dicer/node_modules/isarray"
             }
           ]
         },
@@ -6105,6 +7873,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/dicer/node_modules/readable-stream"
+            }
           ]
         },
         {
@@ -6124,6 +7898,12 @@
               "url": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/dicer/node_modules/string_decoder"
             }
           ]
         }
@@ -6147,6 +7927,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/diff"
+        }
       ]
     },
     {
@@ -6166,6 +7952,12 @@
           "url": "https://registry.npmjs.org/doctypes/-/doctypes-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/doctypes"
         }
       ]
     },
@@ -6187,6 +7979,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/domelementtype"
+        }
       ]
     },
     {
@@ -6206,6 +8004,12 @@
           "url": "https://registry.npmjs.org/domhandler/-/domhandler-2.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/domhandler"
         }
       ]
     },
@@ -6227,6 +8031,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/domutils"
+        }
       ]
     },
     {
@@ -6246,6 +8056,12 @@
           "url": "https://registry.npmjs.org/dottie/-/dottie-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dottie"
         }
       ]
     },
@@ -6267,6 +8083,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/double-ended-queue"
+        }
       ]
     },
     {
@@ -6286,6 +8108,12 @@
           "url": "https://registry.npmjs.org/doublearray/-/doublearray-0.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/doublearray"
         }
       ]
     },
@@ -6308,6 +8136,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/download"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -6326,6 +8160,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-11.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/download/node_modules/file-type"
             }
           ]
         }
@@ -6349,6 +8189,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/duplexer2"
+        }
       ]
     },
     {
@@ -6368,6 +8214,12 @@
           "url": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/duplexer3"
         }
       ]
     },
@@ -6389,6 +8241,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dynamic-dedupe"
+        }
       ]
     },
     {
@@ -6408,6 +8266,12 @@
           "url": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ecc-jsbn"
         }
       ]
     },
@@ -6429,6 +8293,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ee-first"
+        }
       ]
     },
     {
@@ -6448,6 +8318,12 @@
           "url": "https://registry.npmjs.org/eivindfjeldstad-dot/-/eivindfjeldstad-dot-0.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/eivindfjeldstad-dot"
         }
       ]
     },
@@ -6469,6 +8345,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/emoji-regex"
+        }
       ]
     },
     {
@@ -6489,6 +8371,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/enabled"
+        }
       ]
     },
     {
@@ -6508,6 +8396,12 @@
           "url": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/encodeurl"
         }
       ]
     },
@@ -6530,6 +8424,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/encoding"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -6548,6 +8448,12 @@
               "url": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/encoding/node_modules/iconv-lite"
             }
           ]
         }
@@ -6571,6 +8477,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/end-of-stream"
+        }
       ]
     },
     {
@@ -6590,6 +8502,12 @@
           "url": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-4.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/engine.io-parser"
         }
       ]
     },
@@ -6612,6 +8530,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/engine.io"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -6630,6 +8554,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/engine.io/node_modules/debug"
             }
           ]
         },
@@ -6650,6 +8580,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/engine.io/node_modules/ms"
             }
           ]
         }
@@ -6673,6 +8609,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/env-paths"
+        }
       ]
     },
     {
@@ -6692,6 +8634,12 @@
           "url": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/err-code"
         }
       ]
     },
@@ -6713,6 +8661,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/error-ex"
+        }
       ]
     },
     {
@@ -6732,6 +8686,12 @@
           "url": "https://registry.npmjs.org/errorhandler/-/errorhandler-1.5.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/errorhandler"
         }
       ]
     },
@@ -6753,6 +8713,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/es-abstract"
+        }
       ]
     },
     {
@@ -6772,6 +8738,12 @@
           "url": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/es-get-iterator"
         }
       ]
     },
@@ -6793,6 +8765,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/es-to-primitive"
+        }
       ]
     },
     {
@@ -6812,6 +8790,12 @@
           "url": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/escape-html"
         }
       ]
     },
@@ -6833,6 +8817,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/escape-string-regexp"
+        }
       ]
     },
     {
@@ -6852,6 +8842,12 @@
           "url": "https://registry.npmjs.org/escodegen/-/escodegen-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/escodegen"
         }
       ]
     },
@@ -6873,6 +8869,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/esprima"
+        }
       ]
     },
     {
@@ -6892,6 +8894,12 @@
           "url": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/estraverse"
         }
       ]
     },
@@ -6913,6 +8921,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/esutils"
+        }
       ]
     },
     {
@@ -6932,6 +8946,12 @@
           "url": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/etag"
         }
       ]
     },
@@ -6953,6 +8973,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/eventemitter2"
+        }
       ]
     },
     {
@@ -6972,6 +8998,12 @@
           "url": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/eventemitter3"
         }
       ]
     },
@@ -6993,6 +9025,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/exif"
+        }
       ]
     },
     {
@@ -7012,6 +9050,12 @@
           "url": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/exit"
         }
       ]
     },
@@ -7034,6 +9078,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/expand-brackets"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7052,6 +9102,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/define-property"
             }
           ]
         },
@@ -7072,6 +9128,12 @@
               "url": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/extend-shallow"
             }
           ]
         },
@@ -7094,6 +9156,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/is-accessor-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -7112,6 +9180,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/expand-brackets/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -7136,6 +9210,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/is-data-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -7154,6 +9234,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/expand-brackets/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -7177,6 +9263,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/is-descriptor"
+            }
           ]
         },
         {
@@ -7197,6 +9289,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/is-extendable"
+            }
           ]
         },
         {
@@ -7216,6 +9314,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/kind-of"
             }
           ]
         }
@@ -7239,6 +9343,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/expand-template"
+        }
       ]
     },
     {
@@ -7259,6 +9369,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/expand-tilde"
+        }
       ]
     },
     {
@@ -7278,6 +9394,12 @@
           "url": "https://registry.npmjs.org/express-ipfilter/-/express-ipfilter-1.3.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-ipfilter"
         }
       ]
     },
@@ -7300,6 +9422,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-jwt"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7318,6 +9446,12 @@
               "url": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-0.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/express-jwt/node_modules/jsonwebtoken"
             }
           ]
         },
@@ -7338,6 +9472,12 @@
               "url": "https://registry.npmjs.org/moment/-/moment-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/express-jwt/node_modules/moment"
             }
           ]
         }
@@ -7361,6 +9501,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-rate-limit"
+        }
       ]
     },
     {
@@ -7381,6 +9527,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-robots-txt"
+        }
       ]
     },
     {
@@ -7400,6 +9552,12 @@
           "url": "https://registry.npmjs.org/express-security.txt/-/express-security.txt-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-security.txt"
         }
       ]
     },
@@ -7422,6 +9580,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7440,6 +9604,12 @@
               "url": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/express/node_modules/cookie"
             }
           ]
         },
@@ -7460,6 +9630,12 @@
               "url": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/express/node_modules/safe-buffer"
             }
           ]
         }
@@ -7483,6 +9659,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ext-list"
+        }
       ]
     },
     {
@@ -7502,6 +9684,12 @@
           "url": "https://registry.npmjs.org/ext-name/-/ext-name-5.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ext-name"
         }
       ]
     },
@@ -7523,6 +9711,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/extend-shallow"
+        }
       ]
     },
     {
@@ -7542,6 +9736,12 @@
           "url": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/extend"
         }
       ]
     },
@@ -7564,6 +9764,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/extglob"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7582,6 +9788,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/extglob/node_modules/define-property"
             }
           ]
         },
@@ -7603,6 +9815,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/extglob/node_modules/extend-shallow"
+            }
           ]
         },
         {
@@ -7622,6 +9840,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/extglob/node_modules/is-extendable"
             }
           ]
         }
@@ -7645,6 +9869,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/extsprintf"
+        }
       ]
     },
     {
@@ -7664,6 +9894,12 @@
           "url": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fast-deep-equal"
         }
       ]
     },
@@ -7685,6 +9921,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fast-json-stable-stringify"
+        }
       ]
     },
     {
@@ -7704,6 +9946,12 @@
           "url": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fast-levenshtein"
         }
       ]
     },
@@ -7725,6 +9973,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fast.js"
+        }
       ]
     },
     {
@@ -7744,6 +9998,12 @@
           "url": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fd-slicer"
         }
       ]
     },
@@ -7765,6 +10025,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/feature-policy"
+        }
       ]
     },
     {
@@ -7784,6 +10050,12 @@
           "url": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fecha"
         }
       ]
     },
@@ -7806,6 +10078,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/file-js"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7824,6 +10102,12 @@
               "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/file-js/node_modules/brace-expansion"
             }
           ]
         },
@@ -7844,6 +10128,12 @@
               "url": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/file-js/node_modules/minimatch"
             }
           ]
         }
@@ -7867,6 +10157,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/file-stream-rotator"
+        }
       ]
     },
     {
@@ -7886,6 +10182,12 @@
           "url": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/file-type"
         }
       ]
     },
@@ -7907,6 +10209,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/file-uri-to-path"
+        }
       ]
     },
     {
@@ -7926,6 +10234,12 @@
           "url": "https://registry.npmjs.org/filehound/-/filehound-1.17.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/filehound"
         }
       ]
     },
@@ -7947,6 +10261,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/filename-reserved-regex"
+        }
       ]
     },
     {
@@ -7967,6 +10287,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/filenamify"
+        }
       ]
     },
     {
@@ -7986,6 +10312,12 @@
           "url": "https://registry.npmjs.org/filesniffer/-/filesniffer-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/filesniffer"
         }
       ]
     },
@@ -8008,6 +10340,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fill-range"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -8026,6 +10364,12 @@
               "url": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/fill-range/node_modules/extend-shallow"
             }
           ]
         },
@@ -8046,6 +10390,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/fill-range/node_modules/is-extendable"
             }
           ]
         }
@@ -8069,6 +10419,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/finale-rest"
+        }
       ]
     },
     {
@@ -8088,6 +10444,12 @@
           "url": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/finalhandler"
         }
       ]
     },
@@ -8109,6 +10471,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/find-up"
+        }
       ]
     },
     {
@@ -8128,6 +10496,12 @@
           "url": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/findup-sync"
         }
       ]
     },
@@ -8149,6 +10523,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fined"
+        }
       ]
     },
     {
@@ -8168,6 +10548,12 @@
           "url": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/flagged-respawn"
         }
       ]
     },
@@ -8189,6 +10575,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fn.name"
+        }
       ]
     },
     {
@@ -8208,6 +10600,12 @@
           "url": "https://registry.npmjs.org/fontkit/-/fontkit-1.9.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fontkit"
         }
       ]
     },
@@ -8229,6 +10627,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/for-each"
+        }
       ]
     },
     {
@@ -8248,6 +10652,12 @@
           "url": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/for-in"
         }
       ]
     },
@@ -8269,6 +10679,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/for-own"
+        }
       ]
     },
     {
@@ -8288,6 +10704,12 @@
           "url": "https://registry.npmjs.org/foreachasync/-/foreachasync-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/foreachasync"
         }
       ]
     },
@@ -8309,6 +10731,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/forever-agent"
+        }
       ]
     },
     {
@@ -8328,6 +10756,12 @@
           "url": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/form-data"
         }
       ]
     },
@@ -8349,6 +10783,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/formatio"
+        }
       ]
     },
     {
@@ -8368,6 +10808,12 @@
           "url": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/forwarded"
         }
       ]
     },
@@ -8389,6 +10835,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fragment-cache"
+        }
       ]
     },
     {
@@ -8408,6 +10860,12 @@
           "url": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fresh"
         }
       ]
     },
@@ -8429,6 +10887,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/from2"
+        }
       ]
     },
     {
@@ -8448,6 +10912,12 @@
           "url": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fs-constants"
         }
       ]
     },
@@ -8469,6 +10939,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fs-extra"
+        }
       ]
     },
     {
@@ -8489,6 +10965,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fs-minipass"
+        }
       ]
     },
     {
@@ -8508,6 +10990,12 @@
           "url": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fs.realpath"
         }
       ]
     },
@@ -8530,6 +11018,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fstream"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -8548,6 +11042,12 @@
               "url": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/fstream/node_modules/mkdirp"
             }
           ]
         },
@@ -8568,6 +11068,12 @@
               "url": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/fstream/node_modules/rimraf"
             }
           ]
         }
@@ -8591,6 +11097,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/function-bind"
+        }
       ]
     },
     {
@@ -8610,6 +11122,12 @@
           "url": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/function.prototype.name"
         }
       ]
     },
@@ -8631,6 +11149,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/functions-have-names"
+        }
       ]
     },
     {
@@ -8650,6 +11174,12 @@
           "url": "https://registry.npmjs.org/fuzzball/-/fuzzball-1.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fuzzball"
         }
       ]
     },
@@ -8671,6 +11201,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/gauge"
+        }
       ]
     },
     {
@@ -8690,6 +11226,12 @@
           "url": "https://registry.npmjs.org/geojson-utils/-/geojson-utils-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/geojson-utils"
         }
       ]
     },
@@ -8711,6 +11253,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-caller-file"
+        }
       ]
     },
     {
@@ -8730,6 +11278,12 @@
           "url": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-intrinsic"
         }
       ]
     },
@@ -8751,6 +11305,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-stream"
+        }
       ]
     },
     {
@@ -8770,6 +11330,12 @@
           "url": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-symbol-description"
         }
       ]
     },
@@ -8791,6 +11357,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-value"
+        }
       ]
     },
     {
@@ -8810,6 +11382,12 @@
           "url": "https://registry.npmjs.org/getobject/-/getobject-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/getobject"
         }
       ]
     },
@@ -8831,6 +11409,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/getpass"
+        }
       ]
     },
     {
@@ -8850,6 +11434,12 @@
           "url": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/github-from-package"
         }
       ]
     },
@@ -8872,6 +11462,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/glob-parent"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -8890,6 +11486,12 @@
               "url": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/glob-parent/node_modules/is-glob"
             }
           ]
         }
@@ -8914,6 +11516,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/glob"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -8932,6 +11540,12 @@
               "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/glob/node_modules/brace-expansion"
             }
           ]
         },
@@ -8952,6 +11566,12 @@
               "url": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/glob/node_modules/minimatch"
             }
           ]
         }
@@ -8975,6 +11595,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/global-modules"
+        }
       ]
     },
     {
@@ -8996,6 +11622,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/global-prefix"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9014,6 +11646,12 @@
               "url": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/global-prefix/node_modules/which"
             }
           ]
         }
@@ -9038,6 +11676,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/got"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9056,6 +11700,12 @@
               "url": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/got/node_modules/get-stream"
             }
           ]
         },
@@ -9076,6 +11726,12 @@
               "url": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/got/node_modules/pify"
             }
           ]
         }
@@ -9099,6 +11755,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/graceful-fs"
+        }
       ]
     },
     {
@@ -9120,6 +11782,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-cli"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9138,6 +11806,12 @@
               "url": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-cli/node_modules/nopt"
             }
           ]
         }
@@ -9162,6 +11836,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-contrib-compress"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9180,6 +11860,12 @@
               "url": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-contrib-compress/node_modules/ansi-styles"
             }
           ]
         },
@@ -9201,6 +11887,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-contrib-compress/node_modules/chalk"
+            }
           ]
         },
         {
@@ -9220,6 +11912,12 @@
               "url": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-contrib-compress/node_modules/supports-color"
             }
           ]
         }
@@ -9243,6 +11941,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-known-options"
+        }
       ]
     },
     {
@@ -9264,6 +11968,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-legacy-log-utils"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9282,6 +11992,12 @@
               "url": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils/node_modules/ansi-styles"
             }
           ]
         },
@@ -9303,6 +12019,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils/node_modules/chalk"
+            }
           ]
         },
         {
@@ -9322,6 +12044,12 @@
               "url": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils/node_modules/color-convert"
             }
           ]
         },
@@ -9343,6 +12071,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils/node_modules/color-name"
+            }
           ]
         },
         {
@@ -9363,6 +12097,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils/node_modules/has-flag"
+            }
           ]
         },
         {
@@ -9382,6 +12122,12 @@
               "url": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils/node_modules/supports-color"
             }
           ]
         }
@@ -9406,6 +12152,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-legacy-log"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9424,6 +12176,12 @@
               "url": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log/node_modules/colors"
             }
           ]
         }
@@ -9448,6 +12206,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-legacy-util"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9466,6 +12230,12 @@
               "url": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-util/node_modules/async"
             }
           ]
         }
@@ -9489,6 +12259,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-replace-json"
+        }
       ]
     },
     {
@@ -9510,6 +12286,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9528,6 +12310,12 @@
               "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt/node_modules/brace-expansion"
             }
           ]
         },
@@ -9550,6 +12338,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt/node_modules/findup-sync"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -9568,6 +12362,12 @@
                   "url": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/grunt/node_modules/findup-sync/node_modules/glob"
                 }
               ]
             }
@@ -9591,6 +12391,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt/node_modules/glob"
+            }
           ]
         },
         {
@@ -9610,6 +12416,12 @@
               "url": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.8.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt/node_modules/minimatch"
             }
           ]
         }
@@ -9634,6 +12446,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/handlebars"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9652,6 +12470,12 @@
               "url": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/handlebars/node_modules/wordwrap"
             }
           ]
         }
@@ -9675,6 +12499,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/har-schema"
+        }
       ]
     },
     {
@@ -9694,6 +12524,12 @@
           "url": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/har-validator"
         }
       ]
     },
@@ -9715,6 +12551,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-ansi"
+        }
       ]
     },
     {
@@ -9734,6 +12576,12 @@
           "url": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-bigints"
         }
       ]
     },
@@ -9755,6 +12603,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-flag"
+        }
       ]
     },
     {
@@ -9774,6 +12628,12 @@
           "url": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-property-descriptors"
         }
       ]
     },
@@ -9795,6 +12655,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-symbol-support-x"
+        }
       ]
     },
     {
@@ -9814,6 +12680,12 @@
           "url": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-symbols"
         }
       ]
     },
@@ -9835,6 +12707,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-to-string-tag-x"
+        }
       ]
     },
     {
@@ -9854,6 +12732,12 @@
           "url": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-tostringtag"
         }
       ]
     },
@@ -9875,6 +12759,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-unicode"
+        }
       ]
     },
     {
@@ -9894,6 +12784,12 @@
           "url": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-value"
         }
       ]
     },
@@ -9916,6 +12812,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-values"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9934,6 +12836,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/has-values/node_modules/kind-of"
             }
           ]
         }
@@ -9957,6 +12865,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has"
+        }
       ]
     },
     {
@@ -9976,6 +12890,12 @@
           "url": "https://registry.npmjs.org/hashids/-/hashids-2.2.10.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hashids"
         }
       ]
     },
@@ -9997,6 +12917,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hbs"
+        }
       ]
     },
     {
@@ -10016,6 +12942,12 @@
           "url": "https://registry.npmjs.org/he/-/he-0.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/he"
         }
       ]
     },
@@ -10037,6 +12969,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/heap"
+        }
       ]
     },
     {
@@ -10056,6 +12994,12 @@
           "url": "https://registry.npmjs.org/helmet/-/helmet-4.6.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/helmet"
         }
       ]
     },
@@ -10077,6 +13021,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hoister"
+        }
       ]
     },
     {
@@ -10096,6 +13046,12 @@
           "url": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/homedir-polyfill"
         }
       ]
     },
@@ -10117,6 +13073,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hooker"
+        }
       ]
     },
     {
@@ -10137,6 +13099,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hosted-git-info"
+        }
       ]
     },
     {
@@ -10156,6 +13124,12 @@
           "url": "https://registry.npmjs.org/html-entities/-/html-entities-1.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/html-entities"
         }
       ]
     },
@@ -10178,6 +13152,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/htmlparser2"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -10196,6 +13176,12 @@
               "url": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/htmlparser2/node_modules/isarray"
             }
           ]
         },
@@ -10217,6 +13203,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/htmlparser2/node_modules/readable-stream"
+            }
           ]
         },
         {
@@ -10236,6 +13228,12 @@
               "url": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/htmlparser2/node_modules/string_decoder"
             }
           ]
         }
@@ -10259,6 +13257,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/http-cache-semantics"
+        }
       ]
     },
     {
@@ -10278,6 +13282,12 @@
           "url": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/http-errors"
         }
       ]
     },
@@ -10300,6 +13310,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/http-proxy-agent"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -10318,6 +13334,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/http-proxy-agent/node_modules/debug"
             }
           ]
         },
@@ -10338,6 +13360,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/http-proxy-agent/node_modules/ms"
             }
           ]
         }
@@ -10361,6 +13389,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/http-signature"
+        }
       ]
     },
     {
@@ -10382,6 +13416,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/https-proxy-agent"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -10400,6 +13440,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/https-proxy-agent/node_modules/debug"
             }
           ]
         },
@@ -10420,6 +13466,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/https-proxy-agent/node_modules/ms"
             }
           ]
         }
@@ -10443,6 +13495,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/humanize-ms"
+        }
       ]
     },
     {
@@ -10462,6 +13520,12 @@
           "url": "https://registry.npmjs.org/i18n/-/i18n-0.11.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/i18n"
         }
       ]
     },
@@ -10483,6 +13547,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/iconv-lite"
+        }
       ]
     },
     {
@@ -10502,6 +13572,12 @@
           "url": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ieee754"
         }
       ]
     },
@@ -10524,6 +13600,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ignore-walk"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -10542,6 +13624,12 @@
               "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/ignore-walk/node_modules/brace-expansion"
             }
           ]
         },
@@ -10562,6 +13650,12 @@
               "url": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/ignore-walk/node_modules/minimatch"
             }
           ]
         }
@@ -10585,6 +13679,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/iltorb"
+        }
       ]
     },
     {
@@ -10604,6 +13704,12 @@
           "url": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/imurmurhash"
         }
       ]
     },
@@ -10625,6 +13731,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/indent-string"
+        }
       ]
     },
     {
@@ -10644,6 +13756,12 @@
           "url": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/infer-owner"
         }
       ]
     },
@@ -10665,6 +13783,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/inflection"
+        }
       ]
     },
     {
@@ -10684,6 +13808,12 @@
           "url": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/inflight"
         }
       ]
     },
@@ -10705,6 +13835,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/inherits"
+        }
       ]
     },
     {
@@ -10724,6 +13860,12 @@
           "url": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ini"
         }
       ]
     },
@@ -10745,6 +13887,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/internal-slot"
+        }
       ]
     },
     {
@@ -10764,6 +13912,12 @@
           "url": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/interpret"
         }
       ]
     },
@@ -10785,6 +13939,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/into-stream"
+        }
       ]
     },
     {
@@ -10804,6 +13964,12 @@
           "url": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/invariant"
         }
       ]
     },
@@ -10825,6 +13991,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ip"
+        }
       ]
     },
     {
@@ -10844,6 +14016,12 @@
           "url": "https://registry.npmjs.org/ip6/-/ip6-0.2.10.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ip6"
         }
       ]
     },
@@ -10865,6 +14043,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ipaddr.js"
+        }
       ]
     },
     {
@@ -10884,6 +14068,12 @@
           "url": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-absolute"
         }
       ]
     },
@@ -10905,6 +14095,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-accessor-descriptor"
+        }
       ]
     },
     {
@@ -10924,6 +14120,12 @@
           "url": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-arguments"
         }
       ]
     },
@@ -10945,6 +14147,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-arrayish"
+        }
       ]
     },
     {
@@ -10964,6 +14172,12 @@
           "url": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-bigint"
         }
       ]
     },
@@ -10985,6 +14199,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-binary-path"
+        }
       ]
     },
     {
@@ -11004,6 +14224,12 @@
           "url": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-boolean-object"
         }
       ]
     },
@@ -11025,6 +14251,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-buffer"
+        }
       ]
     },
     {
@@ -11044,6 +14276,12 @@
           "url": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-callable"
         }
       ]
     },
@@ -11065,6 +14303,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-core-module"
+        }
       ]
     },
     {
@@ -11084,6 +14328,12 @@
           "url": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-data-descriptor"
         }
       ]
     },
@@ -11105,6 +14355,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-date-object"
+        }
       ]
     },
     {
@@ -11124,6 +14380,12 @@
           "url": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-descriptor"
         }
       ]
     },
@@ -11145,6 +14407,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-docker"
+        }
       ]
     },
     {
@@ -11164,6 +14432,12 @@
           "url": "https://registry.npmjs.org/is-expression/-/is-expression-4.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-expression"
         }
       ]
     },
@@ -11185,6 +14459,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-extendable"
+        }
       ]
     },
     {
@@ -11204,6 +14484,12 @@
           "url": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-extglob"
         }
       ]
     },
@@ -11225,6 +14511,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-fullwidth-code-point"
+        }
       ]
     },
     {
@@ -11244,6 +14536,12 @@
           "url": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-generator-function"
         }
       ]
     },
@@ -11265,6 +14563,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-glob"
+        }
       ]
     },
     {
@@ -11284,6 +14588,12 @@
           "url": "https://registry.npmjs.org/is-heroku/-/is-heroku-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-heroku"
         }
       ]
     },
@@ -11305,6 +14615,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-lambda"
+        }
       ]
     },
     {
@@ -11324,6 +14640,12 @@
           "url": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-map"
         }
       ]
     },
@@ -11345,6 +14667,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-natural-number"
+        }
       ]
     },
     {
@@ -11364,6 +14692,12 @@
           "url": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-negative-zero"
         }
       ]
     },
@@ -11385,6 +14719,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-number-like"
+        }
       ]
     },
     {
@@ -11404,6 +14744,12 @@
           "url": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-number-object"
         }
       ]
     },
@@ -11426,6 +14772,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-number"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -11444,6 +14796,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/is-number/node_modules/kind-of"
             }
           ]
         }
@@ -11467,6 +14825,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-object"
+        }
       ]
     },
     {
@@ -11486,6 +14850,12 @@
           "url": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-plain-obj"
         }
       ]
     },
@@ -11507,6 +14877,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-plain-object"
+        }
       ]
     },
     {
@@ -11526,6 +14902,12 @@
           "url": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-promise"
         }
       ]
     },
@@ -11547,6 +14929,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-regex"
+        }
       ]
     },
     {
@@ -11566,6 +14954,12 @@
           "url": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-relative"
         }
       ]
     },
@@ -11587,6 +14981,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-retry-allowed"
+        }
       ]
     },
     {
@@ -11606,6 +15006,12 @@
           "url": "https://registry.npmjs.org/is-set/-/is-set-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-set"
         }
       ]
     },
@@ -11627,6 +15033,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-shared-array-buffer"
+        }
       ]
     },
     {
@@ -11646,6 +15058,12 @@
           "url": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-stream"
         }
       ]
     },
@@ -11667,6 +15085,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-string"
+        }
       ]
     },
     {
@@ -11686,6 +15110,12 @@
           "url": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-symbol"
         }
       ]
     },
@@ -11707,6 +15137,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-typed-array"
+        }
       ]
     },
     {
@@ -11726,6 +15162,12 @@
           "url": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-typedarray"
         }
       ]
     },
@@ -11747,6 +15189,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-unc-path"
+        }
       ]
     },
     {
@@ -11766,6 +15214,12 @@
           "url": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-weakmap"
         }
       ]
     },
@@ -11787,6 +15241,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-weakref"
+        }
       ]
     },
     {
@@ -11806,6 +15266,12 @@
           "url": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-weakset"
         }
       ]
     },
@@ -11827,6 +15293,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-windows"
+        }
       ]
     },
     {
@@ -11846,6 +15318,12 @@
           "url": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isarray"
         }
       ]
     },
@@ -11867,6 +15345,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isexe"
+        }
       ]
     },
     {
@@ -11886,6 +15370,12 @@
           "url": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isobject"
         }
       ]
     },
@@ -11907,6 +15397,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isstream"
+        }
       ]
     },
     {
@@ -11926,6 +15422,12 @@
           "url": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isurl"
         }
       ]
     },
@@ -11947,6 +15449,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/js-stringify"
+        }
       ]
     },
     {
@@ -11966,6 +15474,12 @@
           "url": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/js-tokens"
         }
       ]
     },
@@ -11987,6 +15501,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/js-yaml"
+        }
       ]
     },
     {
@@ -12006,6 +15526,12 @@
           "url": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jsbn"
         }
       ]
     },
@@ -12027,6 +15553,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-buffer"
+        }
       ]
     },
     {
@@ -12046,6 +15578,12 @@
           "url": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-parse-better-errors"
         }
       ]
     },
@@ -12067,6 +15605,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-schema-traverse"
+        }
       ]
     },
     {
@@ -12086,6 +15630,12 @@
           "url": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-schema"
         }
       ]
     },
@@ -12107,6 +15657,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-stringify-safe"
+        }
       ]
     },
     {
@@ -12126,6 +15682,12 @@
           "url": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json5"
         }
       ]
     },
@@ -12147,6 +15709,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jsonfile"
+        }
       ]
     },
     {
@@ -12166,6 +15734,12 @@
           "url": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-0.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jsonwebtoken"
         }
       ]
     },
@@ -12187,6 +15761,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jsprim"
+        }
       ]
     },
     {
@@ -12206,6 +15786,12 @@
           "url": "https://registry.npmjs.org/jssha/-/jssha-3.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jssha"
         }
       ]
     },
@@ -12227,6 +15813,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jstransformer"
+        }
       ]
     },
     {
@@ -12246,6 +15838,12 @@
           "url": "https://registry.npmjs.org/juicy-chat-bot/-/juicy-chat-bot-0.6.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/juicy-chat-bot"
         }
       ]
     },
@@ -12267,6 +15865,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jwa"
+        }
       ]
     },
     {
@@ -12286,6 +15890,12 @@
           "url": "https://registry.npmjs.org/jws/-/jws-0.2.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jws"
         }
       ]
     },
@@ -12307,6 +15917,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/keyv"
+        }
       ]
     },
     {
@@ -12326,6 +15942,12 @@
           "url": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/kind-of"
         }
       ]
     },
@@ -12347,6 +15969,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/kuler"
+        }
       ]
     },
     {
@@ -12366,6 +15994,12 @@
           "url": "https://registry.npmjs.org/kuromoji/-/kuromoji-0.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/kuromoji"
         }
       ]
     },
@@ -12387,6 +16021,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lazystream"
+        }
       ]
     },
     {
@@ -12406,6 +16046,12 @@
           "url": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/levn"
         }
       ]
     },
@@ -12428,6 +16074,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/libxmljs2"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12446,6 +16098,12 @@
               "url": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/libxmljs2/node_modules/nan"
             }
           ]
         }
@@ -12470,6 +16128,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/liftup"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12488,6 +16152,12 @@
               "url": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/braces"
             }
           ]
         },
@@ -12509,6 +16179,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/fill-range"
+            }
           ]
         },
         {
@@ -12528,6 +16204,12 @@
               "url": "https://registry.npmjs.org/findup-sync/-/findup-sync-4.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/findup-sync"
             }
           ]
         },
@@ -12549,6 +16231,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/is-glob"
+            }
           ]
         },
         {
@@ -12568,6 +16256,12 @@
               "url": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/is-number"
             }
           ]
         },
@@ -12589,6 +16283,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/micromatch"
+            }
           ]
         },
         {
@@ -12608,6 +16308,12 @@
               "url": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/to-regex-range"
             }
           ]
         }
@@ -12632,6 +16338,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/linebreak"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12650,6 +16362,12 @@
               "url": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/linebreak/node_modules/base64-js"
             }
           ]
         }
@@ -12673,6 +16391,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/listenercount"
+        }
       ]
     },
     {
@@ -12692,6 +16416,12 @@
           "url": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/locate-path"
         }
       ]
     },
@@ -12713,6 +16443,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lodash.camelcase"
+        }
       ]
     },
     {
@@ -12732,6 +16468,12 @@
           "url": "https://registry.npmjs.org/lodash.isfinite/-/lodash.isfinite-3.3.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lodash.isfinite"
         }
       ]
     },
@@ -12753,6 +16495,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lodash.set"
+        }
       ]
     },
     {
@@ -12772,6 +16520,12 @@
           "url": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lodash"
         }
       ]
     },
@@ -12794,6 +16548,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/logform"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12812,6 +16572,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/logform/node_modules/ms"
             }
           ]
         }
@@ -12835,6 +16601,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lolex"
+        }
       ]
     },
     {
@@ -12854,6 +16626,12 @@
           "url": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/loose-envify"
         }
       ]
     },
@@ -12875,6 +16653,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lowercase-keys"
+        }
       ]
     },
     {
@@ -12894,6 +16678,12 @@
           "url": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lru-cache"
         }
       ]
     },
@@ -12916,6 +16706,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-dir"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12934,6 +16730,12 @@
               "url": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-dir/node_modules/semver"
             }
           ]
         }
@@ -12957,6 +16759,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-error"
+        }
       ]
     },
     {
@@ -12976,6 +16784,12 @@
           "url": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-9.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-fetch-happen"
         }
       ],
       "components": [
@@ -12998,6 +16812,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen/node_modules/@tootallnate/once"
+            }
           ]
         },
         {
@@ -13017,6 +16837,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen/node_modules/debug"
             }
           ]
         },
@@ -13038,6 +16864,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen/node_modules/http-cache-semantics"
+            }
           ]
         },
         {
@@ -13058,6 +16890,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen/node_modules/http-proxy-agent"
+            }
           ]
         },
         {
@@ -13077,6 +16915,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen/node_modules/ms"
             }
           ]
         }
@@ -13100,6 +16944,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-iterator"
+        }
       ]
     },
     {
@@ -13119,6 +16969,12 @@
           "url": "https://registry.npmjs.org/make-plural/-/make-plural-6.2.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-plural"
         }
       ]
     },
@@ -13140,6 +16996,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/map-cache"
+        }
       ]
     },
     {
@@ -13159,6 +17021,12 @@
           "url": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/map-visit"
         }
       ]
     },
@@ -13180,6 +17048,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/marsdb"
+        }
       ]
     },
     {
@@ -13199,6 +17073,12 @@
           "url": "https://registry.npmjs.org/math-interval-parser/-/math-interval-parser-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/math-interval-parser"
         }
       ]
     },
@@ -13220,6 +17100,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/media-typer"
+        }
       ]
     },
     {
@@ -13239,6 +17125,12 @@
           "url": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/merge-descriptors"
         }
       ]
     },
@@ -13260,6 +17152,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/messageformat-formatters"
+        }
       ]
     },
     {
@@ -13279,6 +17177,12 @@
           "url": "https://registry.npmjs.org/messageformat-parser/-/messageformat-parser-4.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/messageformat-parser"
         }
       ]
     },
@@ -13301,6 +17205,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/messageformat"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -13319,6 +17229,12 @@
               "url": "https://registry.npmjs.org/make-plural/-/make-plural-4.3.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/messageformat/node_modules/make-plural"
             }
           ]
         }
@@ -13342,6 +17258,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/methods"
+        }
       ]
     },
     {
@@ -13361,6 +17283,12 @@
           "url": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/micromatch"
         }
       ]
     },
@@ -13382,6 +17310,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mime-db"
+        }
       ]
     },
     {
@@ -13401,6 +17335,12 @@
           "url": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mime-types"
         }
       ]
     },
@@ -13422,6 +17362,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mime"
+        }
       ]
     },
     {
@@ -13441,6 +17387,12 @@
           "url": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mimic-response"
         }
       ]
     },
@@ -13462,6 +17414,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minimatch"
+        }
       ]
     },
     {
@@ -13481,6 +17439,12 @@
           "url": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minimist"
         }
       ]
     },
@@ -13502,6 +17466,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-collect"
+        }
       ]
     },
     {
@@ -13521,6 +17491,12 @@
           "url": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-1.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-fetch"
         }
       ]
     },
@@ -13542,6 +17518,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-flush"
+        }
       ]
     },
     {
@@ -13561,6 +17543,12 @@
           "url": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-pipeline"
         }
       ]
     },
@@ -13582,6 +17570,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-sized"
+        }
       ]
     },
     {
@@ -13601,6 +17595,12 @@
           "url": "https://registry.npmjs.org/minipass/-/minipass-3.3.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass"
         }
       ]
     },
@@ -13622,6 +17622,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minizlib"
+        }
       ]
     },
     {
@@ -13641,6 +17647,12 @@
           "url": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mixin-deep"
         }
       ]
     },
@@ -13662,6 +17674,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mkdirp-classic"
+        }
       ]
     },
     {
@@ -13681,6 +17699,12 @@
           "url": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mkdirp"
         }
       ]
     },
@@ -13702,6 +17726,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/moment-timezone"
+        }
       ]
     },
     {
@@ -13721,6 +17751,12 @@
           "url": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/moment"
         }
       ]
     },
@@ -13743,6 +17779,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/morgan"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -13761,6 +17803,12 @@
               "url": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/morgan/node_modules/on-finished"
             }
           ]
         }
@@ -13784,6 +17832,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mout"
+        }
       ]
     },
     {
@@ -13803,6 +17857,12 @@
           "url": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ms"
         }
       ]
     },
@@ -13825,6 +17885,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/multer"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -13843,6 +17909,12 @@
               "url": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/multer/node_modules/mkdirp"
             }
           ]
         }
@@ -13866,6 +17938,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mustache"
+        }
       ]
     },
     {
@@ -13885,6 +17963,12 @@
           "url": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/nan"
         }
       ]
     },
@@ -13906,6 +17990,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/nanomatch"
+        }
       ]
     },
     {
@@ -13925,6 +18015,12 @@
           "url": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/napi-build-utils"
         }
       ]
     },
@@ -13947,6 +18043,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/needle"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -13965,6 +18067,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/needle/node_modules/debug"
             }
           ]
         },
@@ -13985,6 +18093,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/needle/node_modules/ms"
             }
           ]
         }
@@ -14008,6 +18122,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/negotiator"
+        }
       ]
     },
     {
@@ -14027,6 +18147,12 @@
           "url": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/neo-async"
         }
       ]
     },
@@ -14049,6 +18175,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-abi"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14067,6 +18199,12 @@
               "url": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-abi/node_modules/semver"
             }
           ]
         }
@@ -14090,6 +18228,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-addon-api"
+        }
       ]
     },
     {
@@ -14109,6 +18253,12 @@
           "url": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-fetch"
         }
       ]
     },
@@ -14131,6 +18281,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-gyp"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14149,6 +18305,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/ansi-regex"
             }
           ]
         },
@@ -14170,6 +18332,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/are-we-there-yet"
+            }
           ]
         },
         {
@@ -14189,6 +18357,12 @@
               "url": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/gauge"
             }
           ]
         },
@@ -14210,6 +18384,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/is-fullwidth-code-point"
+            }
           ]
         },
         {
@@ -14229,6 +18409,12 @@
               "url": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/nopt"
             }
           ]
         },
@@ -14250,6 +18436,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/npmlog"
+            }
           ]
         },
         {
@@ -14269,6 +18461,12 @@
               "url": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/readable-stream"
             }
           ]
         },
@@ -14290,6 +18488,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/string-width"
+            }
           ]
         },
         {
@@ -14309,6 +18513,12 @@
               "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/strip-ansi"
             }
           ]
         }
@@ -14333,6 +18543,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-pre-gyp"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14351,6 +18567,12 @@
               "url": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/chownr"
             }
           ]
         },
@@ -14372,6 +18594,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/fs-minipass"
+            }
           ]
         },
         {
@@ -14391,6 +18619,12 @@
               "url": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/minipass"
             }
           ]
         },
@@ -14412,6 +18646,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/minizlib"
+            }
           ]
         },
         {
@@ -14431,6 +18671,12 @@
               "url": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/mkdirp"
             }
           ]
         },
@@ -14452,6 +18698,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/nopt"
+            }
           ]
         },
         {
@@ -14471,6 +18723,12 @@
               "url": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/rimraf"
             }
           ]
         },
@@ -14492,6 +18750,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/safe-buffer"
+            }
           ]
         },
         {
@@ -14511,6 +18775,12 @@
               "url": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/semver"
             }
           ]
         },
@@ -14532,6 +18802,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/tar"
+            }
           ]
         },
         {
@@ -14551,6 +18827,12 @@
               "url": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/yallist"
             }
           ]
         }
@@ -14574,6 +18856,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/noop-logger"
+        }
       ]
     },
     {
@@ -14593,6 +18881,12 @@
           "url": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/nopt"
         }
       ]
     },
@@ -14615,6 +18909,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/normalize-package-data"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14633,6 +18933,12 @@
               "url": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/normalize-package-data/node_modules/semver"
             }
           ]
         }
@@ -14656,6 +18962,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/normalize-path"
+        }
       ]
     },
     {
@@ -14675,6 +18987,12 @@
           "url": "https://registry.npmjs.org/normalize-url/-/normalize-url-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/normalize-url"
         }
       ]
     },
@@ -14697,6 +19015,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/notevil"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14715,6 +19039,12 @@
               "url": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/notevil/node_modules/esprima"
             }
           ]
         }
@@ -14738,6 +19068,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/npm-bundled"
+        }
       ]
     },
     {
@@ -14757,6 +19093,12 @@
           "url": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/npm-normalize-package-bin"
         }
       ]
     },
@@ -14778,6 +19120,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/npm-packlist"
+        }
       ]
     },
     {
@@ -14797,6 +19145,12 @@
           "url": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/npmlog"
         }
       ]
     },
@@ -14818,6 +19172,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/number-is-nan"
+        }
       ]
     },
     {
@@ -14838,6 +19198,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/oauth-sign"
+        }
       ]
     },
     {
@@ -14857,6 +19223,12 @@
           "url": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-assign"
         }
       ]
     },
@@ -14879,6 +19251,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-copy"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14897,6 +19275,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy/node_modules/define-property"
             }
           ]
         },
@@ -14918,6 +19302,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy/node_modules/is-accessor-descriptor"
+            }
           ]
         },
         {
@@ -14937,6 +19327,12 @@
               "url": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy/node_modules/is-data-descriptor"
             }
           ]
         },
@@ -14959,6 +19355,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy/node_modules/is-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -14977,6 +19379,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/object-copy/node_modules/is-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -15000,6 +19408,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy/node_modules/kind-of"
+            }
           ]
         }
       ]
@@ -15022,6 +19436,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-inspect"
+        }
       ]
     },
     {
@@ -15041,6 +19461,12 @@
           "url": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-is"
         }
       ]
     },
@@ -15062,6 +19488,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-keys"
+        }
       ]
     },
     {
@@ -15081,6 +19513,12 @@
           "url": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-visit"
         }
       ]
     },
@@ -15102,6 +19540,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object.assign"
+        }
       ]
     },
     {
@@ -15121,6 +19565,12 @@
           "url": "https://registry.npmjs.org/object.defaults/-/object.defaults-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object.defaults"
         }
       ]
     },
@@ -15142,6 +19592,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object.map"
+        }
       ]
     },
     {
@@ -15161,6 +19617,12 @@
           "url": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object.pick"
         }
       ]
     },
@@ -15182,6 +19644,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/on-finished"
+        }
       ]
     },
     {
@@ -15201,6 +19669,12 @@
           "url": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/on-headers"
         }
       ]
     },
@@ -15222,6 +19696,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/once"
+        }
       ]
     },
     {
@@ -15241,6 +19721,12 @@
           "url": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/one-time"
         }
       ]
     },
@@ -15262,6 +19748,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/opentype.js"
+        }
       ]
     },
     {
@@ -15281,6 +19773,12 @@
           "url": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/optionator"
         }
       ]
     },
@@ -15302,6 +19800,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/os-homedir"
+        }
       ]
     },
     {
@@ -15321,6 +19825,12 @@
           "url": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/os-tmpdir"
         }
       ]
     },
@@ -15342,6 +19852,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/osenv"
+        }
       ]
     },
     {
@@ -15361,6 +19877,12 @@
           "url": "https://registry.npmjs.org/otplib/-/otplib-12.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/otplib"
         }
       ]
     },
@@ -15382,6 +19904,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-cancelable"
+        }
       ]
     },
     {
@@ -15401,6 +19929,12 @@
           "url": "https://registry.npmjs.org/p-event/-/p-event-2.3.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-event"
         }
       ]
     },
@@ -15422,6 +19956,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-finally"
+        }
       ]
     },
     {
@@ -15441,6 +19981,12 @@
           "url": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-is-promise"
         }
       ]
     },
@@ -15462,6 +20008,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-limit"
+        }
       ]
     },
     {
@@ -15481,6 +20033,12 @@
           "url": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-locate"
         }
       ]
     },
@@ -15502,6 +20060,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-map"
+        }
       ]
     },
     {
@@ -15521,6 +20085,12 @@
           "url": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-timeout"
         }
       ]
     },
@@ -15542,6 +20112,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-try"
+        }
       ]
     },
     {
@@ -15561,6 +20137,12 @@
           "url": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pako"
         }
       ]
     },
@@ -15582,6 +20164,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/parse-filepath"
+        }
       ]
     },
     {
@@ -15601,6 +20189,12 @@
           "url": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/parse-json"
         }
       ]
     },
@@ -15622,6 +20216,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/parse-passwd"
+        }
       ]
     },
     {
@@ -15641,6 +20241,12 @@
           "url": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/parseurl"
         }
       ]
     },
@@ -15662,6 +20268,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pascalcase"
+        }
       ]
     },
     {
@@ -15681,6 +20293,12 @@
           "url": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-exists"
         }
       ]
     },
@@ -15702,6 +20320,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-is-absolute"
+        }
       ]
     },
     {
@@ -15721,6 +20345,12 @@
           "url": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-parse"
         }
       ]
     },
@@ -15742,6 +20372,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-root-regex"
+        }
       ]
     },
     {
@@ -15761,6 +20397,12 @@
           "url": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-root"
         }
       ]
     },
@@ -15782,6 +20424,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-to-regexp"
+        }
       ]
     },
     {
@@ -15801,6 +20449,12 @@
           "url": "https://registry.npmjs.org/pdfkit/-/pdfkit-0.11.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pdfkit"
         }
       ]
     },
@@ -15822,6 +20476,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/peek-readable"
+        }
       ]
     },
     {
@@ -15841,6 +20501,12 @@
           "url": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pend"
         }
       ]
     },
@@ -15862,6 +20528,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/performance-now"
+        }
       ]
     },
     {
@@ -15881,6 +20553,12 @@
           "url": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.5.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pg-connection-string"
         }
       ]
     },
@@ -15902,6 +20580,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/picomatch"
+        }
       ]
     },
     {
@@ -15921,6 +20605,12 @@
           "url": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pify"
         }
       ]
     },
@@ -15942,6 +20632,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pinkie-promise"
+        }
       ]
     },
     {
@@ -15961,6 +20657,12 @@
           "url": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pinkie"
         }
       ]
     },
@@ -15982,6 +20684,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/png-js"
+        }
       ]
     },
     {
@@ -16001,6 +20709,12 @@
           "url": "https://registry.npmjs.org/portscanner/-/portscanner-2.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/portscanner"
         }
       ]
     },
@@ -16022,6 +20736,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/posix-character-classes"
+        }
       ]
     },
     {
@@ -16041,6 +20761,12 @@
           "url": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.3.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/prebuild-install"
         }
       ]
     },
@@ -16062,6 +20788,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/prelude-ls"
+        }
       ]
     },
     {
@@ -16081,6 +20813,12 @@
           "url": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/prepend-http"
         }
       ]
     },
@@ -16102,6 +20840,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pretty-bytes"
+        }
       ]
     },
     {
@@ -16121,6 +20865,12 @@
           "url": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/process-nextick-args"
         }
       ]
     },
@@ -16142,6 +20892,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/prom-client"
+        }
       ]
     },
     {
@@ -16161,6 +20917,12 @@
           "url": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/promise-inflight"
         }
       ]
     },
@@ -16183,6 +20945,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/promise-retry"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -16201,6 +20969,12 @@
               "url": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/promise-retry/node_modules/err-code"
             }
           ]
         },
@@ -16221,6 +20995,12 @@
               "url": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/promise-retry/node_modules/retry"
             }
           ]
         }
@@ -16244,6 +21024,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/promise"
+        }
       ]
     },
     {
@@ -16263,6 +21049,12 @@
           "url": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/proper-lockfile"
         }
       ]
     },
@@ -16284,6 +21076,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/proxy-addr"
+        }
       ]
     },
     {
@@ -16303,6 +21101,12 @@
           "url": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/psl"
         }
       ]
     },
@@ -16324,6 +21128,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-attrs"
+        }
       ]
     },
     {
@@ -16343,6 +21153,12 @@
           "url": "https://registry.npmjs.org/pug-code-gen/-/pug-code-gen-3.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-code-gen"
         }
       ]
     },
@@ -16364,6 +21180,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-error"
+        }
       ]
     },
     {
@@ -16383,6 +21205,12 @@
           "url": "https://registry.npmjs.org/pug-filters/-/pug-filters-4.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-filters"
         }
       ]
     },
@@ -16404,6 +21232,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-lexer"
+        }
       ]
     },
     {
@@ -16423,6 +21257,12 @@
           "url": "https://registry.npmjs.org/pug-linker/-/pug-linker-4.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-linker"
         }
       ]
     },
@@ -16444,6 +21284,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-load"
+        }
       ]
     },
     {
@@ -16463,6 +21309,12 @@
           "url": "https://registry.npmjs.org/pug-parser/-/pug-parser-6.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-parser"
         }
       ]
     },
@@ -16484,6 +21336,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-runtime"
+        }
       ]
     },
     {
@@ -16503,6 +21361,12 @@
           "url": "https://registry.npmjs.org/pug-strip-comments/-/pug-strip-comments-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-strip-comments"
         }
       ]
     },
@@ -16524,6 +21388,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-walk"
+        }
       ]
     },
     {
@@ -16543,6 +21413,12 @@
           "url": "https://registry.npmjs.org/pug/-/pug-3.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug"
         }
       ]
     },
@@ -16564,6 +21440,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pump"
+        }
       ]
     },
     {
@@ -16583,6 +21465,12 @@
           "url": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/punycode"
         }
       ]
     },
@@ -16604,6 +21492,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/qs"
+        }
       ]
     },
     {
@@ -16623,6 +21517,12 @@
           "url": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/query-string"
         }
       ]
     },
@@ -16644,6 +21544,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/range_check"
+        }
       ]
     },
     {
@@ -16663,6 +21569,12 @@
           "url": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/range-parser"
         }
       ]
     },
@@ -16684,6 +21596,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/raw-body"
+        }
       ]
     },
     {
@@ -16703,6 +21621,12 @@
           "url": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/rc"
         }
       ]
     },
@@ -16725,6 +21649,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/read-pkg"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -16743,6 +21673,12 @@
               "url": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/read-pkg/node_modules/pify"
             }
           ]
         }
@@ -16767,6 +21703,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/readable-stream"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -16785,6 +21727,12 @@
               "url": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/readable-stream/node_modules/isarray"
             }
           ]
         }
@@ -16809,6 +21757,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/readable-web-to-node-stream"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -16827,6 +21781,12 @@
               "url": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/readable-web-to-node-stream/node_modules/readable-stream"
             }
           ]
         }
@@ -16850,6 +21810,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/readdirp"
+        }
       ]
     },
     {
@@ -16869,6 +21835,12 @@
           "url": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/rechoir"
         }
       ]
     },
@@ -16890,6 +21862,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/regex-not"
+        }
       ]
     },
     {
@@ -16909,6 +21887,12 @@
           "url": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/regexp.prototype.flags"
         }
       ]
     },
@@ -16930,6 +21914,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/remove-trailing-separator"
+        }
       ]
     },
     {
@@ -16950,6 +21940,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/repeat-element"
+        }
       ]
     },
     {
@@ -16969,6 +21965,12 @@
           "url": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/repeat-string"
         }
       ]
     },
@@ -16991,6 +21993,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/replace"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17009,6 +22017,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/ansi-regex"
             }
           ]
         },
@@ -17030,6 +22044,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/ansi-styles"
+            }
           ]
         },
         {
@@ -17049,6 +22069,12 @@
               "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/brace-expansion"
             }
           ]
         },
@@ -17070,6 +22096,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/cliui"
+            }
           ]
         },
         {
@@ -17089,6 +22121,12 @@
               "url": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/color-convert"
             }
           ]
         },
@@ -17110,6 +22148,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/color-name"
+            }
           ]
         },
         {
@@ -17129,6 +22173,12 @@
               "url": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/find-up"
             }
           ]
         },
@@ -17150,6 +22200,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/is-fullwidth-code-point"
+            }
           ]
         },
         {
@@ -17169,6 +22225,12 @@
               "url": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/locate-path"
             }
           ]
         },
@@ -17190,6 +22252,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/minimatch"
+            }
           ]
         },
         {
@@ -17209,6 +22277,12 @@
               "url": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/p-locate"
             }
           ]
         },
@@ -17230,6 +22304,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/path-exists"
+            }
           ]
         },
         {
@@ -17249,6 +22329,12 @@
               "url": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/string-width"
             }
           ]
         },
@@ -17270,6 +22356,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/strip-ansi"
+            }
           ]
         },
         {
@@ -17289,6 +22381,12 @@
               "url": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/wrap-ansi"
             }
           ]
         },
@@ -17310,6 +22408,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/yargs-parser"
+            }
           ]
         },
         {
@@ -17329,6 +22433,12 @@
               "url": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/yargs"
             }
           ]
         }
@@ -17353,6 +22463,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/request"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17371,6 +22487,12 @@
               "url": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/request/node_modules/qs"
             }
           ]
         }
@@ -17394,6 +22516,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/require-directory"
+        }
       ]
     },
     {
@@ -17413,6 +22541,12 @@
           "url": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/require-main-filename"
         }
       ]
     },
@@ -17434,6 +22568,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/resolve-dir"
+        }
       ]
     },
     {
@@ -17453,6 +22593,12 @@
           "url": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/resolve-url"
         }
       ]
     },
@@ -17474,6 +22620,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/resolve"
+        }
       ]
     },
     {
@@ -17493,6 +22645,12 @@
           "url": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/responselike"
         }
       ]
     },
@@ -17514,6 +22672,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/restructure"
+        }
       ]
     },
     {
@@ -17533,6 +22697,12 @@
           "url": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ret"
         }
       ]
     },
@@ -17554,6 +22724,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/retry-as-promised"
+        }
       ]
     },
     {
@@ -17574,6 +22750,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/retry"
+        }
       ]
     },
     {
@@ -17593,6 +22775,12 @@
           "url": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/rimraf"
         }
       ]
     },
@@ -17615,6 +22803,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/rxjs"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17633,6 +22827,12 @@
               "url": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/rxjs/node_modules/tslib"
             }
           ]
         }
@@ -17656,6 +22856,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safe-buffer"
+        }
       ]
     },
     {
@@ -17675,6 +22881,12 @@
           "url": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safe-regex-test"
         }
       ]
     },
@@ -17696,6 +22908,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safe-regex"
+        }
       ]
     },
     {
@@ -17715,6 +22933,12 @@
           "url": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safe-stable-stringify"
         }
       ]
     },
@@ -17736,6 +22960,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safer-buffer"
+        }
       ]
     },
     {
@@ -17756,6 +22986,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/samsam"
+        }
       ]
     },
     {
@@ -17775,6 +23011,12 @@
           "url": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sanitize-filename"
         }
       ]
     },
@@ -17797,6 +23039,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sanitize-html"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17815,6 +23063,12 @@
               "url": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sanitize-html/node_modules/lodash"
             }
           ]
         }
@@ -17838,6 +23092,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sax"
+        }
       ]
     },
     {
@@ -17858,6 +23118,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/seek-bzip"
+        }
       ]
     },
     {
@@ -17877,6 +23143,12 @@
           "url": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/semver"
         }
       ]
     },
@@ -17899,6 +23171,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/send"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17917,6 +23195,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/send/node_modules/ms"
             }
           ]
         }
@@ -17940,6 +23224,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sequelize-pool"
+        }
       ]
     },
     {
@@ -17961,6 +23251,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sequelize"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17979,6 +23275,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sequelize/node_modules/debug"
             }
           ]
         },
@@ -18000,6 +23302,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sequelize/node_modules/ms"
+            }
           ]
         },
         {
@@ -18019,6 +23327,12 @@
               "url": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sequelize/node_modules/uuid"
             }
           ]
         }
@@ -18043,6 +23357,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/serve-index"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18061,6 +23381,12 @@
               "url": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index/node_modules/depd"
             }
           ]
         },
@@ -18082,6 +23408,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index/node_modules/http-errors"
+            }
           ]
         },
         {
@@ -18101,6 +23433,12 @@
               "url": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index/node_modules/inherits"
             }
           ]
         },
@@ -18122,6 +23460,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index/node_modules/setprototypeof"
+            }
           ]
         },
         {
@@ -18141,6 +23485,12 @@
               "url": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index/node_modules/statuses"
             }
           ]
         }
@@ -18164,6 +23514,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/serve-static"
+        }
       ]
     },
     {
@@ -18183,6 +23539,12 @@
           "url": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/set-blocking"
         }
       ]
     },
@@ -18205,6 +23567,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/set-value"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18223,6 +23591,12 @@
               "url": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/set-value/node_modules/extend-shallow"
             }
           ]
         },
@@ -18243,6 +23617,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/set-value/node_modules/is-extendable"
             }
           ]
         }
@@ -18266,6 +23646,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/setimmediate"
+        }
       ]
     },
     {
@@ -18285,6 +23671,12 @@
           "url": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/setprototypeof"
         }
       ]
     },
@@ -18306,6 +23698,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/side-channel"
+        }
       ]
     },
     {
@@ -18326,6 +23724,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/signal-exit"
+        }
       ]
     },
     {
@@ -18345,6 +23749,12 @@
           "url": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/simple-concat"
         }
       ]
     },
@@ -18367,6 +23777,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/simple-get"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18385,6 +23801,12 @@
               "url": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/simple-get/node_modules/decompress-response"
             }
           ]
         },
@@ -18405,6 +23827,12 @@
               "url": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/simple-get/node_modules/mimic-response"
             }
           ]
         }
@@ -18429,6 +23857,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/simple-swizzle"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18447,6 +23881,12 @@
               "url": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/simple-swizzle/node_modules/is-arrayish"
             }
           ]
         }
@@ -18470,6 +23910,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sinon"
+        }
       ]
     },
     {
@@ -18489,6 +23935,12 @@
           "url": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/smart-buffer"
         }
       ]
     },
@@ -18511,6 +23963,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/snapdragon-node"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18529,6 +23987,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon-node/node_modules/define-property"
             }
           ]
         }
@@ -18553,6 +24017,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/snapdragon-util"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18571,6 +24041,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon-util/node_modules/kind-of"
             }
           ]
         }
@@ -18595,6 +24071,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/snapdragon"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18613,6 +24095,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/define-property"
             }
           ]
         },
@@ -18633,6 +24121,12 @@
               "url": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/extend-shallow"
             }
           ]
         },
@@ -18655,6 +24149,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/is-accessor-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -18673,6 +24173,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/snapdragon/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -18697,6 +24203,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/is-data-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -18715,6 +24227,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/snapdragon/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -18738,6 +24256,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/is-descriptor"
+            }
           ]
         },
         {
@@ -18757,6 +24281,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/is-extendable"
             }
           ]
         },
@@ -18778,6 +24308,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/kind-of"
+            }
           ]
         },
         {
@@ -18797,6 +24333,12 @@
               "url": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/source-map"
             }
           ]
         }
@@ -18820,6 +24362,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socket.io-adapter"
+        }
       ]
     },
     {
@@ -18841,6 +24389,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socket.io-parser"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18859,6 +24413,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socket.io-parser/node_modules/debug"
             }
           ]
         },
@@ -18879,6 +24439,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socket.io-parser/node_modules/ms"
             }
           ]
         }
@@ -18903,6 +24469,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socket.io"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18921,6 +24493,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socket.io/node_modules/debug"
             }
           ]
         },
@@ -18941,6 +24519,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socket.io/node_modules/ms"
             }
           ]
         }
@@ -18965,6 +24549,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socks-proxy-agent"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18983,6 +24573,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socks-proxy-agent/node_modules/debug"
             }
           ]
         },
@@ -19003,6 +24599,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socks-proxy-agent/node_modules/ms"
             }
           ]
         }
@@ -19027,6 +24629,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socks"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -19045,6 +24653,12 @@
               "url": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socks/node_modules/ip"
             }
           ]
         }
@@ -19069,6 +24683,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sort-keys-length"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -19087,6 +24707,12 @@
               "url": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sort-keys-length/node_modules/sort-keys"
             }
           ]
         }
@@ -19110,6 +24736,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sort-keys"
+        }
       ]
     },
     {
@@ -19129,6 +24761,12 @@
           "url": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/source-map-resolve"
         }
       ]
     },
@@ -19150,6 +24788,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/source-map-support"
+        }
       ]
     },
     {
@@ -19169,6 +24813,12 @@
           "url": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/source-map-url"
         }
       ]
     },
@@ -19190,6 +24840,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/source-map"
+        }
       ]
     },
     {
@@ -19209,6 +24865,12 @@
           "url": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2-1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spawn-command"
         }
       ]
     },
@@ -19230,6 +24892,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spdx-correct"
+        }
       ]
     },
     {
@@ -19249,6 +24917,12 @@
           "url": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spdx-exceptions"
         }
       ]
     },
@@ -19270,6 +24944,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spdx-expression-parse"
+        }
       ]
     },
     {
@@ -19289,6 +24969,12 @@
           "url": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.12.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spdx-license-ids"
         }
       ]
     },
@@ -19310,6 +24996,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/split-string"
+        }
       ]
     },
     {
@@ -19329,6 +25021,12 @@
           "url": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sprintf-js"
         }
       ]
     },
@@ -19350,6 +25048,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sqlite3"
+        }
       ]
     },
     {
@@ -19369,6 +25073,12 @@
           "url": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sshpk"
         }
       ]
     },
@@ -19390,6 +25100,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ssri"
+        }
       ]
     },
     {
@@ -19409,6 +25125,12 @@
           "url": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/stack-trace"
         }
       ]
     },
@@ -19431,6 +25153,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/static-extend"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -19449,6 +25177,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend/node_modules/define-property"
             }
           ]
         },
@@ -19471,6 +25205,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend/node_modules/is-accessor-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -19489,6 +25229,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/static-extend/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -19513,6 +25259,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend/node_modules/is-data-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -19531,6 +25283,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/static-extend/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -19554,6 +25312,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend/node_modules/is-descriptor"
+            }
           ]
         },
         {
@@ -19573,6 +25337,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend/node_modules/kind-of"
             }
           ]
         }
@@ -19596,6 +25366,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/statuses"
+        }
       ]
     },
     {
@@ -19615,6 +25391,12 @@
           "url": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-2.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/stream-buffers"
         }
       ]
     },
@@ -19636,6 +25418,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/streamsearch"
+        }
       ]
     },
     {
@@ -19655,6 +25443,12 @@
           "url": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strict-uri-encode"
         }
       ]
     },
@@ -19676,6 +25470,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string_decoder"
+        }
       ]
     },
     {
@@ -19695,6 +25495,12 @@
           "url": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string-width"
         }
       ]
     },
@@ -19716,6 +25522,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string.fromcodepoint"
+        }
       ]
     },
     {
@@ -19735,6 +25547,12 @@
           "url": "https://registry.npmjs.org/string.prototype.codepointat/-/string.prototype.codepointat-0.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string.prototype.codepointat"
         }
       ]
     },
@@ -19756,6 +25574,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string.prototype.trimend"
+        }
       ]
     },
     {
@@ -19775,6 +25599,12 @@
           "url": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string.prototype.trimstart"
         }
       ]
     },
@@ -19796,6 +25626,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-ansi"
+        }
       ]
     },
     {
@@ -19815,6 +25651,12 @@
           "url": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-bom"
         }
       ]
     },
@@ -19836,6 +25678,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-dirs"
+        }
       ]
     },
     {
@@ -19855,6 +25703,12 @@
           "url": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-json-comments"
         }
       ]
     },
@@ -19876,6 +25730,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-outer"
+        }
       ]
     },
     {
@@ -19895,6 +25755,12 @@
           "url": "https://registry.npmjs.org/strtok3/-/strtok3-6.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strtok3"
         }
       ]
     },
@@ -19916,6 +25782,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/supports-color"
+        }
       ]
     },
     {
@@ -19935,6 +25807,12 @@
           "url": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/supports-preserve-symlinks-flag"
         }
       ]
     },
@@ -19956,6 +25834,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/svg-captcha"
+        }
       ]
     },
     {
@@ -19976,6 +25860,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/swagger-ui-dist"
+        }
       ]
     },
     {
@@ -19995,6 +25885,12 @@
           "url": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-4.5.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/swagger-ui-express"
         }
       ]
     },
@@ -20017,6 +25913,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tar-fs"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -20035,6 +25937,12 @@
               "url": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/tar-fs/node_modules/bl"
             }
           ]
         },
@@ -20056,6 +25964,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/tar-fs/node_modules/chownr"
+            }
           ]
         },
         {
@@ -20076,6 +25990,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/tar-fs/node_modules/readable-stream"
+            }
           ]
         },
         {
@@ -20095,6 +26015,12 @@
               "url": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/tar-fs/node_modules/tar-stream"
             }
           ]
         }
@@ -20118,6 +26044,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tar-stream"
+        }
       ]
     },
     {
@@ -20137,6 +26069,12 @@
           "url": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tar"
         }
       ]
     },
@@ -20158,6 +26096,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tdigest"
+        }
       ]
     },
     {
@@ -20177,6 +26121,12 @@
           "url": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/text-hex"
         }
       ]
     },
@@ -20198,6 +26148,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/thirty-two"
+        }
       ]
     },
     {
@@ -20217,6 +26173,12 @@
           "url": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/through"
         }
       ]
     },
@@ -20238,6 +26200,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/timed-out"
+        }
       ]
     },
     {
@@ -20257,6 +26225,12 @@
           "url": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tiny-inflate"
         }
       ]
     },
@@ -20278,6 +26252,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-buffer"
+        }
       ]
     },
     {
@@ -20297,6 +26277,12 @@
           "url": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-fast-properties"
         }
       ]
     },
@@ -20319,6 +26305,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-object-path"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -20337,6 +26329,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/to-object-path/node_modules/kind-of"
             }
           ]
         }
@@ -20360,6 +26358,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-regex-range"
+        }
       ]
     },
     {
@@ -20379,6 +26383,12 @@
           "url": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-regex"
         }
       ]
     },
@@ -20400,6 +26410,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/toidentifier"
+        }
       ]
     },
     {
@@ -20419,6 +26435,12 @@
           "url": "https://registry.npmjs.org/token-stream/-/token-stream-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/token-stream"
         }
       ]
     },
@@ -20440,6 +26462,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/token-types"
+        }
       ]
     },
     {
@@ -20459,6 +26487,12 @@
           "url": "https://registry.npmjs.org/toposort-class/-/toposort-class-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/toposort-class"
         }
       ]
     },
@@ -20480,6 +26514,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tough-cookie"
+        }
       ]
     },
     {
@@ -20499,6 +26539,12 @@
           "url": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tr46"
         }
       ]
     },
@@ -20520,6 +26566,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/traverse"
+        }
       ]
     },
     {
@@ -20539,6 +26591,12 @@
           "url": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tree-kill"
         }
       ]
     },
@@ -20560,6 +26618,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/trim-repeated"
+        }
       ]
     },
     {
@@ -20580,6 +26644,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/triple-beam"
+        }
       ]
     },
     {
@@ -20599,6 +26669,12 @@
           "url": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/truncate-utf8-bytes"
         }
       ]
     },
@@ -20621,6 +26697,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ts-node-dev"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -20639,6 +26721,12 @@
               "url": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/ts-node-dev/node_modules/rimraf"
             }
           ]
         }
@@ -20662,6 +26750,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ts-node"
+        }
       ]
     },
     {
@@ -20681,6 +26775,12 @@
           "url": "https://registry.npmjs.org/tsconfig/-/tsconfig-7.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tsconfig"
         }
       ]
     },
@@ -20702,6 +26802,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tslib"
+        }
       ]
     },
     {
@@ -20721,6 +26827,12 @@
           "url": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tunnel-agent"
         }
       ]
     },
@@ -20742,6 +26854,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tweetnacl"
+        }
       ]
     },
     {
@@ -20761,6 +26879,12 @@
           "url": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/type-check"
         }
       ]
     },
@@ -20782,6 +26906,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/type-is"
+        }
       ]
     },
     {
@@ -20801,6 +26931,12 @@
           "url": "https://registry.npmjs.org/typecast/-/typecast-0.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/typecast"
         }
       ]
     },
@@ -20822,6 +26958,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/typedarray"
+        }
       ]
     },
     {
@@ -20841,6 +26983,12 @@
           "url": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/typescript"
         }
       ]
     },
@@ -20862,6 +27010,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/uglify-js"
+        }
       ]
     },
     {
@@ -20881,6 +27035,12 @@
           "url": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unbox-primitive"
         }
       ]
     },
@@ -20902,6 +27062,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unbzip2-stream"
+        }
       ]
     },
     {
@@ -20921,6 +27087,12 @@
           "url": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unc-path-regex"
         }
       ]
     },
@@ -20942,6 +27114,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/underscore.string"
+        }
       ]
     },
     {
@@ -20962,6 +27140,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unicode-properties"
+        }
       ]
     },
     {
@@ -20981,6 +27165,12 @@
           "url": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unicode-trie"
         }
       ]
     },
@@ -21003,6 +27193,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/union-value"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21021,6 +27217,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/union-value/node_modules/is-extendable"
             }
           ]
         }
@@ -21044,6 +27246,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unique-filename"
+        }
       ]
     },
     {
@@ -21063,6 +27271,12 @@
           "url": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unique-slug"
         }
       ]
     },
@@ -21084,6 +27298,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unit-compare"
+        }
       ]
     },
     {
@@ -21104,6 +27324,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/universalify"
+        }
       ]
     },
     {
@@ -21123,6 +27349,12 @@
           "url": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unpipe"
         }
       ]
     },
@@ -21145,6 +27377,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unset-value"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21165,6 +27403,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/unset-value/node_modules/has-value"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -21183,6 +27427,12 @@
                   "url": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/unset-value/node_modules/has-value/node_modules/isobject"
                 }
               ]
             }
@@ -21206,6 +27456,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/unset-value/node_modules/has-values"
+            }
           ]
         },
         {
@@ -21225,6 +27481,12 @@
               "url": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/unset-value/node_modules/isarray"
             }
           ]
         }
@@ -21248,6 +27510,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/untildify"
+        }
       ]
     },
     {
@@ -21269,6 +27537,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unzipper"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21287,6 +27561,12 @@
               "url": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/unzipper/node_modules/bluebird"
             }
           ]
         }
@@ -21310,6 +27590,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/uri-js"
+        }
       ]
     },
     {
@@ -21329,6 +27615,12 @@
           "url": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/urix"
         }
       ]
     },
@@ -21350,6 +27642,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/url-parse-lax"
+        }
       ]
     },
     {
@@ -21369,6 +27667,12 @@
           "url": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/url-to-options"
         }
       ]
     },
@@ -21390,6 +27694,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/use"
+        }
       ]
     },
     {
@@ -21409,6 +27719,12 @@
           "url": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/utf8-byte-length"
         }
       ]
     },
@@ -21430,6 +27746,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/util-deprecate"
+        }
       ]
     },
     {
@@ -21449,6 +27771,12 @@
           "url": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/util"
         }
       ]
     },
@@ -21470,6 +27798,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/utils-merge"
+        }
       ]
     },
     {
@@ -21489,6 +27823,12 @@
           "url": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/uuid"
         }
       ]
     },
@@ -21510,6 +27850,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/v8flags"
+        }
       ]
     },
     {
@@ -21529,6 +27875,12 @@
           "url": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/validate-npm-package-license"
         }
       ]
     },
@@ -21550,6 +27902,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/validate"
+        }
       ]
     },
     {
@@ -21570,6 +27928,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/validator"
+        }
       ]
     },
     {
@@ -21589,6 +27953,12 @@
           "url": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/vary"
         }
       ]
     },
@@ -21611,6 +27981,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/verror"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21629,6 +28005,12 @@
               "url": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/verror/node_modules/core-util-is"
             }
           ]
         }
@@ -21653,6 +28035,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/vm2"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21671,6 +28059,12 @@
               "url": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/vm2/node_modules/acorn"
             }
           ]
         }
@@ -21694,6 +28088,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/void-elements"
+        }
       ]
     },
     {
@@ -21713,6 +28113,12 @@
           "url": "https://registry.npmjs.org/walk/-/walk-2.3.15.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/walk"
         }
       ]
     },
@@ -21734,6 +28140,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/walkdir"
+        }
       ]
     },
     {
@@ -21753,6 +28165,12 @@
           "url": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/webidl-conversions"
         }
       ]
     },
@@ -21774,6 +28192,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/whatwg-url"
+        }
       ]
     },
     {
@@ -21793,6 +28217,12 @@
           "url": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-boxed-primitive"
         }
       ]
     },
@@ -21814,6 +28244,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-collection"
+        }
       ]
     },
     {
@@ -21833,6 +28269,12 @@
           "url": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-module"
         }
       ]
     },
@@ -21854,6 +28296,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-pm-runs"
+        }
       ]
     },
     {
@@ -21873,6 +28321,12 @@
           "url": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-typed-array"
         }
       ]
     },
@@ -21894,6 +28348,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which"
+        }
       ]
     },
     {
@@ -21913,6 +28373,12 @@
           "url": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wide-align"
         }
       ]
     },
@@ -21935,6 +28401,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/winston-transport"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21953,6 +28425,12 @@
               "url": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/winston-transport/node_modules/readable-stream"
             }
           ]
         }
@@ -21977,6 +28455,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/winston"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21995,6 +28479,12 @@
               "url": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/winston/node_modules/async"
             }
           ]
         },
@@ -22016,6 +28506,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/winston/node_modules/is-stream"
+            }
           ]
         },
         {
@@ -22035,6 +28531,12 @@
               "url": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/winston/node_modules/readable-stream"
             }
           ]
         }
@@ -22058,6 +28560,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/with"
+        }
       ]
     },
     {
@@ -22077,6 +28585,12 @@
           "url": "https://registry.npmjs.org/wkx/-/wkx-0.5.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wkx"
         }
       ]
     },
@@ -22098,6 +28612,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/word-wrap"
+        }
       ]
     },
     {
@@ -22117,6 +28637,12 @@
           "url": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wordwrap"
         }
       ]
     },
@@ -22139,6 +28665,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wrap-ansi"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -22157,6 +28689,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi/node_modules/ansi-regex"
             }
           ]
         },
@@ -22178,6 +28716,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi/node_modules/emoji-regex"
+            }
           ]
         },
         {
@@ -22197,6 +28741,12 @@
               "url": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi/node_modules/is-fullwidth-code-point"
             }
           ]
         },
@@ -22218,6 +28768,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi/node_modules/string-width"
+            }
           ]
         },
         {
@@ -22237,6 +28793,12 @@
               "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi/node_modules/strip-ansi"
             }
           ]
         }
@@ -22260,6 +28822,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wrappy"
+        }
       ]
     },
     {
@@ -22279,6 +28847,12 @@
           "url": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ws"
         }
       ]
     },
@@ -22300,6 +28874,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/xtend"
+        }
       ]
     },
     {
@@ -22319,6 +28899,12 @@
           "url": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/y18n"
         }
       ]
     },
@@ -22340,6 +28926,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yallist"
+        }
       ]
     },
     {
@@ -22360,6 +28952,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yaml-schema-validator"
+        }
       ]
     },
     {
@@ -22379,6 +28977,12 @@
           "url": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yargs-parser"
         }
       ]
     },
@@ -22401,6 +29005,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yargs"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -22419,6 +29029,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs/node_modules/ansi-regex"
             }
           ]
         },
@@ -22440,6 +29056,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs/node_modules/emoji-regex"
+            }
           ]
         },
         {
@@ -22459,6 +29081,12 @@
               "url": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs/node_modules/is-fullwidth-code-point"
             }
           ]
         },
@@ -22480,6 +29108,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs/node_modules/string-width"
+            }
           ]
         },
         {
@@ -22499,6 +29133,12 @@
               "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs/node_modules/strip-ansi"
             }
           ]
         }
@@ -22522,6 +29162,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yauzl"
+        }
       ]
     },
     {
@@ -22541,6 +29187,12 @@
           "url": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yn"
         }
       ]
     },
@@ -22562,6 +29214,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/z85"
+        }
       ]
     },
     {
@@ -22582,6 +29240,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/zip-stream"
+        }
       ]
     },
     {
@@ -22601,6 +29265,12 @@
           "url": "https://registry.npmjs.org/zlibjs/-/zlibjs-0.3.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/zlibjs"
         }
       ]
     }

--- a/tests/_data/sbom_demo-results/juice-shop_npm8_node18_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/juice-shop_npm8_node18_ubuntu-latest.snap.json
@@ -62,7 +62,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -95,7 +95,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@babel/helper-string-parser"
         }
       ]
@@ -122,7 +122,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@babel/helper-validator-identifier"
         }
       ]
@@ -149,7 +149,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@babel/parser"
         }
       ]
@@ -176,7 +176,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@babel/types"
         }
       ]
@@ -203,7 +203,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@colors/colors"
         }
       ]
@@ -230,7 +230,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@dabh/diagnostics"
         }
       ]
@@ -257,7 +257,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@gar/promisify"
         }
       ]
@@ -284,7 +284,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@mapbox/node-pre-gyp"
         }
       ],
@@ -310,7 +310,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/ansi-regex"
             }
           ]
@@ -336,7 +336,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/are-we-there-yet"
             }
           ]
@@ -362,7 +362,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/detect-libc"
             }
           ]
@@ -388,7 +388,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/gauge"
             }
           ]
@@ -414,7 +414,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -440,7 +440,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/make-dir"
             }
           ],
@@ -466,7 +466,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/@mapbox/node-pre-gyp/node_modules/make-dir/node_modules/semver"
                 }
               ]
@@ -494,7 +494,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/nopt"
             }
           ]
@@ -520,7 +520,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/npmlog"
             }
           ]
@@ -546,7 +546,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/readable-stream"
             }
           ]
@@ -572,7 +572,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/string-width"
             }
           ]
@@ -598,7 +598,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/strip-ansi"
             }
           ]
@@ -627,7 +627,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/core-loader"
         }
       ]
@@ -654,7 +654,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/core"
         }
       ]
@@ -681,7 +681,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/evaluator"
         }
       ]
@@ -708,7 +708,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-all"
         }
       ]
@@ -735,7 +735,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ar"
         }
       ]
@@ -762,7 +762,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-bn"
         }
       ]
@@ -789,7 +789,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ca"
         }
       ]
@@ -816,7 +816,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-cs"
         }
       ]
@@ -843,7 +843,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-da"
         }
       ]
@@ -870,7 +870,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-de"
         }
       ]
@@ -897,7 +897,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-el"
         }
       ]
@@ -924,7 +924,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-en-min"
         }
       ]
@@ -951,7 +951,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-en"
         }
       ]
@@ -978,7 +978,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-es"
         }
       ]
@@ -1005,7 +1005,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-eu"
         }
       ]
@@ -1032,7 +1032,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-fa"
         }
       ]
@@ -1059,7 +1059,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-fi"
         }
       ]
@@ -1086,7 +1086,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-fr"
         }
       ]
@@ -1113,7 +1113,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ga"
         }
       ]
@@ -1140,7 +1140,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-gl"
         }
       ]
@@ -1167,7 +1167,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-hi"
         }
       ]
@@ -1194,7 +1194,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-hu"
         }
       ]
@@ -1221,7 +1221,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-hy"
         }
       ]
@@ -1248,7 +1248,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-id"
         }
       ]
@@ -1275,7 +1275,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-it"
         }
       ]
@@ -1302,7 +1302,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ja"
         }
       ]
@@ -1329,7 +1329,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ko"
         }
       ]
@@ -1356,7 +1356,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-lt"
         }
       ]
@@ -1383,7 +1383,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ms"
         }
       ]
@@ -1410,7 +1410,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ne"
         }
       ]
@@ -1437,7 +1437,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-nl"
         }
       ]
@@ -1464,7 +1464,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-no"
         }
       ]
@@ -1491,7 +1491,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-pl"
         }
       ]
@@ -1518,7 +1518,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-pt"
         }
       ]
@@ -1545,7 +1545,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ro"
         }
       ]
@@ -1572,7 +1572,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ru"
         }
       ]
@@ -1599,7 +1599,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-sl"
         }
       ]
@@ -1626,7 +1626,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-sr"
         }
       ]
@@ -1653,7 +1653,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-sv"
         }
       ]
@@ -1680,7 +1680,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ta"
         }
       ]
@@ -1707,7 +1707,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-th"
         }
       ]
@@ -1734,7 +1734,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-tl"
         }
       ]
@@ -1761,7 +1761,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-tr"
         }
       ]
@@ -1788,7 +1788,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-uk"
         }
       ]
@@ -1815,7 +1815,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-zh"
         }
       ]
@@ -1842,7 +1842,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/language-min"
         }
       ]
@@ -1869,7 +1869,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/language"
         }
       ]
@@ -1896,7 +1896,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/ner"
         }
       ]
@@ -1923,7 +1923,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/neural"
         }
       ]
@@ -1950,7 +1950,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/nlg"
         }
       ]
@@ -1977,7 +1977,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/nlp"
         }
       ]
@@ -2004,7 +2004,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/nlu"
         }
       ]
@@ -2031,7 +2031,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/request"
         }
       ]
@@ -2058,7 +2058,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/sentiment"
         }
       ]
@@ -2085,7 +2085,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/similarity"
         }
       ]
@@ -2112,7 +2112,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/slot"
         }
       ]
@@ -2139,7 +2139,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@npmcli/fs"
         }
       ]
@@ -2166,7 +2166,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@npmcli/move-file"
         }
       ]
@@ -2193,7 +2193,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib/core"
         }
       ]
@@ -2220,7 +2220,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib/plugin-crypto"
         }
       ]
@@ -2247,7 +2247,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib/plugin-thirty-two"
         }
       ]
@@ -2274,7 +2274,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib/preset-default"
         }
       ]
@@ -2301,7 +2301,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib/preset-v11"
         }
       ]
@@ -2328,7 +2328,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@sindresorhus/is"
         }
       ]
@@ -2355,7 +2355,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@swc/helpers"
         }
       ]
@@ -2382,7 +2382,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@tokenizer/token"
         }
       ]
@@ -2409,7 +2409,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@tootallnate/once"
         }
       ]
@@ -2436,7 +2436,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/component-emitter"
         }
       ]
@@ -2463,7 +2463,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/cookie"
         }
       ]
@@ -2490,7 +2490,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/cors"
         }
       ]
@@ -2517,7 +2517,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/debug"
         }
       ]
@@ -2544,7 +2544,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/ms"
         }
       ]
@@ -2571,7 +2571,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/node"
         }
       ]
@@ -2598,7 +2598,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/strip-bom"
         }
       ]
@@ -2625,7 +2625,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/strip-json-comments"
         }
       ]
@@ -2652,7 +2652,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/validator"
         }
       ]
@@ -2678,7 +2678,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/abbrev"
         }
       ]
@@ -2704,7 +2704,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/accepts"
         }
       ]
@@ -2730,7 +2730,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/acorn-walk"
         }
       ]
@@ -2756,7 +2756,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/acorn"
         }
       ]
@@ -2782,7 +2782,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/agent-base"
         }
       ],
@@ -2808,7 +2808,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agent-base/node_modules/debug"
             }
           ]
@@ -2834,7 +2834,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agent-base/node_modules/ms"
             }
           ]
@@ -2862,7 +2862,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/agentkeepalive"
         }
       ],
@@ -2888,7 +2888,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agentkeepalive/node_modules/debug"
             }
           ]
@@ -2914,7 +2914,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agentkeepalive/node_modules/depd"
             }
           ]
@@ -2940,7 +2940,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agentkeepalive/node_modules/ms"
             }
           ]
@@ -2968,7 +2968,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/aggregate-error"
         }
       ]
@@ -2994,7 +2994,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ajv"
         }
       ]
@@ -3020,7 +3020,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ansi-regex"
         }
       ]
@@ -3046,7 +3046,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ansi-styles"
         }
       ]
@@ -3072,7 +3072,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/anymatch"
         }
       ],
@@ -3098,7 +3098,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/anymatch/node_modules/normalize-path"
             }
           ]
@@ -3126,7 +3126,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/append-field"
         }
       ]
@@ -3152,7 +3152,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/aproba"
         }
       ]
@@ -3178,7 +3178,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/archive-type"
         }
       ],
@@ -3204,7 +3204,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/archive-type/node_modules/file-type"
             }
           ]
@@ -3232,7 +3232,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/archiver-utils"
         }
       ]
@@ -3258,7 +3258,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/archiver"
         }
       ]
@@ -3284,7 +3284,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/are-we-there-yet"
         }
       ]
@@ -3310,7 +3310,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/arg"
         }
       ]
@@ -3336,7 +3336,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/argparse"
         }
       ],
@@ -3362,7 +3362,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/argparse/node_modules/sprintf-js"
             }
           ]
@@ -3390,7 +3390,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/arr-diff"
         }
       ]
@@ -3416,7 +3416,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/arr-flatten"
         }
       ]
@@ -3442,7 +3442,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/arr-union"
         }
       ]
@@ -3468,7 +3468,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/array-each"
         }
       ]
@@ -3494,7 +3494,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/array-flatten"
         }
       ]
@@ -3520,7 +3520,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/array-slice"
         }
       ]
@@ -3546,7 +3546,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/array-unique"
         }
       ]
@@ -3572,7 +3572,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/asap"
         }
       ]
@@ -3598,7 +3598,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/asn1"
         }
       ]
@@ -3624,7 +3624,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/assert-never"
         }
       ]
@@ -3650,7 +3650,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/assert-plus"
         }
       ]
@@ -3676,7 +3676,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/assign-symbols"
         }
       ]
@@ -3702,7 +3702,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/async"
         }
       ]
@@ -3728,7 +3728,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/asynckit"
         }
       ]
@@ -3754,7 +3754,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/at-least-node"
         }
       ]
@@ -3780,7 +3780,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/atob"
         }
       ]
@@ -3806,7 +3806,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/available-typed-arrays"
         }
       ]
@@ -3832,7 +3832,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/aws-sign2"
         }
       ]
@@ -3858,7 +3858,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/aws4"
         }
       ]
@@ -3884,7 +3884,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/babel-walk"
         }
       ]
@@ -3910,7 +3910,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/balanced-match"
         }
       ]
@@ -3936,7 +3936,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base"
         }
       ],
@@ -3962,7 +3962,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/base/node_modules/define-property"
             }
           ]
@@ -3990,7 +3990,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base64-arraybuffer"
         }
       ]
@@ -4016,7 +4016,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base64-js"
         }
       ]
@@ -4042,7 +4042,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base64id"
         }
       ]
@@ -4068,7 +4068,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base64url"
         }
       ]
@@ -4094,7 +4094,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/basic-auth"
         }
       ]
@@ -4120,7 +4120,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/batch"
         }
       ]
@@ -4146,7 +4146,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bcrypt-pbkdf"
         }
       ]
@@ -4172,7 +4172,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/big-integer"
         }
       ]
@@ -4198,7 +4198,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/binary-extensions"
         }
       ]
@@ -4224,7 +4224,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/binary"
         }
       ]
@@ -4250,7 +4250,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bindings"
         }
       ]
@@ -4276,7 +4276,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bintrees"
         }
       ]
@@ -4302,7 +4302,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bl"
         }
       ]
@@ -4328,7 +4328,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bluebird"
         }
       ]
@@ -4354,7 +4354,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/body-parser"
         }
       ]
@@ -4380,7 +4380,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bower-config"
         }
       ],
@@ -4406,7 +4406,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bower-config/node_modules/minimist"
             }
           ]
@@ -4434,7 +4434,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/brace-expansion"
         }
       ]
@@ -4460,7 +4460,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/braces"
         }
       ],
@@ -4486,7 +4486,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/braces/node_modules/extend-shallow"
             }
           ]
@@ -4512,7 +4512,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/braces/node_modules/is-extendable"
             }
           ]
@@ -4540,7 +4540,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/brotli"
         }
       ]
@@ -4566,7 +4566,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-alloc-unsafe"
         }
       ]
@@ -4592,7 +4592,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-alloc"
         }
       ]
@@ -4618,7 +4618,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-crc32"
         }
       ]
@@ -4644,7 +4644,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-fill"
         }
       ]
@@ -4670,7 +4670,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-from"
         }
       ]
@@ -4696,7 +4696,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-indexof-polyfill"
         }
       ]
@@ -4722,7 +4722,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer"
         }
       ]
@@ -4748,7 +4748,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffers"
         }
       ]
@@ -4774,7 +4774,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/busboy"
         }
       ],
@@ -4800,7 +4800,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/busboy/node_modules/isarray"
             }
           ]
@@ -4826,7 +4826,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/busboy/node_modules/readable-stream"
             }
           ]
@@ -4852,7 +4852,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/busboy/node_modules/string_decoder"
             }
           ]
@@ -4880,7 +4880,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/byline"
         }
       ]
@@ -4906,7 +4906,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bytes"
         }
       ]
@@ -4932,7 +4932,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cacache"
         }
       ]
@@ -4958,7 +4958,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cache-base"
         }
       ]
@@ -4984,7 +4984,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cacheable-request"
         }
       ],
@@ -5010,7 +5010,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cacheable-request/node_modules/get-stream"
             }
           ]
@@ -5036,7 +5036,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cacheable-request/node_modules/lowercase-keys"
             }
           ]
@@ -5064,7 +5064,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/call-bind"
         }
       ]
@@ -5090,7 +5090,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/camelcase"
         }
       ]
@@ -5116,7 +5116,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/caseless"
         }
       ]
@@ -5142,7 +5142,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/chainsaw"
         }
       ]
@@ -5168,7 +5168,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/chalk"
         }
       ]
@@ -5194,7 +5194,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/character-parser"
         }
       ]
@@ -5220,7 +5220,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/check-dependencies"
         }
       ],
@@ -5246,7 +5246,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/check-dependencies/node_modules/semver"
             }
           ]
@@ -5274,7 +5274,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/check-types"
         }
       ]
@@ -5300,7 +5300,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/chokidar"
         }
       ],
@@ -5326,7 +5326,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar/node_modules/braces"
             }
           ]
@@ -5352,7 +5352,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar/node_modules/fill-range"
             }
           ]
@@ -5378,7 +5378,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar/node_modules/is-glob"
             }
           ]
@@ -5404,7 +5404,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar/node_modules/is-number"
             }
           ]
@@ -5430,7 +5430,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar/node_modules/normalize-path"
             }
           ]
@@ -5456,7 +5456,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar/node_modules/to-regex-range"
             }
           ]
@@ -5484,7 +5484,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/chownr"
         }
       ]
@@ -5510,7 +5510,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/clarinet"
         }
       ]
@@ -5536,7 +5536,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/class-utils"
         }
       ],
@@ -5562,7 +5562,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils/node_modules/define-property"
             }
           ]
@@ -5588,7 +5588,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils/node_modules/is-accessor-descriptor"
             }
           ],
@@ -5614,7 +5614,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/class-utils/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
@@ -5642,7 +5642,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils/node_modules/is-data-descriptor"
             }
           ],
@@ -5668,7 +5668,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/class-utils/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
@@ -5696,7 +5696,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils/node_modules/is-descriptor"
             }
           ]
@@ -5722,7 +5722,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils/node_modules/kind-of"
             }
           ]
@@ -5750,7 +5750,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/clean-stack"
         }
       ]
@@ -5776,7 +5776,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cliui"
         }
       ],
@@ -5802,7 +5802,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui/node_modules/ansi-regex"
             }
           ]
@@ -5828,7 +5828,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui/node_modules/emoji-regex"
             }
           ]
@@ -5854,7 +5854,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -5880,7 +5880,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui/node_modules/string-width"
             }
           ]
@@ -5906,7 +5906,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui/node_modules/strip-ansi"
             }
           ]
@@ -5934,7 +5934,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/clone-response"
         }
       ]
@@ -5960,7 +5960,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/clone"
         }
       ]
@@ -5986,7 +5986,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/code-point-at"
         }
       ]
@@ -6012,7 +6012,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/collection-visit"
         }
       ]
@@ -6038,7 +6038,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color-convert"
         }
       ]
@@ -6064,7 +6064,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color-name"
         }
       ]
@@ -6090,7 +6090,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color-string"
         }
       ]
@@ -6116,7 +6116,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color-support"
         }
       ]
@@ -6142,7 +6142,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color"
         }
       ]
@@ -6168,7 +6168,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/colors"
         }
       ]
@@ -6194,7 +6194,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/colorspace"
         }
       ]
@@ -6220,7 +6220,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/combined-stream"
         }
       ]
@@ -6246,7 +6246,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/commander"
         }
       ]
@@ -6272,7 +6272,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/component-emitter"
         }
       ]
@@ -6298,7 +6298,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/component-type"
         }
       ]
@@ -6324,7 +6324,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/compress-commons"
         }
       ]
@@ -6350,7 +6350,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/compressible"
         }
       ]
@@ -6376,7 +6376,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/compression"
         }
       ],
@@ -6402,7 +6402,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/compression/node_modules/bytes"
             }
           ]
@@ -6430,7 +6430,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/concat-map"
         }
       ]
@@ -6456,7 +6456,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/concat-stream"
         }
       ]
@@ -6482,7 +6482,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/concurrently"
         }
       ],
@@ -6508,7 +6508,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/concurrently/node_modules/supports-color"
             }
           ]
@@ -6536,7 +6536,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/config"
         }
       ]
@@ -6562,7 +6562,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/console-control-strings"
         }
       ]
@@ -6588,7 +6588,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/constantinople"
         }
       ]
@@ -6614,7 +6614,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/content-disposition"
         }
       ],
@@ -6640,7 +6640,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/content-disposition/node_modules/safe-buffer"
             }
           ]
@@ -6668,7 +6668,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/content-type"
         }
       ]
@@ -6694,7 +6694,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cookie-parser"
         }
       ]
@@ -6720,7 +6720,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cookie-signature"
         }
       ]
@@ -6746,7 +6746,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cookie"
         }
       ]
@@ -6772,7 +6772,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/copy-descriptor"
         }
       ]
@@ -6798,7 +6798,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/core-util-is"
         }
       ]
@@ -6824,7 +6824,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cors"
         }
       ]
@@ -6850,7 +6850,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/crc"
         }
       ]
@@ -6876,7 +6876,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/crc32-stream"
         }
       ]
@@ -6902,7 +6902,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/create-require"
         }
       ]
@@ -6928,7 +6928,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/crypto-js"
         }
       ]
@@ -6954,7 +6954,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dashdash"
         }
       ]
@@ -6980,7 +6980,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/date-fns"
         }
       ]
@@ -7006,7 +7006,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dateformat"
         }
       ]
@@ -7032,7 +7032,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/debug"
         }
       ]
@@ -7058,7 +7058,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decamelize"
         }
       ]
@@ -7084,7 +7084,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decode-uri-component"
         }
       ]
@@ -7110,7 +7110,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-response"
         }
       ]
@@ -7136,7 +7136,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-tar"
         }
       ],
@@ -7162,7 +7162,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-tar/node_modules/file-type"
             }
           ]
@@ -7190,7 +7190,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-tarbz2"
         }
       ],
@@ -7216,7 +7216,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-tarbz2/node_modules/file-type"
             }
           ]
@@ -7244,7 +7244,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-targz"
         }
       ],
@@ -7270,7 +7270,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-targz/node_modules/file-type"
             }
           ]
@@ -7298,7 +7298,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-unzip"
         }
       ],
@@ -7324,7 +7324,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-unzip/node_modules/file-type"
             }
           ]
@@ -7350,7 +7350,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-unzip/node_modules/get-stream"
             }
           ]
@@ -7376,7 +7376,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-unzip/node_modules/pify"
             }
           ]
@@ -7404,7 +7404,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress"
         }
       ],
@@ -7430,7 +7430,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress/node_modules/make-dir"
             }
           ],
@@ -7456,7 +7456,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/decompress/node_modules/make-dir/node_modules/pify"
                 }
               ]
@@ -7484,7 +7484,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress/node_modules/pify"
             }
           ]
@@ -7512,7 +7512,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/deep-equal"
         }
       ]
@@ -7538,7 +7538,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/deep-extend"
         }
       ]
@@ -7564,7 +7564,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/deep-is"
         }
       ]
@@ -7590,7 +7590,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/define-properties"
         }
       ]
@@ -7616,7 +7616,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/define-property"
         }
       ]
@@ -7642,7 +7642,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/delayed-stream"
         }
       ]
@@ -7668,7 +7668,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/delegates"
         }
       ]
@@ -7694,7 +7694,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/depd"
         }
       ]
@@ -7720,7 +7720,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/destroy"
         }
       ]
@@ -7746,7 +7746,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/detect-file"
         }
       ]
@@ -7772,7 +7772,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/detect-libc"
         }
       ]
@@ -7798,7 +7798,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dfa"
         }
       ]
@@ -7824,7 +7824,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dicer"
         }
       ],
@@ -7850,7 +7850,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/dicer/node_modules/isarray"
             }
           ]
@@ -7876,7 +7876,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/dicer/node_modules/readable-stream"
             }
           ]
@@ -7902,7 +7902,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/dicer/node_modules/string_decoder"
             }
           ]
@@ -7930,7 +7930,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/diff"
         }
       ]
@@ -7956,7 +7956,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/doctypes"
         }
       ]
@@ -7982,7 +7982,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/domelementtype"
         }
       ]
@@ -8008,7 +8008,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/domhandler"
         }
       ]
@@ -8034,7 +8034,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/domutils"
         }
       ]
@@ -8060,7 +8060,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dottie"
         }
       ]
@@ -8086,7 +8086,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/double-ended-queue"
         }
       ]
@@ -8112,7 +8112,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/doublearray"
         }
       ]
@@ -8138,7 +8138,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/download"
         }
       ],
@@ -8164,7 +8164,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/download/node_modules/file-type"
             }
           ]
@@ -8192,7 +8192,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/duplexer2"
         }
       ]
@@ -8218,7 +8218,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/duplexer3"
         }
       ]
@@ -8244,7 +8244,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dynamic-dedupe"
         }
       ]
@@ -8270,7 +8270,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ecc-jsbn"
         }
       ]
@@ -8296,7 +8296,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ee-first"
         }
       ]
@@ -8322,7 +8322,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/eivindfjeldstad-dot"
         }
       ]
@@ -8348,7 +8348,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/emoji-regex"
         }
       ]
@@ -8374,7 +8374,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/enabled"
         }
       ]
@@ -8400,7 +8400,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/encodeurl"
         }
       ]
@@ -8426,7 +8426,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/encoding"
         }
       ],
@@ -8452,7 +8452,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/encoding/node_modules/iconv-lite"
             }
           ]
@@ -8480,7 +8480,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/end-of-stream"
         }
       ]
@@ -8506,7 +8506,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/engine.io-parser"
         }
       ]
@@ -8532,7 +8532,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/engine.io"
         }
       ],
@@ -8558,7 +8558,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/engine.io/node_modules/debug"
             }
           ]
@@ -8584,7 +8584,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/engine.io/node_modules/ms"
             }
           ]
@@ -8612,7 +8612,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/env-paths"
         }
       ]
@@ -8638,7 +8638,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/err-code"
         }
       ]
@@ -8664,7 +8664,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/error-ex"
         }
       ]
@@ -8690,7 +8690,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/errorhandler"
         }
       ]
@@ -8716,7 +8716,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/es-abstract"
         }
       ]
@@ -8742,7 +8742,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/es-get-iterator"
         }
       ]
@@ -8768,7 +8768,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/es-to-primitive"
         }
       ]
@@ -8794,7 +8794,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/escape-html"
         }
       ]
@@ -8820,7 +8820,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/escape-string-regexp"
         }
       ]
@@ -8846,7 +8846,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/escodegen"
         }
       ]
@@ -8872,7 +8872,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/esprima"
         }
       ]
@@ -8898,7 +8898,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/estraverse"
         }
       ]
@@ -8924,7 +8924,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/esutils"
         }
       ]
@@ -8950,7 +8950,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/etag"
         }
       ]
@@ -8976,7 +8976,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/eventemitter2"
         }
       ]
@@ -9002,7 +9002,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/eventemitter3"
         }
       ]
@@ -9028,7 +9028,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/exif"
         }
       ]
@@ -9054,7 +9054,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/exit"
         }
       ]
@@ -9080,7 +9080,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/expand-brackets"
         }
       ],
@@ -9106,7 +9106,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/define-property"
             }
           ]
@@ -9132,7 +9132,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/extend-shallow"
             }
           ]
@@ -9158,7 +9158,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/is-accessor-descriptor"
             }
           ],
@@ -9184,7 +9184,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/expand-brackets/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
@@ -9212,7 +9212,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/is-data-descriptor"
             }
           ],
@@ -9238,7 +9238,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/expand-brackets/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
@@ -9266,7 +9266,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/is-descriptor"
             }
           ]
@@ -9292,7 +9292,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/is-extendable"
             }
           ]
@@ -9318,7 +9318,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/kind-of"
             }
           ]
@@ -9346,7 +9346,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/expand-template"
         }
       ]
@@ -9372,7 +9372,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/expand-tilde"
         }
       ]
@@ -9398,7 +9398,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-ipfilter"
         }
       ]
@@ -9424,7 +9424,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-jwt"
         }
       ],
@@ -9450,7 +9450,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/express-jwt/node_modules/jsonwebtoken"
             }
           ]
@@ -9476,7 +9476,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/express-jwt/node_modules/moment"
             }
           ]
@@ -9504,7 +9504,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-rate-limit"
         }
       ]
@@ -9530,7 +9530,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-robots-txt"
         }
       ]
@@ -9556,7 +9556,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-security.txt"
         }
       ]
@@ -9582,7 +9582,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express"
         }
       ],
@@ -9608,7 +9608,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/express/node_modules/cookie"
             }
           ]
@@ -9634,7 +9634,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/express/node_modules/safe-buffer"
             }
           ]
@@ -9662,7 +9662,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ext-list"
         }
       ]
@@ -9688,7 +9688,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ext-name"
         }
       ]
@@ -9714,7 +9714,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/extend-shallow"
         }
       ]
@@ -9740,7 +9740,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/extend"
         }
       ]
@@ -9766,7 +9766,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/extglob"
         }
       ],
@@ -9792,7 +9792,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/extglob/node_modules/define-property"
             }
           ]
@@ -9818,7 +9818,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/extglob/node_modules/extend-shallow"
             }
           ]
@@ -9844,7 +9844,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/extglob/node_modules/is-extendable"
             }
           ]
@@ -9872,7 +9872,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/extsprintf"
         }
       ]
@@ -9898,7 +9898,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fast-deep-equal"
         }
       ]
@@ -9924,7 +9924,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fast-json-stable-stringify"
         }
       ]
@@ -9950,7 +9950,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fast-levenshtein"
         }
       ]
@@ -9976,7 +9976,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fast.js"
         }
       ]
@@ -10002,7 +10002,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fd-slicer"
         }
       ]
@@ -10028,7 +10028,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/feature-policy"
         }
       ]
@@ -10054,7 +10054,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fecha"
         }
       ]
@@ -10080,7 +10080,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/file-js"
         }
       ],
@@ -10106,7 +10106,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/file-js/node_modules/brace-expansion"
             }
           ]
@@ -10132,7 +10132,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/file-js/node_modules/minimatch"
             }
           ]
@@ -10160,7 +10160,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/file-stream-rotator"
         }
       ]
@@ -10186,7 +10186,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/file-type"
         }
       ]
@@ -10212,7 +10212,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/file-uri-to-path"
         }
       ]
@@ -10238,7 +10238,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/filehound"
         }
       ]
@@ -10264,7 +10264,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/filename-reserved-regex"
         }
       ]
@@ -10290,7 +10290,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/filenamify"
         }
       ]
@@ -10316,7 +10316,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/filesniffer"
         }
       ]
@@ -10342,7 +10342,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fill-range"
         }
       ],
@@ -10368,7 +10368,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/fill-range/node_modules/extend-shallow"
             }
           ]
@@ -10394,7 +10394,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/fill-range/node_modules/is-extendable"
             }
           ]
@@ -10422,7 +10422,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/finale-rest"
         }
       ]
@@ -10448,7 +10448,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/finalhandler"
         }
       ]
@@ -10474,7 +10474,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/find-up"
         }
       ]
@@ -10500,7 +10500,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/findup-sync"
         }
       ]
@@ -10526,7 +10526,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fined"
         }
       ]
@@ -10552,7 +10552,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/flagged-respawn"
         }
       ]
@@ -10578,7 +10578,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fn.name"
         }
       ]
@@ -10604,7 +10604,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fontkit"
         }
       ]
@@ -10630,7 +10630,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/for-each"
         }
       ]
@@ -10656,7 +10656,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/for-in"
         }
       ]
@@ -10682,7 +10682,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/for-own"
         }
       ]
@@ -10708,7 +10708,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/foreachasync"
         }
       ]
@@ -10734,7 +10734,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/forever-agent"
         }
       ]
@@ -10760,7 +10760,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/form-data"
         }
       ]
@@ -10786,7 +10786,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/formatio"
         }
       ]
@@ -10812,7 +10812,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/forwarded"
         }
       ]
@@ -10838,7 +10838,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fragment-cache"
         }
       ]
@@ -10864,7 +10864,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fresh"
         }
       ]
@@ -10890,7 +10890,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/from2"
         }
       ]
@@ -10916,7 +10916,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fs-constants"
         }
       ]
@@ -10942,7 +10942,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fs-extra"
         }
       ]
@@ -10968,7 +10968,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fs-minipass"
         }
       ]
@@ -10994,7 +10994,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fs.realpath"
         }
       ]
@@ -11020,7 +11020,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fstream"
         }
       ],
@@ -11046,7 +11046,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/fstream/node_modules/mkdirp"
             }
           ]
@@ -11072,7 +11072,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/fstream/node_modules/rimraf"
             }
           ]
@@ -11100,7 +11100,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/function-bind"
         }
       ]
@@ -11126,7 +11126,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/function.prototype.name"
         }
       ]
@@ -11152,7 +11152,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/functions-have-names"
         }
       ]
@@ -11178,7 +11178,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fuzzball"
         }
       ]
@@ -11204,7 +11204,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/gauge"
         }
       ]
@@ -11230,7 +11230,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/geojson-utils"
         }
       ]
@@ -11256,7 +11256,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-caller-file"
         }
       ]
@@ -11282,7 +11282,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-intrinsic"
         }
       ]
@@ -11308,7 +11308,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-stream"
         }
       ]
@@ -11334,7 +11334,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-symbol-description"
         }
       ]
@@ -11360,7 +11360,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-value"
         }
       ]
@@ -11386,7 +11386,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/getobject"
         }
       ]
@@ -11412,7 +11412,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/getpass"
         }
       ]
@@ -11438,7 +11438,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/github-from-package"
         }
       ]
@@ -11464,7 +11464,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/glob-parent"
         }
       ],
@@ -11490,7 +11490,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/glob-parent/node_modules/is-glob"
             }
           ]
@@ -11518,7 +11518,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/glob"
         }
       ],
@@ -11544,7 +11544,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/glob/node_modules/brace-expansion"
             }
           ]
@@ -11570,7 +11570,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/glob/node_modules/minimatch"
             }
           ]
@@ -11598,7 +11598,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/global-modules"
         }
       ]
@@ -11624,7 +11624,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/global-prefix"
         }
       ],
@@ -11650,7 +11650,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/global-prefix/node_modules/which"
             }
           ]
@@ -11678,7 +11678,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/got"
         }
       ],
@@ -11704,7 +11704,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/got/node_modules/get-stream"
             }
           ]
@@ -11730,7 +11730,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/got/node_modules/pify"
             }
           ]
@@ -11758,7 +11758,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/graceful-fs"
         }
       ]
@@ -11784,7 +11784,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-cli"
         }
       ],
@@ -11810,7 +11810,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-cli/node_modules/nopt"
             }
           ]
@@ -11838,7 +11838,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-contrib-compress"
         }
       ],
@@ -11864,7 +11864,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-contrib-compress/node_modules/ansi-styles"
             }
           ]
@@ -11890,7 +11890,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-contrib-compress/node_modules/chalk"
             }
           ]
@@ -11916,7 +11916,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-contrib-compress/node_modules/supports-color"
             }
           ]
@@ -11944,7 +11944,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-known-options"
         }
       ]
@@ -11970,7 +11970,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-legacy-log-utils"
         }
       ],
@@ -11996,7 +11996,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils/node_modules/ansi-styles"
             }
           ]
@@ -12022,7 +12022,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils/node_modules/chalk"
             }
           ]
@@ -12048,7 +12048,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils/node_modules/color-convert"
             }
           ]
@@ -12074,7 +12074,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils/node_modules/color-name"
             }
           ]
@@ -12100,7 +12100,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils/node_modules/has-flag"
             }
           ]
@@ -12126,7 +12126,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils/node_modules/supports-color"
             }
           ]
@@ -12154,7 +12154,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-legacy-log"
         }
       ],
@@ -12180,7 +12180,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log/node_modules/colors"
             }
           ]
@@ -12208,7 +12208,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-legacy-util"
         }
       ],
@@ -12234,7 +12234,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-util/node_modules/async"
             }
           ]
@@ -12262,7 +12262,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-replace-json"
         }
       ]
@@ -12288,7 +12288,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt"
         }
       ],
@@ -12314,7 +12314,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt/node_modules/brace-expansion"
             }
           ]
@@ -12340,7 +12340,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt/node_modules/findup-sync"
             }
           ],
@@ -12366,7 +12366,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/grunt/node_modules/findup-sync/node_modules/glob"
                 }
               ]
@@ -12394,7 +12394,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt/node_modules/glob"
             }
           ]
@@ -12420,7 +12420,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt/node_modules/minimatch"
             }
           ]
@@ -12448,7 +12448,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/handlebars"
         }
       ],
@@ -12474,7 +12474,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/handlebars/node_modules/wordwrap"
             }
           ]
@@ -12502,7 +12502,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/har-schema"
         }
       ]
@@ -12528,7 +12528,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/har-validator"
         }
       ]
@@ -12554,7 +12554,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-ansi"
         }
       ]
@@ -12580,7 +12580,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-bigints"
         }
       ]
@@ -12606,7 +12606,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-flag"
         }
       ]
@@ -12632,7 +12632,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-property-descriptors"
         }
       ]
@@ -12658,7 +12658,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-symbol-support-x"
         }
       ]
@@ -12684,7 +12684,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-symbols"
         }
       ]
@@ -12710,7 +12710,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-to-string-tag-x"
         }
       ]
@@ -12736,7 +12736,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-tostringtag"
         }
       ]
@@ -12762,7 +12762,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-unicode"
         }
       ]
@@ -12788,7 +12788,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-value"
         }
       ]
@@ -12814,7 +12814,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-values"
         }
       ],
@@ -12840,7 +12840,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/has-values/node_modules/kind-of"
             }
           ]
@@ -12868,7 +12868,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has"
         }
       ]
@@ -12894,7 +12894,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hashids"
         }
       ]
@@ -12920,7 +12920,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hbs"
         }
       ]
@@ -12946,7 +12946,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/he"
         }
       ]
@@ -12972,7 +12972,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/heap"
         }
       ]
@@ -12998,7 +12998,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/helmet"
         }
       ]
@@ -13024,7 +13024,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hoister"
         }
       ]
@@ -13050,7 +13050,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/homedir-polyfill"
         }
       ]
@@ -13076,7 +13076,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hooker"
         }
       ]
@@ -13102,7 +13102,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hosted-git-info"
         }
       ]
@@ -13128,7 +13128,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/html-entities"
         }
       ]
@@ -13154,7 +13154,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/htmlparser2"
         }
       ],
@@ -13180,7 +13180,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/htmlparser2/node_modules/isarray"
             }
           ]
@@ -13206,7 +13206,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/htmlparser2/node_modules/readable-stream"
             }
           ]
@@ -13232,7 +13232,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/htmlparser2/node_modules/string_decoder"
             }
           ]
@@ -13260,7 +13260,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/http-cache-semantics"
         }
       ]
@@ -13286,7 +13286,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/http-errors"
         }
       ]
@@ -13312,7 +13312,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/http-proxy-agent"
         }
       ],
@@ -13338,7 +13338,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/http-proxy-agent/node_modules/debug"
             }
           ]
@@ -13364,7 +13364,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/http-proxy-agent/node_modules/ms"
             }
           ]
@@ -13392,7 +13392,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/http-signature"
         }
       ]
@@ -13418,7 +13418,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/https-proxy-agent"
         }
       ],
@@ -13444,7 +13444,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/https-proxy-agent/node_modules/debug"
             }
           ]
@@ -13470,7 +13470,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/https-proxy-agent/node_modules/ms"
             }
           ]
@@ -13498,7 +13498,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/humanize-ms"
         }
       ]
@@ -13524,7 +13524,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/i18n"
         }
       ]
@@ -13550,7 +13550,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/iconv-lite"
         }
       ]
@@ -13576,7 +13576,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ieee754"
         }
       ]
@@ -13602,7 +13602,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ignore-walk"
         }
       ],
@@ -13628,7 +13628,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/ignore-walk/node_modules/brace-expansion"
             }
           ]
@@ -13654,7 +13654,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/ignore-walk/node_modules/minimatch"
             }
           ]
@@ -13682,7 +13682,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/iltorb"
         }
       ]
@@ -13708,7 +13708,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/imurmurhash"
         }
       ]
@@ -13734,7 +13734,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/indent-string"
         }
       ]
@@ -13760,7 +13760,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/infer-owner"
         }
       ]
@@ -13786,7 +13786,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/inflection"
         }
       ]
@@ -13812,7 +13812,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/inflight"
         }
       ]
@@ -13838,7 +13838,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/inherits"
         }
       ]
@@ -13864,7 +13864,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ini"
         }
       ]
@@ -13890,7 +13890,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/internal-slot"
         }
       ]
@@ -13916,7 +13916,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/interpret"
         }
       ]
@@ -13942,7 +13942,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/into-stream"
         }
       ]
@@ -13968,7 +13968,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/invariant"
         }
       ]
@@ -13994,7 +13994,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ip"
         }
       ]
@@ -14020,7 +14020,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ip6"
         }
       ]
@@ -14046,7 +14046,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ipaddr.js"
         }
       ]
@@ -14072,7 +14072,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-absolute"
         }
       ]
@@ -14098,7 +14098,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-accessor-descriptor"
         }
       ]
@@ -14124,7 +14124,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-arguments"
         }
       ]
@@ -14150,7 +14150,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-arrayish"
         }
       ]
@@ -14176,7 +14176,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-bigint"
         }
       ]
@@ -14202,7 +14202,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-binary-path"
         }
       ]
@@ -14228,7 +14228,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-boolean-object"
         }
       ]
@@ -14254,7 +14254,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-buffer"
         }
       ]
@@ -14280,7 +14280,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-callable"
         }
       ]
@@ -14306,7 +14306,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-core-module"
         }
       ]
@@ -14332,7 +14332,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-data-descriptor"
         }
       ]
@@ -14358,7 +14358,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-date-object"
         }
       ]
@@ -14384,7 +14384,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-descriptor"
         }
       ]
@@ -14410,7 +14410,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-docker"
         }
       ]
@@ -14436,7 +14436,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-expression"
         }
       ]
@@ -14462,7 +14462,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-extendable"
         }
       ]
@@ -14488,7 +14488,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-extglob"
         }
       ]
@@ -14514,7 +14514,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-fullwidth-code-point"
         }
       ]
@@ -14540,7 +14540,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-generator-function"
         }
       ]
@@ -14566,7 +14566,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-glob"
         }
       ]
@@ -14592,7 +14592,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-heroku"
         }
       ]
@@ -14618,7 +14618,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-lambda"
         }
       ]
@@ -14644,7 +14644,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-map"
         }
       ]
@@ -14670,7 +14670,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-natural-number"
         }
       ]
@@ -14696,7 +14696,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-negative-zero"
         }
       ]
@@ -14722,7 +14722,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-number-like"
         }
       ]
@@ -14748,7 +14748,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-number-object"
         }
       ]
@@ -14774,7 +14774,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-number"
         }
       ],
@@ -14800,7 +14800,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/is-number/node_modules/kind-of"
             }
           ]
@@ -14828,7 +14828,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-object"
         }
       ]
@@ -14854,7 +14854,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-plain-obj"
         }
       ]
@@ -14880,7 +14880,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-plain-object"
         }
       ]
@@ -14906,7 +14906,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-promise"
         }
       ]
@@ -14932,7 +14932,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-regex"
         }
       ]
@@ -14958,7 +14958,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-relative"
         }
       ]
@@ -14984,7 +14984,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-retry-allowed"
         }
       ]
@@ -15010,7 +15010,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-set"
         }
       ]
@@ -15036,7 +15036,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-shared-array-buffer"
         }
       ]
@@ -15062,7 +15062,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-stream"
         }
       ]
@@ -15088,7 +15088,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-string"
         }
       ]
@@ -15114,7 +15114,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-symbol"
         }
       ]
@@ -15140,7 +15140,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-typed-array"
         }
       ]
@@ -15166,7 +15166,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-typedarray"
         }
       ]
@@ -15192,7 +15192,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-unc-path"
         }
       ]
@@ -15218,7 +15218,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-weakmap"
         }
       ]
@@ -15244,7 +15244,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-weakref"
         }
       ]
@@ -15270,7 +15270,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-weakset"
         }
       ]
@@ -15296,7 +15296,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-windows"
         }
       ]
@@ -15322,7 +15322,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isarray"
         }
       ]
@@ -15348,7 +15348,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isexe"
         }
       ]
@@ -15374,7 +15374,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isobject"
         }
       ]
@@ -15400,7 +15400,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isstream"
         }
       ]
@@ -15426,7 +15426,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isurl"
         }
       ]
@@ -15452,7 +15452,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/js-stringify"
         }
       ]
@@ -15478,7 +15478,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/js-tokens"
         }
       ]
@@ -15504,7 +15504,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/js-yaml"
         }
       ]
@@ -15530,7 +15530,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jsbn"
         }
       ]
@@ -15556,7 +15556,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-buffer"
         }
       ]
@@ -15582,7 +15582,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-parse-better-errors"
         }
       ]
@@ -15608,7 +15608,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-schema-traverse"
         }
       ]
@@ -15634,7 +15634,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-schema"
         }
       ]
@@ -15660,7 +15660,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-stringify-safe"
         }
       ]
@@ -15686,7 +15686,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json5"
         }
       ]
@@ -15712,7 +15712,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jsonfile"
         }
       ]
@@ -15738,7 +15738,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jsonwebtoken"
         }
       ]
@@ -15764,7 +15764,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jsprim"
         }
       ]
@@ -15790,7 +15790,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jssha"
         }
       ]
@@ -15816,7 +15816,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jstransformer"
         }
       ]
@@ -15842,7 +15842,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/juicy-chat-bot"
         }
       ]
@@ -15868,7 +15868,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jwa"
         }
       ]
@@ -15894,7 +15894,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jws"
         }
       ]
@@ -15920,7 +15920,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/keyv"
         }
       ]
@@ -15946,7 +15946,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/kind-of"
         }
       ]
@@ -15972,7 +15972,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/kuler"
         }
       ]
@@ -15998,7 +15998,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/kuromoji"
         }
       ]
@@ -16024,7 +16024,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lazystream"
         }
       ]
@@ -16050,7 +16050,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/levn"
         }
       ]
@@ -16076,7 +16076,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/libxmljs2"
         }
       ],
@@ -16102,7 +16102,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/libxmljs2/node_modules/nan"
             }
           ]
@@ -16130,7 +16130,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/liftup"
         }
       ],
@@ -16156,7 +16156,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/braces"
             }
           ]
@@ -16182,7 +16182,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/fill-range"
             }
           ]
@@ -16208,7 +16208,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/findup-sync"
             }
           ]
@@ -16234,7 +16234,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/is-glob"
             }
           ]
@@ -16260,7 +16260,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/is-number"
             }
           ]
@@ -16286,7 +16286,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/micromatch"
             }
           ]
@@ -16312,7 +16312,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/to-regex-range"
             }
           ]
@@ -16340,7 +16340,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/linebreak"
         }
       ],
@@ -16366,7 +16366,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/linebreak/node_modules/base64-js"
             }
           ]
@@ -16394,7 +16394,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/listenercount"
         }
       ]
@@ -16420,7 +16420,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/locate-path"
         }
       ]
@@ -16446,7 +16446,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lodash.camelcase"
         }
       ]
@@ -16472,7 +16472,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lodash.isfinite"
         }
       ]
@@ -16498,7 +16498,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lodash.set"
         }
       ]
@@ -16524,7 +16524,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lodash"
         }
       ]
@@ -16550,7 +16550,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/logform"
         }
       ],
@@ -16576,7 +16576,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/logform/node_modules/ms"
             }
           ]
@@ -16604,7 +16604,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lolex"
         }
       ]
@@ -16630,7 +16630,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/loose-envify"
         }
       ]
@@ -16656,7 +16656,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lowercase-keys"
         }
       ]
@@ -16682,7 +16682,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lru-cache"
         }
       ]
@@ -16708,7 +16708,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-dir"
         }
       ],
@@ -16734,7 +16734,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-dir/node_modules/semver"
             }
           ]
@@ -16762,7 +16762,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-error"
         }
       ]
@@ -16788,7 +16788,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-fetch-happen"
         }
       ],
@@ -16815,7 +16815,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen/node_modules/@tootallnate/once"
             }
           ]
@@ -16841,7 +16841,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen/node_modules/debug"
             }
           ]
@@ -16867,7 +16867,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen/node_modules/http-cache-semantics"
             }
           ]
@@ -16893,7 +16893,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen/node_modules/http-proxy-agent"
             }
           ]
@@ -16919,7 +16919,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen/node_modules/ms"
             }
           ]
@@ -16947,7 +16947,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-iterator"
         }
       ]
@@ -16973,7 +16973,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-plural"
         }
       ]
@@ -16999,7 +16999,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/map-cache"
         }
       ]
@@ -17025,7 +17025,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/map-visit"
         }
       ]
@@ -17051,7 +17051,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/marsdb"
         }
       ]
@@ -17077,7 +17077,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/math-interval-parser"
         }
       ]
@@ -17103,7 +17103,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/media-typer"
         }
       ]
@@ -17129,7 +17129,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/merge-descriptors"
         }
       ]
@@ -17155,7 +17155,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/messageformat-formatters"
         }
       ]
@@ -17181,7 +17181,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/messageformat-parser"
         }
       ]
@@ -17207,7 +17207,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/messageformat"
         }
       ],
@@ -17233,7 +17233,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/messageformat/node_modules/make-plural"
             }
           ]
@@ -17261,7 +17261,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/methods"
         }
       ]
@@ -17287,7 +17287,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/micromatch"
         }
       ]
@@ -17313,7 +17313,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mime-db"
         }
       ]
@@ -17339,7 +17339,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mime-types"
         }
       ]
@@ -17365,7 +17365,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mime"
         }
       ]
@@ -17391,7 +17391,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mimic-response"
         }
       ]
@@ -17417,7 +17417,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minimatch"
         }
       ]
@@ -17443,7 +17443,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minimist"
         }
       ]
@@ -17469,7 +17469,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-collect"
         }
       ]
@@ -17495,7 +17495,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-fetch"
         }
       ]
@@ -17521,7 +17521,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-flush"
         }
       ]
@@ -17547,7 +17547,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-pipeline"
         }
       ]
@@ -17573,7 +17573,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-sized"
         }
       ]
@@ -17599,7 +17599,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass"
         }
       ]
@@ -17625,7 +17625,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minizlib"
         }
       ]
@@ -17651,7 +17651,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mixin-deep"
         }
       ]
@@ -17677,7 +17677,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mkdirp-classic"
         }
       ]
@@ -17703,7 +17703,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mkdirp"
         }
       ]
@@ -17729,7 +17729,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/moment-timezone"
         }
       ]
@@ -17755,7 +17755,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/moment"
         }
       ]
@@ -17781,7 +17781,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/morgan"
         }
       ],
@@ -17807,7 +17807,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/morgan/node_modules/on-finished"
             }
           ]
@@ -17835,7 +17835,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mout"
         }
       ]
@@ -17861,7 +17861,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ms"
         }
       ]
@@ -17887,7 +17887,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/multer"
         }
       ],
@@ -17913,7 +17913,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/multer/node_modules/mkdirp"
             }
           ]
@@ -17941,7 +17941,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mustache"
         }
       ]
@@ -17967,7 +17967,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/nan"
         }
       ]
@@ -17993,7 +17993,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/nanomatch"
         }
       ]
@@ -18019,7 +18019,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/napi-build-utils"
         }
       ]
@@ -18045,7 +18045,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/needle"
         }
       ],
@@ -18071,7 +18071,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/needle/node_modules/debug"
             }
           ]
@@ -18097,7 +18097,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/needle/node_modules/ms"
             }
           ]
@@ -18125,7 +18125,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/negotiator"
         }
       ]
@@ -18151,7 +18151,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/neo-async"
         }
       ]
@@ -18177,7 +18177,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-abi"
         }
       ],
@@ -18203,7 +18203,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-abi/node_modules/semver"
             }
           ]
@@ -18231,7 +18231,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-addon-api"
         }
       ]
@@ -18257,7 +18257,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-fetch"
         }
       ]
@@ -18283,7 +18283,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-gyp"
         }
       ],
@@ -18309,7 +18309,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/ansi-regex"
             }
           ]
@@ -18335,7 +18335,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/are-we-there-yet"
             }
           ]
@@ -18361,7 +18361,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/gauge"
             }
           ]
@@ -18387,7 +18387,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -18413,7 +18413,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/nopt"
             }
           ]
@@ -18439,7 +18439,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/npmlog"
             }
           ]
@@ -18465,7 +18465,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/readable-stream"
             }
           ]
@@ -18491,7 +18491,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/string-width"
             }
           ]
@@ -18517,7 +18517,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/strip-ansi"
             }
           ]
@@ -18545,7 +18545,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-pre-gyp"
         }
       ],
@@ -18571,7 +18571,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/chownr"
             }
           ]
@@ -18597,7 +18597,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/fs-minipass"
             }
           ]
@@ -18623,7 +18623,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/minipass"
             }
           ]
@@ -18649,7 +18649,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/minizlib"
             }
           ]
@@ -18675,7 +18675,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/mkdirp"
             }
           ]
@@ -18701,7 +18701,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/nopt"
             }
           ]
@@ -18727,7 +18727,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/rimraf"
             }
           ]
@@ -18753,7 +18753,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/safe-buffer"
             }
           ]
@@ -18779,7 +18779,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/semver"
             }
           ]
@@ -18805,7 +18805,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/tar"
             }
           ]
@@ -18831,7 +18831,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/yallist"
             }
           ]
@@ -18859,7 +18859,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/noop-logger"
         }
       ]
@@ -18885,7 +18885,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/nopt"
         }
       ]
@@ -18911,7 +18911,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/normalize-package-data"
         }
       ],
@@ -18937,7 +18937,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/normalize-package-data/node_modules/semver"
             }
           ]
@@ -18965,7 +18965,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/normalize-path"
         }
       ]
@@ -18991,7 +18991,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/normalize-url"
         }
       ]
@@ -19017,7 +19017,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/notevil"
         }
       ],
@@ -19043,7 +19043,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/notevil/node_modules/esprima"
             }
           ]
@@ -19071,7 +19071,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/npm-bundled"
         }
       ]
@@ -19097,7 +19097,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/npm-normalize-package-bin"
         }
       ]
@@ -19123,7 +19123,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/npm-packlist"
         }
       ]
@@ -19149,7 +19149,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/npmlog"
         }
       ]
@@ -19175,7 +19175,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/number-is-nan"
         }
       ]
@@ -19201,7 +19201,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/oauth-sign"
         }
       ]
@@ -19227,7 +19227,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-assign"
         }
       ]
@@ -19253,7 +19253,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-copy"
         }
       ],
@@ -19279,7 +19279,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy/node_modules/define-property"
             }
           ]
@@ -19305,7 +19305,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy/node_modules/is-accessor-descriptor"
             }
           ]
@@ -19331,7 +19331,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy/node_modules/is-data-descriptor"
             }
           ]
@@ -19357,7 +19357,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy/node_modules/is-descriptor"
             }
           ],
@@ -19383,7 +19383,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/object-copy/node_modules/is-descriptor/node_modules/kind-of"
                 }
               ]
@@ -19411,7 +19411,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy/node_modules/kind-of"
             }
           ]
@@ -19439,7 +19439,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-inspect"
         }
       ]
@@ -19465,7 +19465,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-is"
         }
       ]
@@ -19491,7 +19491,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-keys"
         }
       ]
@@ -19517,7 +19517,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-visit"
         }
       ]
@@ -19543,7 +19543,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object.assign"
         }
       ]
@@ -19569,7 +19569,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object.defaults"
         }
       ]
@@ -19595,7 +19595,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object.map"
         }
       ]
@@ -19621,7 +19621,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object.pick"
         }
       ]
@@ -19647,7 +19647,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/on-finished"
         }
       ]
@@ -19673,7 +19673,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/on-headers"
         }
       ]
@@ -19699,7 +19699,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/once"
         }
       ]
@@ -19725,7 +19725,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/one-time"
         }
       ]
@@ -19751,7 +19751,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/opentype.js"
         }
       ]
@@ -19777,7 +19777,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/optionator"
         }
       ]
@@ -19803,7 +19803,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/os-homedir"
         }
       ]
@@ -19829,7 +19829,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/os-tmpdir"
         }
       ]
@@ -19855,7 +19855,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/osenv"
         }
       ]
@@ -19881,7 +19881,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/otplib"
         }
       ]
@@ -19907,7 +19907,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-cancelable"
         }
       ]
@@ -19933,7 +19933,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-event"
         }
       ]
@@ -19959,7 +19959,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-finally"
         }
       ]
@@ -19985,7 +19985,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-is-promise"
         }
       ]
@@ -20011,7 +20011,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-limit"
         }
       ]
@@ -20037,7 +20037,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-locate"
         }
       ]
@@ -20063,7 +20063,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-map"
         }
       ]
@@ -20089,7 +20089,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-timeout"
         }
       ]
@@ -20115,7 +20115,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-try"
         }
       ]
@@ -20141,7 +20141,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pako"
         }
       ]
@@ -20167,7 +20167,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/parse-filepath"
         }
       ]
@@ -20193,7 +20193,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/parse-json"
         }
       ]
@@ -20219,7 +20219,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/parse-passwd"
         }
       ]
@@ -20245,7 +20245,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/parseurl"
         }
       ]
@@ -20271,7 +20271,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pascalcase"
         }
       ]
@@ -20297,7 +20297,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-exists"
         }
       ]
@@ -20323,7 +20323,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-is-absolute"
         }
       ]
@@ -20349,7 +20349,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-parse"
         }
       ]
@@ -20375,7 +20375,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-root-regex"
         }
       ]
@@ -20401,7 +20401,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-root"
         }
       ]
@@ -20427,7 +20427,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-to-regexp"
         }
       ]
@@ -20453,7 +20453,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pdfkit"
         }
       ]
@@ -20479,7 +20479,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/peek-readable"
         }
       ]
@@ -20505,7 +20505,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pend"
         }
       ]
@@ -20531,7 +20531,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/performance-now"
         }
       ]
@@ -20557,7 +20557,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pg-connection-string"
         }
       ]
@@ -20583,7 +20583,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/picomatch"
         }
       ]
@@ -20609,7 +20609,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pify"
         }
       ]
@@ -20635,7 +20635,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pinkie-promise"
         }
       ]
@@ -20661,7 +20661,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pinkie"
         }
       ]
@@ -20687,7 +20687,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/png-js"
         }
       ]
@@ -20713,7 +20713,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/portscanner"
         }
       ]
@@ -20739,7 +20739,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/posix-character-classes"
         }
       ]
@@ -20765,7 +20765,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/prebuild-install"
         }
       ]
@@ -20791,7 +20791,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/prelude-ls"
         }
       ]
@@ -20817,7 +20817,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/prepend-http"
         }
       ]
@@ -20843,7 +20843,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pretty-bytes"
         }
       ]
@@ -20869,7 +20869,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/process-nextick-args"
         }
       ]
@@ -20895,7 +20895,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/prom-client"
         }
       ]
@@ -20921,7 +20921,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/promise-inflight"
         }
       ]
@@ -20947,7 +20947,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/promise-retry"
         }
       ],
@@ -20973,7 +20973,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/promise-retry/node_modules/err-code"
             }
           ]
@@ -20999,7 +20999,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/promise-retry/node_modules/retry"
             }
           ]
@@ -21027,7 +21027,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/promise"
         }
       ]
@@ -21053,7 +21053,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/proper-lockfile"
         }
       ]
@@ -21079,7 +21079,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/proxy-addr"
         }
       ]
@@ -21105,7 +21105,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/psl"
         }
       ]
@@ -21131,7 +21131,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-attrs"
         }
       ]
@@ -21157,7 +21157,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-code-gen"
         }
       ]
@@ -21183,7 +21183,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-error"
         }
       ]
@@ -21209,7 +21209,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-filters"
         }
       ]
@@ -21235,7 +21235,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-lexer"
         }
       ]
@@ -21261,7 +21261,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-linker"
         }
       ]
@@ -21287,7 +21287,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-load"
         }
       ]
@@ -21313,7 +21313,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-parser"
         }
       ]
@@ -21339,7 +21339,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-runtime"
         }
       ]
@@ -21365,7 +21365,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-strip-comments"
         }
       ]
@@ -21391,7 +21391,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-walk"
         }
       ]
@@ -21417,7 +21417,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug"
         }
       ]
@@ -21443,7 +21443,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pump"
         }
       ]
@@ -21469,7 +21469,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/punycode"
         }
       ]
@@ -21495,7 +21495,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/qs"
         }
       ]
@@ -21521,7 +21521,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/query-string"
         }
       ]
@@ -21547,7 +21547,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/range_check"
         }
       ]
@@ -21573,7 +21573,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/range-parser"
         }
       ]
@@ -21599,7 +21599,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/raw-body"
         }
       ]
@@ -21625,7 +21625,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/rc"
         }
       ]
@@ -21651,7 +21651,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/read-pkg"
         }
       ],
@@ -21677,7 +21677,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/read-pkg/node_modules/pify"
             }
           ]
@@ -21705,7 +21705,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/readable-stream"
         }
       ],
@@ -21731,7 +21731,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/readable-stream/node_modules/isarray"
             }
           ]
@@ -21759,7 +21759,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/readable-web-to-node-stream"
         }
       ],
@@ -21785,7 +21785,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/readable-web-to-node-stream/node_modules/readable-stream"
             }
           ]
@@ -21813,7 +21813,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/readdirp"
         }
       ]
@@ -21839,7 +21839,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/rechoir"
         }
       ]
@@ -21865,7 +21865,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/regex-not"
         }
       ]
@@ -21891,7 +21891,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/regexp.prototype.flags"
         }
       ]
@@ -21917,7 +21917,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/remove-trailing-separator"
         }
       ]
@@ -21943,7 +21943,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/repeat-element"
         }
       ]
@@ -21969,7 +21969,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/repeat-string"
         }
       ]
@@ -21995,7 +21995,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/replace"
         }
       ],
@@ -22021,7 +22021,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/ansi-regex"
             }
           ]
@@ -22047,7 +22047,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/ansi-styles"
             }
           ]
@@ -22073,7 +22073,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/brace-expansion"
             }
           ]
@@ -22099,7 +22099,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/cliui"
             }
           ]
@@ -22125,7 +22125,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/color-convert"
             }
           ]
@@ -22151,7 +22151,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/color-name"
             }
           ]
@@ -22177,7 +22177,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/find-up"
             }
           ]
@@ -22203,7 +22203,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -22229,7 +22229,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/locate-path"
             }
           ]
@@ -22255,7 +22255,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/minimatch"
             }
           ]
@@ -22281,7 +22281,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/p-locate"
             }
           ]
@@ -22307,7 +22307,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/path-exists"
             }
           ]
@@ -22333,7 +22333,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/string-width"
             }
           ]
@@ -22359,7 +22359,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/strip-ansi"
             }
           ]
@@ -22385,7 +22385,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/wrap-ansi"
             }
           ]
@@ -22411,7 +22411,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/yargs-parser"
             }
           ]
@@ -22437,7 +22437,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/yargs"
             }
           ]
@@ -22465,7 +22465,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/request"
         }
       ],
@@ -22491,7 +22491,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/request/node_modules/qs"
             }
           ]
@@ -22519,7 +22519,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/require-directory"
         }
       ]
@@ -22545,7 +22545,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/require-main-filename"
         }
       ]
@@ -22571,7 +22571,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/resolve-dir"
         }
       ]
@@ -22597,7 +22597,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/resolve-url"
         }
       ]
@@ -22623,7 +22623,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/resolve"
         }
       ]
@@ -22649,7 +22649,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/responselike"
         }
       ]
@@ -22675,7 +22675,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/restructure"
         }
       ]
@@ -22701,7 +22701,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ret"
         }
       ]
@@ -22727,7 +22727,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/retry-as-promised"
         }
       ]
@@ -22753,7 +22753,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/retry"
         }
       ]
@@ -22779,7 +22779,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/rimraf"
         }
       ]
@@ -22805,7 +22805,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/rxjs"
         }
       ],
@@ -22831,7 +22831,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/rxjs/node_modules/tslib"
             }
           ]
@@ -22859,7 +22859,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safe-buffer"
         }
       ]
@@ -22885,7 +22885,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safe-regex-test"
         }
       ]
@@ -22911,7 +22911,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safe-regex"
         }
       ]
@@ -22937,7 +22937,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safe-stable-stringify"
         }
       ]
@@ -22963,7 +22963,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safer-buffer"
         }
       ]
@@ -22989,7 +22989,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/samsam"
         }
       ]
@@ -23015,7 +23015,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sanitize-filename"
         }
       ]
@@ -23041,7 +23041,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sanitize-html"
         }
       ],
@@ -23067,7 +23067,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sanitize-html/node_modules/lodash"
             }
           ]
@@ -23095,7 +23095,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sax"
         }
       ]
@@ -23121,7 +23121,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/seek-bzip"
         }
       ]
@@ -23147,7 +23147,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/semver"
         }
       ]
@@ -23173,7 +23173,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/send"
         }
       ],
@@ -23199,7 +23199,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/send/node_modules/ms"
             }
           ]
@@ -23227,7 +23227,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sequelize-pool"
         }
       ]
@@ -23253,7 +23253,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sequelize"
         }
       ],
@@ -23279,7 +23279,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sequelize/node_modules/debug"
             }
           ]
@@ -23305,7 +23305,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sequelize/node_modules/ms"
             }
           ]
@@ -23331,7 +23331,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sequelize/node_modules/uuid"
             }
           ]
@@ -23359,7 +23359,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/serve-index"
         }
       ],
@@ -23385,7 +23385,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index/node_modules/depd"
             }
           ]
@@ -23411,7 +23411,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index/node_modules/http-errors"
             }
           ]
@@ -23437,7 +23437,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index/node_modules/inherits"
             }
           ]
@@ -23463,7 +23463,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index/node_modules/setprototypeof"
             }
           ]
@@ -23489,7 +23489,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index/node_modules/statuses"
             }
           ]
@@ -23517,7 +23517,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/serve-static"
         }
       ]
@@ -23543,7 +23543,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/set-blocking"
         }
       ]
@@ -23569,7 +23569,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/set-value"
         }
       ],
@@ -23595,7 +23595,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/set-value/node_modules/extend-shallow"
             }
           ]
@@ -23621,7 +23621,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/set-value/node_modules/is-extendable"
             }
           ]
@@ -23649,7 +23649,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/setimmediate"
         }
       ]
@@ -23675,7 +23675,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/setprototypeof"
         }
       ]
@@ -23701,7 +23701,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/side-channel"
         }
       ]
@@ -23727,7 +23727,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/signal-exit"
         }
       ]
@@ -23753,7 +23753,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/simple-concat"
         }
       ]
@@ -23779,7 +23779,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/simple-get"
         }
       ],
@@ -23805,7 +23805,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/simple-get/node_modules/decompress-response"
             }
           ]
@@ -23831,7 +23831,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/simple-get/node_modules/mimic-response"
             }
           ]
@@ -23859,7 +23859,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/simple-swizzle"
         }
       ],
@@ -23885,7 +23885,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/simple-swizzle/node_modules/is-arrayish"
             }
           ]
@@ -23913,7 +23913,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sinon"
         }
       ]
@@ -23939,7 +23939,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/smart-buffer"
         }
       ]
@@ -23965,7 +23965,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/snapdragon-node"
         }
       ],
@@ -23991,7 +23991,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon-node/node_modules/define-property"
             }
           ]
@@ -24019,7 +24019,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/snapdragon-util"
         }
       ],
@@ -24045,7 +24045,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon-util/node_modules/kind-of"
             }
           ]
@@ -24073,7 +24073,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/snapdragon"
         }
       ],
@@ -24099,7 +24099,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/define-property"
             }
           ]
@@ -24125,7 +24125,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/extend-shallow"
             }
           ]
@@ -24151,7 +24151,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/is-accessor-descriptor"
             }
           ],
@@ -24177,7 +24177,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/snapdragon/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
@@ -24205,7 +24205,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/is-data-descriptor"
             }
           ],
@@ -24231,7 +24231,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/snapdragon/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
@@ -24259,7 +24259,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/is-descriptor"
             }
           ]
@@ -24285,7 +24285,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/is-extendable"
             }
           ]
@@ -24311,7 +24311,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/kind-of"
             }
           ]
@@ -24337,7 +24337,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/source-map"
             }
           ]
@@ -24365,7 +24365,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socket.io-adapter"
         }
       ]
@@ -24391,7 +24391,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socket.io-parser"
         }
       ],
@@ -24417,7 +24417,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socket.io-parser/node_modules/debug"
             }
           ]
@@ -24443,7 +24443,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socket.io-parser/node_modules/ms"
             }
           ]
@@ -24471,7 +24471,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socket.io"
         }
       ],
@@ -24497,7 +24497,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socket.io/node_modules/debug"
             }
           ]
@@ -24523,7 +24523,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socket.io/node_modules/ms"
             }
           ]
@@ -24551,7 +24551,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socks-proxy-agent"
         }
       ],
@@ -24577,7 +24577,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socks-proxy-agent/node_modules/debug"
             }
           ]
@@ -24603,7 +24603,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socks-proxy-agent/node_modules/ms"
             }
           ]
@@ -24631,7 +24631,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socks"
         }
       ],
@@ -24657,7 +24657,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socks/node_modules/ip"
             }
           ]
@@ -24685,7 +24685,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sort-keys-length"
         }
       ],
@@ -24711,7 +24711,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sort-keys-length/node_modules/sort-keys"
             }
           ]
@@ -24739,7 +24739,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sort-keys"
         }
       ]
@@ -24765,7 +24765,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/source-map-resolve"
         }
       ]
@@ -24791,7 +24791,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/source-map-support"
         }
       ]
@@ -24817,7 +24817,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/source-map-url"
         }
       ]
@@ -24843,7 +24843,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/source-map"
         }
       ]
@@ -24869,7 +24869,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spawn-command"
         }
       ]
@@ -24895,7 +24895,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spdx-correct"
         }
       ]
@@ -24921,7 +24921,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spdx-exceptions"
         }
       ]
@@ -24947,7 +24947,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spdx-expression-parse"
         }
       ]
@@ -24973,7 +24973,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spdx-license-ids"
         }
       ]
@@ -24999,7 +24999,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/split-string"
         }
       ]
@@ -25025,7 +25025,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sprintf-js"
         }
       ]
@@ -25051,7 +25051,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sqlite3"
         }
       ]
@@ -25077,7 +25077,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sshpk"
         }
       ]
@@ -25103,7 +25103,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ssri"
         }
       ]
@@ -25129,7 +25129,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/stack-trace"
         }
       ]
@@ -25155,7 +25155,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/static-extend"
         }
       ],
@@ -25181,7 +25181,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend/node_modules/define-property"
             }
           ]
@@ -25207,7 +25207,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend/node_modules/is-accessor-descriptor"
             }
           ],
@@ -25233,7 +25233,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/static-extend/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
@@ -25261,7 +25261,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend/node_modules/is-data-descriptor"
             }
           ],
@@ -25287,7 +25287,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/static-extend/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
@@ -25315,7 +25315,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend/node_modules/is-descriptor"
             }
           ]
@@ -25341,7 +25341,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend/node_modules/kind-of"
             }
           ]
@@ -25369,7 +25369,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/statuses"
         }
       ]
@@ -25395,7 +25395,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/stream-buffers"
         }
       ]
@@ -25421,7 +25421,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/streamsearch"
         }
       ]
@@ -25447,7 +25447,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strict-uri-encode"
         }
       ]
@@ -25473,7 +25473,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string_decoder"
         }
       ]
@@ -25499,7 +25499,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string-width"
         }
       ]
@@ -25525,7 +25525,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string.fromcodepoint"
         }
       ]
@@ -25551,7 +25551,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string.prototype.codepointat"
         }
       ]
@@ -25577,7 +25577,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string.prototype.trimend"
         }
       ]
@@ -25603,7 +25603,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string.prototype.trimstart"
         }
       ]
@@ -25629,7 +25629,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-ansi"
         }
       ]
@@ -25655,7 +25655,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-bom"
         }
       ]
@@ -25681,7 +25681,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-dirs"
         }
       ]
@@ -25707,7 +25707,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-json-comments"
         }
       ]
@@ -25733,7 +25733,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-outer"
         }
       ]
@@ -25759,7 +25759,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strtok3"
         }
       ]
@@ -25785,7 +25785,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/supports-color"
         }
       ]
@@ -25811,7 +25811,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/supports-preserve-symlinks-flag"
         }
       ]
@@ -25837,7 +25837,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/svg-captcha"
         }
       ]
@@ -25863,7 +25863,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/swagger-ui-dist"
         }
       ]
@@ -25889,7 +25889,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/swagger-ui-express"
         }
       ]
@@ -25915,7 +25915,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tar-fs"
         }
       ],
@@ -25941,7 +25941,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/tar-fs/node_modules/bl"
             }
           ]
@@ -25967,7 +25967,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/tar-fs/node_modules/chownr"
             }
           ]
@@ -25993,7 +25993,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/tar-fs/node_modules/readable-stream"
             }
           ]
@@ -26019,7 +26019,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/tar-fs/node_modules/tar-stream"
             }
           ]
@@ -26047,7 +26047,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tar-stream"
         }
       ]
@@ -26073,7 +26073,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tar"
         }
       ]
@@ -26099,7 +26099,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tdigest"
         }
       ]
@@ -26125,7 +26125,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/text-hex"
         }
       ]
@@ -26151,7 +26151,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/thirty-two"
         }
       ]
@@ -26177,7 +26177,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/through"
         }
       ]
@@ -26203,7 +26203,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/timed-out"
         }
       ]
@@ -26229,7 +26229,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tiny-inflate"
         }
       ]
@@ -26255,7 +26255,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-buffer"
         }
       ]
@@ -26281,7 +26281,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-fast-properties"
         }
       ]
@@ -26307,7 +26307,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-object-path"
         }
       ],
@@ -26333,7 +26333,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/to-object-path/node_modules/kind-of"
             }
           ]
@@ -26361,7 +26361,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-regex-range"
         }
       ]
@@ -26387,7 +26387,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-regex"
         }
       ]
@@ -26413,7 +26413,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/toidentifier"
         }
       ]
@@ -26439,7 +26439,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/token-stream"
         }
       ]
@@ -26465,7 +26465,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/token-types"
         }
       ]
@@ -26491,7 +26491,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/toposort-class"
         }
       ]
@@ -26517,7 +26517,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tough-cookie"
         }
       ]
@@ -26543,7 +26543,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tr46"
         }
       ]
@@ -26569,7 +26569,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/traverse"
         }
       ]
@@ -26595,7 +26595,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tree-kill"
         }
       ]
@@ -26621,7 +26621,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/trim-repeated"
         }
       ]
@@ -26647,7 +26647,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/triple-beam"
         }
       ]
@@ -26673,7 +26673,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/truncate-utf8-bytes"
         }
       ]
@@ -26699,7 +26699,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ts-node-dev"
         }
       ],
@@ -26725,7 +26725,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/ts-node-dev/node_modules/rimraf"
             }
           ]
@@ -26753,7 +26753,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ts-node"
         }
       ]
@@ -26779,7 +26779,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tsconfig"
         }
       ]
@@ -26805,7 +26805,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tslib"
         }
       ]
@@ -26831,7 +26831,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tunnel-agent"
         }
       ]
@@ -26857,7 +26857,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tweetnacl"
         }
       ]
@@ -26883,7 +26883,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/type-check"
         }
       ]
@@ -26909,7 +26909,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/type-is"
         }
       ]
@@ -26935,7 +26935,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/typecast"
         }
       ]
@@ -26961,7 +26961,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/typedarray"
         }
       ]
@@ -26987,7 +26987,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/typescript"
         }
       ]
@@ -27013,7 +27013,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/uglify-js"
         }
       ]
@@ -27039,7 +27039,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unbox-primitive"
         }
       ]
@@ -27065,7 +27065,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unbzip2-stream"
         }
       ]
@@ -27091,7 +27091,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unc-path-regex"
         }
       ]
@@ -27117,7 +27117,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/underscore.string"
         }
       ]
@@ -27143,7 +27143,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unicode-properties"
         }
       ]
@@ -27169,7 +27169,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unicode-trie"
         }
       ]
@@ -27195,7 +27195,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/union-value"
         }
       ],
@@ -27221,7 +27221,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/union-value/node_modules/is-extendable"
             }
           ]
@@ -27249,7 +27249,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unique-filename"
         }
       ]
@@ -27275,7 +27275,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unique-slug"
         }
       ]
@@ -27301,7 +27301,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unit-compare"
         }
       ]
@@ -27327,7 +27327,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/universalify"
         }
       ]
@@ -27353,7 +27353,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unpipe"
         }
       ]
@@ -27379,7 +27379,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unset-value"
         }
       ],
@@ -27405,7 +27405,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/unset-value/node_modules/has-value"
             }
           ],
@@ -27431,7 +27431,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/unset-value/node_modules/has-value/node_modules/isobject"
                 }
               ]
@@ -27459,7 +27459,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/unset-value/node_modules/has-values"
             }
           ]
@@ -27485,7 +27485,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/unset-value/node_modules/isarray"
             }
           ]
@@ -27513,7 +27513,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/untildify"
         }
       ]
@@ -27539,7 +27539,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unzipper"
         }
       ],
@@ -27565,7 +27565,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/unzipper/node_modules/bluebird"
             }
           ]
@@ -27593,7 +27593,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/uri-js"
         }
       ]
@@ -27619,7 +27619,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/urix"
         }
       ]
@@ -27645,7 +27645,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/url-parse-lax"
         }
       ]
@@ -27671,7 +27671,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/url-to-options"
         }
       ]
@@ -27697,7 +27697,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/use"
         }
       ]
@@ -27723,7 +27723,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/utf8-byte-length"
         }
       ]
@@ -27749,7 +27749,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/util-deprecate"
         }
       ]
@@ -27775,7 +27775,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/util"
         }
       ]
@@ -27801,7 +27801,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/utils-merge"
         }
       ]
@@ -27827,7 +27827,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/uuid"
         }
       ]
@@ -27853,7 +27853,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/v8flags"
         }
       ]
@@ -27879,7 +27879,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/validate-npm-package-license"
         }
       ]
@@ -27905,7 +27905,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/validate"
         }
       ]
@@ -27931,7 +27931,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/validator"
         }
       ]
@@ -27957,7 +27957,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/vary"
         }
       ]
@@ -27983,7 +27983,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/verror"
         }
       ],
@@ -28009,7 +28009,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/verror/node_modules/core-util-is"
             }
           ]
@@ -28037,7 +28037,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/vm2"
         }
       ],
@@ -28063,7 +28063,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/vm2/node_modules/acorn"
             }
           ]
@@ -28091,7 +28091,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/void-elements"
         }
       ]
@@ -28117,7 +28117,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/walk"
         }
       ]
@@ -28143,7 +28143,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/walkdir"
         }
       ]
@@ -28169,7 +28169,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/webidl-conversions"
         }
       ]
@@ -28195,7 +28195,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/whatwg-url"
         }
       ]
@@ -28221,7 +28221,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-boxed-primitive"
         }
       ]
@@ -28247,7 +28247,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-collection"
         }
       ]
@@ -28273,7 +28273,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-module"
         }
       ]
@@ -28299,7 +28299,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-pm-runs"
         }
       ]
@@ -28325,7 +28325,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-typed-array"
         }
       ]
@@ -28351,7 +28351,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which"
         }
       ]
@@ -28377,7 +28377,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wide-align"
         }
       ]
@@ -28403,7 +28403,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/winston-transport"
         }
       ],
@@ -28429,7 +28429,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/winston-transport/node_modules/readable-stream"
             }
           ]
@@ -28457,7 +28457,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/winston"
         }
       ],
@@ -28483,7 +28483,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/winston/node_modules/async"
             }
           ]
@@ -28509,7 +28509,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/winston/node_modules/is-stream"
             }
           ]
@@ -28535,7 +28535,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/winston/node_modules/readable-stream"
             }
           ]
@@ -28563,7 +28563,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/with"
         }
       ]
@@ -28589,7 +28589,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wkx"
         }
       ]
@@ -28615,7 +28615,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/word-wrap"
         }
       ]
@@ -28641,7 +28641,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wordwrap"
         }
       ]
@@ -28667,7 +28667,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wrap-ansi"
         }
       ],
@@ -28693,7 +28693,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi/node_modules/ansi-regex"
             }
           ]
@@ -28719,7 +28719,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi/node_modules/emoji-regex"
             }
           ]
@@ -28745,7 +28745,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -28771,7 +28771,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi/node_modules/string-width"
             }
           ]
@@ -28797,7 +28797,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi/node_modules/strip-ansi"
             }
           ]
@@ -28825,7 +28825,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wrappy"
         }
       ]
@@ -28851,7 +28851,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ws"
         }
       ]
@@ -28877,7 +28877,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/xtend"
         }
       ]
@@ -28903,7 +28903,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/y18n"
         }
       ]
@@ -28929,7 +28929,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yallist"
         }
       ]
@@ -28955,7 +28955,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yaml-schema-validator"
         }
       ]
@@ -28981,7 +28981,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yargs-parser"
         }
       ]
@@ -29007,7 +29007,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yargs"
         }
       ],
@@ -29033,7 +29033,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs/node_modules/ansi-regex"
             }
           ]
@@ -29059,7 +29059,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs/node_modules/emoji-regex"
             }
           ]
@@ -29085,7 +29085,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -29111,7 +29111,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs/node_modules/string-width"
             }
           ]
@@ -29137,7 +29137,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs/node_modules/strip-ansi"
             }
           ]
@@ -29165,7 +29165,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yauzl"
         }
       ]
@@ -29191,7 +29191,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yn"
         }
       ]
@@ -29217,7 +29217,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/z85"
         }
       ]
@@ -29243,7 +29243,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/zip-stream"
         }
       ]
@@ -29269,7 +29269,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/zlibjs"
         }
       ]

--- a/tests/_data/sbom_demo-results/juice-shop_npm8_node18_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/juice-shop_npm8_node18_windows-latest.snap.json
@@ -62,6 +62,10 @@
       ],
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -88,6 +92,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@babel\\helper-string-parser"
+        }
       ]
     },
     {
@@ -108,6 +118,12 @@
           "url": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@babel\\helper-validator-identifier"
         }
       ]
     },
@@ -130,6 +146,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@babel\\parser"
+        }
       ]
     },
     {
@@ -150,6 +172,12 @@
           "url": "https://registry.npmjs.org/@babel/types/-/types-7.20.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@babel\\types"
         }
       ]
     },
@@ -172,6 +200,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@colors\\colors"
+        }
       ]
     },
     {
@@ -193,6 +227,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@dabh\\diagnostics"
+        }
       ]
     },
     {
@@ -213,6 +253,12 @@
           "url": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@gar\\promisify"
         }
       ]
     },
@@ -236,6 +282,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@mapbox\\node-pre-gyp"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -254,6 +306,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\ansi-regex"
             }
           ]
         },
@@ -275,6 +333,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\are-we-there-yet"
+            }
           ]
         },
         {
@@ -294,6 +358,12 @@
               "url": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\detect-libc"
             }
           ]
         },
@@ -315,6 +385,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\gauge"
+            }
           ]
         },
         {
@@ -334,6 +410,12 @@
               "url": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\is-fullwidth-code-point"
             }
           ]
         },
@@ -356,6 +438,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\make-dir"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -374,6 +462,12 @@
                   "url": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\make-dir\\node_modules\\semver"
                 }
               ]
             }
@@ -397,6 +491,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\nopt"
+            }
           ]
         },
         {
@@ -416,6 +516,12 @@
               "url": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\npmlog"
             }
           ]
         },
@@ -437,6 +543,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\readable-stream"
+            }
           ]
         },
         {
@@ -457,6 +569,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\string-width"
+            }
           ]
         },
         {
@@ -476,6 +594,12 @@
               "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\strip-ansi"
             }
           ]
         }
@@ -500,6 +624,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\core-loader"
+        }
       ]
     },
     {
@@ -520,6 +650,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/core/-/core-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\core"
         }
       ]
     },
@@ -542,6 +678,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\evaluator"
+        }
       ]
     },
     {
@@ -562,6 +704,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-all/-/lang-all-4.24.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-all"
         }
       ]
     },
@@ -584,6 +732,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-ar"
+        }
       ]
     },
     {
@@ -604,6 +758,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-bn/-/lang-bn-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-bn"
         }
       ]
     },
@@ -626,6 +786,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-ca"
+        }
       ]
     },
     {
@@ -646,6 +812,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-cs/-/lang-cs-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-cs"
         }
       ]
     },
@@ -668,6 +840,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-da"
+        }
       ]
     },
     {
@@ -688,6 +866,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-de/-/lang-de-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-de"
         }
       ]
     },
@@ -710,6 +894,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-el"
+        }
       ]
     },
     {
@@ -730,6 +920,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-en-min/-/lang-en-min-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-en-min"
         }
       ]
     },
@@ -752,6 +948,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-en"
+        }
       ]
     },
     {
@@ -772,6 +974,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-es/-/lang-es-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-es"
         }
       ]
     },
@@ -794,6 +1002,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-eu"
+        }
       ]
     },
     {
@@ -814,6 +1028,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-fa/-/lang-fa-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-fa"
         }
       ]
     },
@@ -836,6 +1056,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-fi"
+        }
       ]
     },
     {
@@ -856,6 +1082,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-fr/-/lang-fr-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-fr"
         }
       ]
     },
@@ -878,6 +1110,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-ga"
+        }
       ]
     },
     {
@@ -898,6 +1136,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-gl/-/lang-gl-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-gl"
         }
       ]
     },
@@ -920,6 +1164,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-hi"
+        }
       ]
     },
     {
@@ -940,6 +1190,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-hu/-/lang-hu-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-hu"
         }
       ]
     },
@@ -962,6 +1218,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-hy"
+        }
       ]
     },
     {
@@ -982,6 +1244,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-id/-/lang-id-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-id"
         }
       ]
     },
@@ -1004,6 +1272,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-it"
+        }
       ]
     },
     {
@@ -1024,6 +1298,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-ja/-/lang-ja-4.24.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-ja"
         }
       ]
     },
@@ -1046,6 +1326,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-ko"
+        }
       ]
     },
     {
@@ -1066,6 +1352,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-lt/-/lang-lt-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-lt"
         }
       ]
     },
@@ -1088,6 +1380,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-ms"
+        }
       ]
     },
     {
@@ -1108,6 +1406,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-ne/-/lang-ne-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-ne"
         }
       ]
     },
@@ -1130,6 +1434,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-nl"
+        }
       ]
     },
     {
@@ -1150,6 +1460,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-no/-/lang-no-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-no"
         }
       ]
     },
@@ -1172,6 +1488,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-pl"
+        }
       ]
     },
     {
@@ -1192,6 +1514,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-pt/-/lang-pt-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-pt"
         }
       ]
     },
@@ -1214,6 +1542,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-ro"
+        }
       ]
     },
     {
@@ -1234,6 +1568,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-ru/-/lang-ru-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-ru"
         }
       ]
     },
@@ -1256,6 +1596,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-sl"
+        }
       ]
     },
     {
@@ -1276,6 +1622,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-sr/-/lang-sr-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-sr"
         }
       ]
     },
@@ -1298,6 +1650,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-sv"
+        }
       ]
     },
     {
@@ -1318,6 +1676,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-ta/-/lang-ta-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-ta"
         }
       ]
     },
@@ -1340,6 +1704,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-th"
+        }
       ]
     },
     {
@@ -1360,6 +1730,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-tl/-/lang-tl-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-tl"
         }
       ]
     },
@@ -1382,6 +1758,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-tr"
+        }
       ]
     },
     {
@@ -1402,6 +1784,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-uk/-/lang-uk-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-uk"
         }
       ]
     },
@@ -1424,6 +1812,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-zh"
+        }
       ]
     },
     {
@@ -1444,6 +1838,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/language-min/-/language-min-4.22.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\language-min"
         }
       ]
     },
@@ -1466,6 +1866,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\language"
+        }
       ]
     },
     {
@@ -1486,6 +1892,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/ner/-/ner-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\ner"
         }
       ]
     },
@@ -1508,6 +1920,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\neural"
+        }
       ]
     },
     {
@@ -1528,6 +1946,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/nlg/-/nlg-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\nlg"
         }
       ]
     },
@@ -1550,6 +1974,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\nlp"
+        }
       ]
     },
     {
@@ -1570,6 +2000,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/nlu/-/nlu-4.23.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\nlu"
         }
       ]
     },
@@ -1592,6 +2028,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\request"
+        }
       ]
     },
     {
@@ -1612,6 +2054,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/sentiment/-/sentiment-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\sentiment"
         }
       ]
     },
@@ -1634,6 +2082,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\similarity"
+        }
       ]
     },
     {
@@ -1654,6 +2108,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/slot/-/slot-4.22.17.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\slot"
         }
       ]
     },
@@ -1676,6 +2136,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@npmcli\\fs"
+        }
       ]
     },
     {
@@ -1696,6 +2162,12 @@
           "url": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@npmcli\\move-file"
         }
       ]
     },
@@ -1718,6 +2190,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib\\core"
+        }
       ]
     },
     {
@@ -1738,6 +2216,12 @@
           "url": "https://registry.npmjs.org/@otplib/plugin-crypto/-/plugin-crypto-12.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib\\plugin-crypto"
         }
       ]
     },
@@ -1760,6 +2244,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib\\plugin-thirty-two"
+        }
       ]
     },
     {
@@ -1780,6 +2270,12 @@
           "url": "https://registry.npmjs.org/@otplib/preset-default/-/preset-default-12.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib\\preset-default"
         }
       ]
     },
@@ -1802,6 +2298,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib\\preset-v11"
+        }
       ]
     },
     {
@@ -1822,6 +2324,12 @@
           "url": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@sindresorhus\\is"
         }
       ]
     },
@@ -1844,6 +2352,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@swc\\helpers"
+        }
       ]
     },
     {
@@ -1864,6 +2378,12 @@
           "url": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@tokenizer\\token"
         }
       ]
     },
@@ -1886,6 +2406,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@tootallnate\\once"
+        }
       ]
     },
     {
@@ -1906,6 +2432,12 @@
           "url": "https://registry.npmjs.org/@types/component-emitter/-/component-emitter-1.2.11.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types\\component-emitter"
         }
       ]
     },
@@ -1928,6 +2460,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types\\cookie"
+        }
       ]
     },
     {
@@ -1948,6 +2486,12 @@
           "url": "https://registry.npmjs.org/@types/cors/-/cors-2.8.12.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types\\cors"
         }
       ]
     },
@@ -1970,6 +2514,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types\\debug"
+        }
       ]
     },
     {
@@ -1990,6 +2540,12 @@
           "url": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types\\ms"
         }
       ]
     },
@@ -2012,6 +2568,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types\\node"
+        }
       ]
     },
     {
@@ -2032,6 +2594,12 @@
           "url": "https://registry.npmjs.org/@types/strip-bom/-/strip-bom-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types\\strip-bom"
         }
       ]
     },
@@ -2054,6 +2622,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types\\strip-json-comments"
+        }
       ]
     },
     {
@@ -2075,6 +2649,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types\\validator"
+        }
       ]
     },
     {
@@ -2094,6 +2674,12 @@
           "url": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/abbrev"
         }
       ]
     },
@@ -2115,6 +2701,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/accepts"
+        }
       ]
     },
     {
@@ -2135,6 +2727,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/acorn-walk"
+        }
       ]
     },
     {
@@ -2154,6 +2752,12 @@
           "url": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/acorn"
         }
       ]
     },
@@ -2176,6 +2780,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/agent-base"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -2194,6 +2804,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agent-base\\node_modules\\debug"
             }
           ]
         },
@@ -2214,6 +2830,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agent-base\\node_modules\\ms"
             }
           ]
         }
@@ -2238,6 +2860,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/agentkeepalive"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -2256,6 +2884,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agentkeepalive\\node_modules\\debug"
             }
           ]
         },
@@ -2277,6 +2911,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agentkeepalive\\node_modules\\depd"
+            }
           ]
         },
         {
@@ -2296,6 +2936,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agentkeepalive\\node_modules\\ms"
             }
           ]
         }
@@ -2319,6 +2965,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/aggregate-error"
+        }
       ]
     },
     {
@@ -2338,6 +2990,12 @@
           "url": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ajv"
         }
       ]
     },
@@ -2359,6 +3017,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ansi-regex"
+        }
       ]
     },
     {
@@ -2378,6 +3042,12 @@
           "url": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ansi-styles"
         }
       ]
     },
@@ -2400,6 +3070,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/anymatch"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -2418,6 +3094,12 @@
               "url": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/anymatch\\node_modules\\normalize-path"
             }
           ]
         }
@@ -2441,6 +3123,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/append-field"
+        }
       ]
     },
     {
@@ -2460,6 +3148,12 @@
           "url": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/aproba"
         }
       ]
     },
@@ -2482,6 +3176,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/archive-type"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -2500,6 +3200,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-4.4.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/archive-type\\node_modules\\file-type"
             }
           ]
         }
@@ -2523,6 +3229,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/archiver-utils"
+        }
       ]
     },
     {
@@ -2542,6 +3254,12 @@
           "url": "https://registry.npmjs.org/archiver/-/archiver-1.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/archiver"
         }
       ]
     },
@@ -2563,6 +3281,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/are-we-there-yet"
+        }
       ]
     },
     {
@@ -2582,6 +3306,12 @@
           "url": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/arg"
         }
       ]
     },
@@ -2604,6 +3334,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/argparse"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -2622,6 +3358,12 @@
               "url": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/argparse\\node_modules\\sprintf-js"
             }
           ]
         }
@@ -2645,6 +3387,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/arr-diff"
+        }
       ]
     },
     {
@@ -2664,6 +3412,12 @@
           "url": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/arr-flatten"
         }
       ]
     },
@@ -2685,6 +3439,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/arr-union"
+        }
       ]
     },
     {
@@ -2704,6 +3464,12 @@
           "url": "https://registry.npmjs.org/array-each/-/array-each-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/array-each"
         }
       ]
     },
@@ -2725,6 +3491,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/array-flatten"
+        }
       ]
     },
     {
@@ -2744,6 +3516,12 @@
           "url": "https://registry.npmjs.org/array-slice/-/array-slice-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/array-slice"
         }
       ]
     },
@@ -2765,6 +3543,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/array-unique"
+        }
       ]
     },
     {
@@ -2784,6 +3568,12 @@
           "url": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/asap"
         }
       ]
     },
@@ -2805,6 +3595,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/asn1"
+        }
       ]
     },
     {
@@ -2824,6 +3620,12 @@
           "url": "https://registry.npmjs.org/assert-never/-/assert-never-1.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/assert-never"
         }
       ]
     },
@@ -2845,6 +3647,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/assert-plus"
+        }
       ]
     },
     {
@@ -2864,6 +3672,12 @@
           "url": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/assign-symbols"
         }
       ]
     },
@@ -2885,6 +3699,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/async"
+        }
       ]
     },
     {
@@ -2904,6 +3724,12 @@
           "url": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/asynckit"
         }
       ]
     },
@@ -2925,6 +3751,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/at-least-node"
+        }
       ]
     },
     {
@@ -2944,6 +3776,12 @@
           "url": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/atob"
         }
       ]
     },
@@ -2965,6 +3803,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/available-typed-arrays"
+        }
       ]
     },
     {
@@ -2984,6 +3828,12 @@
           "url": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/aws-sign2"
         }
       ]
     },
@@ -3005,6 +3855,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/aws4"
+        }
       ]
     },
     {
@@ -3025,6 +3881,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/babel-walk"
+        }
       ]
     },
     {
@@ -3044,6 +3906,12 @@
           "url": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/balanced-match"
         }
       ]
     },
@@ -3066,6 +3934,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -3084,6 +3958,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/base\\node_modules\\define-property"
             }
           ]
         }
@@ -3107,6 +3987,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base64-arraybuffer"
+        }
       ]
     },
     {
@@ -3126,6 +4012,12 @@
           "url": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base64-js"
         }
       ]
     },
@@ -3147,6 +4039,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base64id"
+        }
       ]
     },
     {
@@ -3166,6 +4064,12 @@
           "url": "https://registry.npmjs.org/base64url/-/base64url-0.0.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base64url"
         }
       ]
     },
@@ -3187,6 +4091,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/basic-auth"
+        }
       ]
     },
     {
@@ -3206,6 +4116,12 @@
           "url": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/batch"
         }
       ]
     },
@@ -3227,6 +4143,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bcrypt-pbkdf"
+        }
       ]
     },
     {
@@ -3246,6 +4168,12 @@
           "url": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/big-integer"
         }
       ]
     },
@@ -3267,6 +4195,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/binary-extensions"
+        }
       ]
     },
     {
@@ -3286,6 +4220,12 @@
           "url": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/binary"
         }
       ]
     },
@@ -3307,6 +4247,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bindings"
+        }
       ]
     },
     {
@@ -3326,6 +4272,12 @@
           "url": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bintrees"
         }
       ]
     },
@@ -3347,6 +4299,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bl"
+        }
       ]
     },
     {
@@ -3367,6 +4325,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bluebird"
+        }
       ]
     },
     {
@@ -3386,6 +4350,12 @@
           "url": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/body-parser"
         }
       ]
     },
@@ -3408,6 +4378,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bower-config"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -3426,6 +4402,12 @@
               "url": "https://registry.npmjs.org/minimist/-/minimist-0.2.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bower-config\\node_modules\\minimist"
             }
           ]
         }
@@ -3449,6 +4431,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/brace-expansion"
+        }
       ]
     },
     {
@@ -3470,6 +4458,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/braces"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -3488,6 +4482,12 @@
               "url": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/braces\\node_modules\\extend-shallow"
             }
           ]
         },
@@ -3508,6 +4508,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/braces\\node_modules\\is-extendable"
             }
           ]
         }
@@ -3531,6 +4537,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/brotli"
+        }
       ]
     },
     {
@@ -3550,6 +4562,12 @@
           "url": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-alloc-unsafe"
         }
       ]
     },
@@ -3571,6 +4589,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-alloc"
+        }
       ]
     },
     {
@@ -3590,6 +4614,12 @@
           "url": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-crc32"
         }
       ]
     },
@@ -3611,6 +4641,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-fill"
+        }
       ]
     },
     {
@@ -3630,6 +4666,12 @@
           "url": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-from"
         }
       ]
     },
@@ -3651,6 +4693,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-indexof-polyfill"
+        }
       ]
     },
     {
@@ -3671,6 +4719,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer"
+        }
       ]
     },
     {
@@ -3690,6 +4744,12 @@
           "url": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffers"
         }
       ]
     },
@@ -3712,6 +4772,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/busboy"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -3730,6 +4796,12 @@
               "url": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/busboy\\node_modules\\isarray"
             }
           ]
         },
@@ -3751,6 +4823,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/busboy\\node_modules\\readable-stream"
+            }
           ]
         },
         {
@@ -3770,6 +4848,12 @@
               "url": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/busboy\\node_modules\\string_decoder"
             }
           ]
         }
@@ -3793,6 +4877,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/byline"
+        }
       ]
     },
     {
@@ -3812,6 +4902,12 @@
           "url": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bytes"
         }
       ]
     },
@@ -3833,6 +4929,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cacache"
+        }
       ]
     },
     {
@@ -3852,6 +4954,12 @@
           "url": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cache-base"
         }
       ]
     },
@@ -3874,6 +4982,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cacheable-request"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -3892,6 +5006,12 @@
               "url": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cacheable-request\\node_modules\\get-stream"
             }
           ]
         },
@@ -3912,6 +5032,12 @@
               "url": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cacheable-request\\node_modules\\lowercase-keys"
             }
           ]
         }
@@ -3935,6 +5061,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/call-bind"
+        }
       ]
     },
     {
@@ -3954,6 +5086,12 @@
           "url": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/camelcase"
         }
       ]
     },
@@ -3975,6 +5113,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/caseless"
+        }
       ]
     },
     {
@@ -3994,6 +5138,12 @@
           "url": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/chainsaw"
         }
       ]
     },
@@ -4015,6 +5165,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/chalk"
+        }
       ]
     },
     {
@@ -4034,6 +5190,12 @@
           "url": "https://registry.npmjs.org/character-parser/-/character-parser-2.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/character-parser"
         }
       ]
     },
@@ -4056,6 +5218,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/check-dependencies"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4074,6 +5242,12 @@
               "url": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/check-dependencies\\node_modules\\semver"
             }
           ]
         }
@@ -4097,6 +5271,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/check-types"
+        }
       ]
     },
     {
@@ -4118,6 +5298,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/chokidar"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4136,6 +5322,12 @@
               "url": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar\\node_modules\\braces"
             }
           ]
         },
@@ -4157,6 +5349,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar\\node_modules\\fill-range"
+            }
           ]
         },
         {
@@ -4176,6 +5374,12 @@
               "url": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar\\node_modules\\is-glob"
             }
           ]
         },
@@ -4197,6 +5401,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar\\node_modules\\is-number"
+            }
           ]
         },
         {
@@ -4217,6 +5427,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar\\node_modules\\normalize-path"
+            }
           ]
         },
         {
@@ -4236,6 +5452,12 @@
               "url": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar\\node_modules\\to-regex-range"
             }
           ]
         }
@@ -4259,6 +5481,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/chownr"
+        }
       ]
     },
     {
@@ -4278,6 +5506,12 @@
           "url": "https://registry.npmjs.org/clarinet/-/clarinet-0.12.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/clarinet"
         }
       ]
     },
@@ -4300,6 +5534,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/class-utils"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4318,6 +5558,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils\\node_modules\\define-property"
             }
           ]
         },
@@ -4340,6 +5586,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils\\node_modules\\is-accessor-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -4358,6 +5610,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/class-utils\\node_modules\\is-accessor-descriptor\\node_modules\\kind-of"
                 }
               ]
             }
@@ -4382,6 +5640,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils\\node_modules\\is-data-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -4400,6 +5664,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/class-utils\\node_modules\\is-data-descriptor\\node_modules\\kind-of"
                 }
               ]
             }
@@ -4423,6 +5693,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils\\node_modules\\is-descriptor"
+            }
           ]
         },
         {
@@ -4442,6 +5718,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils\\node_modules\\kind-of"
             }
           ]
         }
@@ -4465,6 +5747,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/clean-stack"
+        }
       ]
     },
     {
@@ -4486,6 +5774,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cliui"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4504,6 +5798,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui\\node_modules\\ansi-regex"
             }
           ]
         },
@@ -4525,6 +5825,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui\\node_modules\\emoji-regex"
+            }
           ]
         },
         {
@@ -4544,6 +5850,12 @@
               "url": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui\\node_modules\\is-fullwidth-code-point"
             }
           ]
         },
@@ -4565,6 +5877,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui\\node_modules\\string-width"
+            }
           ]
         },
         {
@@ -4584,6 +5902,12 @@
               "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui\\node_modules\\strip-ansi"
             }
           ]
         }
@@ -4607,6 +5931,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/clone-response"
+        }
       ]
     },
     {
@@ -4626,6 +5956,12 @@
           "url": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/clone"
         }
       ]
     },
@@ -4647,6 +5983,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/code-point-at"
+        }
       ]
     },
     {
@@ -4666,6 +6008,12 @@
           "url": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/collection-visit"
         }
       ]
     },
@@ -4687,6 +6035,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color-convert"
+        }
       ]
     },
     {
@@ -4706,6 +6060,12 @@
           "url": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color-name"
         }
       ]
     },
@@ -4727,6 +6087,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color-string"
+        }
       ]
     },
     {
@@ -4746,6 +6112,12 @@
           "url": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color-support"
         }
       ]
     },
@@ -4767,6 +6139,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color"
+        }
       ]
     },
     {
@@ -4786,6 +6164,12 @@
           "url": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/colors"
         }
       ]
     },
@@ -4807,6 +6191,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/colorspace"
+        }
       ]
     },
     {
@@ -4826,6 +6216,12 @@
           "url": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/combined-stream"
         }
       ]
     },
@@ -4847,6 +6243,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/commander"
+        }
       ]
     },
     {
@@ -4866,6 +6268,12 @@
           "url": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/component-emitter"
         }
       ]
     },
@@ -4887,6 +6295,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/component-type"
+        }
       ]
     },
     {
@@ -4907,6 +6321,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/compress-commons"
+        }
       ]
     },
     {
@@ -4926,6 +6346,12 @@
           "url": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/compressible"
         }
       ]
     },
@@ -4948,6 +6374,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/compression"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4966,6 +6398,12 @@
               "url": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/compression\\node_modules\\bytes"
             }
           ]
         }
@@ -4989,6 +6427,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/concat-map"
+        }
       ]
     },
     {
@@ -5008,6 +6452,12 @@
           "url": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/concat-stream"
         }
       ]
     },
@@ -5030,6 +6480,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/concurrently"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5048,6 +6504,12 @@
               "url": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/concurrently\\node_modules\\supports-color"
             }
           ]
         }
@@ -5071,6 +6533,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/config"
+        }
       ]
     },
     {
@@ -5091,6 +6559,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/console-control-strings"
+        }
       ]
     },
     {
@@ -5110,6 +6584,12 @@
           "url": "https://registry.npmjs.org/constantinople/-/constantinople-4.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/constantinople"
         }
       ]
     },
@@ -5132,6 +6612,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/content-disposition"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5150,6 +6636,12 @@
               "url": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/content-disposition\\node_modules\\safe-buffer"
             }
           ]
         }
@@ -5173,6 +6665,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/content-type"
+        }
       ]
     },
     {
@@ -5192,6 +6690,12 @@
           "url": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cookie-parser"
         }
       ]
     },
@@ -5213,6 +6717,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cookie-signature"
+        }
       ]
     },
     {
@@ -5232,6 +6742,12 @@
           "url": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cookie"
         }
       ]
     },
@@ -5253,6 +6769,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/copy-descriptor"
+        }
       ]
     },
     {
@@ -5272,6 +6794,12 @@
           "url": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/core-util-is"
         }
       ]
     },
@@ -5293,6 +6821,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cors"
+        }
       ]
     },
     {
@@ -5312,6 +6846,12 @@
           "url": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/crc"
         }
       ]
     },
@@ -5333,6 +6873,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/crc32-stream"
+        }
       ]
     },
     {
@@ -5352,6 +6898,12 @@
           "url": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/create-require"
         }
       ]
     },
@@ -5373,6 +6925,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/crypto-js"
+        }
       ]
     },
     {
@@ -5392,6 +6950,12 @@
           "url": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dashdash"
         }
       ]
     },
@@ -5413,6 +6977,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/date-fns"
+        }
       ]
     },
     {
@@ -5432,6 +7002,12 @@
           "url": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dateformat"
         }
       ]
     },
@@ -5453,6 +7029,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/debug"
+        }
       ]
     },
     {
@@ -5472,6 +7054,12 @@
           "url": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decamelize"
         }
       ]
     },
@@ -5493,6 +7081,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decode-uri-component"
+        }
       ]
     },
     {
@@ -5512,6 +7106,12 @@
           "url": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-response"
         }
       ]
     },
@@ -5534,6 +7134,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-tar"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5552,6 +7158,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-tar\\node_modules\\file-type"
             }
           ]
         }
@@ -5576,6 +7188,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-tarbz2"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5594,6 +7212,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-6.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-tarbz2\\node_modules\\file-type"
             }
           ]
         }
@@ -5618,6 +7242,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-targz"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5636,6 +7266,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-targz\\node_modules\\file-type"
             }
           ]
         }
@@ -5660,6 +7296,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-unzip"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5678,6 +7320,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-unzip\\node_modules\\file-type"
             }
           ]
         },
@@ -5699,6 +7347,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-unzip\\node_modules\\get-stream"
+            }
           ]
         },
         {
@@ -5718,6 +7372,12 @@
               "url": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-unzip\\node_modules\\pify"
             }
           ]
         }
@@ -5742,6 +7402,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5762,6 +7428,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress\\node_modules\\make-dir"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -5780,6 +7452,12 @@
                   "url": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/decompress\\node_modules\\make-dir\\node_modules\\pify"
                 }
               ]
             }
@@ -5803,6 +7481,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress\\node_modules\\pify"
+            }
           ]
         }
       ]
@@ -5825,6 +7509,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/deep-equal"
+        }
       ]
     },
     {
@@ -5844,6 +7534,12 @@
           "url": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/deep-extend"
         }
       ]
     },
@@ -5865,6 +7561,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/deep-is"
+        }
       ]
     },
     {
@@ -5884,6 +7586,12 @@
           "url": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/define-properties"
         }
       ]
     },
@@ -5905,6 +7613,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/define-property"
+        }
       ]
     },
     {
@@ -5924,6 +7638,12 @@
           "url": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/delayed-stream"
         }
       ]
     },
@@ -5945,6 +7665,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/delegates"
+        }
       ]
     },
     {
@@ -5964,6 +7690,12 @@
           "url": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/depd"
         }
       ]
     },
@@ -5985,6 +7717,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/destroy"
+        }
       ]
     },
     {
@@ -6004,6 +7742,12 @@
           "url": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/detect-file"
         }
       ]
     },
@@ -6025,6 +7769,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/detect-libc"
+        }
       ]
     },
     {
@@ -6044,6 +7794,12 @@
           "url": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dfa"
         }
       ]
     },
@@ -6066,6 +7822,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dicer"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -6084,6 +7846,12 @@
               "url": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/dicer\\node_modules\\isarray"
             }
           ]
         },
@@ -6105,6 +7873,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/dicer\\node_modules\\readable-stream"
+            }
           ]
         },
         {
@@ -6124,6 +7898,12 @@
               "url": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/dicer\\node_modules\\string_decoder"
             }
           ]
         }
@@ -6147,6 +7927,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/diff"
+        }
       ]
     },
     {
@@ -6166,6 +7952,12 @@
           "url": "https://registry.npmjs.org/doctypes/-/doctypes-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/doctypes"
         }
       ]
     },
@@ -6187,6 +7979,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/domelementtype"
+        }
       ]
     },
     {
@@ -6206,6 +8004,12 @@
           "url": "https://registry.npmjs.org/domhandler/-/domhandler-2.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/domhandler"
         }
       ]
     },
@@ -6227,6 +8031,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/domutils"
+        }
       ]
     },
     {
@@ -6246,6 +8056,12 @@
           "url": "https://registry.npmjs.org/dottie/-/dottie-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dottie"
         }
       ]
     },
@@ -6267,6 +8083,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/double-ended-queue"
+        }
       ]
     },
     {
@@ -6286,6 +8108,12 @@
           "url": "https://registry.npmjs.org/doublearray/-/doublearray-0.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/doublearray"
         }
       ]
     },
@@ -6308,6 +8136,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/download"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -6326,6 +8160,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-11.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/download\\node_modules\\file-type"
             }
           ]
         }
@@ -6349,6 +8189,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/duplexer2"
+        }
       ]
     },
     {
@@ -6368,6 +8214,12 @@
           "url": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/duplexer3"
         }
       ]
     },
@@ -6389,6 +8241,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dynamic-dedupe"
+        }
       ]
     },
     {
@@ -6408,6 +8266,12 @@
           "url": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ecc-jsbn"
         }
       ]
     },
@@ -6429,6 +8293,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ee-first"
+        }
       ]
     },
     {
@@ -6448,6 +8318,12 @@
           "url": "https://registry.npmjs.org/eivindfjeldstad-dot/-/eivindfjeldstad-dot-0.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/eivindfjeldstad-dot"
         }
       ]
     },
@@ -6469,6 +8345,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/emoji-regex"
+        }
       ]
     },
     {
@@ -6489,6 +8371,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/enabled"
+        }
       ]
     },
     {
@@ -6508,6 +8396,12 @@
           "url": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/encodeurl"
         }
       ]
     },
@@ -6530,6 +8424,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/encoding"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -6548,6 +8448,12 @@
               "url": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/encoding\\node_modules\\iconv-lite"
             }
           ]
         }
@@ -6571,6 +8477,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/end-of-stream"
+        }
       ]
     },
     {
@@ -6590,6 +8502,12 @@
           "url": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-4.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/engine.io-parser"
         }
       ]
     },
@@ -6612,6 +8530,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/engine.io"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -6630,6 +8554,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/engine.io\\node_modules\\debug"
             }
           ]
         },
@@ -6650,6 +8580,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/engine.io\\node_modules\\ms"
             }
           ]
         }
@@ -6673,6 +8609,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/env-paths"
+        }
       ]
     },
     {
@@ -6692,6 +8634,12 @@
           "url": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/err-code"
         }
       ]
     },
@@ -6713,6 +8661,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/error-ex"
+        }
       ]
     },
     {
@@ -6732,6 +8686,12 @@
           "url": "https://registry.npmjs.org/errorhandler/-/errorhandler-1.5.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/errorhandler"
         }
       ]
     },
@@ -6753,6 +8713,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/es-abstract"
+        }
       ]
     },
     {
@@ -6772,6 +8738,12 @@
           "url": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/es-get-iterator"
         }
       ]
     },
@@ -6793,6 +8765,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/es-to-primitive"
+        }
       ]
     },
     {
@@ -6812,6 +8790,12 @@
           "url": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/escape-html"
         }
       ]
     },
@@ -6833,6 +8817,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/escape-string-regexp"
+        }
       ]
     },
     {
@@ -6852,6 +8842,12 @@
           "url": "https://registry.npmjs.org/escodegen/-/escodegen-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/escodegen"
         }
       ]
     },
@@ -6873,6 +8869,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/esprima"
+        }
       ]
     },
     {
@@ -6892,6 +8894,12 @@
           "url": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/estraverse"
         }
       ]
     },
@@ -6913,6 +8921,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/esutils"
+        }
       ]
     },
     {
@@ -6932,6 +8946,12 @@
           "url": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/etag"
         }
       ]
     },
@@ -6953,6 +8973,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/eventemitter2"
+        }
       ]
     },
     {
@@ -6972,6 +8998,12 @@
           "url": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/eventemitter3"
         }
       ]
     },
@@ -6993,6 +9025,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/exif"
+        }
       ]
     },
     {
@@ -7012,6 +9050,12 @@
           "url": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/exit"
         }
       ]
     },
@@ -7034,6 +9078,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/expand-brackets"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7052,6 +9102,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets\\node_modules\\define-property"
             }
           ]
         },
@@ -7072,6 +9128,12 @@
               "url": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets\\node_modules\\extend-shallow"
             }
           ]
         },
@@ -7094,6 +9156,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets\\node_modules\\is-accessor-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -7112,6 +9180,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/expand-brackets\\node_modules\\is-accessor-descriptor\\node_modules\\kind-of"
                 }
               ]
             }
@@ -7136,6 +9210,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets\\node_modules\\is-data-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -7154,6 +9234,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/expand-brackets\\node_modules\\is-data-descriptor\\node_modules\\kind-of"
                 }
               ]
             }
@@ -7177,6 +9263,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets\\node_modules\\is-descriptor"
+            }
           ]
         },
         {
@@ -7197,6 +9289,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets\\node_modules\\is-extendable"
+            }
           ]
         },
         {
@@ -7216,6 +9314,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets\\node_modules\\kind-of"
             }
           ]
         }
@@ -7239,6 +9343,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/expand-template"
+        }
       ]
     },
     {
@@ -7259,6 +9369,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/expand-tilde"
+        }
       ]
     },
     {
@@ -7278,6 +9394,12 @@
           "url": "https://registry.npmjs.org/express-ipfilter/-/express-ipfilter-1.3.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-ipfilter"
         }
       ]
     },
@@ -7300,6 +9422,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-jwt"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7318,6 +9446,12 @@
               "url": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-0.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/express-jwt\\node_modules\\jsonwebtoken"
             }
           ]
         },
@@ -7338,6 +9472,12 @@
               "url": "https://registry.npmjs.org/moment/-/moment-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/express-jwt\\node_modules\\moment"
             }
           ]
         }
@@ -7361,6 +9501,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-rate-limit"
+        }
       ]
     },
     {
@@ -7381,6 +9527,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-robots-txt"
+        }
       ]
     },
     {
@@ -7400,6 +9552,12 @@
           "url": "https://registry.npmjs.org/express-security.txt/-/express-security.txt-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-security.txt"
         }
       ]
     },
@@ -7422,6 +9580,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7440,6 +9604,12 @@
               "url": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/express\\node_modules\\cookie"
             }
           ]
         },
@@ -7460,6 +9630,12 @@
               "url": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/express\\node_modules\\safe-buffer"
             }
           ]
         }
@@ -7483,6 +9659,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ext-list"
+        }
       ]
     },
     {
@@ -7502,6 +9684,12 @@
           "url": "https://registry.npmjs.org/ext-name/-/ext-name-5.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ext-name"
         }
       ]
     },
@@ -7523,6 +9711,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/extend-shallow"
+        }
       ]
     },
     {
@@ -7542,6 +9736,12 @@
           "url": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/extend"
         }
       ]
     },
@@ -7564,6 +9764,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/extglob"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7582,6 +9788,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/extglob\\node_modules\\define-property"
             }
           ]
         },
@@ -7603,6 +9815,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/extglob\\node_modules\\extend-shallow"
+            }
           ]
         },
         {
@@ -7622,6 +9840,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/extglob\\node_modules\\is-extendable"
             }
           ]
         }
@@ -7645,6 +9869,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/extsprintf"
+        }
       ]
     },
     {
@@ -7664,6 +9894,12 @@
           "url": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fast-deep-equal"
         }
       ]
     },
@@ -7685,6 +9921,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fast-json-stable-stringify"
+        }
       ]
     },
     {
@@ -7704,6 +9946,12 @@
           "url": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fast-levenshtein"
         }
       ]
     },
@@ -7725,6 +9973,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fast.js"
+        }
       ]
     },
     {
@@ -7744,6 +9998,12 @@
           "url": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fd-slicer"
         }
       ]
     },
@@ -7765,6 +10025,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/feature-policy"
+        }
       ]
     },
     {
@@ -7784,6 +10050,12 @@
           "url": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fecha"
         }
       ]
     },
@@ -7806,6 +10078,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/file-js"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7824,6 +10102,12 @@
               "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/file-js\\node_modules\\brace-expansion"
             }
           ]
         },
@@ -7844,6 +10128,12 @@
               "url": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/file-js\\node_modules\\minimatch"
             }
           ]
         }
@@ -7867,6 +10157,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/file-stream-rotator"
+        }
       ]
     },
     {
@@ -7886,6 +10182,12 @@
           "url": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/file-type"
         }
       ]
     },
@@ -7907,6 +10209,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/file-uri-to-path"
+        }
       ]
     },
     {
@@ -7926,6 +10234,12 @@
           "url": "https://registry.npmjs.org/filehound/-/filehound-1.17.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/filehound"
         }
       ]
     },
@@ -7947,6 +10261,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/filename-reserved-regex"
+        }
       ]
     },
     {
@@ -7967,6 +10287,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/filenamify"
+        }
       ]
     },
     {
@@ -7986,6 +10312,12 @@
           "url": "https://registry.npmjs.org/filesniffer/-/filesniffer-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/filesniffer"
         }
       ]
     },
@@ -8008,6 +10340,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fill-range"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -8026,6 +10364,12 @@
               "url": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/fill-range\\node_modules\\extend-shallow"
             }
           ]
         },
@@ -8046,6 +10390,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/fill-range\\node_modules\\is-extendable"
             }
           ]
         }
@@ -8069,6 +10419,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/finale-rest"
+        }
       ]
     },
     {
@@ -8088,6 +10444,12 @@
           "url": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/finalhandler"
         }
       ]
     },
@@ -8109,6 +10471,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/find-up"
+        }
       ]
     },
     {
@@ -8128,6 +10496,12 @@
           "url": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/findup-sync"
         }
       ]
     },
@@ -8149,6 +10523,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fined"
+        }
       ]
     },
     {
@@ -8168,6 +10548,12 @@
           "url": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/flagged-respawn"
         }
       ]
     },
@@ -8189,6 +10575,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fn.name"
+        }
       ]
     },
     {
@@ -8208,6 +10600,12 @@
           "url": "https://registry.npmjs.org/fontkit/-/fontkit-1.9.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fontkit"
         }
       ]
     },
@@ -8229,6 +10627,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/for-each"
+        }
       ]
     },
     {
@@ -8248,6 +10652,12 @@
           "url": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/for-in"
         }
       ]
     },
@@ -8269,6 +10679,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/for-own"
+        }
       ]
     },
     {
@@ -8288,6 +10704,12 @@
           "url": "https://registry.npmjs.org/foreachasync/-/foreachasync-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/foreachasync"
         }
       ]
     },
@@ -8309,6 +10731,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/forever-agent"
+        }
       ]
     },
     {
@@ -8328,6 +10756,12 @@
           "url": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/form-data"
         }
       ]
     },
@@ -8349,6 +10783,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/formatio"
+        }
       ]
     },
     {
@@ -8368,6 +10808,12 @@
           "url": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/forwarded"
         }
       ]
     },
@@ -8389,6 +10835,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fragment-cache"
+        }
       ]
     },
     {
@@ -8408,6 +10860,12 @@
           "url": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fresh"
         }
       ]
     },
@@ -8429,6 +10887,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/from2"
+        }
       ]
     },
     {
@@ -8448,6 +10912,12 @@
           "url": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fs-constants"
         }
       ]
     },
@@ -8469,6 +10939,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fs-extra"
+        }
       ]
     },
     {
@@ -8489,6 +10965,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fs-minipass"
+        }
       ]
     },
     {
@@ -8508,6 +10990,12 @@
           "url": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fs.realpath"
         }
       ]
     },
@@ -8530,6 +11018,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fstream"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -8548,6 +11042,12 @@
               "url": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/fstream\\node_modules\\mkdirp"
             }
           ]
         },
@@ -8568,6 +11068,12 @@
               "url": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/fstream\\node_modules\\rimraf"
             }
           ]
         }
@@ -8591,6 +11097,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/function-bind"
+        }
       ]
     },
     {
@@ -8610,6 +11122,12 @@
           "url": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/function.prototype.name"
         }
       ]
     },
@@ -8631,6 +11149,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/functions-have-names"
+        }
       ]
     },
     {
@@ -8650,6 +11174,12 @@
           "url": "https://registry.npmjs.org/fuzzball/-/fuzzball-1.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fuzzball"
         }
       ]
     },
@@ -8671,6 +11201,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/gauge"
+        }
       ]
     },
     {
@@ -8690,6 +11226,12 @@
           "url": "https://registry.npmjs.org/geojson-utils/-/geojson-utils-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/geojson-utils"
         }
       ]
     },
@@ -8711,6 +11253,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-caller-file"
+        }
       ]
     },
     {
@@ -8730,6 +11278,12 @@
           "url": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-intrinsic"
         }
       ]
     },
@@ -8751,6 +11305,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-stream"
+        }
       ]
     },
     {
@@ -8770,6 +11330,12 @@
           "url": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-symbol-description"
         }
       ]
     },
@@ -8791,6 +11357,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-value"
+        }
       ]
     },
     {
@@ -8810,6 +11382,12 @@
           "url": "https://registry.npmjs.org/getobject/-/getobject-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/getobject"
         }
       ]
     },
@@ -8831,6 +11409,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/getpass"
+        }
       ]
     },
     {
@@ -8850,6 +11434,12 @@
           "url": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/github-from-package"
         }
       ]
     },
@@ -8872,6 +11462,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/glob-parent"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -8890,6 +11486,12 @@
               "url": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/glob-parent\\node_modules\\is-glob"
             }
           ]
         }
@@ -8914,6 +11516,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/glob"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -8932,6 +11540,12 @@
               "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/glob\\node_modules\\brace-expansion"
             }
           ]
         },
@@ -8952,6 +11566,12 @@
               "url": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/glob\\node_modules\\minimatch"
             }
           ]
         }
@@ -8975,6 +11595,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/global-modules"
+        }
       ]
     },
     {
@@ -8996,6 +11622,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/global-prefix"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9014,6 +11646,12 @@
               "url": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/global-prefix\\node_modules\\which"
             }
           ]
         }
@@ -9038,6 +11676,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/got"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9056,6 +11700,12 @@
               "url": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/got\\node_modules\\get-stream"
             }
           ]
         },
@@ -9076,6 +11726,12 @@
               "url": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/got\\node_modules\\pify"
             }
           ]
         }
@@ -9099,6 +11755,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/graceful-fs"
+        }
       ]
     },
     {
@@ -9120,6 +11782,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-cli"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9138,6 +11806,12 @@
               "url": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-cli\\node_modules\\nopt"
             }
           ]
         }
@@ -9162,6 +11836,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-contrib-compress"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9180,6 +11860,12 @@
               "url": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-contrib-compress\\node_modules\\ansi-styles"
             }
           ]
         },
@@ -9201,6 +11887,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-contrib-compress\\node_modules\\chalk"
+            }
           ]
         },
         {
@@ -9220,6 +11912,12 @@
               "url": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-contrib-compress\\node_modules\\supports-color"
             }
           ]
         }
@@ -9243,6 +11941,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-known-options"
+        }
       ]
     },
     {
@@ -9264,6 +11968,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-legacy-log-utils"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9282,6 +11992,12 @@
               "url": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils\\node_modules\\ansi-styles"
             }
           ]
         },
@@ -9303,6 +12019,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils\\node_modules\\chalk"
+            }
           ]
         },
         {
@@ -9322,6 +12044,12 @@
               "url": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils\\node_modules\\color-convert"
             }
           ]
         },
@@ -9343,6 +12071,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils\\node_modules\\color-name"
+            }
           ]
         },
         {
@@ -9363,6 +12097,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils\\node_modules\\has-flag"
+            }
           ]
         },
         {
@@ -9382,6 +12122,12 @@
               "url": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils\\node_modules\\supports-color"
             }
           ]
         }
@@ -9406,6 +12152,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-legacy-log"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9424,6 +12176,12 @@
               "url": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log\\node_modules\\colors"
             }
           ]
         }
@@ -9448,6 +12206,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-legacy-util"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9466,6 +12230,12 @@
               "url": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-util\\node_modules\\async"
             }
           ]
         }
@@ -9489,6 +12259,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-replace-json"
+        }
       ]
     },
     {
@@ -9510,6 +12286,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9528,6 +12310,12 @@
               "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt\\node_modules\\brace-expansion"
             }
           ]
         },
@@ -9550,6 +12338,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt\\node_modules\\findup-sync"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -9568,6 +12362,12 @@
                   "url": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/grunt\\node_modules\\findup-sync\\node_modules\\glob"
                 }
               ]
             }
@@ -9591,6 +12391,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt\\node_modules\\glob"
+            }
           ]
         },
         {
@@ -9610,6 +12416,12 @@
               "url": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.8.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt\\node_modules\\minimatch"
             }
           ]
         }
@@ -9634,6 +12446,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/handlebars"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9652,6 +12470,12 @@
               "url": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/handlebars\\node_modules\\wordwrap"
             }
           ]
         }
@@ -9675,6 +12499,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/har-schema"
+        }
       ]
     },
     {
@@ -9694,6 +12524,12 @@
           "url": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/har-validator"
         }
       ]
     },
@@ -9715,6 +12551,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-ansi"
+        }
       ]
     },
     {
@@ -9734,6 +12576,12 @@
           "url": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-bigints"
         }
       ]
     },
@@ -9755,6 +12603,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-flag"
+        }
       ]
     },
     {
@@ -9774,6 +12628,12 @@
           "url": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-property-descriptors"
         }
       ]
     },
@@ -9795,6 +12655,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-symbol-support-x"
+        }
       ]
     },
     {
@@ -9814,6 +12680,12 @@
           "url": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-symbols"
         }
       ]
     },
@@ -9835,6 +12707,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-to-string-tag-x"
+        }
       ]
     },
     {
@@ -9854,6 +12732,12 @@
           "url": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-tostringtag"
         }
       ]
     },
@@ -9875,6 +12759,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-unicode"
+        }
       ]
     },
     {
@@ -9894,6 +12784,12 @@
           "url": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-value"
         }
       ]
     },
@@ -9916,6 +12812,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-values"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9934,6 +12836,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/has-values\\node_modules\\kind-of"
             }
           ]
         }
@@ -9957,6 +12865,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has"
+        }
       ]
     },
     {
@@ -9976,6 +12890,12 @@
           "url": "https://registry.npmjs.org/hashids/-/hashids-2.2.10.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hashids"
         }
       ]
     },
@@ -9997,6 +12917,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hbs"
+        }
       ]
     },
     {
@@ -10016,6 +12942,12 @@
           "url": "https://registry.npmjs.org/he/-/he-0.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/he"
         }
       ]
     },
@@ -10037,6 +12969,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/heap"
+        }
       ]
     },
     {
@@ -10056,6 +12994,12 @@
           "url": "https://registry.npmjs.org/helmet/-/helmet-4.6.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/helmet"
         }
       ]
     },
@@ -10077,6 +13021,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hoister"
+        }
       ]
     },
     {
@@ -10096,6 +13046,12 @@
           "url": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/homedir-polyfill"
         }
       ]
     },
@@ -10117,6 +13073,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hooker"
+        }
       ]
     },
     {
@@ -10137,6 +13099,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hosted-git-info"
+        }
       ]
     },
     {
@@ -10156,6 +13124,12 @@
           "url": "https://registry.npmjs.org/html-entities/-/html-entities-1.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/html-entities"
         }
       ]
     },
@@ -10178,6 +13152,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/htmlparser2"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -10196,6 +13176,12 @@
               "url": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/htmlparser2\\node_modules\\isarray"
             }
           ]
         },
@@ -10217,6 +13203,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/htmlparser2\\node_modules\\readable-stream"
+            }
           ]
         },
         {
@@ -10236,6 +13228,12 @@
               "url": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/htmlparser2\\node_modules\\string_decoder"
             }
           ]
         }
@@ -10259,6 +13257,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/http-cache-semantics"
+        }
       ]
     },
     {
@@ -10278,6 +13282,12 @@
           "url": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/http-errors"
         }
       ]
     },
@@ -10300,6 +13310,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/http-proxy-agent"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -10318,6 +13334,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/http-proxy-agent\\node_modules\\debug"
             }
           ]
         },
@@ -10338,6 +13360,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/http-proxy-agent\\node_modules\\ms"
             }
           ]
         }
@@ -10361,6 +13389,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/http-signature"
+        }
       ]
     },
     {
@@ -10382,6 +13416,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/https-proxy-agent"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -10400,6 +13440,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/https-proxy-agent\\node_modules\\debug"
             }
           ]
         },
@@ -10420,6 +13466,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/https-proxy-agent\\node_modules\\ms"
             }
           ]
         }
@@ -10443,6 +13495,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/humanize-ms"
+        }
       ]
     },
     {
@@ -10462,6 +13520,12 @@
           "url": "https://registry.npmjs.org/i18n/-/i18n-0.11.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/i18n"
         }
       ]
     },
@@ -10483,6 +13547,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/iconv-lite"
+        }
       ]
     },
     {
@@ -10502,6 +13572,12 @@
           "url": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ieee754"
         }
       ]
     },
@@ -10524,6 +13600,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ignore-walk"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -10542,6 +13624,12 @@
               "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/ignore-walk\\node_modules\\brace-expansion"
             }
           ]
         },
@@ -10562,6 +13650,12 @@
               "url": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/ignore-walk\\node_modules\\minimatch"
             }
           ]
         }
@@ -10585,6 +13679,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/iltorb"
+        }
       ]
     },
     {
@@ -10604,6 +13704,12 @@
           "url": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/imurmurhash"
         }
       ]
     },
@@ -10625,6 +13731,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/indent-string"
+        }
       ]
     },
     {
@@ -10644,6 +13756,12 @@
           "url": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/infer-owner"
         }
       ]
     },
@@ -10665,6 +13783,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/inflection"
+        }
       ]
     },
     {
@@ -10684,6 +13808,12 @@
           "url": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/inflight"
         }
       ]
     },
@@ -10705,6 +13835,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/inherits"
+        }
       ]
     },
     {
@@ -10724,6 +13860,12 @@
           "url": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ini"
         }
       ]
     },
@@ -10745,6 +13887,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/internal-slot"
+        }
       ]
     },
     {
@@ -10764,6 +13912,12 @@
           "url": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/interpret"
         }
       ]
     },
@@ -10785,6 +13939,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/into-stream"
+        }
       ]
     },
     {
@@ -10804,6 +13964,12 @@
           "url": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/invariant"
         }
       ]
     },
@@ -10825,6 +13991,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ip"
+        }
       ]
     },
     {
@@ -10844,6 +14016,12 @@
           "url": "https://registry.npmjs.org/ip6/-/ip6-0.2.10.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ip6"
         }
       ]
     },
@@ -10865,6 +14043,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ipaddr.js"
+        }
       ]
     },
     {
@@ -10884,6 +14068,12 @@
           "url": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-absolute"
         }
       ]
     },
@@ -10905,6 +14095,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-accessor-descriptor"
+        }
       ]
     },
     {
@@ -10924,6 +14120,12 @@
           "url": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-arguments"
         }
       ]
     },
@@ -10945,6 +14147,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-arrayish"
+        }
       ]
     },
     {
@@ -10964,6 +14172,12 @@
           "url": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-bigint"
         }
       ]
     },
@@ -10985,6 +14199,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-binary-path"
+        }
       ]
     },
     {
@@ -11004,6 +14224,12 @@
           "url": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-boolean-object"
         }
       ]
     },
@@ -11025,6 +14251,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-buffer"
+        }
       ]
     },
     {
@@ -11044,6 +14276,12 @@
           "url": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-callable"
         }
       ]
     },
@@ -11065,6 +14303,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-core-module"
+        }
       ]
     },
     {
@@ -11084,6 +14328,12 @@
           "url": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-data-descriptor"
         }
       ]
     },
@@ -11105,6 +14355,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-date-object"
+        }
       ]
     },
     {
@@ -11124,6 +14380,12 @@
           "url": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-descriptor"
         }
       ]
     },
@@ -11145,6 +14407,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-docker"
+        }
       ]
     },
     {
@@ -11164,6 +14432,12 @@
           "url": "https://registry.npmjs.org/is-expression/-/is-expression-4.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-expression"
         }
       ]
     },
@@ -11185,6 +14459,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-extendable"
+        }
       ]
     },
     {
@@ -11204,6 +14484,12 @@
           "url": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-extglob"
         }
       ]
     },
@@ -11225,6 +14511,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-fullwidth-code-point"
+        }
       ]
     },
     {
@@ -11244,6 +14536,12 @@
           "url": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-generator-function"
         }
       ]
     },
@@ -11265,6 +14563,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-glob"
+        }
       ]
     },
     {
@@ -11284,6 +14588,12 @@
           "url": "https://registry.npmjs.org/is-heroku/-/is-heroku-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-heroku"
         }
       ]
     },
@@ -11305,6 +14615,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-lambda"
+        }
       ]
     },
     {
@@ -11324,6 +14640,12 @@
           "url": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-map"
         }
       ]
     },
@@ -11345,6 +14667,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-natural-number"
+        }
       ]
     },
     {
@@ -11364,6 +14692,12 @@
           "url": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-negative-zero"
         }
       ]
     },
@@ -11385,6 +14719,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-number-like"
+        }
       ]
     },
     {
@@ -11404,6 +14744,12 @@
           "url": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-number-object"
         }
       ]
     },
@@ -11426,6 +14772,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-number"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -11444,6 +14796,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/is-number\\node_modules\\kind-of"
             }
           ]
         }
@@ -11467,6 +14825,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-object"
+        }
       ]
     },
     {
@@ -11486,6 +14850,12 @@
           "url": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-plain-obj"
         }
       ]
     },
@@ -11507,6 +14877,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-plain-object"
+        }
       ]
     },
     {
@@ -11526,6 +14902,12 @@
           "url": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-promise"
         }
       ]
     },
@@ -11547,6 +14929,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-regex"
+        }
       ]
     },
     {
@@ -11566,6 +14954,12 @@
           "url": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-relative"
         }
       ]
     },
@@ -11587,6 +14981,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-retry-allowed"
+        }
       ]
     },
     {
@@ -11606,6 +15006,12 @@
           "url": "https://registry.npmjs.org/is-set/-/is-set-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-set"
         }
       ]
     },
@@ -11627,6 +15033,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-shared-array-buffer"
+        }
       ]
     },
     {
@@ -11646,6 +15058,12 @@
           "url": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-stream"
         }
       ]
     },
@@ -11667,6 +15085,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-string"
+        }
       ]
     },
     {
@@ -11686,6 +15110,12 @@
           "url": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-symbol"
         }
       ]
     },
@@ -11707,6 +15137,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-typed-array"
+        }
       ]
     },
     {
@@ -11726,6 +15162,12 @@
           "url": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-typedarray"
         }
       ]
     },
@@ -11747,6 +15189,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-unc-path"
+        }
       ]
     },
     {
@@ -11766,6 +15214,12 @@
           "url": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-weakmap"
         }
       ]
     },
@@ -11787,6 +15241,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-weakref"
+        }
       ]
     },
     {
@@ -11806,6 +15266,12 @@
           "url": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-weakset"
         }
       ]
     },
@@ -11827,6 +15293,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-windows"
+        }
       ]
     },
     {
@@ -11846,6 +15318,12 @@
           "url": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isarray"
         }
       ]
     },
@@ -11867,6 +15345,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isexe"
+        }
       ]
     },
     {
@@ -11886,6 +15370,12 @@
           "url": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isobject"
         }
       ]
     },
@@ -11907,6 +15397,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isstream"
+        }
       ]
     },
     {
@@ -11926,6 +15422,12 @@
           "url": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isurl"
         }
       ]
     },
@@ -11947,6 +15449,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/js-stringify"
+        }
       ]
     },
     {
@@ -11966,6 +15474,12 @@
           "url": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/js-tokens"
         }
       ]
     },
@@ -11987,6 +15501,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/js-yaml"
+        }
       ]
     },
     {
@@ -12006,6 +15526,12 @@
           "url": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jsbn"
         }
       ]
     },
@@ -12027,6 +15553,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-buffer"
+        }
       ]
     },
     {
@@ -12046,6 +15578,12 @@
           "url": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-parse-better-errors"
         }
       ]
     },
@@ -12067,6 +15605,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-schema-traverse"
+        }
       ]
     },
     {
@@ -12086,6 +15630,12 @@
           "url": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-schema"
         }
       ]
     },
@@ -12107,6 +15657,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-stringify-safe"
+        }
       ]
     },
     {
@@ -12126,6 +15682,12 @@
           "url": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json5"
         }
       ]
     },
@@ -12147,6 +15709,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jsonfile"
+        }
       ]
     },
     {
@@ -12166,6 +15734,12 @@
           "url": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-0.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jsonwebtoken"
         }
       ]
     },
@@ -12187,6 +15761,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jsprim"
+        }
       ]
     },
     {
@@ -12206,6 +15786,12 @@
           "url": "https://registry.npmjs.org/jssha/-/jssha-3.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jssha"
         }
       ]
     },
@@ -12227,6 +15813,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jstransformer"
+        }
       ]
     },
     {
@@ -12246,6 +15838,12 @@
           "url": "https://registry.npmjs.org/juicy-chat-bot/-/juicy-chat-bot-0.6.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/juicy-chat-bot"
         }
       ]
     },
@@ -12267,6 +15865,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jwa"
+        }
       ]
     },
     {
@@ -12286,6 +15890,12 @@
           "url": "https://registry.npmjs.org/jws/-/jws-0.2.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jws"
         }
       ]
     },
@@ -12307,6 +15917,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/keyv"
+        }
       ]
     },
     {
@@ -12326,6 +15942,12 @@
           "url": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/kind-of"
         }
       ]
     },
@@ -12347,6 +15969,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/kuler"
+        }
       ]
     },
     {
@@ -12366,6 +15994,12 @@
           "url": "https://registry.npmjs.org/kuromoji/-/kuromoji-0.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/kuromoji"
         }
       ]
     },
@@ -12387,6 +16021,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lazystream"
+        }
       ]
     },
     {
@@ -12406,6 +16046,12 @@
           "url": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/levn"
         }
       ]
     },
@@ -12428,6 +16074,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/libxmljs2"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12446,6 +16098,12 @@
               "url": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/libxmljs2\\node_modules\\nan"
             }
           ]
         }
@@ -12470,6 +16128,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/liftup"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12488,6 +16152,12 @@
               "url": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup\\node_modules\\braces"
             }
           ]
         },
@@ -12509,6 +16179,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup\\node_modules\\fill-range"
+            }
           ]
         },
         {
@@ -12528,6 +16204,12 @@
               "url": "https://registry.npmjs.org/findup-sync/-/findup-sync-4.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup\\node_modules\\findup-sync"
             }
           ]
         },
@@ -12549,6 +16231,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup\\node_modules\\is-glob"
+            }
           ]
         },
         {
@@ -12568,6 +16256,12 @@
               "url": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup\\node_modules\\is-number"
             }
           ]
         },
@@ -12589,6 +16283,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup\\node_modules\\micromatch"
+            }
           ]
         },
         {
@@ -12608,6 +16308,12 @@
               "url": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup\\node_modules\\to-regex-range"
             }
           ]
         }
@@ -12632,6 +16338,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/linebreak"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12650,6 +16362,12 @@
               "url": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/linebreak\\node_modules\\base64-js"
             }
           ]
         }
@@ -12673,6 +16391,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/listenercount"
+        }
       ]
     },
     {
@@ -12692,6 +16416,12 @@
           "url": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/locate-path"
         }
       ]
     },
@@ -12713,6 +16443,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lodash.camelcase"
+        }
       ]
     },
     {
@@ -12732,6 +16468,12 @@
           "url": "https://registry.npmjs.org/lodash.isfinite/-/lodash.isfinite-3.3.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lodash.isfinite"
         }
       ]
     },
@@ -12753,6 +16495,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lodash.set"
+        }
       ]
     },
     {
@@ -12772,6 +16520,12 @@
           "url": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lodash"
         }
       ]
     },
@@ -12794,6 +16548,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/logform"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12812,6 +16572,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/logform\\node_modules\\ms"
             }
           ]
         }
@@ -12835,6 +16601,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lolex"
+        }
       ]
     },
     {
@@ -12854,6 +16626,12 @@
           "url": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/loose-envify"
         }
       ]
     },
@@ -12875,6 +16653,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lowercase-keys"
+        }
       ]
     },
     {
@@ -12894,6 +16678,12 @@
           "url": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lru-cache"
         }
       ]
     },
@@ -12916,6 +16706,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-dir"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12934,6 +16730,12 @@
               "url": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-dir\\node_modules\\semver"
             }
           ]
         }
@@ -12957,6 +16759,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-error"
+        }
       ]
     },
     {
@@ -12976,6 +16784,12 @@
           "url": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-9.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-fetch-happen"
         }
       ],
       "components": [
@@ -12998,6 +16812,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen\\node_modules\\@tootallnate\\once"
+            }
           ]
         },
         {
@@ -13017,6 +16837,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen\\node_modules\\debug"
             }
           ]
         },
@@ -13038,6 +16864,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen\\node_modules\\http-cache-semantics"
+            }
           ]
         },
         {
@@ -13058,6 +16890,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen\\node_modules\\http-proxy-agent"
+            }
           ]
         },
         {
@@ -13077,6 +16915,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen\\node_modules\\ms"
             }
           ]
         }
@@ -13100,6 +16944,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-iterator"
+        }
       ]
     },
     {
@@ -13119,6 +16969,12 @@
           "url": "https://registry.npmjs.org/make-plural/-/make-plural-6.2.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-plural"
         }
       ]
     },
@@ -13140,6 +16996,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/map-cache"
+        }
       ]
     },
     {
@@ -13159,6 +17021,12 @@
           "url": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/map-visit"
         }
       ]
     },
@@ -13180,6 +17048,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/marsdb"
+        }
       ]
     },
     {
@@ -13199,6 +17073,12 @@
           "url": "https://registry.npmjs.org/math-interval-parser/-/math-interval-parser-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/math-interval-parser"
         }
       ]
     },
@@ -13220,6 +17100,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/media-typer"
+        }
       ]
     },
     {
@@ -13239,6 +17125,12 @@
           "url": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/merge-descriptors"
         }
       ]
     },
@@ -13260,6 +17152,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/messageformat-formatters"
+        }
       ]
     },
     {
@@ -13279,6 +17177,12 @@
           "url": "https://registry.npmjs.org/messageformat-parser/-/messageformat-parser-4.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/messageformat-parser"
         }
       ]
     },
@@ -13301,6 +17205,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/messageformat"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -13319,6 +17229,12 @@
               "url": "https://registry.npmjs.org/make-plural/-/make-plural-4.3.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/messageformat\\node_modules\\make-plural"
             }
           ]
         }
@@ -13342,6 +17258,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/methods"
+        }
       ]
     },
     {
@@ -13361,6 +17283,12 @@
           "url": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/micromatch"
         }
       ]
     },
@@ -13382,6 +17310,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mime-db"
+        }
       ]
     },
     {
@@ -13401,6 +17335,12 @@
           "url": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mime-types"
         }
       ]
     },
@@ -13422,6 +17362,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mime"
+        }
       ]
     },
     {
@@ -13441,6 +17387,12 @@
           "url": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mimic-response"
         }
       ]
     },
@@ -13462,6 +17414,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minimatch"
+        }
       ]
     },
     {
@@ -13481,6 +17439,12 @@
           "url": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minimist"
         }
       ]
     },
@@ -13502,6 +17466,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-collect"
+        }
       ]
     },
     {
@@ -13521,6 +17491,12 @@
           "url": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-1.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-fetch"
         }
       ]
     },
@@ -13542,6 +17518,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-flush"
+        }
       ]
     },
     {
@@ -13561,6 +17543,12 @@
           "url": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-pipeline"
         }
       ]
     },
@@ -13582,6 +17570,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-sized"
+        }
       ]
     },
     {
@@ -13601,6 +17595,12 @@
           "url": "https://registry.npmjs.org/minipass/-/minipass-3.3.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass"
         }
       ]
     },
@@ -13622,6 +17622,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minizlib"
+        }
       ]
     },
     {
@@ -13641,6 +17647,12 @@
           "url": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mixin-deep"
         }
       ]
     },
@@ -13662,6 +17674,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mkdirp-classic"
+        }
       ]
     },
     {
@@ -13681,6 +17699,12 @@
           "url": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mkdirp"
         }
       ]
     },
@@ -13702,6 +17726,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/moment-timezone"
+        }
       ]
     },
     {
@@ -13721,6 +17751,12 @@
           "url": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/moment"
         }
       ]
     },
@@ -13743,6 +17779,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/morgan"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -13761,6 +17803,12 @@
               "url": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/morgan\\node_modules\\on-finished"
             }
           ]
         }
@@ -13784,6 +17832,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mout"
+        }
       ]
     },
     {
@@ -13803,6 +17857,12 @@
           "url": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ms"
         }
       ]
     },
@@ -13825,6 +17885,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/multer"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -13843,6 +17909,12 @@
               "url": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/multer\\node_modules\\mkdirp"
             }
           ]
         }
@@ -13866,6 +17938,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mustache"
+        }
       ]
     },
     {
@@ -13885,6 +17963,12 @@
           "url": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/nan"
         }
       ]
     },
@@ -13906,6 +17990,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/nanomatch"
+        }
       ]
     },
     {
@@ -13925,6 +18015,12 @@
           "url": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/napi-build-utils"
         }
       ]
     },
@@ -13947,6 +18043,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/needle"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -13965,6 +18067,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/needle\\node_modules\\debug"
             }
           ]
         },
@@ -13985,6 +18093,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/needle\\node_modules\\ms"
             }
           ]
         }
@@ -14008,6 +18122,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/negotiator"
+        }
       ]
     },
     {
@@ -14027,6 +18147,12 @@
           "url": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/neo-async"
         }
       ]
     },
@@ -14049,6 +18175,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-abi"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14067,6 +18199,12 @@
               "url": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-abi\\node_modules\\semver"
             }
           ]
         }
@@ -14090,6 +18228,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-addon-api"
+        }
       ]
     },
     {
@@ -14109,6 +18253,12 @@
           "url": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-fetch"
         }
       ]
     },
@@ -14131,6 +18281,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-gyp"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14149,6 +18305,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp\\node_modules\\ansi-regex"
             }
           ]
         },
@@ -14170,6 +18332,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp\\node_modules\\are-we-there-yet"
+            }
           ]
         },
         {
@@ -14189,6 +18357,12 @@
               "url": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp\\node_modules\\gauge"
             }
           ]
         },
@@ -14210,6 +18384,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp\\node_modules\\is-fullwidth-code-point"
+            }
           ]
         },
         {
@@ -14229,6 +18409,12 @@
               "url": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp\\node_modules\\nopt"
             }
           ]
         },
@@ -14250,6 +18436,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp\\node_modules\\npmlog"
+            }
           ]
         },
         {
@@ -14269,6 +18461,12 @@
               "url": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp\\node_modules\\readable-stream"
             }
           ]
         },
@@ -14290,6 +18488,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp\\node_modules\\string-width"
+            }
           ]
         },
         {
@@ -14309,6 +18513,12 @@
               "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp\\node_modules\\strip-ansi"
             }
           ]
         }
@@ -14333,6 +18543,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-pre-gyp"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14351,6 +18567,12 @@
               "url": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp\\node_modules\\chownr"
             }
           ]
         },
@@ -14372,6 +18594,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp\\node_modules\\fs-minipass"
+            }
           ]
         },
         {
@@ -14391,6 +18619,12 @@
               "url": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp\\node_modules\\minipass"
             }
           ]
         },
@@ -14412,6 +18646,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp\\node_modules\\minizlib"
+            }
           ]
         },
         {
@@ -14431,6 +18671,12 @@
               "url": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp\\node_modules\\mkdirp"
             }
           ]
         },
@@ -14452,6 +18698,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp\\node_modules\\nopt"
+            }
           ]
         },
         {
@@ -14471,6 +18723,12 @@
               "url": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp\\node_modules\\rimraf"
             }
           ]
         },
@@ -14492,6 +18750,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp\\node_modules\\safe-buffer"
+            }
           ]
         },
         {
@@ -14511,6 +18775,12 @@
               "url": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp\\node_modules\\semver"
             }
           ]
         },
@@ -14532,6 +18802,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp\\node_modules\\tar"
+            }
           ]
         },
         {
@@ -14551,6 +18827,12 @@
               "url": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp\\node_modules\\yallist"
             }
           ]
         }
@@ -14574,6 +18856,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/noop-logger"
+        }
       ]
     },
     {
@@ -14593,6 +18881,12 @@
           "url": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/nopt"
         }
       ]
     },
@@ -14615,6 +18909,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/normalize-package-data"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14633,6 +18933,12 @@
               "url": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/normalize-package-data\\node_modules\\semver"
             }
           ]
         }
@@ -14656,6 +18962,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/normalize-path"
+        }
       ]
     },
     {
@@ -14675,6 +18987,12 @@
           "url": "https://registry.npmjs.org/normalize-url/-/normalize-url-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/normalize-url"
         }
       ]
     },
@@ -14697,6 +19015,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/notevil"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14715,6 +19039,12 @@
               "url": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/notevil\\node_modules\\esprima"
             }
           ]
         }
@@ -14738,6 +19068,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/npm-bundled"
+        }
       ]
     },
     {
@@ -14757,6 +19093,12 @@
           "url": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/npm-normalize-package-bin"
         }
       ]
     },
@@ -14778,6 +19120,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/npm-packlist"
+        }
       ]
     },
     {
@@ -14797,6 +19145,12 @@
           "url": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/npmlog"
         }
       ]
     },
@@ -14818,6 +19172,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/number-is-nan"
+        }
       ]
     },
     {
@@ -14838,6 +19198,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/oauth-sign"
+        }
       ]
     },
     {
@@ -14857,6 +19223,12 @@
           "url": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-assign"
         }
       ]
     },
@@ -14879,6 +19251,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-copy"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14897,6 +19275,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy\\node_modules\\define-property"
             }
           ]
         },
@@ -14918,6 +19302,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy\\node_modules\\is-accessor-descriptor"
+            }
           ]
         },
         {
@@ -14937,6 +19327,12 @@
               "url": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy\\node_modules\\is-data-descriptor"
             }
           ]
         },
@@ -14959,6 +19355,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy\\node_modules\\is-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -14977,6 +19379,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/object-copy\\node_modules\\is-descriptor\\node_modules\\kind-of"
                 }
               ]
             }
@@ -15000,6 +19408,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy\\node_modules\\kind-of"
+            }
           ]
         }
       ]
@@ -15022,6 +19436,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-inspect"
+        }
       ]
     },
     {
@@ -15041,6 +19461,12 @@
           "url": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-is"
         }
       ]
     },
@@ -15062,6 +19488,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-keys"
+        }
       ]
     },
     {
@@ -15081,6 +19513,12 @@
           "url": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-visit"
         }
       ]
     },
@@ -15102,6 +19540,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object.assign"
+        }
       ]
     },
     {
@@ -15121,6 +19565,12 @@
           "url": "https://registry.npmjs.org/object.defaults/-/object.defaults-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object.defaults"
         }
       ]
     },
@@ -15142,6 +19592,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object.map"
+        }
       ]
     },
     {
@@ -15161,6 +19617,12 @@
           "url": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object.pick"
         }
       ]
     },
@@ -15182,6 +19644,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/on-finished"
+        }
       ]
     },
     {
@@ -15201,6 +19669,12 @@
           "url": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/on-headers"
         }
       ]
     },
@@ -15222,6 +19696,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/once"
+        }
       ]
     },
     {
@@ -15241,6 +19721,12 @@
           "url": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/one-time"
         }
       ]
     },
@@ -15262,6 +19748,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/opentype.js"
+        }
       ]
     },
     {
@@ -15281,6 +19773,12 @@
           "url": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/optionator"
         }
       ]
     },
@@ -15302,6 +19800,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/os-homedir"
+        }
       ]
     },
     {
@@ -15321,6 +19825,12 @@
           "url": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/os-tmpdir"
         }
       ]
     },
@@ -15342,6 +19852,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/osenv"
+        }
       ]
     },
     {
@@ -15361,6 +19877,12 @@
           "url": "https://registry.npmjs.org/otplib/-/otplib-12.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/otplib"
         }
       ]
     },
@@ -15382,6 +19904,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-cancelable"
+        }
       ]
     },
     {
@@ -15401,6 +19929,12 @@
           "url": "https://registry.npmjs.org/p-event/-/p-event-2.3.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-event"
         }
       ]
     },
@@ -15422,6 +19956,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-finally"
+        }
       ]
     },
     {
@@ -15441,6 +19981,12 @@
           "url": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-is-promise"
         }
       ]
     },
@@ -15462,6 +20008,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-limit"
+        }
       ]
     },
     {
@@ -15481,6 +20033,12 @@
           "url": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-locate"
         }
       ]
     },
@@ -15502,6 +20060,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-map"
+        }
       ]
     },
     {
@@ -15521,6 +20085,12 @@
           "url": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-timeout"
         }
       ]
     },
@@ -15542,6 +20112,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-try"
+        }
       ]
     },
     {
@@ -15561,6 +20137,12 @@
           "url": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pako"
         }
       ]
     },
@@ -15582,6 +20164,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/parse-filepath"
+        }
       ]
     },
     {
@@ -15601,6 +20189,12 @@
           "url": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/parse-json"
         }
       ]
     },
@@ -15622,6 +20216,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/parse-passwd"
+        }
       ]
     },
     {
@@ -15641,6 +20241,12 @@
           "url": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/parseurl"
         }
       ]
     },
@@ -15662,6 +20268,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pascalcase"
+        }
       ]
     },
     {
@@ -15681,6 +20293,12 @@
           "url": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-exists"
         }
       ]
     },
@@ -15702,6 +20320,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-is-absolute"
+        }
       ]
     },
     {
@@ -15721,6 +20345,12 @@
           "url": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-parse"
         }
       ]
     },
@@ -15742,6 +20372,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-root-regex"
+        }
       ]
     },
     {
@@ -15761,6 +20397,12 @@
           "url": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-root"
         }
       ]
     },
@@ -15782,6 +20424,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-to-regexp"
+        }
       ]
     },
     {
@@ -15801,6 +20449,12 @@
           "url": "https://registry.npmjs.org/pdfkit/-/pdfkit-0.11.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pdfkit"
         }
       ]
     },
@@ -15822,6 +20476,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/peek-readable"
+        }
       ]
     },
     {
@@ -15841,6 +20501,12 @@
           "url": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pend"
         }
       ]
     },
@@ -15862,6 +20528,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/performance-now"
+        }
       ]
     },
     {
@@ -15881,6 +20553,12 @@
           "url": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.5.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pg-connection-string"
         }
       ]
     },
@@ -15902,6 +20580,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/picomatch"
+        }
       ]
     },
     {
@@ -15921,6 +20605,12 @@
           "url": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pify"
         }
       ]
     },
@@ -15942,6 +20632,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pinkie-promise"
+        }
       ]
     },
     {
@@ -15961,6 +20657,12 @@
           "url": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pinkie"
         }
       ]
     },
@@ -15982,6 +20684,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/png-js"
+        }
       ]
     },
     {
@@ -16001,6 +20709,12 @@
           "url": "https://registry.npmjs.org/portscanner/-/portscanner-2.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/portscanner"
         }
       ]
     },
@@ -16022,6 +20736,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/posix-character-classes"
+        }
       ]
     },
     {
@@ -16041,6 +20761,12 @@
           "url": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.3.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/prebuild-install"
         }
       ]
     },
@@ -16062,6 +20788,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/prelude-ls"
+        }
       ]
     },
     {
@@ -16081,6 +20813,12 @@
           "url": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/prepend-http"
         }
       ]
     },
@@ -16102,6 +20840,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pretty-bytes"
+        }
       ]
     },
     {
@@ -16121,6 +20865,12 @@
           "url": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/process-nextick-args"
         }
       ]
     },
@@ -16142,6 +20892,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/prom-client"
+        }
       ]
     },
     {
@@ -16161,6 +20917,12 @@
           "url": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/promise-inflight"
         }
       ]
     },
@@ -16183,6 +20945,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/promise-retry"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -16201,6 +20969,12 @@
               "url": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/promise-retry\\node_modules\\err-code"
             }
           ]
         },
@@ -16221,6 +20995,12 @@
               "url": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/promise-retry\\node_modules\\retry"
             }
           ]
         }
@@ -16244,6 +21024,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/promise"
+        }
       ]
     },
     {
@@ -16263,6 +21049,12 @@
           "url": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/proper-lockfile"
         }
       ]
     },
@@ -16284,6 +21076,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/proxy-addr"
+        }
       ]
     },
     {
@@ -16303,6 +21101,12 @@
           "url": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/psl"
         }
       ]
     },
@@ -16324,6 +21128,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-attrs"
+        }
       ]
     },
     {
@@ -16343,6 +21153,12 @@
           "url": "https://registry.npmjs.org/pug-code-gen/-/pug-code-gen-3.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-code-gen"
         }
       ]
     },
@@ -16364,6 +21180,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-error"
+        }
       ]
     },
     {
@@ -16383,6 +21205,12 @@
           "url": "https://registry.npmjs.org/pug-filters/-/pug-filters-4.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-filters"
         }
       ]
     },
@@ -16404,6 +21232,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-lexer"
+        }
       ]
     },
     {
@@ -16423,6 +21257,12 @@
           "url": "https://registry.npmjs.org/pug-linker/-/pug-linker-4.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-linker"
         }
       ]
     },
@@ -16444,6 +21284,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-load"
+        }
       ]
     },
     {
@@ -16463,6 +21309,12 @@
           "url": "https://registry.npmjs.org/pug-parser/-/pug-parser-6.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-parser"
         }
       ]
     },
@@ -16484,6 +21336,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-runtime"
+        }
       ]
     },
     {
@@ -16503,6 +21361,12 @@
           "url": "https://registry.npmjs.org/pug-strip-comments/-/pug-strip-comments-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-strip-comments"
         }
       ]
     },
@@ -16524,6 +21388,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-walk"
+        }
       ]
     },
     {
@@ -16543,6 +21413,12 @@
           "url": "https://registry.npmjs.org/pug/-/pug-3.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug"
         }
       ]
     },
@@ -16564,6 +21440,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pump"
+        }
       ]
     },
     {
@@ -16583,6 +21465,12 @@
           "url": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/punycode"
         }
       ]
     },
@@ -16604,6 +21492,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/qs"
+        }
       ]
     },
     {
@@ -16623,6 +21517,12 @@
           "url": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/query-string"
         }
       ]
     },
@@ -16644,6 +21544,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/range_check"
+        }
       ]
     },
     {
@@ -16663,6 +21569,12 @@
           "url": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/range-parser"
         }
       ]
     },
@@ -16684,6 +21596,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/raw-body"
+        }
       ]
     },
     {
@@ -16703,6 +21621,12 @@
           "url": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/rc"
         }
       ]
     },
@@ -16725,6 +21649,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/read-pkg"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -16743,6 +21673,12 @@
               "url": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/read-pkg\\node_modules\\pify"
             }
           ]
         }
@@ -16767,6 +21703,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/readable-stream"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -16785,6 +21727,12 @@
               "url": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/readable-stream\\node_modules\\isarray"
             }
           ]
         }
@@ -16809,6 +21757,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/readable-web-to-node-stream"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -16827,6 +21781,12 @@
               "url": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/readable-web-to-node-stream\\node_modules\\readable-stream"
             }
           ]
         }
@@ -16850,6 +21810,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/readdirp"
+        }
       ]
     },
     {
@@ -16869,6 +21835,12 @@
           "url": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/rechoir"
         }
       ]
     },
@@ -16890,6 +21862,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/regex-not"
+        }
       ]
     },
     {
@@ -16909,6 +21887,12 @@
           "url": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/regexp.prototype.flags"
         }
       ]
     },
@@ -16930,6 +21914,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/remove-trailing-separator"
+        }
       ]
     },
     {
@@ -16950,6 +21940,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/repeat-element"
+        }
       ]
     },
     {
@@ -16969,6 +21965,12 @@
           "url": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/repeat-string"
         }
       ]
     },
@@ -16991,6 +21993,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/replace"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17009,6 +22017,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\ansi-regex"
             }
           ]
         },
@@ -17030,6 +22044,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\ansi-styles"
+            }
           ]
         },
         {
@@ -17049,6 +22069,12 @@
               "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\brace-expansion"
             }
           ]
         },
@@ -17070,6 +22096,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\cliui"
+            }
           ]
         },
         {
@@ -17089,6 +22121,12 @@
               "url": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\color-convert"
             }
           ]
         },
@@ -17110,6 +22148,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\color-name"
+            }
           ]
         },
         {
@@ -17129,6 +22173,12 @@
               "url": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\find-up"
             }
           ]
         },
@@ -17150,6 +22200,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\is-fullwidth-code-point"
+            }
           ]
         },
         {
@@ -17169,6 +22225,12 @@
               "url": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\locate-path"
             }
           ]
         },
@@ -17190,6 +22252,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\minimatch"
+            }
           ]
         },
         {
@@ -17209,6 +22277,12 @@
               "url": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\p-locate"
             }
           ]
         },
@@ -17230,6 +22304,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\path-exists"
+            }
           ]
         },
         {
@@ -17249,6 +22329,12 @@
               "url": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\string-width"
             }
           ]
         },
@@ -17270,6 +22356,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\strip-ansi"
+            }
           ]
         },
         {
@@ -17289,6 +22381,12 @@
               "url": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\wrap-ansi"
             }
           ]
         },
@@ -17310,6 +22408,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\yargs-parser"
+            }
           ]
         },
         {
@@ -17329,6 +22433,12 @@
               "url": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\yargs"
             }
           ]
         }
@@ -17353,6 +22463,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/request"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17371,6 +22487,12 @@
               "url": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/request\\node_modules\\qs"
             }
           ]
         }
@@ -17394,6 +22516,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/require-directory"
+        }
       ]
     },
     {
@@ -17413,6 +22541,12 @@
           "url": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/require-main-filename"
         }
       ]
     },
@@ -17434,6 +22568,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/resolve-dir"
+        }
       ]
     },
     {
@@ -17453,6 +22593,12 @@
           "url": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/resolve-url"
         }
       ]
     },
@@ -17474,6 +22620,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/resolve"
+        }
       ]
     },
     {
@@ -17493,6 +22645,12 @@
           "url": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/responselike"
         }
       ]
     },
@@ -17514,6 +22672,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/restructure"
+        }
       ]
     },
     {
@@ -17533,6 +22697,12 @@
           "url": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ret"
         }
       ]
     },
@@ -17554,6 +22724,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/retry-as-promised"
+        }
       ]
     },
     {
@@ -17574,6 +22750,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/retry"
+        }
       ]
     },
     {
@@ -17593,6 +22775,12 @@
           "url": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/rimraf"
         }
       ]
     },
@@ -17615,6 +22803,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/rxjs"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17633,6 +22827,12 @@
               "url": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/rxjs\\node_modules\\tslib"
             }
           ]
         }
@@ -17656,6 +22856,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safe-buffer"
+        }
       ]
     },
     {
@@ -17675,6 +22881,12 @@
           "url": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safe-regex-test"
         }
       ]
     },
@@ -17696,6 +22908,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safe-regex"
+        }
       ]
     },
     {
@@ -17715,6 +22933,12 @@
           "url": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safe-stable-stringify"
         }
       ]
     },
@@ -17736,6 +22960,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safer-buffer"
+        }
       ]
     },
     {
@@ -17756,6 +22986,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/samsam"
+        }
       ]
     },
     {
@@ -17775,6 +23011,12 @@
           "url": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sanitize-filename"
         }
       ]
     },
@@ -17797,6 +23039,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sanitize-html"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17815,6 +23063,12 @@
               "url": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sanitize-html\\node_modules\\lodash"
             }
           ]
         }
@@ -17838,6 +23092,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sax"
+        }
       ]
     },
     {
@@ -17858,6 +23118,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/seek-bzip"
+        }
       ]
     },
     {
@@ -17877,6 +23143,12 @@
           "url": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/semver"
         }
       ]
     },
@@ -17899,6 +23171,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/send"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17917,6 +23195,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/send\\node_modules\\ms"
             }
           ]
         }
@@ -17940,6 +23224,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sequelize-pool"
+        }
       ]
     },
     {
@@ -17961,6 +23251,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sequelize"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17979,6 +23275,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sequelize\\node_modules\\debug"
             }
           ]
         },
@@ -18000,6 +23302,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sequelize\\node_modules\\ms"
+            }
           ]
         },
         {
@@ -18019,6 +23327,12 @@
               "url": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sequelize\\node_modules\\uuid"
             }
           ]
         }
@@ -18043,6 +23357,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/serve-index"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18061,6 +23381,12 @@
               "url": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index\\node_modules\\depd"
             }
           ]
         },
@@ -18082,6 +23408,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index\\node_modules\\http-errors"
+            }
           ]
         },
         {
@@ -18101,6 +23433,12 @@
               "url": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index\\node_modules\\inherits"
             }
           ]
         },
@@ -18122,6 +23460,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index\\node_modules\\setprototypeof"
+            }
           ]
         },
         {
@@ -18141,6 +23485,12 @@
               "url": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index\\node_modules\\statuses"
             }
           ]
         }
@@ -18164,6 +23514,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/serve-static"
+        }
       ]
     },
     {
@@ -18183,6 +23539,12 @@
           "url": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/set-blocking"
         }
       ]
     },
@@ -18205,6 +23567,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/set-value"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18223,6 +23591,12 @@
               "url": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/set-value\\node_modules\\extend-shallow"
             }
           ]
         },
@@ -18243,6 +23617,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/set-value\\node_modules\\is-extendable"
             }
           ]
         }
@@ -18266,6 +23646,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/setimmediate"
+        }
       ]
     },
     {
@@ -18285,6 +23671,12 @@
           "url": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/setprototypeof"
         }
       ]
     },
@@ -18306,6 +23698,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/side-channel"
+        }
       ]
     },
     {
@@ -18326,6 +23724,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/signal-exit"
+        }
       ]
     },
     {
@@ -18345,6 +23749,12 @@
           "url": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/simple-concat"
         }
       ]
     },
@@ -18367,6 +23777,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/simple-get"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18385,6 +23801,12 @@
               "url": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/simple-get\\node_modules\\decompress-response"
             }
           ]
         },
@@ -18405,6 +23827,12 @@
               "url": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/simple-get\\node_modules\\mimic-response"
             }
           ]
         }
@@ -18429,6 +23857,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/simple-swizzle"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18447,6 +23881,12 @@
               "url": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/simple-swizzle\\node_modules\\is-arrayish"
             }
           ]
         }
@@ -18470,6 +23910,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sinon"
+        }
       ]
     },
     {
@@ -18489,6 +23935,12 @@
           "url": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/smart-buffer"
         }
       ]
     },
@@ -18511,6 +23963,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/snapdragon-node"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18529,6 +23987,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon-node\\node_modules\\define-property"
             }
           ]
         }
@@ -18553,6 +24017,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/snapdragon-util"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18571,6 +24041,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon-util\\node_modules\\kind-of"
             }
           ]
         }
@@ -18595,6 +24071,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/snapdragon"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18613,6 +24095,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon\\node_modules\\define-property"
             }
           ]
         },
@@ -18633,6 +24121,12 @@
               "url": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon\\node_modules\\extend-shallow"
             }
           ]
         },
@@ -18655,6 +24149,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon\\node_modules\\is-accessor-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -18673,6 +24173,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/snapdragon\\node_modules\\is-accessor-descriptor\\node_modules\\kind-of"
                 }
               ]
             }
@@ -18697,6 +24203,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon\\node_modules\\is-data-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -18715,6 +24227,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/snapdragon\\node_modules\\is-data-descriptor\\node_modules\\kind-of"
                 }
               ]
             }
@@ -18738,6 +24256,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon\\node_modules\\is-descriptor"
+            }
           ]
         },
         {
@@ -18757,6 +24281,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon\\node_modules\\is-extendable"
             }
           ]
         },
@@ -18778,6 +24308,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon\\node_modules\\kind-of"
+            }
           ]
         },
         {
@@ -18797,6 +24333,12 @@
               "url": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon\\node_modules\\source-map"
             }
           ]
         }
@@ -18820,6 +24362,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socket.io-adapter"
+        }
       ]
     },
     {
@@ -18841,6 +24389,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socket.io-parser"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18859,6 +24413,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socket.io-parser\\node_modules\\debug"
             }
           ]
         },
@@ -18879,6 +24439,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socket.io-parser\\node_modules\\ms"
             }
           ]
         }
@@ -18903,6 +24469,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socket.io"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18921,6 +24493,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socket.io\\node_modules\\debug"
             }
           ]
         },
@@ -18941,6 +24519,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socket.io\\node_modules\\ms"
             }
           ]
         }
@@ -18965,6 +24549,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socks-proxy-agent"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18983,6 +24573,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socks-proxy-agent\\node_modules\\debug"
             }
           ]
         },
@@ -19003,6 +24599,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socks-proxy-agent\\node_modules\\ms"
             }
           ]
         }
@@ -19027,6 +24629,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socks"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -19045,6 +24653,12 @@
               "url": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socks\\node_modules\\ip"
             }
           ]
         }
@@ -19069,6 +24683,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sort-keys-length"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -19087,6 +24707,12 @@
               "url": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sort-keys-length\\node_modules\\sort-keys"
             }
           ]
         }
@@ -19110,6 +24736,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sort-keys"
+        }
       ]
     },
     {
@@ -19129,6 +24761,12 @@
           "url": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/source-map-resolve"
         }
       ]
     },
@@ -19150,6 +24788,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/source-map-support"
+        }
       ]
     },
     {
@@ -19169,6 +24813,12 @@
           "url": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/source-map-url"
         }
       ]
     },
@@ -19190,6 +24840,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/source-map"
+        }
       ]
     },
     {
@@ -19209,6 +24865,12 @@
           "url": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2-1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spawn-command"
         }
       ]
     },
@@ -19230,6 +24892,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spdx-correct"
+        }
       ]
     },
     {
@@ -19249,6 +24917,12 @@
           "url": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spdx-exceptions"
         }
       ]
     },
@@ -19270,6 +24944,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spdx-expression-parse"
+        }
       ]
     },
     {
@@ -19289,6 +24969,12 @@
           "url": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.12.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spdx-license-ids"
         }
       ]
     },
@@ -19310,6 +24996,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/split-string"
+        }
       ]
     },
     {
@@ -19329,6 +25021,12 @@
           "url": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sprintf-js"
         }
       ]
     },
@@ -19350,6 +25048,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sqlite3"
+        }
       ]
     },
     {
@@ -19369,6 +25073,12 @@
           "url": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sshpk"
         }
       ]
     },
@@ -19390,6 +25100,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ssri"
+        }
       ]
     },
     {
@@ -19409,6 +25125,12 @@
           "url": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/stack-trace"
         }
       ]
     },
@@ -19431,6 +25153,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/static-extend"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -19449,6 +25177,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend\\node_modules\\define-property"
             }
           ]
         },
@@ -19471,6 +25205,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend\\node_modules\\is-accessor-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -19489,6 +25229,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/static-extend\\node_modules\\is-accessor-descriptor\\node_modules\\kind-of"
                 }
               ]
             }
@@ -19513,6 +25259,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend\\node_modules\\is-data-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -19531,6 +25283,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/static-extend\\node_modules\\is-data-descriptor\\node_modules\\kind-of"
                 }
               ]
             }
@@ -19554,6 +25312,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend\\node_modules\\is-descriptor"
+            }
           ]
         },
         {
@@ -19573,6 +25337,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend\\node_modules\\kind-of"
             }
           ]
         }
@@ -19596,6 +25366,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/statuses"
+        }
       ]
     },
     {
@@ -19615,6 +25391,12 @@
           "url": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-2.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/stream-buffers"
         }
       ]
     },
@@ -19636,6 +25418,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/streamsearch"
+        }
       ]
     },
     {
@@ -19655,6 +25443,12 @@
           "url": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strict-uri-encode"
         }
       ]
     },
@@ -19676,6 +25470,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string_decoder"
+        }
       ]
     },
     {
@@ -19695,6 +25495,12 @@
           "url": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string-width"
         }
       ]
     },
@@ -19716,6 +25522,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string.fromcodepoint"
+        }
       ]
     },
     {
@@ -19735,6 +25547,12 @@
           "url": "https://registry.npmjs.org/string.prototype.codepointat/-/string.prototype.codepointat-0.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string.prototype.codepointat"
         }
       ]
     },
@@ -19756,6 +25574,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string.prototype.trimend"
+        }
       ]
     },
     {
@@ -19775,6 +25599,12 @@
           "url": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string.prototype.trimstart"
         }
       ]
     },
@@ -19796,6 +25626,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-ansi"
+        }
       ]
     },
     {
@@ -19815,6 +25651,12 @@
           "url": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-bom"
         }
       ]
     },
@@ -19836,6 +25678,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-dirs"
+        }
       ]
     },
     {
@@ -19855,6 +25703,12 @@
           "url": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-json-comments"
         }
       ]
     },
@@ -19876,6 +25730,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-outer"
+        }
       ]
     },
     {
@@ -19895,6 +25755,12 @@
           "url": "https://registry.npmjs.org/strtok3/-/strtok3-6.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strtok3"
         }
       ]
     },
@@ -19916,6 +25782,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/supports-color"
+        }
       ]
     },
     {
@@ -19935,6 +25807,12 @@
           "url": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/supports-preserve-symlinks-flag"
         }
       ]
     },
@@ -19956,6 +25834,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/svg-captcha"
+        }
       ]
     },
     {
@@ -19976,6 +25860,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/swagger-ui-dist"
+        }
       ]
     },
     {
@@ -19995,6 +25885,12 @@
           "url": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-4.5.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/swagger-ui-express"
         }
       ]
     },
@@ -20017,6 +25913,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tar-fs"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -20035,6 +25937,12 @@
               "url": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/tar-fs\\node_modules\\bl"
             }
           ]
         },
@@ -20056,6 +25964,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/tar-fs\\node_modules\\chownr"
+            }
           ]
         },
         {
@@ -20076,6 +25990,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/tar-fs\\node_modules\\readable-stream"
+            }
           ]
         },
         {
@@ -20095,6 +26015,12 @@
               "url": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/tar-fs\\node_modules\\tar-stream"
             }
           ]
         }
@@ -20118,6 +26044,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tar-stream"
+        }
       ]
     },
     {
@@ -20137,6 +26069,12 @@
           "url": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tar"
         }
       ]
     },
@@ -20158,6 +26096,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tdigest"
+        }
       ]
     },
     {
@@ -20177,6 +26121,12 @@
           "url": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/text-hex"
         }
       ]
     },
@@ -20198,6 +26148,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/thirty-two"
+        }
       ]
     },
     {
@@ -20217,6 +26173,12 @@
           "url": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/through"
         }
       ]
     },
@@ -20238,6 +26200,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/timed-out"
+        }
       ]
     },
     {
@@ -20257,6 +26225,12 @@
           "url": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tiny-inflate"
         }
       ]
     },
@@ -20278,6 +26252,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-buffer"
+        }
       ]
     },
     {
@@ -20297,6 +26277,12 @@
           "url": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-fast-properties"
         }
       ]
     },
@@ -20319,6 +26305,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-object-path"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -20337,6 +26329,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/to-object-path\\node_modules\\kind-of"
             }
           ]
         }
@@ -20360,6 +26358,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-regex-range"
+        }
       ]
     },
     {
@@ -20379,6 +26383,12 @@
           "url": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-regex"
         }
       ]
     },
@@ -20400,6 +26410,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/toidentifier"
+        }
       ]
     },
     {
@@ -20419,6 +26435,12 @@
           "url": "https://registry.npmjs.org/token-stream/-/token-stream-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/token-stream"
         }
       ]
     },
@@ -20440,6 +26462,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/token-types"
+        }
       ]
     },
     {
@@ -20459,6 +26487,12 @@
           "url": "https://registry.npmjs.org/toposort-class/-/toposort-class-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/toposort-class"
         }
       ]
     },
@@ -20480,6 +26514,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tough-cookie"
+        }
       ]
     },
     {
@@ -20499,6 +26539,12 @@
           "url": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tr46"
         }
       ]
     },
@@ -20520,6 +26566,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/traverse"
+        }
       ]
     },
     {
@@ -20539,6 +26591,12 @@
           "url": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tree-kill"
         }
       ]
     },
@@ -20560,6 +26618,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/trim-repeated"
+        }
       ]
     },
     {
@@ -20580,6 +26644,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/triple-beam"
+        }
       ]
     },
     {
@@ -20599,6 +26669,12 @@
           "url": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/truncate-utf8-bytes"
         }
       ]
     },
@@ -20621,6 +26697,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ts-node-dev"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -20639,6 +26721,12 @@
               "url": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/ts-node-dev\\node_modules\\rimraf"
             }
           ]
         }
@@ -20662,6 +26750,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ts-node"
+        }
       ]
     },
     {
@@ -20681,6 +26775,12 @@
           "url": "https://registry.npmjs.org/tsconfig/-/tsconfig-7.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tsconfig"
         }
       ]
     },
@@ -20702,6 +26802,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tslib"
+        }
       ]
     },
     {
@@ -20721,6 +26827,12 @@
           "url": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tunnel-agent"
         }
       ]
     },
@@ -20742,6 +26854,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tweetnacl"
+        }
       ]
     },
     {
@@ -20761,6 +26879,12 @@
           "url": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/type-check"
         }
       ]
     },
@@ -20782,6 +26906,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/type-is"
+        }
       ]
     },
     {
@@ -20801,6 +26931,12 @@
           "url": "https://registry.npmjs.org/typecast/-/typecast-0.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/typecast"
         }
       ]
     },
@@ -20822,6 +26958,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/typedarray"
+        }
       ]
     },
     {
@@ -20841,6 +26983,12 @@
           "url": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/typescript"
         }
       ]
     },
@@ -20862,6 +27010,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/uglify-js"
+        }
       ]
     },
     {
@@ -20881,6 +27035,12 @@
           "url": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unbox-primitive"
         }
       ]
     },
@@ -20902,6 +27062,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unbzip2-stream"
+        }
       ]
     },
     {
@@ -20921,6 +27087,12 @@
           "url": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unc-path-regex"
         }
       ]
     },
@@ -20942,6 +27114,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/underscore.string"
+        }
       ]
     },
     {
@@ -20962,6 +27140,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unicode-properties"
+        }
       ]
     },
     {
@@ -20981,6 +27165,12 @@
           "url": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unicode-trie"
         }
       ]
     },
@@ -21003,6 +27193,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/union-value"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21021,6 +27217,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/union-value\\node_modules\\is-extendable"
             }
           ]
         }
@@ -21044,6 +27246,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unique-filename"
+        }
       ]
     },
     {
@@ -21063,6 +27271,12 @@
           "url": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unique-slug"
         }
       ]
     },
@@ -21084,6 +27298,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unit-compare"
+        }
       ]
     },
     {
@@ -21104,6 +27324,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/universalify"
+        }
       ]
     },
     {
@@ -21123,6 +27349,12 @@
           "url": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unpipe"
         }
       ]
     },
@@ -21145,6 +27377,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unset-value"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21165,6 +27403,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/unset-value\\node_modules\\has-value"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -21183,6 +27427,12 @@
                   "url": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/unset-value\\node_modules\\has-value\\node_modules\\isobject"
                 }
               ]
             }
@@ -21206,6 +27456,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/unset-value\\node_modules\\has-values"
+            }
           ]
         },
         {
@@ -21225,6 +27481,12 @@
               "url": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/unset-value\\node_modules\\isarray"
             }
           ]
         }
@@ -21248,6 +27510,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/untildify"
+        }
       ]
     },
     {
@@ -21269,6 +27537,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unzipper"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21287,6 +27561,12 @@
               "url": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/unzipper\\node_modules\\bluebird"
             }
           ]
         }
@@ -21310,6 +27590,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/uri-js"
+        }
       ]
     },
     {
@@ -21329,6 +27615,12 @@
           "url": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/urix"
         }
       ]
     },
@@ -21350,6 +27642,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/url-parse-lax"
+        }
       ]
     },
     {
@@ -21369,6 +27667,12 @@
           "url": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/url-to-options"
         }
       ]
     },
@@ -21390,6 +27694,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/use"
+        }
       ]
     },
     {
@@ -21409,6 +27719,12 @@
           "url": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/utf8-byte-length"
         }
       ]
     },
@@ -21430,6 +27746,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/util-deprecate"
+        }
       ]
     },
     {
@@ -21449,6 +27771,12 @@
           "url": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/util"
         }
       ]
     },
@@ -21470,6 +27798,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/utils-merge"
+        }
       ]
     },
     {
@@ -21489,6 +27823,12 @@
           "url": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/uuid"
         }
       ]
     },
@@ -21510,6 +27850,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/v8flags"
+        }
       ]
     },
     {
@@ -21529,6 +27875,12 @@
           "url": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/validate-npm-package-license"
         }
       ]
     },
@@ -21550,6 +27902,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/validate"
+        }
       ]
     },
     {
@@ -21570,6 +27928,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/validator"
+        }
       ]
     },
     {
@@ -21589,6 +27953,12 @@
           "url": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/vary"
         }
       ]
     },
@@ -21611,6 +27981,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/verror"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21629,6 +28005,12 @@
               "url": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/verror\\node_modules\\core-util-is"
             }
           ]
         }
@@ -21653,6 +28035,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/vm2"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21671,6 +28059,12 @@
               "url": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/vm2\\node_modules\\acorn"
             }
           ]
         }
@@ -21694,6 +28088,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/void-elements"
+        }
       ]
     },
     {
@@ -21713,6 +28113,12 @@
           "url": "https://registry.npmjs.org/walk/-/walk-2.3.15.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/walk"
         }
       ]
     },
@@ -21734,6 +28140,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/walkdir"
+        }
       ]
     },
     {
@@ -21753,6 +28165,12 @@
           "url": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/webidl-conversions"
         }
       ]
     },
@@ -21774,6 +28192,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/whatwg-url"
+        }
       ]
     },
     {
@@ -21793,6 +28217,12 @@
           "url": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-boxed-primitive"
         }
       ]
     },
@@ -21814,6 +28244,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-collection"
+        }
       ]
     },
     {
@@ -21833,6 +28269,12 @@
           "url": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-module"
         }
       ]
     },
@@ -21854,6 +28296,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-pm-runs"
+        }
       ]
     },
     {
@@ -21873,6 +28321,12 @@
           "url": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-typed-array"
         }
       ]
     },
@@ -21894,6 +28348,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which"
+        }
       ]
     },
     {
@@ -21913,6 +28373,12 @@
           "url": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wide-align"
         }
       ]
     },
@@ -21935,6 +28401,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/winston-transport"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21953,6 +28425,12 @@
               "url": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/winston-transport\\node_modules\\readable-stream"
             }
           ]
         }
@@ -21977,6 +28455,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/winston"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21995,6 +28479,12 @@
               "url": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/winston\\node_modules\\async"
             }
           ]
         },
@@ -22016,6 +28506,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/winston\\node_modules\\is-stream"
+            }
           ]
         },
         {
@@ -22035,6 +28531,12 @@
               "url": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/winston\\node_modules\\readable-stream"
             }
           ]
         }
@@ -22058,6 +28560,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/with"
+        }
       ]
     },
     {
@@ -22077,6 +28585,12 @@
           "url": "https://registry.npmjs.org/wkx/-/wkx-0.5.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wkx"
         }
       ]
     },
@@ -22098,6 +28612,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/word-wrap"
+        }
       ]
     },
     {
@@ -22117,6 +28637,12 @@
           "url": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wordwrap"
         }
       ]
     },
@@ -22139,6 +28665,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wrap-ansi"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -22157,6 +28689,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi\\node_modules\\ansi-regex"
             }
           ]
         },
@@ -22178,6 +28716,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi\\node_modules\\emoji-regex"
+            }
           ]
         },
         {
@@ -22197,6 +28741,12 @@
               "url": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi\\node_modules\\is-fullwidth-code-point"
             }
           ]
         },
@@ -22218,6 +28768,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi\\node_modules\\string-width"
+            }
           ]
         },
         {
@@ -22237,6 +28793,12 @@
               "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi\\node_modules\\strip-ansi"
             }
           ]
         }
@@ -22260,6 +28822,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wrappy"
+        }
       ]
     },
     {
@@ -22279,6 +28847,12 @@
           "url": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ws"
         }
       ]
     },
@@ -22300,6 +28874,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/xtend"
+        }
       ]
     },
     {
@@ -22319,6 +28899,12 @@
           "url": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/y18n"
         }
       ]
     },
@@ -22340,6 +28926,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yallist"
+        }
       ]
     },
     {
@@ -22360,6 +28952,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yaml-schema-validator"
+        }
       ]
     },
     {
@@ -22379,6 +28977,12 @@
           "url": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yargs-parser"
         }
       ]
     },
@@ -22401,6 +29005,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yargs"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -22419,6 +29029,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs\\node_modules\\ansi-regex"
             }
           ]
         },
@@ -22440,6 +29056,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs\\node_modules\\emoji-regex"
+            }
           ]
         },
         {
@@ -22459,6 +29081,12 @@
               "url": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs\\node_modules\\is-fullwidth-code-point"
             }
           ]
         },
@@ -22480,6 +29108,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs\\node_modules\\string-width"
+            }
           ]
         },
         {
@@ -22499,6 +29133,12 @@
               "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs\\node_modules\\strip-ansi"
             }
           ]
         }
@@ -22522,6 +29162,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yauzl"
+        }
       ]
     },
     {
@@ -22541,6 +29187,12 @@
           "url": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yn"
         }
       ]
     },
@@ -22562,6 +29214,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/z85"
+        }
       ]
     },
     {
@@ -22582,6 +29240,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/zip-stream"
+        }
       ]
     },
     {
@@ -22601,6 +29265,12 @@
           "url": "https://registry.npmjs.org/zlibjs/-/zlibjs-0.3.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/zlibjs"
         }
       ]
     }

--- a/tests/_data/sbom_demo-results/juice-shop_npm8_node18_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/juice-shop_npm8_node18_windows-latest.snap.json
@@ -62,7 +62,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -95,7 +95,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@babel\\helper-string-parser"
         }
       ]
@@ -122,7 +122,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@babel\\helper-validator-identifier"
         }
       ]
@@ -149,7 +149,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@babel\\parser"
         }
       ]
@@ -176,7 +176,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@babel\\types"
         }
       ]
@@ -203,7 +203,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@colors\\colors"
         }
       ]
@@ -230,7 +230,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@dabh\\diagnostics"
         }
       ]
@@ -257,7 +257,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@gar\\promisify"
         }
       ]
@@ -284,7 +284,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@mapbox\\node-pre-gyp"
         }
       ],
@@ -310,7 +310,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\ansi-regex"
             }
           ]
@@ -336,7 +336,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\are-we-there-yet"
             }
           ]
@@ -362,7 +362,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\detect-libc"
             }
           ]
@@ -388,7 +388,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\gauge"
             }
           ]
@@ -414,7 +414,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\is-fullwidth-code-point"
             }
           ]
@@ -440,7 +440,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\make-dir"
             }
           ],
@@ -466,7 +466,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\make-dir\\node_modules\\semver"
                 }
               ]
@@ -494,7 +494,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\nopt"
             }
           ]
@@ -520,7 +520,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\npmlog"
             }
           ]
@@ -546,7 +546,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\readable-stream"
             }
           ]
@@ -572,7 +572,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\string-width"
             }
           ]
@@ -598,7 +598,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\strip-ansi"
             }
           ]
@@ -627,7 +627,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\core-loader"
         }
       ]
@@ -654,7 +654,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\core"
         }
       ]
@@ -681,7 +681,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\evaluator"
         }
       ]
@@ -708,7 +708,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-all"
         }
       ]
@@ -735,7 +735,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-ar"
         }
       ]
@@ -762,7 +762,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-bn"
         }
       ]
@@ -789,7 +789,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-ca"
         }
       ]
@@ -816,7 +816,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-cs"
         }
       ]
@@ -843,7 +843,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-da"
         }
       ]
@@ -870,7 +870,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-de"
         }
       ]
@@ -897,7 +897,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-el"
         }
       ]
@@ -924,7 +924,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-en-min"
         }
       ]
@@ -951,7 +951,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-en"
         }
       ]
@@ -978,7 +978,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-es"
         }
       ]
@@ -1005,7 +1005,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-eu"
         }
       ]
@@ -1032,7 +1032,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-fa"
         }
       ]
@@ -1059,7 +1059,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-fi"
         }
       ]
@@ -1086,7 +1086,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-fr"
         }
       ]
@@ -1113,7 +1113,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-ga"
         }
       ]
@@ -1140,7 +1140,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-gl"
         }
       ]
@@ -1167,7 +1167,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-hi"
         }
       ]
@@ -1194,7 +1194,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-hu"
         }
       ]
@@ -1221,7 +1221,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-hy"
         }
       ]
@@ -1248,7 +1248,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-id"
         }
       ]
@@ -1275,7 +1275,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-it"
         }
       ]
@@ -1302,7 +1302,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-ja"
         }
       ]
@@ -1329,7 +1329,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-ko"
         }
       ]
@@ -1356,7 +1356,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-lt"
         }
       ]
@@ -1383,7 +1383,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-ms"
         }
       ]
@@ -1410,7 +1410,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-ne"
         }
       ]
@@ -1437,7 +1437,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-nl"
         }
       ]
@@ -1464,7 +1464,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-no"
         }
       ]
@@ -1491,7 +1491,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-pl"
         }
       ]
@@ -1518,7 +1518,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-pt"
         }
       ]
@@ -1545,7 +1545,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-ro"
         }
       ]
@@ -1572,7 +1572,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-ru"
         }
       ]
@@ -1599,7 +1599,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-sl"
         }
       ]
@@ -1626,7 +1626,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-sr"
         }
       ]
@@ -1653,7 +1653,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-sv"
         }
       ]
@@ -1680,7 +1680,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-ta"
         }
       ]
@@ -1707,7 +1707,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-th"
         }
       ]
@@ -1734,7 +1734,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-tl"
         }
       ]
@@ -1761,7 +1761,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-tr"
         }
       ]
@@ -1788,7 +1788,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-uk"
         }
       ]
@@ -1815,7 +1815,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-zh"
         }
       ]
@@ -1842,7 +1842,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\language-min"
         }
       ]
@@ -1869,7 +1869,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\language"
         }
       ]
@@ -1896,7 +1896,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\ner"
         }
       ]
@@ -1923,7 +1923,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\neural"
         }
       ]
@@ -1950,7 +1950,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\nlg"
         }
       ]
@@ -1977,7 +1977,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\nlp"
         }
       ]
@@ -2004,7 +2004,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\nlu"
         }
       ]
@@ -2031,7 +2031,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\request"
         }
       ]
@@ -2058,7 +2058,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\sentiment"
         }
       ]
@@ -2085,7 +2085,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\similarity"
         }
       ]
@@ -2112,7 +2112,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\slot"
         }
       ]
@@ -2139,7 +2139,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@npmcli\\fs"
         }
       ]
@@ -2166,7 +2166,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@npmcli\\move-file"
         }
       ]
@@ -2193,7 +2193,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib\\core"
         }
       ]
@@ -2220,7 +2220,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib\\plugin-crypto"
         }
       ]
@@ -2247,7 +2247,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib\\plugin-thirty-two"
         }
       ]
@@ -2274,7 +2274,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib\\preset-default"
         }
       ]
@@ -2301,7 +2301,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib\\preset-v11"
         }
       ]
@@ -2328,7 +2328,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@sindresorhus\\is"
         }
       ]
@@ -2355,7 +2355,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@swc\\helpers"
         }
       ]
@@ -2382,7 +2382,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@tokenizer\\token"
         }
       ]
@@ -2409,7 +2409,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@tootallnate\\once"
         }
       ]
@@ -2436,7 +2436,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types\\component-emitter"
         }
       ]
@@ -2463,7 +2463,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types\\cookie"
         }
       ]
@@ -2490,7 +2490,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types\\cors"
         }
       ]
@@ -2517,7 +2517,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types\\debug"
         }
       ]
@@ -2544,7 +2544,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types\\ms"
         }
       ]
@@ -2571,7 +2571,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types\\node"
         }
       ]
@@ -2598,7 +2598,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types\\strip-bom"
         }
       ]
@@ -2625,7 +2625,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types\\strip-json-comments"
         }
       ]
@@ -2652,7 +2652,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types\\validator"
         }
       ]
@@ -2678,7 +2678,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/abbrev"
         }
       ]
@@ -2704,7 +2704,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/accepts"
         }
       ]
@@ -2730,7 +2730,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/acorn-walk"
         }
       ]
@@ -2756,7 +2756,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/acorn"
         }
       ]
@@ -2782,7 +2782,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/agent-base"
         }
       ],
@@ -2808,7 +2808,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agent-base\\node_modules\\debug"
             }
           ]
@@ -2834,7 +2834,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agent-base\\node_modules\\ms"
             }
           ]
@@ -2862,7 +2862,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/agentkeepalive"
         }
       ],
@@ -2888,7 +2888,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agentkeepalive\\node_modules\\debug"
             }
           ]
@@ -2914,7 +2914,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agentkeepalive\\node_modules\\depd"
             }
           ]
@@ -2940,7 +2940,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agentkeepalive\\node_modules\\ms"
             }
           ]
@@ -2968,7 +2968,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/aggregate-error"
         }
       ]
@@ -2994,7 +2994,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ajv"
         }
       ]
@@ -3020,7 +3020,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ansi-regex"
         }
       ]
@@ -3046,7 +3046,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ansi-styles"
         }
       ]
@@ -3072,7 +3072,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/anymatch"
         }
       ],
@@ -3098,7 +3098,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/anymatch\\node_modules\\normalize-path"
             }
           ]
@@ -3126,7 +3126,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/append-field"
         }
       ]
@@ -3152,7 +3152,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/aproba"
         }
       ]
@@ -3178,7 +3178,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/archive-type"
         }
       ],
@@ -3204,7 +3204,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/archive-type\\node_modules\\file-type"
             }
           ]
@@ -3232,7 +3232,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/archiver-utils"
         }
       ]
@@ -3258,7 +3258,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/archiver"
         }
       ]
@@ -3284,7 +3284,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/are-we-there-yet"
         }
       ]
@@ -3310,7 +3310,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/arg"
         }
       ]
@@ -3336,7 +3336,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/argparse"
         }
       ],
@@ -3362,7 +3362,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/argparse\\node_modules\\sprintf-js"
             }
           ]
@@ -3390,7 +3390,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/arr-diff"
         }
       ]
@@ -3416,7 +3416,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/arr-flatten"
         }
       ]
@@ -3442,7 +3442,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/arr-union"
         }
       ]
@@ -3468,7 +3468,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/array-each"
         }
       ]
@@ -3494,7 +3494,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/array-flatten"
         }
       ]
@@ -3520,7 +3520,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/array-slice"
         }
       ]
@@ -3546,7 +3546,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/array-unique"
         }
       ]
@@ -3572,7 +3572,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/asap"
         }
       ]
@@ -3598,7 +3598,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/asn1"
         }
       ]
@@ -3624,7 +3624,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/assert-never"
         }
       ]
@@ -3650,7 +3650,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/assert-plus"
         }
       ]
@@ -3676,7 +3676,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/assign-symbols"
         }
       ]
@@ -3702,7 +3702,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/async"
         }
       ]
@@ -3728,7 +3728,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/asynckit"
         }
       ]
@@ -3754,7 +3754,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/at-least-node"
         }
       ]
@@ -3780,7 +3780,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/atob"
         }
       ]
@@ -3806,7 +3806,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/available-typed-arrays"
         }
       ]
@@ -3832,7 +3832,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/aws-sign2"
         }
       ]
@@ -3858,7 +3858,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/aws4"
         }
       ]
@@ -3884,7 +3884,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/babel-walk"
         }
       ]
@@ -3910,7 +3910,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/balanced-match"
         }
       ]
@@ -3936,7 +3936,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base"
         }
       ],
@@ -3962,7 +3962,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/base\\node_modules\\define-property"
             }
           ]
@@ -3990,7 +3990,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base64-arraybuffer"
         }
       ]
@@ -4016,7 +4016,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base64-js"
         }
       ]
@@ -4042,7 +4042,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base64id"
         }
       ]
@@ -4068,7 +4068,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base64url"
         }
       ]
@@ -4094,7 +4094,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/basic-auth"
         }
       ]
@@ -4120,7 +4120,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/batch"
         }
       ]
@@ -4146,7 +4146,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bcrypt-pbkdf"
         }
       ]
@@ -4172,7 +4172,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/big-integer"
         }
       ]
@@ -4198,7 +4198,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/binary-extensions"
         }
       ]
@@ -4224,7 +4224,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/binary"
         }
       ]
@@ -4250,7 +4250,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bindings"
         }
       ]
@@ -4276,7 +4276,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bintrees"
         }
       ]
@@ -4302,7 +4302,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bl"
         }
       ]
@@ -4328,7 +4328,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bluebird"
         }
       ]
@@ -4354,7 +4354,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/body-parser"
         }
       ]
@@ -4380,7 +4380,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bower-config"
         }
       ],
@@ -4406,7 +4406,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bower-config\\node_modules\\minimist"
             }
           ]
@@ -4434,7 +4434,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/brace-expansion"
         }
       ]
@@ -4460,7 +4460,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/braces"
         }
       ],
@@ -4486,7 +4486,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/braces\\node_modules\\extend-shallow"
             }
           ]
@@ -4512,7 +4512,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/braces\\node_modules\\is-extendable"
             }
           ]
@@ -4540,7 +4540,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/brotli"
         }
       ]
@@ -4566,7 +4566,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-alloc-unsafe"
         }
       ]
@@ -4592,7 +4592,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-alloc"
         }
       ]
@@ -4618,7 +4618,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-crc32"
         }
       ]
@@ -4644,7 +4644,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-fill"
         }
       ]
@@ -4670,7 +4670,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-from"
         }
       ]
@@ -4696,7 +4696,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-indexof-polyfill"
         }
       ]
@@ -4722,7 +4722,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer"
         }
       ]
@@ -4748,7 +4748,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffers"
         }
       ]
@@ -4774,7 +4774,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/busboy"
         }
       ],
@@ -4800,7 +4800,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/busboy\\node_modules\\isarray"
             }
           ]
@@ -4826,7 +4826,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/busboy\\node_modules\\readable-stream"
             }
           ]
@@ -4852,7 +4852,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/busboy\\node_modules\\string_decoder"
             }
           ]
@@ -4880,7 +4880,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/byline"
         }
       ]
@@ -4906,7 +4906,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bytes"
         }
       ]
@@ -4932,7 +4932,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cacache"
         }
       ]
@@ -4958,7 +4958,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cache-base"
         }
       ]
@@ -4984,7 +4984,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cacheable-request"
         }
       ],
@@ -5010,7 +5010,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cacheable-request\\node_modules\\get-stream"
             }
           ]
@@ -5036,7 +5036,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cacheable-request\\node_modules\\lowercase-keys"
             }
           ]
@@ -5064,7 +5064,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/call-bind"
         }
       ]
@@ -5090,7 +5090,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/camelcase"
         }
       ]
@@ -5116,7 +5116,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/caseless"
         }
       ]
@@ -5142,7 +5142,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/chainsaw"
         }
       ]
@@ -5168,7 +5168,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/chalk"
         }
       ]
@@ -5194,7 +5194,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/character-parser"
         }
       ]
@@ -5220,7 +5220,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/check-dependencies"
         }
       ],
@@ -5246,7 +5246,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/check-dependencies\\node_modules\\semver"
             }
           ]
@@ -5274,7 +5274,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/check-types"
         }
       ]
@@ -5300,7 +5300,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/chokidar"
         }
       ],
@@ -5326,7 +5326,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar\\node_modules\\braces"
             }
           ]
@@ -5352,7 +5352,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar\\node_modules\\fill-range"
             }
           ]
@@ -5378,7 +5378,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar\\node_modules\\is-glob"
             }
           ]
@@ -5404,7 +5404,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar\\node_modules\\is-number"
             }
           ]
@@ -5430,7 +5430,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar\\node_modules\\normalize-path"
             }
           ]
@@ -5456,7 +5456,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar\\node_modules\\to-regex-range"
             }
           ]
@@ -5484,7 +5484,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/chownr"
         }
       ]
@@ -5510,7 +5510,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/clarinet"
         }
       ]
@@ -5536,7 +5536,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/class-utils"
         }
       ],
@@ -5562,7 +5562,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils\\node_modules\\define-property"
             }
           ]
@@ -5588,7 +5588,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils\\node_modules\\is-accessor-descriptor"
             }
           ],
@@ -5614,7 +5614,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/class-utils\\node_modules\\is-accessor-descriptor\\node_modules\\kind-of"
                 }
               ]
@@ -5642,7 +5642,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils\\node_modules\\is-data-descriptor"
             }
           ],
@@ -5668,7 +5668,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/class-utils\\node_modules\\is-data-descriptor\\node_modules\\kind-of"
                 }
               ]
@@ -5696,7 +5696,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils\\node_modules\\is-descriptor"
             }
           ]
@@ -5722,7 +5722,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils\\node_modules\\kind-of"
             }
           ]
@@ -5750,7 +5750,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/clean-stack"
         }
       ]
@@ -5776,7 +5776,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cliui"
         }
       ],
@@ -5802,7 +5802,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui\\node_modules\\ansi-regex"
             }
           ]
@@ -5828,7 +5828,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui\\node_modules\\emoji-regex"
             }
           ]
@@ -5854,7 +5854,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui\\node_modules\\is-fullwidth-code-point"
             }
           ]
@@ -5880,7 +5880,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui\\node_modules\\string-width"
             }
           ]
@@ -5906,7 +5906,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui\\node_modules\\strip-ansi"
             }
           ]
@@ -5934,7 +5934,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/clone-response"
         }
       ]
@@ -5960,7 +5960,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/clone"
         }
       ]
@@ -5986,7 +5986,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/code-point-at"
         }
       ]
@@ -6012,7 +6012,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/collection-visit"
         }
       ]
@@ -6038,7 +6038,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color-convert"
         }
       ]
@@ -6064,7 +6064,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color-name"
         }
       ]
@@ -6090,7 +6090,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color-string"
         }
       ]
@@ -6116,7 +6116,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color-support"
         }
       ]
@@ -6142,7 +6142,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color"
         }
       ]
@@ -6168,7 +6168,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/colors"
         }
       ]
@@ -6194,7 +6194,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/colorspace"
         }
       ]
@@ -6220,7 +6220,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/combined-stream"
         }
       ]
@@ -6246,7 +6246,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/commander"
         }
       ]
@@ -6272,7 +6272,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/component-emitter"
         }
       ]
@@ -6298,7 +6298,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/component-type"
         }
       ]
@@ -6324,7 +6324,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/compress-commons"
         }
       ]
@@ -6350,7 +6350,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/compressible"
         }
       ]
@@ -6376,7 +6376,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/compression"
         }
       ],
@@ -6402,7 +6402,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/compression\\node_modules\\bytes"
             }
           ]
@@ -6430,7 +6430,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/concat-map"
         }
       ]
@@ -6456,7 +6456,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/concat-stream"
         }
       ]
@@ -6482,7 +6482,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/concurrently"
         }
       ],
@@ -6508,7 +6508,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/concurrently\\node_modules\\supports-color"
             }
           ]
@@ -6536,7 +6536,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/config"
         }
       ]
@@ -6562,7 +6562,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/console-control-strings"
         }
       ]
@@ -6588,7 +6588,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/constantinople"
         }
       ]
@@ -6614,7 +6614,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/content-disposition"
         }
       ],
@@ -6640,7 +6640,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/content-disposition\\node_modules\\safe-buffer"
             }
           ]
@@ -6668,7 +6668,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/content-type"
         }
       ]
@@ -6694,7 +6694,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cookie-parser"
         }
       ]
@@ -6720,7 +6720,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cookie-signature"
         }
       ]
@@ -6746,7 +6746,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cookie"
         }
       ]
@@ -6772,7 +6772,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/copy-descriptor"
         }
       ]
@@ -6798,7 +6798,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/core-util-is"
         }
       ]
@@ -6824,7 +6824,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cors"
         }
       ]
@@ -6850,7 +6850,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/crc"
         }
       ]
@@ -6876,7 +6876,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/crc32-stream"
         }
       ]
@@ -6902,7 +6902,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/create-require"
         }
       ]
@@ -6928,7 +6928,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/crypto-js"
         }
       ]
@@ -6954,7 +6954,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dashdash"
         }
       ]
@@ -6980,7 +6980,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/date-fns"
         }
       ]
@@ -7006,7 +7006,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dateformat"
         }
       ]
@@ -7032,7 +7032,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/debug"
         }
       ]
@@ -7058,7 +7058,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decamelize"
         }
       ]
@@ -7084,7 +7084,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decode-uri-component"
         }
       ]
@@ -7110,7 +7110,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-response"
         }
       ]
@@ -7136,7 +7136,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-tar"
         }
       ],
@@ -7162,7 +7162,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-tar\\node_modules\\file-type"
             }
           ]
@@ -7190,7 +7190,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-tarbz2"
         }
       ],
@@ -7216,7 +7216,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-tarbz2\\node_modules\\file-type"
             }
           ]
@@ -7244,7 +7244,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-targz"
         }
       ],
@@ -7270,7 +7270,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-targz\\node_modules\\file-type"
             }
           ]
@@ -7298,7 +7298,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-unzip"
         }
       ],
@@ -7324,7 +7324,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-unzip\\node_modules\\file-type"
             }
           ]
@@ -7350,7 +7350,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-unzip\\node_modules\\get-stream"
             }
           ]
@@ -7376,7 +7376,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-unzip\\node_modules\\pify"
             }
           ]
@@ -7404,7 +7404,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress"
         }
       ],
@@ -7430,7 +7430,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress\\node_modules\\make-dir"
             }
           ],
@@ -7456,7 +7456,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/decompress\\node_modules\\make-dir\\node_modules\\pify"
                 }
               ]
@@ -7484,7 +7484,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress\\node_modules\\pify"
             }
           ]
@@ -7512,7 +7512,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/deep-equal"
         }
       ]
@@ -7538,7 +7538,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/deep-extend"
         }
       ]
@@ -7564,7 +7564,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/deep-is"
         }
       ]
@@ -7590,7 +7590,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/define-properties"
         }
       ]
@@ -7616,7 +7616,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/define-property"
         }
       ]
@@ -7642,7 +7642,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/delayed-stream"
         }
       ]
@@ -7668,7 +7668,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/delegates"
         }
       ]
@@ -7694,7 +7694,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/depd"
         }
       ]
@@ -7720,7 +7720,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/destroy"
         }
       ]
@@ -7746,7 +7746,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/detect-file"
         }
       ]
@@ -7772,7 +7772,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/detect-libc"
         }
       ]
@@ -7798,7 +7798,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dfa"
         }
       ]
@@ -7824,7 +7824,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dicer"
         }
       ],
@@ -7850,7 +7850,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/dicer\\node_modules\\isarray"
             }
           ]
@@ -7876,7 +7876,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/dicer\\node_modules\\readable-stream"
             }
           ]
@@ -7902,7 +7902,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/dicer\\node_modules\\string_decoder"
             }
           ]
@@ -7930,7 +7930,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/diff"
         }
       ]
@@ -7956,7 +7956,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/doctypes"
         }
       ]
@@ -7982,7 +7982,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/domelementtype"
         }
       ]
@@ -8008,7 +8008,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/domhandler"
         }
       ]
@@ -8034,7 +8034,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/domutils"
         }
       ]
@@ -8060,7 +8060,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dottie"
         }
       ]
@@ -8086,7 +8086,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/double-ended-queue"
         }
       ]
@@ -8112,7 +8112,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/doublearray"
         }
       ]
@@ -8138,7 +8138,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/download"
         }
       ],
@@ -8164,7 +8164,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/download\\node_modules\\file-type"
             }
           ]
@@ -8192,7 +8192,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/duplexer2"
         }
       ]
@@ -8218,7 +8218,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/duplexer3"
         }
       ]
@@ -8244,7 +8244,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dynamic-dedupe"
         }
       ]
@@ -8270,7 +8270,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ecc-jsbn"
         }
       ]
@@ -8296,7 +8296,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ee-first"
         }
       ]
@@ -8322,7 +8322,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/eivindfjeldstad-dot"
         }
       ]
@@ -8348,7 +8348,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/emoji-regex"
         }
       ]
@@ -8374,7 +8374,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/enabled"
         }
       ]
@@ -8400,7 +8400,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/encodeurl"
         }
       ]
@@ -8426,7 +8426,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/encoding"
         }
       ],
@@ -8452,7 +8452,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/encoding\\node_modules\\iconv-lite"
             }
           ]
@@ -8480,7 +8480,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/end-of-stream"
         }
       ]
@@ -8506,7 +8506,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/engine.io-parser"
         }
       ]
@@ -8532,7 +8532,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/engine.io"
         }
       ],
@@ -8558,7 +8558,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/engine.io\\node_modules\\debug"
             }
           ]
@@ -8584,7 +8584,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/engine.io\\node_modules\\ms"
             }
           ]
@@ -8612,7 +8612,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/env-paths"
         }
       ]
@@ -8638,7 +8638,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/err-code"
         }
       ]
@@ -8664,7 +8664,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/error-ex"
         }
       ]
@@ -8690,7 +8690,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/errorhandler"
         }
       ]
@@ -8716,7 +8716,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/es-abstract"
         }
       ]
@@ -8742,7 +8742,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/es-get-iterator"
         }
       ]
@@ -8768,7 +8768,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/es-to-primitive"
         }
       ]
@@ -8794,7 +8794,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/escape-html"
         }
       ]
@@ -8820,7 +8820,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/escape-string-regexp"
         }
       ]
@@ -8846,7 +8846,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/escodegen"
         }
       ]
@@ -8872,7 +8872,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/esprima"
         }
       ]
@@ -8898,7 +8898,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/estraverse"
         }
       ]
@@ -8924,7 +8924,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/esutils"
         }
       ]
@@ -8950,7 +8950,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/etag"
         }
       ]
@@ -8976,7 +8976,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/eventemitter2"
         }
       ]
@@ -9002,7 +9002,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/eventemitter3"
         }
       ]
@@ -9028,7 +9028,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/exif"
         }
       ]
@@ -9054,7 +9054,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/exit"
         }
       ]
@@ -9080,7 +9080,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/expand-brackets"
         }
       ],
@@ -9106,7 +9106,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets\\node_modules\\define-property"
             }
           ]
@@ -9132,7 +9132,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets\\node_modules\\extend-shallow"
             }
           ]
@@ -9158,7 +9158,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets\\node_modules\\is-accessor-descriptor"
             }
           ],
@@ -9184,7 +9184,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/expand-brackets\\node_modules\\is-accessor-descriptor\\node_modules\\kind-of"
                 }
               ]
@@ -9212,7 +9212,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets\\node_modules\\is-data-descriptor"
             }
           ],
@@ -9238,7 +9238,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/expand-brackets\\node_modules\\is-data-descriptor\\node_modules\\kind-of"
                 }
               ]
@@ -9266,7 +9266,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets\\node_modules\\is-descriptor"
             }
           ]
@@ -9292,7 +9292,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets\\node_modules\\is-extendable"
             }
           ]
@@ -9318,7 +9318,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets\\node_modules\\kind-of"
             }
           ]
@@ -9346,7 +9346,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/expand-template"
         }
       ]
@@ -9372,7 +9372,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/expand-tilde"
         }
       ]
@@ -9398,7 +9398,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-ipfilter"
         }
       ]
@@ -9424,7 +9424,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-jwt"
         }
       ],
@@ -9450,7 +9450,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/express-jwt\\node_modules\\jsonwebtoken"
             }
           ]
@@ -9476,7 +9476,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/express-jwt\\node_modules\\moment"
             }
           ]
@@ -9504,7 +9504,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-rate-limit"
         }
       ]
@@ -9530,7 +9530,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-robots-txt"
         }
       ]
@@ -9556,7 +9556,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-security.txt"
         }
       ]
@@ -9582,7 +9582,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express"
         }
       ],
@@ -9608,7 +9608,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/express\\node_modules\\cookie"
             }
           ]
@@ -9634,7 +9634,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/express\\node_modules\\safe-buffer"
             }
           ]
@@ -9662,7 +9662,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ext-list"
         }
       ]
@@ -9688,7 +9688,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ext-name"
         }
       ]
@@ -9714,7 +9714,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/extend-shallow"
         }
       ]
@@ -9740,7 +9740,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/extend"
         }
       ]
@@ -9766,7 +9766,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/extglob"
         }
       ],
@@ -9792,7 +9792,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/extglob\\node_modules\\define-property"
             }
           ]
@@ -9818,7 +9818,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/extglob\\node_modules\\extend-shallow"
             }
           ]
@@ -9844,7 +9844,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/extglob\\node_modules\\is-extendable"
             }
           ]
@@ -9872,7 +9872,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/extsprintf"
         }
       ]
@@ -9898,7 +9898,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fast-deep-equal"
         }
       ]
@@ -9924,7 +9924,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fast-json-stable-stringify"
         }
       ]
@@ -9950,7 +9950,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fast-levenshtein"
         }
       ]
@@ -9976,7 +9976,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fast.js"
         }
       ]
@@ -10002,7 +10002,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fd-slicer"
         }
       ]
@@ -10028,7 +10028,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/feature-policy"
         }
       ]
@@ -10054,7 +10054,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fecha"
         }
       ]
@@ -10080,7 +10080,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/file-js"
         }
       ],
@@ -10106,7 +10106,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/file-js\\node_modules\\brace-expansion"
             }
           ]
@@ -10132,7 +10132,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/file-js\\node_modules\\minimatch"
             }
           ]
@@ -10160,7 +10160,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/file-stream-rotator"
         }
       ]
@@ -10186,7 +10186,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/file-type"
         }
       ]
@@ -10212,7 +10212,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/file-uri-to-path"
         }
       ]
@@ -10238,7 +10238,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/filehound"
         }
       ]
@@ -10264,7 +10264,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/filename-reserved-regex"
         }
       ]
@@ -10290,7 +10290,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/filenamify"
         }
       ]
@@ -10316,7 +10316,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/filesniffer"
         }
       ]
@@ -10342,7 +10342,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fill-range"
         }
       ],
@@ -10368,7 +10368,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/fill-range\\node_modules\\extend-shallow"
             }
           ]
@@ -10394,7 +10394,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/fill-range\\node_modules\\is-extendable"
             }
           ]
@@ -10422,7 +10422,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/finale-rest"
         }
       ]
@@ -10448,7 +10448,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/finalhandler"
         }
       ]
@@ -10474,7 +10474,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/find-up"
         }
       ]
@@ -10500,7 +10500,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/findup-sync"
         }
       ]
@@ -10526,7 +10526,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fined"
         }
       ]
@@ -10552,7 +10552,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/flagged-respawn"
         }
       ]
@@ -10578,7 +10578,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fn.name"
         }
       ]
@@ -10604,7 +10604,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fontkit"
         }
       ]
@@ -10630,7 +10630,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/for-each"
         }
       ]
@@ -10656,7 +10656,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/for-in"
         }
       ]
@@ -10682,7 +10682,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/for-own"
         }
       ]
@@ -10708,7 +10708,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/foreachasync"
         }
       ]
@@ -10734,7 +10734,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/forever-agent"
         }
       ]
@@ -10760,7 +10760,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/form-data"
         }
       ]
@@ -10786,7 +10786,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/formatio"
         }
       ]
@@ -10812,7 +10812,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/forwarded"
         }
       ]
@@ -10838,7 +10838,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fragment-cache"
         }
       ]
@@ -10864,7 +10864,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fresh"
         }
       ]
@@ -10890,7 +10890,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/from2"
         }
       ]
@@ -10916,7 +10916,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fs-constants"
         }
       ]
@@ -10942,7 +10942,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fs-extra"
         }
       ]
@@ -10968,7 +10968,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fs-minipass"
         }
       ]
@@ -10994,7 +10994,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fs.realpath"
         }
       ]
@@ -11020,7 +11020,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fstream"
         }
       ],
@@ -11046,7 +11046,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/fstream\\node_modules\\mkdirp"
             }
           ]
@@ -11072,7 +11072,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/fstream\\node_modules\\rimraf"
             }
           ]
@@ -11100,7 +11100,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/function-bind"
         }
       ]
@@ -11126,7 +11126,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/function.prototype.name"
         }
       ]
@@ -11152,7 +11152,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/functions-have-names"
         }
       ]
@@ -11178,7 +11178,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fuzzball"
         }
       ]
@@ -11204,7 +11204,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/gauge"
         }
       ]
@@ -11230,7 +11230,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/geojson-utils"
         }
       ]
@@ -11256,7 +11256,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-caller-file"
         }
       ]
@@ -11282,7 +11282,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-intrinsic"
         }
       ]
@@ -11308,7 +11308,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-stream"
         }
       ]
@@ -11334,7 +11334,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-symbol-description"
         }
       ]
@@ -11360,7 +11360,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-value"
         }
       ]
@@ -11386,7 +11386,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/getobject"
         }
       ]
@@ -11412,7 +11412,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/getpass"
         }
       ]
@@ -11438,7 +11438,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/github-from-package"
         }
       ]
@@ -11464,7 +11464,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/glob-parent"
         }
       ],
@@ -11490,7 +11490,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/glob-parent\\node_modules\\is-glob"
             }
           ]
@@ -11518,7 +11518,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/glob"
         }
       ],
@@ -11544,7 +11544,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/glob\\node_modules\\brace-expansion"
             }
           ]
@@ -11570,7 +11570,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/glob\\node_modules\\minimatch"
             }
           ]
@@ -11598,7 +11598,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/global-modules"
         }
       ]
@@ -11624,7 +11624,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/global-prefix"
         }
       ],
@@ -11650,7 +11650,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/global-prefix\\node_modules\\which"
             }
           ]
@@ -11678,7 +11678,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/got"
         }
       ],
@@ -11704,7 +11704,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/got\\node_modules\\get-stream"
             }
           ]
@@ -11730,7 +11730,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/got\\node_modules\\pify"
             }
           ]
@@ -11758,7 +11758,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/graceful-fs"
         }
       ]
@@ -11784,7 +11784,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-cli"
         }
       ],
@@ -11810,7 +11810,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-cli\\node_modules\\nopt"
             }
           ]
@@ -11838,7 +11838,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-contrib-compress"
         }
       ],
@@ -11864,7 +11864,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-contrib-compress\\node_modules\\ansi-styles"
             }
           ]
@@ -11890,7 +11890,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-contrib-compress\\node_modules\\chalk"
             }
           ]
@@ -11916,7 +11916,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-contrib-compress\\node_modules\\supports-color"
             }
           ]
@@ -11944,7 +11944,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-known-options"
         }
       ]
@@ -11970,7 +11970,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-legacy-log-utils"
         }
       ],
@@ -11996,7 +11996,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils\\node_modules\\ansi-styles"
             }
           ]
@@ -12022,7 +12022,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils\\node_modules\\chalk"
             }
           ]
@@ -12048,7 +12048,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils\\node_modules\\color-convert"
             }
           ]
@@ -12074,7 +12074,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils\\node_modules\\color-name"
             }
           ]
@@ -12100,7 +12100,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils\\node_modules\\has-flag"
             }
           ]
@@ -12126,7 +12126,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils\\node_modules\\supports-color"
             }
           ]
@@ -12154,7 +12154,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-legacy-log"
         }
       ],
@@ -12180,7 +12180,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log\\node_modules\\colors"
             }
           ]
@@ -12208,7 +12208,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-legacy-util"
         }
       ],
@@ -12234,7 +12234,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-util\\node_modules\\async"
             }
           ]
@@ -12262,7 +12262,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-replace-json"
         }
       ]
@@ -12288,7 +12288,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt"
         }
       ],
@@ -12314,7 +12314,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt\\node_modules\\brace-expansion"
             }
           ]
@@ -12340,7 +12340,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt\\node_modules\\findup-sync"
             }
           ],
@@ -12366,7 +12366,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/grunt\\node_modules\\findup-sync\\node_modules\\glob"
                 }
               ]
@@ -12394,7 +12394,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt\\node_modules\\glob"
             }
           ]
@@ -12420,7 +12420,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt\\node_modules\\minimatch"
             }
           ]
@@ -12448,7 +12448,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/handlebars"
         }
       ],
@@ -12474,7 +12474,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/handlebars\\node_modules\\wordwrap"
             }
           ]
@@ -12502,7 +12502,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/har-schema"
         }
       ]
@@ -12528,7 +12528,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/har-validator"
         }
       ]
@@ -12554,7 +12554,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-ansi"
         }
       ]
@@ -12580,7 +12580,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-bigints"
         }
       ]
@@ -12606,7 +12606,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-flag"
         }
       ]
@@ -12632,7 +12632,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-property-descriptors"
         }
       ]
@@ -12658,7 +12658,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-symbol-support-x"
         }
       ]
@@ -12684,7 +12684,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-symbols"
         }
       ]
@@ -12710,7 +12710,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-to-string-tag-x"
         }
       ]
@@ -12736,7 +12736,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-tostringtag"
         }
       ]
@@ -12762,7 +12762,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-unicode"
         }
       ]
@@ -12788,7 +12788,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-value"
         }
       ]
@@ -12814,7 +12814,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-values"
         }
       ],
@@ -12840,7 +12840,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/has-values\\node_modules\\kind-of"
             }
           ]
@@ -12868,7 +12868,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has"
         }
       ]
@@ -12894,7 +12894,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hashids"
         }
       ]
@@ -12920,7 +12920,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hbs"
         }
       ]
@@ -12946,7 +12946,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/he"
         }
       ]
@@ -12972,7 +12972,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/heap"
         }
       ]
@@ -12998,7 +12998,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/helmet"
         }
       ]
@@ -13024,7 +13024,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hoister"
         }
       ]
@@ -13050,7 +13050,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/homedir-polyfill"
         }
       ]
@@ -13076,7 +13076,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hooker"
         }
       ]
@@ -13102,7 +13102,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hosted-git-info"
         }
       ]
@@ -13128,7 +13128,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/html-entities"
         }
       ]
@@ -13154,7 +13154,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/htmlparser2"
         }
       ],
@@ -13180,7 +13180,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/htmlparser2\\node_modules\\isarray"
             }
           ]
@@ -13206,7 +13206,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/htmlparser2\\node_modules\\readable-stream"
             }
           ]
@@ -13232,7 +13232,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/htmlparser2\\node_modules\\string_decoder"
             }
           ]
@@ -13260,7 +13260,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/http-cache-semantics"
         }
       ]
@@ -13286,7 +13286,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/http-errors"
         }
       ]
@@ -13312,7 +13312,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/http-proxy-agent"
         }
       ],
@@ -13338,7 +13338,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/http-proxy-agent\\node_modules\\debug"
             }
           ]
@@ -13364,7 +13364,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/http-proxy-agent\\node_modules\\ms"
             }
           ]
@@ -13392,7 +13392,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/http-signature"
         }
       ]
@@ -13418,7 +13418,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/https-proxy-agent"
         }
       ],
@@ -13444,7 +13444,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/https-proxy-agent\\node_modules\\debug"
             }
           ]
@@ -13470,7 +13470,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/https-proxy-agent\\node_modules\\ms"
             }
           ]
@@ -13498,7 +13498,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/humanize-ms"
         }
       ]
@@ -13524,7 +13524,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/i18n"
         }
       ]
@@ -13550,7 +13550,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/iconv-lite"
         }
       ]
@@ -13576,7 +13576,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ieee754"
         }
       ]
@@ -13602,7 +13602,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ignore-walk"
         }
       ],
@@ -13628,7 +13628,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/ignore-walk\\node_modules\\brace-expansion"
             }
           ]
@@ -13654,7 +13654,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/ignore-walk\\node_modules\\minimatch"
             }
           ]
@@ -13682,7 +13682,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/iltorb"
         }
       ]
@@ -13708,7 +13708,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/imurmurhash"
         }
       ]
@@ -13734,7 +13734,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/indent-string"
         }
       ]
@@ -13760,7 +13760,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/infer-owner"
         }
       ]
@@ -13786,7 +13786,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/inflection"
         }
       ]
@@ -13812,7 +13812,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/inflight"
         }
       ]
@@ -13838,7 +13838,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/inherits"
         }
       ]
@@ -13864,7 +13864,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ini"
         }
       ]
@@ -13890,7 +13890,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/internal-slot"
         }
       ]
@@ -13916,7 +13916,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/interpret"
         }
       ]
@@ -13942,7 +13942,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/into-stream"
         }
       ]
@@ -13968,7 +13968,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/invariant"
         }
       ]
@@ -13994,7 +13994,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ip"
         }
       ]
@@ -14020,7 +14020,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ip6"
         }
       ]
@@ -14046,7 +14046,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ipaddr.js"
         }
       ]
@@ -14072,7 +14072,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-absolute"
         }
       ]
@@ -14098,7 +14098,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-accessor-descriptor"
         }
       ]
@@ -14124,7 +14124,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-arguments"
         }
       ]
@@ -14150,7 +14150,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-arrayish"
         }
       ]
@@ -14176,7 +14176,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-bigint"
         }
       ]
@@ -14202,7 +14202,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-binary-path"
         }
       ]
@@ -14228,7 +14228,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-boolean-object"
         }
       ]
@@ -14254,7 +14254,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-buffer"
         }
       ]
@@ -14280,7 +14280,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-callable"
         }
       ]
@@ -14306,7 +14306,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-core-module"
         }
       ]
@@ -14332,7 +14332,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-data-descriptor"
         }
       ]
@@ -14358,7 +14358,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-date-object"
         }
       ]
@@ -14384,7 +14384,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-descriptor"
         }
       ]
@@ -14410,7 +14410,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-docker"
         }
       ]
@@ -14436,7 +14436,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-expression"
         }
       ]
@@ -14462,7 +14462,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-extendable"
         }
       ]
@@ -14488,7 +14488,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-extglob"
         }
       ]
@@ -14514,7 +14514,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-fullwidth-code-point"
         }
       ]
@@ -14540,7 +14540,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-generator-function"
         }
       ]
@@ -14566,7 +14566,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-glob"
         }
       ]
@@ -14592,7 +14592,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-heroku"
         }
       ]
@@ -14618,7 +14618,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-lambda"
         }
       ]
@@ -14644,7 +14644,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-map"
         }
       ]
@@ -14670,7 +14670,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-natural-number"
         }
       ]
@@ -14696,7 +14696,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-negative-zero"
         }
       ]
@@ -14722,7 +14722,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-number-like"
         }
       ]
@@ -14748,7 +14748,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-number-object"
         }
       ]
@@ -14774,7 +14774,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-number"
         }
       ],
@@ -14800,7 +14800,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/is-number\\node_modules\\kind-of"
             }
           ]
@@ -14828,7 +14828,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-object"
         }
       ]
@@ -14854,7 +14854,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-plain-obj"
         }
       ]
@@ -14880,7 +14880,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-plain-object"
         }
       ]
@@ -14906,7 +14906,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-promise"
         }
       ]
@@ -14932,7 +14932,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-regex"
         }
       ]
@@ -14958,7 +14958,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-relative"
         }
       ]
@@ -14984,7 +14984,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-retry-allowed"
         }
       ]
@@ -15010,7 +15010,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-set"
         }
       ]
@@ -15036,7 +15036,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-shared-array-buffer"
         }
       ]
@@ -15062,7 +15062,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-stream"
         }
       ]
@@ -15088,7 +15088,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-string"
         }
       ]
@@ -15114,7 +15114,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-symbol"
         }
       ]
@@ -15140,7 +15140,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-typed-array"
         }
       ]
@@ -15166,7 +15166,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-typedarray"
         }
       ]
@@ -15192,7 +15192,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-unc-path"
         }
       ]
@@ -15218,7 +15218,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-weakmap"
         }
       ]
@@ -15244,7 +15244,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-weakref"
         }
       ]
@@ -15270,7 +15270,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-weakset"
         }
       ]
@@ -15296,7 +15296,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-windows"
         }
       ]
@@ -15322,7 +15322,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isarray"
         }
       ]
@@ -15348,7 +15348,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isexe"
         }
       ]
@@ -15374,7 +15374,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isobject"
         }
       ]
@@ -15400,7 +15400,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isstream"
         }
       ]
@@ -15426,7 +15426,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isurl"
         }
       ]
@@ -15452,7 +15452,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/js-stringify"
         }
       ]
@@ -15478,7 +15478,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/js-tokens"
         }
       ]
@@ -15504,7 +15504,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/js-yaml"
         }
       ]
@@ -15530,7 +15530,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jsbn"
         }
       ]
@@ -15556,7 +15556,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-buffer"
         }
       ]
@@ -15582,7 +15582,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-parse-better-errors"
         }
       ]
@@ -15608,7 +15608,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-schema-traverse"
         }
       ]
@@ -15634,7 +15634,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-schema"
         }
       ]
@@ -15660,7 +15660,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-stringify-safe"
         }
       ]
@@ -15686,7 +15686,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json5"
         }
       ]
@@ -15712,7 +15712,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jsonfile"
         }
       ]
@@ -15738,7 +15738,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jsonwebtoken"
         }
       ]
@@ -15764,7 +15764,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jsprim"
         }
       ]
@@ -15790,7 +15790,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jssha"
         }
       ]
@@ -15816,7 +15816,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jstransformer"
         }
       ]
@@ -15842,7 +15842,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/juicy-chat-bot"
         }
       ]
@@ -15868,7 +15868,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jwa"
         }
       ]
@@ -15894,7 +15894,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jws"
         }
       ]
@@ -15920,7 +15920,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/keyv"
         }
       ]
@@ -15946,7 +15946,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/kind-of"
         }
       ]
@@ -15972,7 +15972,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/kuler"
         }
       ]
@@ -15998,7 +15998,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/kuromoji"
         }
       ]
@@ -16024,7 +16024,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lazystream"
         }
       ]
@@ -16050,7 +16050,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/levn"
         }
       ]
@@ -16076,7 +16076,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/libxmljs2"
         }
       ],
@@ -16102,7 +16102,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/libxmljs2\\node_modules\\nan"
             }
           ]
@@ -16130,7 +16130,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/liftup"
         }
       ],
@@ -16156,7 +16156,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup\\node_modules\\braces"
             }
           ]
@@ -16182,7 +16182,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup\\node_modules\\fill-range"
             }
           ]
@@ -16208,7 +16208,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup\\node_modules\\findup-sync"
             }
           ]
@@ -16234,7 +16234,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup\\node_modules\\is-glob"
             }
           ]
@@ -16260,7 +16260,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup\\node_modules\\is-number"
             }
           ]
@@ -16286,7 +16286,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup\\node_modules\\micromatch"
             }
           ]
@@ -16312,7 +16312,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup\\node_modules\\to-regex-range"
             }
           ]
@@ -16340,7 +16340,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/linebreak"
         }
       ],
@@ -16366,7 +16366,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/linebreak\\node_modules\\base64-js"
             }
           ]
@@ -16394,7 +16394,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/listenercount"
         }
       ]
@@ -16420,7 +16420,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/locate-path"
         }
       ]
@@ -16446,7 +16446,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lodash.camelcase"
         }
       ]
@@ -16472,7 +16472,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lodash.isfinite"
         }
       ]
@@ -16498,7 +16498,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lodash.set"
         }
       ]
@@ -16524,7 +16524,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lodash"
         }
       ]
@@ -16550,7 +16550,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/logform"
         }
       ],
@@ -16576,7 +16576,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/logform\\node_modules\\ms"
             }
           ]
@@ -16604,7 +16604,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lolex"
         }
       ]
@@ -16630,7 +16630,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/loose-envify"
         }
       ]
@@ -16656,7 +16656,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lowercase-keys"
         }
       ]
@@ -16682,7 +16682,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lru-cache"
         }
       ]
@@ -16708,7 +16708,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-dir"
         }
       ],
@@ -16734,7 +16734,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-dir\\node_modules\\semver"
             }
           ]
@@ -16762,7 +16762,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-error"
         }
       ]
@@ -16788,7 +16788,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-fetch-happen"
         }
       ],
@@ -16815,7 +16815,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen\\node_modules\\@tootallnate\\once"
             }
           ]
@@ -16841,7 +16841,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen\\node_modules\\debug"
             }
           ]
@@ -16867,7 +16867,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen\\node_modules\\http-cache-semantics"
             }
           ]
@@ -16893,7 +16893,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen\\node_modules\\http-proxy-agent"
             }
           ]
@@ -16919,7 +16919,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen\\node_modules\\ms"
             }
           ]
@@ -16947,7 +16947,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-iterator"
         }
       ]
@@ -16973,7 +16973,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-plural"
         }
       ]
@@ -16999,7 +16999,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/map-cache"
         }
       ]
@@ -17025,7 +17025,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/map-visit"
         }
       ]
@@ -17051,7 +17051,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/marsdb"
         }
       ]
@@ -17077,7 +17077,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/math-interval-parser"
         }
       ]
@@ -17103,7 +17103,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/media-typer"
         }
       ]
@@ -17129,7 +17129,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/merge-descriptors"
         }
       ]
@@ -17155,7 +17155,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/messageformat-formatters"
         }
       ]
@@ -17181,7 +17181,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/messageformat-parser"
         }
       ]
@@ -17207,7 +17207,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/messageformat"
         }
       ],
@@ -17233,7 +17233,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/messageformat\\node_modules\\make-plural"
             }
           ]
@@ -17261,7 +17261,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/methods"
         }
       ]
@@ -17287,7 +17287,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/micromatch"
         }
       ]
@@ -17313,7 +17313,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mime-db"
         }
       ]
@@ -17339,7 +17339,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mime-types"
         }
       ]
@@ -17365,7 +17365,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mime"
         }
       ]
@@ -17391,7 +17391,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mimic-response"
         }
       ]
@@ -17417,7 +17417,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minimatch"
         }
       ]
@@ -17443,7 +17443,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minimist"
         }
       ]
@@ -17469,7 +17469,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-collect"
         }
       ]
@@ -17495,7 +17495,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-fetch"
         }
       ]
@@ -17521,7 +17521,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-flush"
         }
       ]
@@ -17547,7 +17547,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-pipeline"
         }
       ]
@@ -17573,7 +17573,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-sized"
         }
       ]
@@ -17599,7 +17599,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass"
         }
       ]
@@ -17625,7 +17625,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minizlib"
         }
       ]
@@ -17651,7 +17651,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mixin-deep"
         }
       ]
@@ -17677,7 +17677,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mkdirp-classic"
         }
       ]
@@ -17703,7 +17703,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mkdirp"
         }
       ]
@@ -17729,7 +17729,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/moment-timezone"
         }
       ]
@@ -17755,7 +17755,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/moment"
         }
       ]
@@ -17781,7 +17781,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/morgan"
         }
       ],
@@ -17807,7 +17807,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/morgan\\node_modules\\on-finished"
             }
           ]
@@ -17835,7 +17835,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mout"
         }
       ]
@@ -17861,7 +17861,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ms"
         }
       ]
@@ -17887,7 +17887,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/multer"
         }
       ],
@@ -17913,7 +17913,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/multer\\node_modules\\mkdirp"
             }
           ]
@@ -17941,7 +17941,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mustache"
         }
       ]
@@ -17967,7 +17967,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/nan"
         }
       ]
@@ -17993,7 +17993,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/nanomatch"
         }
       ]
@@ -18019,7 +18019,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/napi-build-utils"
         }
       ]
@@ -18045,7 +18045,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/needle"
         }
       ],
@@ -18071,7 +18071,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/needle\\node_modules\\debug"
             }
           ]
@@ -18097,7 +18097,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/needle\\node_modules\\ms"
             }
           ]
@@ -18125,7 +18125,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/negotiator"
         }
       ]
@@ -18151,7 +18151,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/neo-async"
         }
       ]
@@ -18177,7 +18177,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-abi"
         }
       ],
@@ -18203,7 +18203,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-abi\\node_modules\\semver"
             }
           ]
@@ -18231,7 +18231,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-addon-api"
         }
       ]
@@ -18257,7 +18257,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-fetch"
         }
       ]
@@ -18283,7 +18283,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-gyp"
         }
       ],
@@ -18309,7 +18309,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp\\node_modules\\ansi-regex"
             }
           ]
@@ -18335,7 +18335,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp\\node_modules\\are-we-there-yet"
             }
           ]
@@ -18361,7 +18361,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp\\node_modules\\gauge"
             }
           ]
@@ -18387,7 +18387,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp\\node_modules\\is-fullwidth-code-point"
             }
           ]
@@ -18413,7 +18413,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp\\node_modules\\nopt"
             }
           ]
@@ -18439,7 +18439,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp\\node_modules\\npmlog"
             }
           ]
@@ -18465,7 +18465,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp\\node_modules\\readable-stream"
             }
           ]
@@ -18491,7 +18491,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp\\node_modules\\string-width"
             }
           ]
@@ -18517,7 +18517,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp\\node_modules\\strip-ansi"
             }
           ]
@@ -18545,7 +18545,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-pre-gyp"
         }
       ],
@@ -18571,7 +18571,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp\\node_modules\\chownr"
             }
           ]
@@ -18597,7 +18597,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp\\node_modules\\fs-minipass"
             }
           ]
@@ -18623,7 +18623,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp\\node_modules\\minipass"
             }
           ]
@@ -18649,7 +18649,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp\\node_modules\\minizlib"
             }
           ]
@@ -18675,7 +18675,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp\\node_modules\\mkdirp"
             }
           ]
@@ -18701,7 +18701,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp\\node_modules\\nopt"
             }
           ]
@@ -18727,7 +18727,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp\\node_modules\\rimraf"
             }
           ]
@@ -18753,7 +18753,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp\\node_modules\\safe-buffer"
             }
           ]
@@ -18779,7 +18779,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp\\node_modules\\semver"
             }
           ]
@@ -18805,7 +18805,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp\\node_modules\\tar"
             }
           ]
@@ -18831,7 +18831,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp\\node_modules\\yallist"
             }
           ]
@@ -18859,7 +18859,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/noop-logger"
         }
       ]
@@ -18885,7 +18885,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/nopt"
         }
       ]
@@ -18911,7 +18911,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/normalize-package-data"
         }
       ],
@@ -18937,7 +18937,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/normalize-package-data\\node_modules\\semver"
             }
           ]
@@ -18965,7 +18965,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/normalize-path"
         }
       ]
@@ -18991,7 +18991,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/normalize-url"
         }
       ]
@@ -19017,7 +19017,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/notevil"
         }
       ],
@@ -19043,7 +19043,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/notevil\\node_modules\\esprima"
             }
           ]
@@ -19071,7 +19071,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/npm-bundled"
         }
       ]
@@ -19097,7 +19097,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/npm-normalize-package-bin"
         }
       ]
@@ -19123,7 +19123,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/npm-packlist"
         }
       ]
@@ -19149,7 +19149,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/npmlog"
         }
       ]
@@ -19175,7 +19175,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/number-is-nan"
         }
       ]
@@ -19201,7 +19201,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/oauth-sign"
         }
       ]
@@ -19227,7 +19227,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-assign"
         }
       ]
@@ -19253,7 +19253,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-copy"
         }
       ],
@@ -19279,7 +19279,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy\\node_modules\\define-property"
             }
           ]
@@ -19305,7 +19305,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy\\node_modules\\is-accessor-descriptor"
             }
           ]
@@ -19331,7 +19331,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy\\node_modules\\is-data-descriptor"
             }
           ]
@@ -19357,7 +19357,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy\\node_modules\\is-descriptor"
             }
           ],
@@ -19383,7 +19383,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/object-copy\\node_modules\\is-descriptor\\node_modules\\kind-of"
                 }
               ]
@@ -19411,7 +19411,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy\\node_modules\\kind-of"
             }
           ]
@@ -19439,7 +19439,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-inspect"
         }
       ]
@@ -19465,7 +19465,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-is"
         }
       ]
@@ -19491,7 +19491,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-keys"
         }
       ]
@@ -19517,7 +19517,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-visit"
         }
       ]
@@ -19543,7 +19543,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object.assign"
         }
       ]
@@ -19569,7 +19569,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object.defaults"
         }
       ]
@@ -19595,7 +19595,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object.map"
         }
       ]
@@ -19621,7 +19621,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object.pick"
         }
       ]
@@ -19647,7 +19647,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/on-finished"
         }
       ]
@@ -19673,7 +19673,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/on-headers"
         }
       ]
@@ -19699,7 +19699,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/once"
         }
       ]
@@ -19725,7 +19725,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/one-time"
         }
       ]
@@ -19751,7 +19751,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/opentype.js"
         }
       ]
@@ -19777,7 +19777,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/optionator"
         }
       ]
@@ -19803,7 +19803,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/os-homedir"
         }
       ]
@@ -19829,7 +19829,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/os-tmpdir"
         }
       ]
@@ -19855,7 +19855,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/osenv"
         }
       ]
@@ -19881,7 +19881,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/otplib"
         }
       ]
@@ -19907,7 +19907,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-cancelable"
         }
       ]
@@ -19933,7 +19933,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-event"
         }
       ]
@@ -19959,7 +19959,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-finally"
         }
       ]
@@ -19985,7 +19985,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-is-promise"
         }
       ]
@@ -20011,7 +20011,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-limit"
         }
       ]
@@ -20037,7 +20037,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-locate"
         }
       ]
@@ -20063,7 +20063,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-map"
         }
       ]
@@ -20089,7 +20089,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-timeout"
         }
       ]
@@ -20115,7 +20115,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-try"
         }
       ]
@@ -20141,7 +20141,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pako"
         }
       ]
@@ -20167,7 +20167,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/parse-filepath"
         }
       ]
@@ -20193,7 +20193,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/parse-json"
         }
       ]
@@ -20219,7 +20219,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/parse-passwd"
         }
       ]
@@ -20245,7 +20245,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/parseurl"
         }
       ]
@@ -20271,7 +20271,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pascalcase"
         }
       ]
@@ -20297,7 +20297,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-exists"
         }
       ]
@@ -20323,7 +20323,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-is-absolute"
         }
       ]
@@ -20349,7 +20349,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-parse"
         }
       ]
@@ -20375,7 +20375,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-root-regex"
         }
       ]
@@ -20401,7 +20401,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-root"
         }
       ]
@@ -20427,7 +20427,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-to-regexp"
         }
       ]
@@ -20453,7 +20453,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pdfkit"
         }
       ]
@@ -20479,7 +20479,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/peek-readable"
         }
       ]
@@ -20505,7 +20505,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pend"
         }
       ]
@@ -20531,7 +20531,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/performance-now"
         }
       ]
@@ -20557,7 +20557,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pg-connection-string"
         }
       ]
@@ -20583,7 +20583,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/picomatch"
         }
       ]
@@ -20609,7 +20609,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pify"
         }
       ]
@@ -20635,7 +20635,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pinkie-promise"
         }
       ]
@@ -20661,7 +20661,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pinkie"
         }
       ]
@@ -20687,7 +20687,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/png-js"
         }
       ]
@@ -20713,7 +20713,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/portscanner"
         }
       ]
@@ -20739,7 +20739,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/posix-character-classes"
         }
       ]
@@ -20765,7 +20765,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/prebuild-install"
         }
       ]
@@ -20791,7 +20791,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/prelude-ls"
         }
       ]
@@ -20817,7 +20817,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/prepend-http"
         }
       ]
@@ -20843,7 +20843,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pretty-bytes"
         }
       ]
@@ -20869,7 +20869,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/process-nextick-args"
         }
       ]
@@ -20895,7 +20895,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/prom-client"
         }
       ]
@@ -20921,7 +20921,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/promise-inflight"
         }
       ]
@@ -20947,7 +20947,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/promise-retry"
         }
       ],
@@ -20973,7 +20973,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/promise-retry\\node_modules\\err-code"
             }
           ]
@@ -20999,7 +20999,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/promise-retry\\node_modules\\retry"
             }
           ]
@@ -21027,7 +21027,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/promise"
         }
       ]
@@ -21053,7 +21053,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/proper-lockfile"
         }
       ]
@@ -21079,7 +21079,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/proxy-addr"
         }
       ]
@@ -21105,7 +21105,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/psl"
         }
       ]
@@ -21131,7 +21131,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-attrs"
         }
       ]
@@ -21157,7 +21157,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-code-gen"
         }
       ]
@@ -21183,7 +21183,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-error"
         }
       ]
@@ -21209,7 +21209,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-filters"
         }
       ]
@@ -21235,7 +21235,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-lexer"
         }
       ]
@@ -21261,7 +21261,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-linker"
         }
       ]
@@ -21287,7 +21287,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-load"
         }
       ]
@@ -21313,7 +21313,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-parser"
         }
       ]
@@ -21339,7 +21339,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-runtime"
         }
       ]
@@ -21365,7 +21365,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-strip-comments"
         }
       ]
@@ -21391,7 +21391,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-walk"
         }
       ]
@@ -21417,7 +21417,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug"
         }
       ]
@@ -21443,7 +21443,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pump"
         }
       ]
@@ -21469,7 +21469,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/punycode"
         }
       ]
@@ -21495,7 +21495,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/qs"
         }
       ]
@@ -21521,7 +21521,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/query-string"
         }
       ]
@@ -21547,7 +21547,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/range_check"
         }
       ]
@@ -21573,7 +21573,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/range-parser"
         }
       ]
@@ -21599,7 +21599,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/raw-body"
         }
       ]
@@ -21625,7 +21625,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/rc"
         }
       ]
@@ -21651,7 +21651,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/read-pkg"
         }
       ],
@@ -21677,7 +21677,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/read-pkg\\node_modules\\pify"
             }
           ]
@@ -21705,7 +21705,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/readable-stream"
         }
       ],
@@ -21731,7 +21731,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/readable-stream\\node_modules\\isarray"
             }
           ]
@@ -21759,7 +21759,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/readable-web-to-node-stream"
         }
       ],
@@ -21785,7 +21785,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/readable-web-to-node-stream\\node_modules\\readable-stream"
             }
           ]
@@ -21813,7 +21813,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/readdirp"
         }
       ]
@@ -21839,7 +21839,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/rechoir"
         }
       ]
@@ -21865,7 +21865,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/regex-not"
         }
       ]
@@ -21891,7 +21891,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/regexp.prototype.flags"
         }
       ]
@@ -21917,7 +21917,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/remove-trailing-separator"
         }
       ]
@@ -21943,7 +21943,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/repeat-element"
         }
       ]
@@ -21969,7 +21969,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/repeat-string"
         }
       ]
@@ -21995,7 +21995,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/replace"
         }
       ],
@@ -22021,7 +22021,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\ansi-regex"
             }
           ]
@@ -22047,7 +22047,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\ansi-styles"
             }
           ]
@@ -22073,7 +22073,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\brace-expansion"
             }
           ]
@@ -22099,7 +22099,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\cliui"
             }
           ]
@@ -22125,7 +22125,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\color-convert"
             }
           ]
@@ -22151,7 +22151,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\color-name"
             }
           ]
@@ -22177,7 +22177,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\find-up"
             }
           ]
@@ -22203,7 +22203,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\is-fullwidth-code-point"
             }
           ]
@@ -22229,7 +22229,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\locate-path"
             }
           ]
@@ -22255,7 +22255,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\minimatch"
             }
           ]
@@ -22281,7 +22281,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\p-locate"
             }
           ]
@@ -22307,7 +22307,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\path-exists"
             }
           ]
@@ -22333,7 +22333,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\string-width"
             }
           ]
@@ -22359,7 +22359,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\strip-ansi"
             }
           ]
@@ -22385,7 +22385,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\wrap-ansi"
             }
           ]
@@ -22411,7 +22411,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\yargs-parser"
             }
           ]
@@ -22437,7 +22437,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\yargs"
             }
           ]
@@ -22465,7 +22465,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/request"
         }
       ],
@@ -22491,7 +22491,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/request\\node_modules\\qs"
             }
           ]
@@ -22519,7 +22519,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/require-directory"
         }
       ]
@@ -22545,7 +22545,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/require-main-filename"
         }
       ]
@@ -22571,7 +22571,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/resolve-dir"
         }
       ]
@@ -22597,7 +22597,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/resolve-url"
         }
       ]
@@ -22623,7 +22623,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/resolve"
         }
       ]
@@ -22649,7 +22649,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/responselike"
         }
       ]
@@ -22675,7 +22675,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/restructure"
         }
       ]
@@ -22701,7 +22701,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ret"
         }
       ]
@@ -22727,7 +22727,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/retry-as-promised"
         }
       ]
@@ -22753,7 +22753,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/retry"
         }
       ]
@@ -22779,7 +22779,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/rimraf"
         }
       ]
@@ -22805,7 +22805,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/rxjs"
         }
       ],
@@ -22831,7 +22831,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/rxjs\\node_modules\\tslib"
             }
           ]
@@ -22859,7 +22859,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safe-buffer"
         }
       ]
@@ -22885,7 +22885,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safe-regex-test"
         }
       ]
@@ -22911,7 +22911,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safe-regex"
         }
       ]
@@ -22937,7 +22937,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safe-stable-stringify"
         }
       ]
@@ -22963,7 +22963,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safer-buffer"
         }
       ]
@@ -22989,7 +22989,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/samsam"
         }
       ]
@@ -23015,7 +23015,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sanitize-filename"
         }
       ]
@@ -23041,7 +23041,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sanitize-html"
         }
       ],
@@ -23067,7 +23067,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sanitize-html\\node_modules\\lodash"
             }
           ]
@@ -23095,7 +23095,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sax"
         }
       ]
@@ -23121,7 +23121,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/seek-bzip"
         }
       ]
@@ -23147,7 +23147,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/semver"
         }
       ]
@@ -23173,7 +23173,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/send"
         }
       ],
@@ -23199,7 +23199,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/send\\node_modules\\ms"
             }
           ]
@@ -23227,7 +23227,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sequelize-pool"
         }
       ]
@@ -23253,7 +23253,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sequelize"
         }
       ],
@@ -23279,7 +23279,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sequelize\\node_modules\\debug"
             }
           ]
@@ -23305,7 +23305,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sequelize\\node_modules\\ms"
             }
           ]
@@ -23331,7 +23331,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sequelize\\node_modules\\uuid"
             }
           ]
@@ -23359,7 +23359,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/serve-index"
         }
       ],
@@ -23385,7 +23385,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index\\node_modules\\depd"
             }
           ]
@@ -23411,7 +23411,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index\\node_modules\\http-errors"
             }
           ]
@@ -23437,7 +23437,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index\\node_modules\\inherits"
             }
           ]
@@ -23463,7 +23463,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index\\node_modules\\setprototypeof"
             }
           ]
@@ -23489,7 +23489,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index\\node_modules\\statuses"
             }
           ]
@@ -23517,7 +23517,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/serve-static"
         }
       ]
@@ -23543,7 +23543,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/set-blocking"
         }
       ]
@@ -23569,7 +23569,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/set-value"
         }
       ],
@@ -23595,7 +23595,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/set-value\\node_modules\\extend-shallow"
             }
           ]
@@ -23621,7 +23621,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/set-value\\node_modules\\is-extendable"
             }
           ]
@@ -23649,7 +23649,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/setimmediate"
         }
       ]
@@ -23675,7 +23675,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/setprototypeof"
         }
       ]
@@ -23701,7 +23701,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/side-channel"
         }
       ]
@@ -23727,7 +23727,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/signal-exit"
         }
       ]
@@ -23753,7 +23753,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/simple-concat"
         }
       ]
@@ -23779,7 +23779,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/simple-get"
         }
       ],
@@ -23805,7 +23805,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/simple-get\\node_modules\\decompress-response"
             }
           ]
@@ -23831,7 +23831,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/simple-get\\node_modules\\mimic-response"
             }
           ]
@@ -23859,7 +23859,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/simple-swizzle"
         }
       ],
@@ -23885,7 +23885,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/simple-swizzle\\node_modules\\is-arrayish"
             }
           ]
@@ -23913,7 +23913,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sinon"
         }
       ]
@@ -23939,7 +23939,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/smart-buffer"
         }
       ]
@@ -23965,7 +23965,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/snapdragon-node"
         }
       ],
@@ -23991,7 +23991,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon-node\\node_modules\\define-property"
             }
           ]
@@ -24019,7 +24019,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/snapdragon-util"
         }
       ],
@@ -24045,7 +24045,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon-util\\node_modules\\kind-of"
             }
           ]
@@ -24073,7 +24073,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/snapdragon"
         }
       ],
@@ -24099,7 +24099,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon\\node_modules\\define-property"
             }
           ]
@@ -24125,7 +24125,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon\\node_modules\\extend-shallow"
             }
           ]
@@ -24151,7 +24151,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon\\node_modules\\is-accessor-descriptor"
             }
           ],
@@ -24177,7 +24177,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/snapdragon\\node_modules\\is-accessor-descriptor\\node_modules\\kind-of"
                 }
               ]
@@ -24205,7 +24205,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon\\node_modules\\is-data-descriptor"
             }
           ],
@@ -24231,7 +24231,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/snapdragon\\node_modules\\is-data-descriptor\\node_modules\\kind-of"
                 }
               ]
@@ -24259,7 +24259,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon\\node_modules\\is-descriptor"
             }
           ]
@@ -24285,7 +24285,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon\\node_modules\\is-extendable"
             }
           ]
@@ -24311,7 +24311,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon\\node_modules\\kind-of"
             }
           ]
@@ -24337,7 +24337,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon\\node_modules\\source-map"
             }
           ]
@@ -24365,7 +24365,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socket.io-adapter"
         }
       ]
@@ -24391,7 +24391,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socket.io-parser"
         }
       ],
@@ -24417,7 +24417,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socket.io-parser\\node_modules\\debug"
             }
           ]
@@ -24443,7 +24443,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socket.io-parser\\node_modules\\ms"
             }
           ]
@@ -24471,7 +24471,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socket.io"
         }
       ],
@@ -24497,7 +24497,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socket.io\\node_modules\\debug"
             }
           ]
@@ -24523,7 +24523,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socket.io\\node_modules\\ms"
             }
           ]
@@ -24551,7 +24551,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socks-proxy-agent"
         }
       ],
@@ -24577,7 +24577,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socks-proxy-agent\\node_modules\\debug"
             }
           ]
@@ -24603,7 +24603,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socks-proxy-agent\\node_modules\\ms"
             }
           ]
@@ -24631,7 +24631,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socks"
         }
       ],
@@ -24657,7 +24657,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socks\\node_modules\\ip"
             }
           ]
@@ -24685,7 +24685,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sort-keys-length"
         }
       ],
@@ -24711,7 +24711,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sort-keys-length\\node_modules\\sort-keys"
             }
           ]
@@ -24739,7 +24739,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sort-keys"
         }
       ]
@@ -24765,7 +24765,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/source-map-resolve"
         }
       ]
@@ -24791,7 +24791,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/source-map-support"
         }
       ]
@@ -24817,7 +24817,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/source-map-url"
         }
       ]
@@ -24843,7 +24843,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/source-map"
         }
       ]
@@ -24869,7 +24869,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spawn-command"
         }
       ]
@@ -24895,7 +24895,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spdx-correct"
         }
       ]
@@ -24921,7 +24921,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spdx-exceptions"
         }
       ]
@@ -24947,7 +24947,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spdx-expression-parse"
         }
       ]
@@ -24973,7 +24973,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spdx-license-ids"
         }
       ]
@@ -24999,7 +24999,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/split-string"
         }
       ]
@@ -25025,7 +25025,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sprintf-js"
         }
       ]
@@ -25051,7 +25051,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sqlite3"
         }
       ]
@@ -25077,7 +25077,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sshpk"
         }
       ]
@@ -25103,7 +25103,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ssri"
         }
       ]
@@ -25129,7 +25129,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/stack-trace"
         }
       ]
@@ -25155,7 +25155,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/static-extend"
         }
       ],
@@ -25181,7 +25181,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend\\node_modules\\define-property"
             }
           ]
@@ -25207,7 +25207,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend\\node_modules\\is-accessor-descriptor"
             }
           ],
@@ -25233,7 +25233,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/static-extend\\node_modules\\is-accessor-descriptor\\node_modules\\kind-of"
                 }
               ]
@@ -25261,7 +25261,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend\\node_modules\\is-data-descriptor"
             }
           ],
@@ -25287,7 +25287,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/static-extend\\node_modules\\is-data-descriptor\\node_modules\\kind-of"
                 }
               ]
@@ -25315,7 +25315,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend\\node_modules\\is-descriptor"
             }
           ]
@@ -25341,7 +25341,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend\\node_modules\\kind-of"
             }
           ]
@@ -25369,7 +25369,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/statuses"
         }
       ]
@@ -25395,7 +25395,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/stream-buffers"
         }
       ]
@@ -25421,7 +25421,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/streamsearch"
         }
       ]
@@ -25447,7 +25447,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strict-uri-encode"
         }
       ]
@@ -25473,7 +25473,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string_decoder"
         }
       ]
@@ -25499,7 +25499,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string-width"
         }
       ]
@@ -25525,7 +25525,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string.fromcodepoint"
         }
       ]
@@ -25551,7 +25551,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string.prototype.codepointat"
         }
       ]
@@ -25577,7 +25577,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string.prototype.trimend"
         }
       ]
@@ -25603,7 +25603,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string.prototype.trimstart"
         }
       ]
@@ -25629,7 +25629,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-ansi"
         }
       ]
@@ -25655,7 +25655,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-bom"
         }
       ]
@@ -25681,7 +25681,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-dirs"
         }
       ]
@@ -25707,7 +25707,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-json-comments"
         }
       ]
@@ -25733,7 +25733,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-outer"
         }
       ]
@@ -25759,7 +25759,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strtok3"
         }
       ]
@@ -25785,7 +25785,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/supports-color"
         }
       ]
@@ -25811,7 +25811,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/supports-preserve-symlinks-flag"
         }
       ]
@@ -25837,7 +25837,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/svg-captcha"
         }
       ]
@@ -25863,7 +25863,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/swagger-ui-dist"
         }
       ]
@@ -25889,7 +25889,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/swagger-ui-express"
         }
       ]
@@ -25915,7 +25915,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tar-fs"
         }
       ],
@@ -25941,7 +25941,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/tar-fs\\node_modules\\bl"
             }
           ]
@@ -25967,7 +25967,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/tar-fs\\node_modules\\chownr"
             }
           ]
@@ -25993,7 +25993,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/tar-fs\\node_modules\\readable-stream"
             }
           ]
@@ -26019,7 +26019,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/tar-fs\\node_modules\\tar-stream"
             }
           ]
@@ -26047,7 +26047,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tar-stream"
         }
       ]
@@ -26073,7 +26073,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tar"
         }
       ]
@@ -26099,7 +26099,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tdigest"
         }
       ]
@@ -26125,7 +26125,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/text-hex"
         }
       ]
@@ -26151,7 +26151,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/thirty-two"
         }
       ]
@@ -26177,7 +26177,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/through"
         }
       ]
@@ -26203,7 +26203,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/timed-out"
         }
       ]
@@ -26229,7 +26229,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tiny-inflate"
         }
       ]
@@ -26255,7 +26255,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-buffer"
         }
       ]
@@ -26281,7 +26281,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-fast-properties"
         }
       ]
@@ -26307,7 +26307,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-object-path"
         }
       ],
@@ -26333,7 +26333,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/to-object-path\\node_modules\\kind-of"
             }
           ]
@@ -26361,7 +26361,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-regex-range"
         }
       ]
@@ -26387,7 +26387,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-regex"
         }
       ]
@@ -26413,7 +26413,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/toidentifier"
         }
       ]
@@ -26439,7 +26439,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/token-stream"
         }
       ]
@@ -26465,7 +26465,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/token-types"
         }
       ]
@@ -26491,7 +26491,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/toposort-class"
         }
       ]
@@ -26517,7 +26517,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tough-cookie"
         }
       ]
@@ -26543,7 +26543,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tr46"
         }
       ]
@@ -26569,7 +26569,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/traverse"
         }
       ]
@@ -26595,7 +26595,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tree-kill"
         }
       ]
@@ -26621,7 +26621,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/trim-repeated"
         }
       ]
@@ -26647,7 +26647,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/triple-beam"
         }
       ]
@@ -26673,7 +26673,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/truncate-utf8-bytes"
         }
       ]
@@ -26699,7 +26699,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ts-node-dev"
         }
       ],
@@ -26725,7 +26725,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/ts-node-dev\\node_modules\\rimraf"
             }
           ]
@@ -26753,7 +26753,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ts-node"
         }
       ]
@@ -26779,7 +26779,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tsconfig"
         }
       ]
@@ -26805,7 +26805,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tslib"
         }
       ]
@@ -26831,7 +26831,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tunnel-agent"
         }
       ]
@@ -26857,7 +26857,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tweetnacl"
         }
       ]
@@ -26883,7 +26883,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/type-check"
         }
       ]
@@ -26909,7 +26909,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/type-is"
         }
       ]
@@ -26935,7 +26935,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/typecast"
         }
       ]
@@ -26961,7 +26961,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/typedarray"
         }
       ]
@@ -26987,7 +26987,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/typescript"
         }
       ]
@@ -27013,7 +27013,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/uglify-js"
         }
       ]
@@ -27039,7 +27039,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unbox-primitive"
         }
       ]
@@ -27065,7 +27065,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unbzip2-stream"
         }
       ]
@@ -27091,7 +27091,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unc-path-regex"
         }
       ]
@@ -27117,7 +27117,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/underscore.string"
         }
       ]
@@ -27143,7 +27143,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unicode-properties"
         }
       ]
@@ -27169,7 +27169,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unicode-trie"
         }
       ]
@@ -27195,7 +27195,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/union-value"
         }
       ],
@@ -27221,7 +27221,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/union-value\\node_modules\\is-extendable"
             }
           ]
@@ -27249,7 +27249,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unique-filename"
         }
       ]
@@ -27275,7 +27275,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unique-slug"
         }
       ]
@@ -27301,7 +27301,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unit-compare"
         }
       ]
@@ -27327,7 +27327,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/universalify"
         }
       ]
@@ -27353,7 +27353,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unpipe"
         }
       ]
@@ -27379,7 +27379,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unset-value"
         }
       ],
@@ -27405,7 +27405,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/unset-value\\node_modules\\has-value"
             }
           ],
@@ -27431,7 +27431,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/unset-value\\node_modules\\has-value\\node_modules\\isobject"
                 }
               ]
@@ -27459,7 +27459,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/unset-value\\node_modules\\has-values"
             }
           ]
@@ -27485,7 +27485,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/unset-value\\node_modules\\isarray"
             }
           ]
@@ -27513,7 +27513,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/untildify"
         }
       ]
@@ -27539,7 +27539,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unzipper"
         }
       ],
@@ -27565,7 +27565,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/unzipper\\node_modules\\bluebird"
             }
           ]
@@ -27593,7 +27593,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/uri-js"
         }
       ]
@@ -27619,7 +27619,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/urix"
         }
       ]
@@ -27645,7 +27645,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/url-parse-lax"
         }
       ]
@@ -27671,7 +27671,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/url-to-options"
         }
       ]
@@ -27697,7 +27697,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/use"
         }
       ]
@@ -27723,7 +27723,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/utf8-byte-length"
         }
       ]
@@ -27749,7 +27749,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/util-deprecate"
         }
       ]
@@ -27775,7 +27775,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/util"
         }
       ]
@@ -27801,7 +27801,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/utils-merge"
         }
       ]
@@ -27827,7 +27827,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/uuid"
         }
       ]
@@ -27853,7 +27853,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/v8flags"
         }
       ]
@@ -27879,7 +27879,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/validate-npm-package-license"
         }
       ]
@@ -27905,7 +27905,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/validate"
         }
       ]
@@ -27931,7 +27931,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/validator"
         }
       ]
@@ -27957,7 +27957,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/vary"
         }
       ]
@@ -27983,7 +27983,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/verror"
         }
       ],
@@ -28009,7 +28009,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/verror\\node_modules\\core-util-is"
             }
           ]
@@ -28037,7 +28037,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/vm2"
         }
       ],
@@ -28063,7 +28063,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/vm2\\node_modules\\acorn"
             }
           ]
@@ -28091,7 +28091,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/void-elements"
         }
       ]
@@ -28117,7 +28117,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/walk"
         }
       ]
@@ -28143,7 +28143,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/walkdir"
         }
       ]
@@ -28169,7 +28169,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/webidl-conversions"
         }
       ]
@@ -28195,7 +28195,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/whatwg-url"
         }
       ]
@@ -28221,7 +28221,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-boxed-primitive"
         }
       ]
@@ -28247,7 +28247,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-collection"
         }
       ]
@@ -28273,7 +28273,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-module"
         }
       ]
@@ -28299,7 +28299,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-pm-runs"
         }
       ]
@@ -28325,7 +28325,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-typed-array"
         }
       ]
@@ -28351,7 +28351,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which"
         }
       ]
@@ -28377,7 +28377,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wide-align"
         }
       ]
@@ -28403,7 +28403,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/winston-transport"
         }
       ],
@@ -28429,7 +28429,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/winston-transport\\node_modules\\readable-stream"
             }
           ]
@@ -28457,7 +28457,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/winston"
         }
       ],
@@ -28483,7 +28483,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/winston\\node_modules\\async"
             }
           ]
@@ -28509,7 +28509,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/winston\\node_modules\\is-stream"
             }
           ]
@@ -28535,7 +28535,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/winston\\node_modules\\readable-stream"
             }
           ]
@@ -28563,7 +28563,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/with"
         }
       ]
@@ -28589,7 +28589,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wkx"
         }
       ]
@@ -28615,7 +28615,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/word-wrap"
         }
       ]
@@ -28641,7 +28641,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wordwrap"
         }
       ]
@@ -28667,7 +28667,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wrap-ansi"
         }
       ],
@@ -28693,7 +28693,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi\\node_modules\\ansi-regex"
             }
           ]
@@ -28719,7 +28719,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi\\node_modules\\emoji-regex"
             }
           ]
@@ -28745,7 +28745,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi\\node_modules\\is-fullwidth-code-point"
             }
           ]
@@ -28771,7 +28771,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi\\node_modules\\string-width"
             }
           ]
@@ -28797,7 +28797,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi\\node_modules\\strip-ansi"
             }
           ]
@@ -28825,7 +28825,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wrappy"
         }
       ]
@@ -28851,7 +28851,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ws"
         }
       ]
@@ -28877,7 +28877,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/xtend"
         }
       ]
@@ -28903,7 +28903,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/y18n"
         }
       ]
@@ -28929,7 +28929,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yallist"
         }
       ]
@@ -28955,7 +28955,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yaml-schema-validator"
         }
       ]
@@ -28981,7 +28981,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yargs-parser"
         }
       ]
@@ -29007,7 +29007,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yargs"
         }
       ],
@@ -29033,7 +29033,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs\\node_modules\\ansi-regex"
             }
           ]
@@ -29059,7 +29059,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs\\node_modules\\emoji-regex"
             }
           ]
@@ -29085,7 +29085,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs\\node_modules\\is-fullwidth-code-point"
             }
           ]
@@ -29111,7 +29111,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs\\node_modules\\string-width"
             }
           ]
@@ -29137,7 +29137,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs\\node_modules\\strip-ansi"
             }
           ]
@@ -29165,7 +29165,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yauzl"
         }
       ]
@@ -29191,7 +29191,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yn"
         }
       ]
@@ -29217,7 +29217,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/z85"
         }
       ]
@@ -29243,7 +29243,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/zip-stream"
         }
       ]
@@ -29269,7 +29269,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/zlibjs"
         }
       ]

--- a/tests/_data/sbom_demo-results/juice-shop_npm9_node16_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/juice-shop_npm9_node16_macos-latest.snap.json
@@ -62,7 +62,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -95,7 +95,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@babel/helper-string-parser"
         }
       ]
@@ -122,7 +122,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@babel/helper-validator-identifier"
         }
       ]
@@ -149,7 +149,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@babel/parser"
         }
       ]
@@ -176,7 +176,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@babel/types"
         }
       ]
@@ -203,7 +203,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@colors/colors"
         }
       ]
@@ -230,7 +230,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@dabh/diagnostics"
         }
       ]
@@ -257,7 +257,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@gar/promisify"
         }
       ]
@@ -284,7 +284,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@mapbox/node-pre-gyp"
         }
       ],
@@ -310,7 +310,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/ansi-regex"
             }
           ]
@@ -336,7 +336,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/are-we-there-yet"
             }
           ]
@@ -362,7 +362,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/detect-libc"
             }
           ]
@@ -388,7 +388,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/gauge"
             }
           ]
@@ -414,7 +414,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -440,7 +440,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/make-dir"
             }
           ],
@@ -466,7 +466,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/@mapbox/node-pre-gyp/node_modules/make-dir/node_modules/semver"
                 }
               ]
@@ -494,7 +494,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/nopt"
             }
           ]
@@ -520,7 +520,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/npmlog"
             }
           ]
@@ -546,7 +546,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/readable-stream"
             }
           ]
@@ -572,7 +572,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/string-width"
             }
           ]
@@ -598,7 +598,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/strip-ansi"
             }
           ]
@@ -627,7 +627,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/core-loader"
         }
       ]
@@ -654,7 +654,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/core"
         }
       ]
@@ -681,7 +681,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/evaluator"
         }
       ]
@@ -708,7 +708,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-all"
         }
       ]
@@ -735,7 +735,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ar"
         }
       ]
@@ -762,7 +762,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-bn"
         }
       ]
@@ -789,7 +789,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ca"
         }
       ]
@@ -816,7 +816,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-cs"
         }
       ]
@@ -843,7 +843,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-da"
         }
       ]
@@ -870,7 +870,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-de"
         }
       ]
@@ -897,7 +897,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-el"
         }
       ]
@@ -924,7 +924,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-en-min"
         }
       ]
@@ -951,7 +951,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-en"
         }
       ]
@@ -978,7 +978,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-es"
         }
       ]
@@ -1005,7 +1005,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-eu"
         }
       ]
@@ -1032,7 +1032,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-fa"
         }
       ]
@@ -1059,7 +1059,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-fi"
         }
       ]
@@ -1086,7 +1086,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-fr"
         }
       ]
@@ -1113,7 +1113,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ga"
         }
       ]
@@ -1140,7 +1140,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-gl"
         }
       ]
@@ -1167,7 +1167,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-hi"
         }
       ]
@@ -1194,7 +1194,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-hu"
         }
       ]
@@ -1221,7 +1221,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-hy"
         }
       ]
@@ -1248,7 +1248,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-id"
         }
       ]
@@ -1275,7 +1275,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-it"
         }
       ]
@@ -1302,7 +1302,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ja"
         }
       ]
@@ -1329,7 +1329,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ko"
         }
       ]
@@ -1356,7 +1356,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-lt"
         }
       ]
@@ -1383,7 +1383,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ms"
         }
       ]
@@ -1410,7 +1410,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ne"
         }
       ]
@@ -1437,7 +1437,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-nl"
         }
       ]
@@ -1464,7 +1464,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-no"
         }
       ]
@@ -1491,7 +1491,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-pl"
         }
       ]
@@ -1518,7 +1518,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-pt"
         }
       ]
@@ -1545,7 +1545,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ro"
         }
       ]
@@ -1572,7 +1572,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ru"
         }
       ]
@@ -1599,7 +1599,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-sl"
         }
       ]
@@ -1626,7 +1626,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-sr"
         }
       ]
@@ -1653,7 +1653,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-sv"
         }
       ]
@@ -1680,7 +1680,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ta"
         }
       ]
@@ -1707,7 +1707,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-th"
         }
       ]
@@ -1734,7 +1734,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-tl"
         }
       ]
@@ -1761,7 +1761,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-tr"
         }
       ]
@@ -1788,7 +1788,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-uk"
         }
       ]
@@ -1815,7 +1815,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-zh"
         }
       ]
@@ -1842,7 +1842,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/language-min"
         }
       ]
@@ -1869,7 +1869,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/language"
         }
       ]
@@ -1896,7 +1896,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/ner"
         }
       ]
@@ -1923,7 +1923,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/neural"
         }
       ]
@@ -1950,7 +1950,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/nlg"
         }
       ]
@@ -1977,7 +1977,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/nlp"
         }
       ]
@@ -2004,7 +2004,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/nlu"
         }
       ]
@@ -2031,7 +2031,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/request"
         }
       ]
@@ -2058,7 +2058,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/sentiment"
         }
       ]
@@ -2085,7 +2085,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/similarity"
         }
       ]
@@ -2112,7 +2112,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/slot"
         }
       ]
@@ -2139,7 +2139,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@npmcli/fs"
         }
       ]
@@ -2166,7 +2166,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@npmcli/move-file"
         }
       ]
@@ -2193,7 +2193,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib/core"
         }
       ]
@@ -2220,7 +2220,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib/plugin-crypto"
         }
       ]
@@ -2247,7 +2247,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib/plugin-thirty-two"
         }
       ]
@@ -2274,7 +2274,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib/preset-default"
         }
       ]
@@ -2301,7 +2301,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib/preset-v11"
         }
       ]
@@ -2328,7 +2328,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@sindresorhus/is"
         }
       ]
@@ -2355,7 +2355,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@swc/helpers"
         }
       ]
@@ -2382,7 +2382,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@tokenizer/token"
         }
       ]
@@ -2409,7 +2409,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@tootallnate/once"
         }
       ]
@@ -2436,7 +2436,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/component-emitter"
         }
       ]
@@ -2463,7 +2463,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/cookie"
         }
       ]
@@ -2490,7 +2490,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/cors"
         }
       ]
@@ -2517,7 +2517,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/debug"
         }
       ]
@@ -2544,7 +2544,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/ms"
         }
       ]
@@ -2571,7 +2571,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/node"
         }
       ]
@@ -2598,7 +2598,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/strip-bom"
         }
       ]
@@ -2625,7 +2625,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/strip-json-comments"
         }
       ]
@@ -2652,7 +2652,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/validator"
         }
       ]
@@ -2678,7 +2678,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/abbrev"
         }
       ]
@@ -2704,7 +2704,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/accepts"
         }
       ]
@@ -2730,7 +2730,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/acorn-walk"
         }
       ]
@@ -2756,7 +2756,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/acorn"
         }
       ]
@@ -2782,7 +2782,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/agent-base"
         }
       ],
@@ -2808,7 +2808,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agent-base/node_modules/debug"
             }
           ]
@@ -2834,7 +2834,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agent-base/node_modules/ms"
             }
           ]
@@ -2862,7 +2862,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/agentkeepalive"
         }
       ],
@@ -2888,7 +2888,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agentkeepalive/node_modules/debug"
             }
           ]
@@ -2914,7 +2914,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agentkeepalive/node_modules/depd"
             }
           ]
@@ -2940,7 +2940,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agentkeepalive/node_modules/ms"
             }
           ]
@@ -2968,7 +2968,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/aggregate-error"
         }
       ]
@@ -2994,7 +2994,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ajv"
         }
       ]
@@ -3020,7 +3020,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ansi-regex"
         }
       ]
@@ -3046,7 +3046,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ansi-styles"
         }
       ]
@@ -3072,7 +3072,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/anymatch"
         }
       ],
@@ -3098,7 +3098,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/anymatch/node_modules/normalize-path"
             }
           ]
@@ -3126,7 +3126,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/append-field"
         }
       ]
@@ -3152,7 +3152,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/aproba"
         }
       ]
@@ -3178,7 +3178,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/archive-type"
         }
       ],
@@ -3204,7 +3204,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/archive-type/node_modules/file-type"
             }
           ]
@@ -3232,7 +3232,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/archiver-utils"
         }
       ]
@@ -3258,7 +3258,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/archiver"
         }
       ]
@@ -3284,7 +3284,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/are-we-there-yet"
         }
       ]
@@ -3310,7 +3310,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/arg"
         }
       ]
@@ -3336,7 +3336,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/argparse"
         }
       ],
@@ -3362,7 +3362,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/argparse/node_modules/sprintf-js"
             }
           ]
@@ -3390,7 +3390,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/arr-diff"
         }
       ]
@@ -3416,7 +3416,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/arr-flatten"
         }
       ]
@@ -3442,7 +3442,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/arr-union"
         }
       ]
@@ -3468,7 +3468,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/array-each"
         }
       ]
@@ -3494,7 +3494,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/array-flatten"
         }
       ]
@@ -3520,7 +3520,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/array-slice"
         }
       ]
@@ -3546,7 +3546,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/array-unique"
         }
       ]
@@ -3572,7 +3572,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/asap"
         }
       ]
@@ -3598,7 +3598,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/asn1"
         }
       ]
@@ -3624,7 +3624,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/assert-never"
         }
       ]
@@ -3650,7 +3650,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/assert-plus"
         }
       ]
@@ -3676,7 +3676,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/assign-symbols"
         }
       ]
@@ -3702,7 +3702,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/async"
         }
       ]
@@ -3728,7 +3728,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/asynckit"
         }
       ]
@@ -3754,7 +3754,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/at-least-node"
         }
       ]
@@ -3780,7 +3780,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/atob"
         }
       ]
@@ -3806,7 +3806,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/available-typed-arrays"
         }
       ]
@@ -3832,7 +3832,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/aws-sign2"
         }
       ]
@@ -3858,7 +3858,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/aws4"
         }
       ]
@@ -3884,7 +3884,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/babel-walk"
         }
       ]
@@ -3910,7 +3910,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/balanced-match"
         }
       ]
@@ -3936,7 +3936,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base"
         }
       ],
@@ -3962,7 +3962,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/base/node_modules/define-property"
             }
           ]
@@ -3990,7 +3990,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base64-arraybuffer"
         }
       ]
@@ -4016,7 +4016,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base64-js"
         }
       ]
@@ -4042,7 +4042,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base64id"
         }
       ]
@@ -4068,7 +4068,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base64url"
         }
       ]
@@ -4094,7 +4094,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/basic-auth"
         }
       ]
@@ -4120,7 +4120,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/batch"
         }
       ]
@@ -4146,7 +4146,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bcrypt-pbkdf"
         }
       ]
@@ -4172,7 +4172,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/big-integer"
         }
       ]
@@ -4198,7 +4198,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/binary-extensions"
         }
       ]
@@ -4224,7 +4224,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/binary"
         }
       ]
@@ -4250,7 +4250,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bindings"
         }
       ]
@@ -4276,7 +4276,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bintrees"
         }
       ]
@@ -4302,7 +4302,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bl"
         }
       ]
@@ -4328,7 +4328,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bluebird"
         }
       ]
@@ -4354,7 +4354,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/body-parser"
         }
       ]
@@ -4380,7 +4380,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bower-config"
         }
       ],
@@ -4406,7 +4406,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bower-config/node_modules/minimist"
             }
           ]
@@ -4434,7 +4434,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/brace-expansion"
         }
       ]
@@ -4460,7 +4460,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/braces"
         }
       ],
@@ -4486,7 +4486,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/braces/node_modules/extend-shallow"
             }
           ]
@@ -4512,7 +4512,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/braces/node_modules/is-extendable"
             }
           ]
@@ -4540,7 +4540,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/brotli"
         }
       ]
@@ -4566,7 +4566,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-alloc-unsafe"
         }
       ]
@@ -4592,7 +4592,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-alloc"
         }
       ]
@@ -4618,7 +4618,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-crc32"
         }
       ]
@@ -4644,7 +4644,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-fill"
         }
       ]
@@ -4670,7 +4670,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-from"
         }
       ]
@@ -4696,7 +4696,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-indexof-polyfill"
         }
       ]
@@ -4722,7 +4722,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer"
         }
       ]
@@ -4748,7 +4748,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffers"
         }
       ]
@@ -4774,7 +4774,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/busboy"
         }
       ],
@@ -4800,7 +4800,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/busboy/node_modules/isarray"
             }
           ]
@@ -4826,7 +4826,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/busboy/node_modules/readable-stream"
             }
           ]
@@ -4852,7 +4852,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/busboy/node_modules/string_decoder"
             }
           ]
@@ -4880,7 +4880,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/byline"
         }
       ]
@@ -4906,7 +4906,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bytes"
         }
       ]
@@ -4932,7 +4932,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cacache"
         }
       ]
@@ -4958,7 +4958,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cache-base"
         }
       ]
@@ -4984,7 +4984,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cacheable-request"
         }
       ],
@@ -5010,7 +5010,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cacheable-request/node_modules/get-stream"
             }
           ]
@@ -5036,7 +5036,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cacheable-request/node_modules/lowercase-keys"
             }
           ]
@@ -5064,7 +5064,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/call-bind"
         }
       ]
@@ -5090,7 +5090,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/camelcase"
         }
       ]
@@ -5116,7 +5116,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/caseless"
         }
       ]
@@ -5142,7 +5142,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/chainsaw"
         }
       ]
@@ -5168,7 +5168,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/chalk"
         }
       ]
@@ -5194,7 +5194,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/character-parser"
         }
       ]
@@ -5220,7 +5220,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/check-dependencies"
         }
       ],
@@ -5246,7 +5246,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/check-dependencies/node_modules/semver"
             }
           ]
@@ -5274,7 +5274,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/check-types"
         }
       ]
@@ -5300,7 +5300,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/chokidar"
         }
       ],
@@ -5326,7 +5326,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar/node_modules/braces"
             }
           ]
@@ -5352,7 +5352,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar/node_modules/fill-range"
             }
           ]
@@ -5378,7 +5378,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar/node_modules/is-glob"
             }
           ]
@@ -5404,7 +5404,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar/node_modules/is-number"
             }
           ]
@@ -5430,7 +5430,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar/node_modules/normalize-path"
             }
           ]
@@ -5456,7 +5456,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar/node_modules/to-regex-range"
             }
           ]
@@ -5484,7 +5484,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/chownr"
         }
       ]
@@ -5510,7 +5510,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/clarinet"
         }
       ]
@@ -5536,7 +5536,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/class-utils"
         }
       ],
@@ -5562,7 +5562,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils/node_modules/define-property"
             }
           ]
@@ -5588,7 +5588,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils/node_modules/is-accessor-descriptor"
             }
           ],
@@ -5614,7 +5614,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/class-utils/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
@@ -5642,7 +5642,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils/node_modules/is-data-descriptor"
             }
           ],
@@ -5668,7 +5668,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/class-utils/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
@@ -5696,7 +5696,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils/node_modules/is-descriptor"
             }
           ]
@@ -5722,7 +5722,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils/node_modules/kind-of"
             }
           ]
@@ -5750,7 +5750,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/clean-stack"
         }
       ]
@@ -5776,7 +5776,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cliui"
         }
       ],
@@ -5802,7 +5802,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui/node_modules/ansi-regex"
             }
           ]
@@ -5828,7 +5828,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui/node_modules/emoji-regex"
             }
           ]
@@ -5854,7 +5854,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -5880,7 +5880,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui/node_modules/string-width"
             }
           ]
@@ -5906,7 +5906,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui/node_modules/strip-ansi"
             }
           ]
@@ -5934,7 +5934,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/clone-response"
         }
       ]
@@ -5960,7 +5960,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/clone"
         }
       ]
@@ -5986,7 +5986,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/code-point-at"
         }
       ]
@@ -6012,7 +6012,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/collection-visit"
         }
       ]
@@ -6038,7 +6038,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color-convert"
         }
       ]
@@ -6064,7 +6064,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color-name"
         }
       ]
@@ -6090,7 +6090,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color-string"
         }
       ]
@@ -6116,7 +6116,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color-support"
         }
       ]
@@ -6142,7 +6142,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color"
         }
       ]
@@ -6168,7 +6168,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/colors"
         }
       ]
@@ -6194,7 +6194,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/colorspace"
         }
       ]
@@ -6220,7 +6220,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/combined-stream"
         }
       ]
@@ -6246,7 +6246,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/commander"
         }
       ]
@@ -6272,7 +6272,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/component-emitter"
         }
       ]
@@ -6298,7 +6298,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/component-type"
         }
       ]
@@ -6324,7 +6324,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/compress-commons"
         }
       ]
@@ -6350,7 +6350,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/compressible"
         }
       ]
@@ -6376,7 +6376,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/compression"
         }
       ],
@@ -6402,7 +6402,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/compression/node_modules/bytes"
             }
           ]
@@ -6430,7 +6430,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/concat-map"
         }
       ]
@@ -6456,7 +6456,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/concat-stream"
         }
       ]
@@ -6482,7 +6482,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/concurrently"
         }
       ],
@@ -6508,7 +6508,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/concurrently/node_modules/supports-color"
             }
           ]
@@ -6536,7 +6536,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/config"
         }
       ]
@@ -6562,7 +6562,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/console-control-strings"
         }
       ]
@@ -6588,7 +6588,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/constantinople"
         }
       ]
@@ -6614,7 +6614,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/content-disposition"
         }
       ],
@@ -6640,7 +6640,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/content-disposition/node_modules/safe-buffer"
             }
           ]
@@ -6668,7 +6668,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/content-type"
         }
       ]
@@ -6694,7 +6694,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cookie-parser"
         }
       ]
@@ -6720,7 +6720,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cookie-signature"
         }
       ]
@@ -6746,7 +6746,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cookie"
         }
       ]
@@ -6772,7 +6772,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/copy-descriptor"
         }
       ]
@@ -6798,7 +6798,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/core-util-is"
         }
       ]
@@ -6824,7 +6824,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cors"
         }
       ]
@@ -6850,7 +6850,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/crc"
         }
       ]
@@ -6876,7 +6876,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/crc32-stream"
         }
       ]
@@ -6902,7 +6902,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/create-require"
         }
       ]
@@ -6928,7 +6928,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/crypto-js"
         }
       ]
@@ -6954,7 +6954,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dashdash"
         }
       ]
@@ -6980,7 +6980,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/date-fns"
         }
       ]
@@ -7006,7 +7006,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dateformat"
         }
       ]
@@ -7032,7 +7032,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/debug"
         }
       ]
@@ -7058,7 +7058,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decamelize"
         }
       ]
@@ -7084,7 +7084,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decode-uri-component"
         }
       ]
@@ -7110,7 +7110,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-response"
         }
       ]
@@ -7136,7 +7136,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-tar"
         }
       ],
@@ -7162,7 +7162,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-tar/node_modules/file-type"
             }
           ]
@@ -7190,7 +7190,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-tarbz2"
         }
       ],
@@ -7216,7 +7216,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-tarbz2/node_modules/file-type"
             }
           ]
@@ -7244,7 +7244,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-targz"
         }
       ],
@@ -7270,7 +7270,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-targz/node_modules/file-type"
             }
           ]
@@ -7298,7 +7298,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-unzip"
         }
       ],
@@ -7324,7 +7324,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-unzip/node_modules/file-type"
             }
           ]
@@ -7350,7 +7350,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-unzip/node_modules/get-stream"
             }
           ]
@@ -7376,7 +7376,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-unzip/node_modules/pify"
             }
           ]
@@ -7404,7 +7404,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress"
         }
       ],
@@ -7430,7 +7430,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress/node_modules/make-dir"
             }
           ],
@@ -7456,7 +7456,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/decompress/node_modules/make-dir/node_modules/pify"
                 }
               ]
@@ -7484,7 +7484,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress/node_modules/pify"
             }
           ]
@@ -7512,7 +7512,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/deep-equal"
         }
       ]
@@ -7538,7 +7538,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/deep-extend"
         }
       ]
@@ -7564,7 +7564,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/deep-is"
         }
       ]
@@ -7590,7 +7590,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/define-properties"
         }
       ]
@@ -7616,7 +7616,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/define-property"
         }
       ]
@@ -7642,7 +7642,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/delayed-stream"
         }
       ]
@@ -7668,7 +7668,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/delegates"
         }
       ]
@@ -7694,7 +7694,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/depd"
         }
       ]
@@ -7720,7 +7720,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/destroy"
         }
       ]
@@ -7746,7 +7746,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/detect-file"
         }
       ]
@@ -7772,7 +7772,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/detect-libc"
         }
       ]
@@ -7798,7 +7798,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dfa"
         }
       ]
@@ -7824,7 +7824,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dicer"
         }
       ],
@@ -7850,7 +7850,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/dicer/node_modules/isarray"
             }
           ]
@@ -7876,7 +7876,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/dicer/node_modules/readable-stream"
             }
           ]
@@ -7902,7 +7902,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/dicer/node_modules/string_decoder"
             }
           ]
@@ -7930,7 +7930,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/diff"
         }
       ]
@@ -7956,7 +7956,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/doctypes"
         }
       ]
@@ -7982,7 +7982,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/domelementtype"
         }
       ]
@@ -8008,7 +8008,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/domhandler"
         }
       ]
@@ -8034,7 +8034,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/domutils"
         }
       ]
@@ -8060,7 +8060,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dottie"
         }
       ]
@@ -8086,7 +8086,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/double-ended-queue"
         }
       ]
@@ -8112,7 +8112,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/doublearray"
         }
       ]
@@ -8138,7 +8138,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/download"
         }
       ],
@@ -8164,7 +8164,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/download/node_modules/file-type"
             }
           ]
@@ -8192,7 +8192,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/duplexer2"
         }
       ]
@@ -8218,7 +8218,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/duplexer3"
         }
       ]
@@ -8244,7 +8244,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dynamic-dedupe"
         }
       ]
@@ -8270,7 +8270,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ecc-jsbn"
         }
       ]
@@ -8296,7 +8296,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ee-first"
         }
       ]
@@ -8322,7 +8322,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/eivindfjeldstad-dot"
         }
       ]
@@ -8348,7 +8348,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/emoji-regex"
         }
       ]
@@ -8374,7 +8374,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/enabled"
         }
       ]
@@ -8400,7 +8400,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/encodeurl"
         }
       ]
@@ -8426,7 +8426,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/encoding"
         }
       ],
@@ -8452,7 +8452,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/encoding/node_modules/iconv-lite"
             }
           ]
@@ -8480,7 +8480,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/end-of-stream"
         }
       ]
@@ -8506,7 +8506,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/engine.io-parser"
         }
       ]
@@ -8532,7 +8532,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/engine.io"
         }
       ],
@@ -8558,7 +8558,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/engine.io/node_modules/debug"
             }
           ]
@@ -8584,7 +8584,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/engine.io/node_modules/ms"
             }
           ]
@@ -8612,7 +8612,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/env-paths"
         }
       ]
@@ -8638,7 +8638,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/err-code"
         }
       ]
@@ -8664,7 +8664,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/error-ex"
         }
       ]
@@ -8690,7 +8690,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/errorhandler"
         }
       ]
@@ -8716,7 +8716,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/es-abstract"
         }
       ]
@@ -8742,7 +8742,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/es-get-iterator"
         }
       ]
@@ -8768,7 +8768,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/es-to-primitive"
         }
       ]
@@ -8794,7 +8794,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/escape-html"
         }
       ]
@@ -8820,7 +8820,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/escape-string-regexp"
         }
       ]
@@ -8846,7 +8846,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/escodegen"
         }
       ]
@@ -8872,7 +8872,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/esprima"
         }
       ]
@@ -8898,7 +8898,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/estraverse"
         }
       ]
@@ -8924,7 +8924,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/esutils"
         }
       ]
@@ -8950,7 +8950,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/etag"
         }
       ]
@@ -8976,7 +8976,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/eventemitter2"
         }
       ]
@@ -9002,7 +9002,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/eventemitter3"
         }
       ]
@@ -9028,7 +9028,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/exif"
         }
       ]
@@ -9054,7 +9054,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/exit"
         }
       ]
@@ -9080,7 +9080,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/expand-brackets"
         }
       ],
@@ -9106,7 +9106,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/define-property"
             }
           ]
@@ -9132,7 +9132,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/extend-shallow"
             }
           ]
@@ -9158,7 +9158,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/is-accessor-descriptor"
             }
           ],
@@ -9184,7 +9184,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/expand-brackets/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
@@ -9212,7 +9212,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/is-data-descriptor"
             }
           ],
@@ -9238,7 +9238,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/expand-brackets/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
@@ -9266,7 +9266,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/is-descriptor"
             }
           ]
@@ -9292,7 +9292,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/is-extendable"
             }
           ]
@@ -9318,7 +9318,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/kind-of"
             }
           ]
@@ -9346,7 +9346,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/expand-template"
         }
       ]
@@ -9372,7 +9372,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/expand-tilde"
         }
       ]
@@ -9398,7 +9398,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-ipfilter"
         }
       ]
@@ -9424,7 +9424,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-jwt"
         }
       ],
@@ -9450,7 +9450,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/express-jwt/node_modules/jsonwebtoken"
             }
           ]
@@ -9476,7 +9476,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/express-jwt/node_modules/moment"
             }
           ]
@@ -9504,7 +9504,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-rate-limit"
         }
       ]
@@ -9530,7 +9530,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-robots-txt"
         }
       ]
@@ -9556,7 +9556,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-security.txt"
         }
       ]
@@ -9582,7 +9582,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express"
         }
       ],
@@ -9608,7 +9608,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/express/node_modules/cookie"
             }
           ]
@@ -9634,7 +9634,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/express/node_modules/safe-buffer"
             }
           ]
@@ -9662,7 +9662,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ext-list"
         }
       ]
@@ -9688,7 +9688,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ext-name"
         }
       ]
@@ -9714,7 +9714,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/extend-shallow"
         }
       ]
@@ -9740,7 +9740,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/extend"
         }
       ]
@@ -9766,7 +9766,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/extglob"
         }
       ],
@@ -9792,7 +9792,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/extglob/node_modules/define-property"
             }
           ]
@@ -9818,7 +9818,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/extglob/node_modules/extend-shallow"
             }
           ]
@@ -9844,7 +9844,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/extglob/node_modules/is-extendable"
             }
           ]
@@ -9872,7 +9872,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/extsprintf"
         }
       ]
@@ -9898,7 +9898,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fast-deep-equal"
         }
       ]
@@ -9924,7 +9924,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fast-json-stable-stringify"
         }
       ]
@@ -9950,7 +9950,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fast-levenshtein"
         }
       ]
@@ -9976,7 +9976,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fast.js"
         }
       ]
@@ -10002,7 +10002,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fd-slicer"
         }
       ]
@@ -10028,7 +10028,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/feature-policy"
         }
       ]
@@ -10054,7 +10054,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fecha"
         }
       ]
@@ -10080,7 +10080,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/file-js"
         }
       ],
@@ -10106,7 +10106,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/file-js/node_modules/brace-expansion"
             }
           ]
@@ -10132,7 +10132,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/file-js/node_modules/minimatch"
             }
           ]
@@ -10160,7 +10160,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/file-stream-rotator"
         }
       ]
@@ -10186,7 +10186,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/file-type"
         }
       ]
@@ -10212,7 +10212,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/file-uri-to-path"
         }
       ]
@@ -10238,7 +10238,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/filehound"
         }
       ]
@@ -10264,7 +10264,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/filename-reserved-regex"
         }
       ]
@@ -10290,7 +10290,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/filenamify"
         }
       ]
@@ -10316,7 +10316,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/filesniffer"
         }
       ]
@@ -10342,7 +10342,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fill-range"
         }
       ],
@@ -10368,7 +10368,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/fill-range/node_modules/extend-shallow"
             }
           ]
@@ -10394,7 +10394,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/fill-range/node_modules/is-extendable"
             }
           ]
@@ -10422,7 +10422,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/finale-rest"
         }
       ]
@@ -10448,7 +10448,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/finalhandler"
         }
       ]
@@ -10474,7 +10474,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/find-up"
         }
       ]
@@ -10500,7 +10500,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/findup-sync"
         }
       ]
@@ -10526,7 +10526,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fined"
         }
       ]
@@ -10552,7 +10552,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/flagged-respawn"
         }
       ]
@@ -10578,7 +10578,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fn.name"
         }
       ]
@@ -10604,7 +10604,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fontkit"
         }
       ]
@@ -10630,7 +10630,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/for-each"
         }
       ]
@@ -10656,7 +10656,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/for-in"
         }
       ]
@@ -10682,7 +10682,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/for-own"
         }
       ]
@@ -10708,7 +10708,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/foreachasync"
         }
       ]
@@ -10734,7 +10734,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/forever-agent"
         }
       ]
@@ -10760,7 +10760,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/form-data"
         }
       ]
@@ -10786,7 +10786,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/formatio"
         }
       ]
@@ -10812,7 +10812,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/forwarded"
         }
       ]
@@ -10838,7 +10838,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fragment-cache"
         }
       ]
@@ -10864,7 +10864,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fresh"
         }
       ]
@@ -10890,7 +10890,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/from2"
         }
       ]
@@ -10916,7 +10916,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fs-constants"
         }
       ]
@@ -10942,7 +10942,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fs-extra"
         }
       ]
@@ -10968,7 +10968,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fs-minipass"
         }
       ]
@@ -10994,7 +10994,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fs.realpath"
         }
       ]
@@ -11020,7 +11020,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fsevents"
         }
       ]
@@ -11046,7 +11046,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fstream"
         }
       ],
@@ -11072,7 +11072,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/fstream/node_modules/mkdirp"
             }
           ]
@@ -11098,7 +11098,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/fstream/node_modules/rimraf"
             }
           ]
@@ -11126,7 +11126,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/function-bind"
         }
       ]
@@ -11152,7 +11152,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/function.prototype.name"
         }
       ]
@@ -11178,7 +11178,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/functions-have-names"
         }
       ]
@@ -11204,7 +11204,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fuzzball"
         }
       ]
@@ -11230,7 +11230,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/gauge"
         }
       ]
@@ -11256,7 +11256,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/geojson-utils"
         }
       ]
@@ -11282,7 +11282,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-caller-file"
         }
       ]
@@ -11308,7 +11308,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-intrinsic"
         }
       ]
@@ -11334,7 +11334,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-stream"
         }
       ]
@@ -11360,7 +11360,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-symbol-description"
         }
       ]
@@ -11386,7 +11386,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-value"
         }
       ]
@@ -11412,7 +11412,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/getobject"
         }
       ]
@@ -11438,7 +11438,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/getpass"
         }
       ]
@@ -11464,7 +11464,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/github-from-package"
         }
       ]
@@ -11490,7 +11490,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/glob-parent"
         }
       ],
@@ -11516,7 +11516,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/glob-parent/node_modules/is-glob"
             }
           ]
@@ -11544,7 +11544,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/glob"
         }
       ],
@@ -11570,7 +11570,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/glob/node_modules/brace-expansion"
             }
           ]
@@ -11596,7 +11596,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/glob/node_modules/minimatch"
             }
           ]
@@ -11624,7 +11624,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/global-modules"
         }
       ]
@@ -11650,7 +11650,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/global-prefix"
         }
       ],
@@ -11676,7 +11676,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/global-prefix/node_modules/which"
             }
           ]
@@ -11704,7 +11704,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/got"
         }
       ],
@@ -11730,7 +11730,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/got/node_modules/get-stream"
             }
           ]
@@ -11756,7 +11756,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/got/node_modules/pify"
             }
           ]
@@ -11784,7 +11784,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/graceful-fs"
         }
       ]
@@ -11810,7 +11810,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-cli"
         }
       ],
@@ -11836,7 +11836,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-cli/node_modules/nopt"
             }
           ]
@@ -11864,7 +11864,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-contrib-compress"
         }
       ],
@@ -11890,7 +11890,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-contrib-compress/node_modules/ansi-styles"
             }
           ]
@@ -11916,7 +11916,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-contrib-compress/node_modules/chalk"
             }
           ]
@@ -11942,7 +11942,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-contrib-compress/node_modules/supports-color"
             }
           ]
@@ -11970,7 +11970,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-known-options"
         }
       ]
@@ -11996,7 +11996,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-legacy-log-utils"
         }
       ],
@@ -12022,7 +12022,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils/node_modules/ansi-styles"
             }
           ]
@@ -12048,7 +12048,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils/node_modules/chalk"
             }
           ]
@@ -12074,7 +12074,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils/node_modules/color-convert"
             }
           ]
@@ -12100,7 +12100,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils/node_modules/color-name"
             }
           ]
@@ -12126,7 +12126,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils/node_modules/has-flag"
             }
           ]
@@ -12152,7 +12152,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils/node_modules/supports-color"
             }
           ]
@@ -12180,7 +12180,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-legacy-log"
         }
       ],
@@ -12206,7 +12206,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log/node_modules/colors"
             }
           ]
@@ -12234,7 +12234,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-legacy-util"
         }
       ],
@@ -12260,7 +12260,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-util/node_modules/async"
             }
           ]
@@ -12288,7 +12288,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-replace-json"
         }
       ]
@@ -12314,7 +12314,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt"
         }
       ],
@@ -12340,7 +12340,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt/node_modules/brace-expansion"
             }
           ]
@@ -12366,7 +12366,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt/node_modules/findup-sync"
             }
           ],
@@ -12392,7 +12392,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/grunt/node_modules/findup-sync/node_modules/glob"
                 }
               ]
@@ -12420,7 +12420,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt/node_modules/glob"
             }
           ]
@@ -12446,7 +12446,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt/node_modules/minimatch"
             }
           ]
@@ -12474,7 +12474,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/handlebars"
         }
       ],
@@ -12500,7 +12500,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/handlebars/node_modules/wordwrap"
             }
           ]
@@ -12528,7 +12528,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/har-schema"
         }
       ]
@@ -12554,7 +12554,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/har-validator"
         }
       ]
@@ -12580,7 +12580,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-ansi"
         }
       ]
@@ -12606,7 +12606,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-bigints"
         }
       ]
@@ -12632,7 +12632,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-flag"
         }
       ]
@@ -12658,7 +12658,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-property-descriptors"
         }
       ]
@@ -12684,7 +12684,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-symbol-support-x"
         }
       ]
@@ -12710,7 +12710,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-symbols"
         }
       ]
@@ -12736,7 +12736,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-to-string-tag-x"
         }
       ]
@@ -12762,7 +12762,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-tostringtag"
         }
       ]
@@ -12788,7 +12788,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-unicode"
         }
       ]
@@ -12814,7 +12814,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-value"
         }
       ]
@@ -12840,7 +12840,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-values"
         }
       ],
@@ -12866,7 +12866,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/has-values/node_modules/kind-of"
             }
           ]
@@ -12894,7 +12894,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has"
         }
       ]
@@ -12920,7 +12920,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hashids"
         }
       ]
@@ -12946,7 +12946,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hbs"
         }
       ]
@@ -12972,7 +12972,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/he"
         }
       ]
@@ -12998,7 +12998,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/heap"
         }
       ]
@@ -13024,7 +13024,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/helmet"
         }
       ]
@@ -13050,7 +13050,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hoister"
         }
       ]
@@ -13076,7 +13076,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/homedir-polyfill"
         }
       ]
@@ -13102,7 +13102,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hooker"
         }
       ]
@@ -13128,7 +13128,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hosted-git-info"
         }
       ]
@@ -13154,7 +13154,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/html-entities"
         }
       ]
@@ -13180,7 +13180,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/htmlparser2"
         }
       ],
@@ -13206,7 +13206,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/htmlparser2/node_modules/isarray"
             }
           ]
@@ -13232,7 +13232,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/htmlparser2/node_modules/readable-stream"
             }
           ]
@@ -13258,7 +13258,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/htmlparser2/node_modules/string_decoder"
             }
           ]
@@ -13286,7 +13286,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/http-cache-semantics"
         }
       ]
@@ -13312,7 +13312,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/http-errors"
         }
       ]
@@ -13338,7 +13338,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/http-proxy-agent"
         }
       ],
@@ -13364,7 +13364,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/http-proxy-agent/node_modules/debug"
             }
           ]
@@ -13390,7 +13390,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/http-proxy-agent/node_modules/ms"
             }
           ]
@@ -13418,7 +13418,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/http-signature"
         }
       ]
@@ -13444,7 +13444,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/https-proxy-agent"
         }
       ],
@@ -13470,7 +13470,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/https-proxy-agent/node_modules/debug"
             }
           ]
@@ -13496,7 +13496,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/https-proxy-agent/node_modules/ms"
             }
           ]
@@ -13524,7 +13524,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/humanize-ms"
         }
       ]
@@ -13550,7 +13550,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/i18n"
         }
       ]
@@ -13576,7 +13576,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/iconv-lite"
         }
       ]
@@ -13602,7 +13602,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ieee754"
         }
       ]
@@ -13628,7 +13628,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ignore-walk"
         }
       ],
@@ -13654,7 +13654,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/ignore-walk/node_modules/brace-expansion"
             }
           ]
@@ -13680,7 +13680,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/ignore-walk/node_modules/minimatch"
             }
           ]
@@ -13708,7 +13708,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/iltorb"
         }
       ]
@@ -13734,7 +13734,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/imurmurhash"
         }
       ]
@@ -13760,7 +13760,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/indent-string"
         }
       ]
@@ -13786,7 +13786,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/infer-owner"
         }
       ]
@@ -13812,7 +13812,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/inflection"
         }
       ]
@@ -13838,7 +13838,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/inflight"
         }
       ]
@@ -13864,7 +13864,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/inherits"
         }
       ]
@@ -13890,7 +13890,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ini"
         }
       ]
@@ -13916,7 +13916,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/internal-slot"
         }
       ]
@@ -13942,7 +13942,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/interpret"
         }
       ]
@@ -13968,7 +13968,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/into-stream"
         }
       ]
@@ -13994,7 +13994,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/invariant"
         }
       ]
@@ -14020,7 +14020,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ip"
         }
       ]
@@ -14046,7 +14046,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ip6"
         }
       ]
@@ -14072,7 +14072,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ipaddr.js"
         }
       ]
@@ -14098,7 +14098,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-absolute"
         }
       ]
@@ -14124,7 +14124,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-accessor-descriptor"
         }
       ]
@@ -14150,7 +14150,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-arguments"
         }
       ]
@@ -14176,7 +14176,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-arrayish"
         }
       ]
@@ -14202,7 +14202,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-bigint"
         }
       ]
@@ -14228,7 +14228,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-binary-path"
         }
       ]
@@ -14254,7 +14254,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-boolean-object"
         }
       ]
@@ -14280,7 +14280,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-buffer"
         }
       ]
@@ -14306,7 +14306,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-callable"
         }
       ]
@@ -14332,7 +14332,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-core-module"
         }
       ]
@@ -14358,7 +14358,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-data-descriptor"
         }
       ]
@@ -14384,7 +14384,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-date-object"
         }
       ]
@@ -14410,7 +14410,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-descriptor"
         }
       ]
@@ -14436,7 +14436,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-docker"
         }
       ]
@@ -14462,7 +14462,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-expression"
         }
       ]
@@ -14488,7 +14488,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-extendable"
         }
       ]
@@ -14514,7 +14514,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-extglob"
         }
       ]
@@ -14540,7 +14540,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-fullwidth-code-point"
         }
       ]
@@ -14566,7 +14566,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-generator-function"
         }
       ]
@@ -14592,7 +14592,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-glob"
         }
       ]
@@ -14618,7 +14618,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-heroku"
         }
       ]
@@ -14644,7 +14644,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-lambda"
         }
       ]
@@ -14670,7 +14670,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-map"
         }
       ]
@@ -14696,7 +14696,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-natural-number"
         }
       ]
@@ -14722,7 +14722,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-negative-zero"
         }
       ]
@@ -14748,7 +14748,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-number-like"
         }
       ]
@@ -14774,7 +14774,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-number-object"
         }
       ]
@@ -14800,7 +14800,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-number"
         }
       ],
@@ -14826,7 +14826,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/is-number/node_modules/kind-of"
             }
           ]
@@ -14854,7 +14854,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-object"
         }
       ]
@@ -14880,7 +14880,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-plain-obj"
         }
       ]
@@ -14906,7 +14906,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-plain-object"
         }
       ]
@@ -14932,7 +14932,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-promise"
         }
       ]
@@ -14958,7 +14958,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-regex"
         }
       ]
@@ -14984,7 +14984,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-relative"
         }
       ]
@@ -15010,7 +15010,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-retry-allowed"
         }
       ]
@@ -15036,7 +15036,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-set"
         }
       ]
@@ -15062,7 +15062,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-shared-array-buffer"
         }
       ]
@@ -15088,7 +15088,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-stream"
         }
       ]
@@ -15114,7 +15114,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-string"
         }
       ]
@@ -15140,7 +15140,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-symbol"
         }
       ]
@@ -15166,7 +15166,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-typed-array"
         }
       ]
@@ -15192,7 +15192,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-typedarray"
         }
       ]
@@ -15218,7 +15218,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-unc-path"
         }
       ]
@@ -15244,7 +15244,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-weakmap"
         }
       ]
@@ -15270,7 +15270,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-weakref"
         }
       ]
@@ -15296,7 +15296,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-weakset"
         }
       ]
@@ -15322,7 +15322,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-windows"
         }
       ]
@@ -15348,7 +15348,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isarray"
         }
       ]
@@ -15374,7 +15374,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isexe"
         }
       ]
@@ -15400,7 +15400,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isobject"
         }
       ]
@@ -15426,7 +15426,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isstream"
         }
       ]
@@ -15452,7 +15452,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isurl"
         }
       ]
@@ -15478,7 +15478,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/js-stringify"
         }
       ]
@@ -15504,7 +15504,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/js-tokens"
         }
       ]
@@ -15530,7 +15530,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/js-yaml"
         }
       ]
@@ -15556,7 +15556,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jsbn"
         }
       ]
@@ -15582,7 +15582,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-buffer"
         }
       ]
@@ -15608,7 +15608,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-parse-better-errors"
         }
       ]
@@ -15634,7 +15634,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-schema-traverse"
         }
       ]
@@ -15660,7 +15660,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-schema"
         }
       ]
@@ -15686,7 +15686,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-stringify-safe"
         }
       ]
@@ -15712,7 +15712,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json5"
         }
       ]
@@ -15738,7 +15738,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jsonfile"
         }
       ]
@@ -15764,7 +15764,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jsonwebtoken"
         }
       ]
@@ -15790,7 +15790,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jsprim"
         }
       ]
@@ -15816,7 +15816,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jssha"
         }
       ]
@@ -15842,7 +15842,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jstransformer"
         }
       ]
@@ -15868,7 +15868,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/juicy-chat-bot"
         }
       ]
@@ -15894,7 +15894,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jwa"
         }
       ]
@@ -15920,7 +15920,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jws"
         }
       ]
@@ -15946,7 +15946,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/keyv"
         }
       ]
@@ -15972,7 +15972,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/kind-of"
         }
       ]
@@ -15998,7 +15998,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/kuler"
         }
       ]
@@ -16024,7 +16024,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/kuromoji"
         }
       ]
@@ -16050,7 +16050,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lazystream"
         }
       ]
@@ -16076,7 +16076,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/levn"
         }
       ]
@@ -16102,7 +16102,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/libxmljs2"
         }
       ],
@@ -16128,7 +16128,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/libxmljs2/node_modules/nan"
             }
           ]
@@ -16156,7 +16156,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/liftup"
         }
       ],
@@ -16182,7 +16182,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/braces"
             }
           ]
@@ -16208,7 +16208,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/fill-range"
             }
           ]
@@ -16234,7 +16234,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/findup-sync"
             }
           ]
@@ -16260,7 +16260,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/is-glob"
             }
           ]
@@ -16286,7 +16286,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/is-number"
             }
           ]
@@ -16312,7 +16312,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/micromatch"
             }
           ]
@@ -16338,7 +16338,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/to-regex-range"
             }
           ]
@@ -16366,7 +16366,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/linebreak"
         }
       ],
@@ -16392,7 +16392,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/linebreak/node_modules/base64-js"
             }
           ]
@@ -16420,7 +16420,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/listenercount"
         }
       ]
@@ -16446,7 +16446,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/locate-path"
         }
       ]
@@ -16472,7 +16472,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lodash.camelcase"
         }
       ]
@@ -16498,7 +16498,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lodash.isfinite"
         }
       ]
@@ -16524,7 +16524,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lodash.set"
         }
       ]
@@ -16550,7 +16550,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lodash"
         }
       ]
@@ -16576,7 +16576,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/logform"
         }
       ],
@@ -16602,7 +16602,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/logform/node_modules/ms"
             }
           ]
@@ -16630,7 +16630,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lolex"
         }
       ]
@@ -16656,7 +16656,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/loose-envify"
         }
       ]
@@ -16682,7 +16682,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lowercase-keys"
         }
       ]
@@ -16708,7 +16708,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lru-cache"
         }
       ]
@@ -16734,7 +16734,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-dir"
         }
       ],
@@ -16760,7 +16760,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-dir/node_modules/semver"
             }
           ]
@@ -16788,7 +16788,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-error"
         }
       ]
@@ -16814,7 +16814,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-fetch-happen"
         }
       ],
@@ -16841,7 +16841,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen/node_modules/@tootallnate/once"
             }
           ]
@@ -16867,7 +16867,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen/node_modules/debug"
             }
           ]
@@ -16893,7 +16893,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen/node_modules/http-cache-semantics"
             }
           ]
@@ -16919,7 +16919,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen/node_modules/http-proxy-agent"
             }
           ]
@@ -16945,7 +16945,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen/node_modules/ms"
             }
           ]
@@ -16973,7 +16973,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-iterator"
         }
       ]
@@ -16999,7 +16999,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-plural"
         }
       ]
@@ -17025,7 +17025,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/map-cache"
         }
       ]
@@ -17051,7 +17051,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/map-visit"
         }
       ]
@@ -17077,7 +17077,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/marsdb"
         }
       ]
@@ -17103,7 +17103,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/math-interval-parser"
         }
       ]
@@ -17129,7 +17129,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/media-typer"
         }
       ]
@@ -17155,7 +17155,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/merge-descriptors"
         }
       ]
@@ -17181,7 +17181,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/messageformat-formatters"
         }
       ]
@@ -17207,7 +17207,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/messageformat-parser"
         }
       ]
@@ -17233,7 +17233,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/messageformat"
         }
       ],
@@ -17259,7 +17259,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/messageformat/node_modules/make-plural"
             }
           ]
@@ -17287,7 +17287,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/methods"
         }
       ]
@@ -17313,7 +17313,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/micromatch"
         }
       ]
@@ -17339,7 +17339,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mime-db"
         }
       ]
@@ -17365,7 +17365,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mime-types"
         }
       ]
@@ -17391,7 +17391,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mime"
         }
       ]
@@ -17417,7 +17417,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mimic-response"
         }
       ]
@@ -17443,7 +17443,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minimatch"
         }
       ]
@@ -17469,7 +17469,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minimist"
         }
       ]
@@ -17495,7 +17495,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-collect"
         }
       ]
@@ -17521,7 +17521,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-fetch"
         }
       ]
@@ -17547,7 +17547,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-flush"
         }
       ]
@@ -17573,7 +17573,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-pipeline"
         }
       ]
@@ -17599,7 +17599,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-sized"
         }
       ]
@@ -17625,7 +17625,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass"
         }
       ]
@@ -17651,7 +17651,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minizlib"
         }
       ]
@@ -17677,7 +17677,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mixin-deep"
         }
       ]
@@ -17703,7 +17703,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mkdirp-classic"
         }
       ]
@@ -17729,7 +17729,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mkdirp"
         }
       ]
@@ -17755,7 +17755,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/moment-timezone"
         }
       ]
@@ -17781,7 +17781,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/moment"
         }
       ]
@@ -17807,7 +17807,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/morgan"
         }
       ],
@@ -17833,7 +17833,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/morgan/node_modules/on-finished"
             }
           ]
@@ -17861,7 +17861,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mout"
         }
       ]
@@ -17887,7 +17887,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ms"
         }
       ]
@@ -17913,7 +17913,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/multer"
         }
       ],
@@ -17939,7 +17939,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/multer/node_modules/mkdirp"
             }
           ]
@@ -17967,7 +17967,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mustache"
         }
       ]
@@ -17993,7 +17993,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/nan"
         }
       ]
@@ -18019,7 +18019,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/nanomatch"
         }
       ]
@@ -18045,7 +18045,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/napi-build-utils"
         }
       ]
@@ -18071,7 +18071,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/needle"
         }
       ],
@@ -18097,7 +18097,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/needle/node_modules/debug"
             }
           ]
@@ -18123,7 +18123,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/needle/node_modules/ms"
             }
           ]
@@ -18151,7 +18151,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/negotiator"
         }
       ]
@@ -18177,7 +18177,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/neo-async"
         }
       ]
@@ -18203,7 +18203,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-abi"
         }
       ],
@@ -18229,7 +18229,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-abi/node_modules/semver"
             }
           ]
@@ -18257,7 +18257,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-addon-api"
         }
       ]
@@ -18283,7 +18283,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-fetch"
         }
       ]
@@ -18309,7 +18309,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-gyp"
         }
       ],
@@ -18335,7 +18335,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/ansi-regex"
             }
           ]
@@ -18361,7 +18361,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/are-we-there-yet"
             }
           ]
@@ -18387,7 +18387,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/gauge"
             }
           ]
@@ -18413,7 +18413,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -18439,7 +18439,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/nopt"
             }
           ]
@@ -18465,7 +18465,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/npmlog"
             }
           ]
@@ -18491,7 +18491,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/readable-stream"
             }
           ]
@@ -18517,7 +18517,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/string-width"
             }
           ]
@@ -18543,7 +18543,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/strip-ansi"
             }
           ]
@@ -18571,7 +18571,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-pre-gyp"
         }
       ],
@@ -18597,7 +18597,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/chownr"
             }
           ]
@@ -18623,7 +18623,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/fs-minipass"
             }
           ]
@@ -18649,7 +18649,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/minipass"
             }
           ]
@@ -18675,7 +18675,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/minizlib"
             }
           ]
@@ -18701,7 +18701,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/mkdirp"
             }
           ]
@@ -18727,7 +18727,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/nopt"
             }
           ]
@@ -18753,7 +18753,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/rimraf"
             }
           ]
@@ -18779,7 +18779,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/safe-buffer"
             }
           ]
@@ -18805,7 +18805,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/semver"
             }
           ]
@@ -18831,7 +18831,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/tar"
             }
           ]
@@ -18857,7 +18857,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/yallist"
             }
           ]
@@ -18885,7 +18885,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/noop-logger"
         }
       ]
@@ -18911,7 +18911,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/nopt"
         }
       ]
@@ -18937,7 +18937,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/normalize-package-data"
         }
       ],
@@ -18963,7 +18963,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/normalize-package-data/node_modules/semver"
             }
           ]
@@ -18991,7 +18991,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/normalize-path"
         }
       ]
@@ -19017,7 +19017,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/normalize-url"
         }
       ]
@@ -19043,7 +19043,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/notevil"
         }
       ],
@@ -19069,7 +19069,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/notevil/node_modules/esprima"
             }
           ]
@@ -19097,7 +19097,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/npm-bundled"
         }
       ]
@@ -19123,7 +19123,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/npm-normalize-package-bin"
         }
       ]
@@ -19149,7 +19149,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/npm-packlist"
         }
       ]
@@ -19175,7 +19175,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/npmlog"
         }
       ]
@@ -19201,7 +19201,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/number-is-nan"
         }
       ]
@@ -19227,7 +19227,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/oauth-sign"
         }
       ]
@@ -19253,7 +19253,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-assign"
         }
       ]
@@ -19279,7 +19279,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-copy"
         }
       ],
@@ -19305,7 +19305,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy/node_modules/define-property"
             }
           ]
@@ -19331,7 +19331,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy/node_modules/is-accessor-descriptor"
             }
           ]
@@ -19357,7 +19357,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy/node_modules/is-data-descriptor"
             }
           ]
@@ -19383,7 +19383,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy/node_modules/is-descriptor"
             }
           ],
@@ -19409,7 +19409,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/object-copy/node_modules/is-descriptor/node_modules/kind-of"
                 }
               ]
@@ -19437,7 +19437,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy/node_modules/kind-of"
             }
           ]
@@ -19465,7 +19465,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-inspect"
         }
       ]
@@ -19491,7 +19491,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-is"
         }
       ]
@@ -19517,7 +19517,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-keys"
         }
       ]
@@ -19543,7 +19543,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-visit"
         }
       ]
@@ -19569,7 +19569,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object.assign"
         }
       ]
@@ -19595,7 +19595,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object.defaults"
         }
       ]
@@ -19621,7 +19621,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object.map"
         }
       ]
@@ -19647,7 +19647,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object.pick"
         }
       ]
@@ -19673,7 +19673,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/on-finished"
         }
       ]
@@ -19699,7 +19699,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/on-headers"
         }
       ]
@@ -19725,7 +19725,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/once"
         }
       ]
@@ -19751,7 +19751,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/one-time"
         }
       ]
@@ -19777,7 +19777,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/opentype.js"
         }
       ]
@@ -19803,7 +19803,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/optionator"
         }
       ]
@@ -19829,7 +19829,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/os-homedir"
         }
       ]
@@ -19855,7 +19855,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/os-tmpdir"
         }
       ]
@@ -19881,7 +19881,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/osenv"
         }
       ]
@@ -19907,7 +19907,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/otplib"
         }
       ]
@@ -19933,7 +19933,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-cancelable"
         }
       ]
@@ -19959,7 +19959,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-event"
         }
       ]
@@ -19985,7 +19985,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-finally"
         }
       ]
@@ -20011,7 +20011,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-is-promise"
         }
       ]
@@ -20037,7 +20037,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-limit"
         }
       ]
@@ -20063,7 +20063,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-locate"
         }
       ]
@@ -20089,7 +20089,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-map"
         }
       ]
@@ -20115,7 +20115,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-timeout"
         }
       ]
@@ -20141,7 +20141,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-try"
         }
       ]
@@ -20167,7 +20167,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pako"
         }
       ]
@@ -20193,7 +20193,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/parse-filepath"
         }
       ]
@@ -20219,7 +20219,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/parse-json"
         }
       ]
@@ -20245,7 +20245,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/parse-passwd"
         }
       ]
@@ -20271,7 +20271,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/parseurl"
         }
       ]
@@ -20297,7 +20297,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pascalcase"
         }
       ]
@@ -20323,7 +20323,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-exists"
         }
       ]
@@ -20349,7 +20349,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-is-absolute"
         }
       ]
@@ -20375,7 +20375,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-parse"
         }
       ]
@@ -20401,7 +20401,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-root-regex"
         }
       ]
@@ -20427,7 +20427,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-root"
         }
       ]
@@ -20453,7 +20453,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-to-regexp"
         }
       ]
@@ -20479,7 +20479,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pdfkit"
         }
       ]
@@ -20505,7 +20505,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/peek-readable"
         }
       ]
@@ -20531,7 +20531,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pend"
         }
       ]
@@ -20557,7 +20557,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/performance-now"
         }
       ]
@@ -20583,7 +20583,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pg-connection-string"
         }
       ]
@@ -20609,7 +20609,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/picomatch"
         }
       ]
@@ -20635,7 +20635,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pify"
         }
       ]
@@ -20661,7 +20661,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pinkie-promise"
         }
       ]
@@ -20687,7 +20687,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pinkie"
         }
       ]
@@ -20713,7 +20713,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/png-js"
         }
       ]
@@ -20739,7 +20739,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/portscanner"
         }
       ]
@@ -20765,7 +20765,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/posix-character-classes"
         }
       ]
@@ -20791,7 +20791,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/prebuild-install"
         }
       ]
@@ -20817,7 +20817,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/prelude-ls"
         }
       ]
@@ -20843,7 +20843,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/prepend-http"
         }
       ]
@@ -20869,7 +20869,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pretty-bytes"
         }
       ]
@@ -20895,7 +20895,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/process-nextick-args"
         }
       ]
@@ -20921,7 +20921,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/prom-client"
         }
       ]
@@ -20947,7 +20947,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/promise-inflight"
         }
       ]
@@ -20973,7 +20973,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/promise-retry"
         }
       ],
@@ -20999,7 +20999,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/promise-retry/node_modules/err-code"
             }
           ]
@@ -21025,7 +21025,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/promise-retry/node_modules/retry"
             }
           ]
@@ -21053,7 +21053,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/promise"
         }
       ]
@@ -21079,7 +21079,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/proper-lockfile"
         }
       ]
@@ -21105,7 +21105,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/proxy-addr"
         }
       ]
@@ -21131,7 +21131,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/psl"
         }
       ]
@@ -21157,7 +21157,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-attrs"
         }
       ]
@@ -21183,7 +21183,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-code-gen"
         }
       ]
@@ -21209,7 +21209,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-error"
         }
       ]
@@ -21235,7 +21235,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-filters"
         }
       ]
@@ -21261,7 +21261,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-lexer"
         }
       ]
@@ -21287,7 +21287,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-linker"
         }
       ]
@@ -21313,7 +21313,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-load"
         }
       ]
@@ -21339,7 +21339,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-parser"
         }
       ]
@@ -21365,7 +21365,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-runtime"
         }
       ]
@@ -21391,7 +21391,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-strip-comments"
         }
       ]
@@ -21417,7 +21417,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-walk"
         }
       ]
@@ -21443,7 +21443,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug"
         }
       ]
@@ -21469,7 +21469,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pump"
         }
       ]
@@ -21495,7 +21495,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/punycode"
         }
       ]
@@ -21521,7 +21521,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/qs"
         }
       ]
@@ -21547,7 +21547,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/query-string"
         }
       ]
@@ -21573,7 +21573,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/range_check"
         }
       ]
@@ -21599,7 +21599,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/range-parser"
         }
       ]
@@ -21625,7 +21625,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/raw-body"
         }
       ]
@@ -21651,7 +21651,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/rc"
         }
       ]
@@ -21677,7 +21677,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/read-pkg"
         }
       ],
@@ -21703,7 +21703,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/read-pkg/node_modules/pify"
             }
           ]
@@ -21731,7 +21731,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/readable-stream"
         }
       ],
@@ -21757,7 +21757,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/readable-stream/node_modules/isarray"
             }
           ]
@@ -21785,7 +21785,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/readable-web-to-node-stream"
         }
       ],
@@ -21811,7 +21811,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/readable-web-to-node-stream/node_modules/readable-stream"
             }
           ]
@@ -21839,7 +21839,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/readdirp"
         }
       ]
@@ -21865,7 +21865,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/rechoir"
         }
       ]
@@ -21891,7 +21891,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/regex-not"
         }
       ]
@@ -21917,7 +21917,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/regexp.prototype.flags"
         }
       ]
@@ -21943,7 +21943,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/remove-trailing-separator"
         }
       ]
@@ -21969,7 +21969,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/repeat-element"
         }
       ]
@@ -21995,7 +21995,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/repeat-string"
         }
       ]
@@ -22021,7 +22021,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/replace"
         }
       ],
@@ -22047,7 +22047,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/ansi-regex"
             }
           ]
@@ -22073,7 +22073,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/ansi-styles"
             }
           ]
@@ -22099,7 +22099,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/brace-expansion"
             }
           ]
@@ -22125,7 +22125,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/cliui"
             }
           ]
@@ -22151,7 +22151,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/color-convert"
             }
           ]
@@ -22177,7 +22177,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/color-name"
             }
           ]
@@ -22203,7 +22203,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/find-up"
             }
           ]
@@ -22229,7 +22229,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -22255,7 +22255,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/locate-path"
             }
           ]
@@ -22281,7 +22281,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/minimatch"
             }
           ]
@@ -22307,7 +22307,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/p-locate"
             }
           ]
@@ -22333,7 +22333,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/path-exists"
             }
           ]
@@ -22359,7 +22359,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/string-width"
             }
           ]
@@ -22385,7 +22385,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/strip-ansi"
             }
           ]
@@ -22411,7 +22411,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/wrap-ansi"
             }
           ]
@@ -22437,7 +22437,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/yargs-parser"
             }
           ]
@@ -22463,7 +22463,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/yargs"
             }
           ]
@@ -22491,7 +22491,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/request"
         }
       ],
@@ -22517,7 +22517,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/request/node_modules/qs"
             }
           ]
@@ -22545,7 +22545,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/require-directory"
         }
       ]
@@ -22571,7 +22571,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/require-main-filename"
         }
       ]
@@ -22597,7 +22597,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/resolve-dir"
         }
       ]
@@ -22623,7 +22623,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/resolve-url"
         }
       ]
@@ -22649,7 +22649,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/resolve"
         }
       ]
@@ -22675,7 +22675,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/responselike"
         }
       ]
@@ -22701,7 +22701,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/restructure"
         }
       ]
@@ -22727,7 +22727,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ret"
         }
       ]
@@ -22753,7 +22753,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/retry-as-promised"
         }
       ]
@@ -22779,7 +22779,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/retry"
         }
       ]
@@ -22805,7 +22805,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/rimraf"
         }
       ]
@@ -22831,7 +22831,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/rxjs"
         }
       ],
@@ -22857,7 +22857,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/rxjs/node_modules/tslib"
             }
           ]
@@ -22885,7 +22885,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safe-buffer"
         }
       ]
@@ -22911,7 +22911,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safe-regex-test"
         }
       ]
@@ -22937,7 +22937,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safe-regex"
         }
       ]
@@ -22963,7 +22963,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safe-stable-stringify"
         }
       ]
@@ -22989,7 +22989,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safer-buffer"
         }
       ]
@@ -23015,7 +23015,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/samsam"
         }
       ]
@@ -23041,7 +23041,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sanitize-filename"
         }
       ]
@@ -23067,7 +23067,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sanitize-html"
         }
       ],
@@ -23093,7 +23093,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sanitize-html/node_modules/lodash"
             }
           ]
@@ -23121,7 +23121,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sax"
         }
       ]
@@ -23147,7 +23147,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/seek-bzip"
         }
       ]
@@ -23173,7 +23173,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/semver"
         }
       ]
@@ -23199,7 +23199,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/send"
         }
       ],
@@ -23225,7 +23225,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/send/node_modules/ms"
             }
           ]
@@ -23253,7 +23253,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sequelize-pool"
         }
       ]
@@ -23279,7 +23279,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sequelize"
         }
       ],
@@ -23305,7 +23305,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sequelize/node_modules/debug"
             }
           ]
@@ -23331,7 +23331,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sequelize/node_modules/ms"
             }
           ]
@@ -23357,7 +23357,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sequelize/node_modules/uuid"
             }
           ]
@@ -23385,7 +23385,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/serve-index"
         }
       ],
@@ -23411,7 +23411,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index/node_modules/depd"
             }
           ]
@@ -23437,7 +23437,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index/node_modules/http-errors"
             }
           ]
@@ -23463,7 +23463,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index/node_modules/inherits"
             }
           ]
@@ -23489,7 +23489,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index/node_modules/setprototypeof"
             }
           ]
@@ -23515,7 +23515,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index/node_modules/statuses"
             }
           ]
@@ -23543,7 +23543,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/serve-static"
         }
       ]
@@ -23569,7 +23569,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/set-blocking"
         }
       ]
@@ -23595,7 +23595,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/set-value"
         }
       ],
@@ -23621,7 +23621,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/set-value/node_modules/extend-shallow"
             }
           ]
@@ -23647,7 +23647,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/set-value/node_modules/is-extendable"
             }
           ]
@@ -23675,7 +23675,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/setimmediate"
         }
       ]
@@ -23701,7 +23701,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/setprototypeof"
         }
       ]
@@ -23727,7 +23727,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/side-channel"
         }
       ]
@@ -23753,7 +23753,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/signal-exit"
         }
       ]
@@ -23779,7 +23779,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/simple-concat"
         }
       ]
@@ -23805,7 +23805,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/simple-get"
         }
       ],
@@ -23831,7 +23831,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/simple-get/node_modules/decompress-response"
             }
           ]
@@ -23857,7 +23857,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/simple-get/node_modules/mimic-response"
             }
           ]
@@ -23885,7 +23885,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/simple-swizzle"
         }
       ],
@@ -23911,7 +23911,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/simple-swizzle/node_modules/is-arrayish"
             }
           ]
@@ -23939,7 +23939,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sinon"
         }
       ]
@@ -23965,7 +23965,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/smart-buffer"
         }
       ]
@@ -23991,7 +23991,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/snapdragon-node"
         }
       ],
@@ -24017,7 +24017,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon-node/node_modules/define-property"
             }
           ]
@@ -24045,7 +24045,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/snapdragon-util"
         }
       ],
@@ -24071,7 +24071,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon-util/node_modules/kind-of"
             }
           ]
@@ -24099,7 +24099,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/snapdragon"
         }
       ],
@@ -24125,7 +24125,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/define-property"
             }
           ]
@@ -24151,7 +24151,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/extend-shallow"
             }
           ]
@@ -24177,7 +24177,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/is-accessor-descriptor"
             }
           ],
@@ -24203,7 +24203,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/snapdragon/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
@@ -24231,7 +24231,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/is-data-descriptor"
             }
           ],
@@ -24257,7 +24257,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/snapdragon/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
@@ -24285,7 +24285,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/is-descriptor"
             }
           ]
@@ -24311,7 +24311,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/is-extendable"
             }
           ]
@@ -24337,7 +24337,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/kind-of"
             }
           ]
@@ -24363,7 +24363,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/source-map"
             }
           ]
@@ -24391,7 +24391,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socket.io-adapter"
         }
       ]
@@ -24417,7 +24417,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socket.io-parser"
         }
       ],
@@ -24443,7 +24443,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socket.io-parser/node_modules/debug"
             }
           ]
@@ -24469,7 +24469,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socket.io-parser/node_modules/ms"
             }
           ]
@@ -24497,7 +24497,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socket.io"
         }
       ],
@@ -24523,7 +24523,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socket.io/node_modules/debug"
             }
           ]
@@ -24549,7 +24549,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socket.io/node_modules/ms"
             }
           ]
@@ -24577,7 +24577,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socks-proxy-agent"
         }
       ],
@@ -24603,7 +24603,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socks-proxy-agent/node_modules/debug"
             }
           ]
@@ -24629,7 +24629,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socks-proxy-agent/node_modules/ms"
             }
           ]
@@ -24657,7 +24657,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socks"
         }
       ],
@@ -24683,7 +24683,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socks/node_modules/ip"
             }
           ]
@@ -24711,7 +24711,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sort-keys-length"
         }
       ],
@@ -24737,7 +24737,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sort-keys-length/node_modules/sort-keys"
             }
           ]
@@ -24765,7 +24765,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sort-keys"
         }
       ]
@@ -24791,7 +24791,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/source-map-resolve"
         }
       ]
@@ -24817,7 +24817,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/source-map-support"
         }
       ]
@@ -24843,7 +24843,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/source-map-url"
         }
       ]
@@ -24869,7 +24869,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/source-map"
         }
       ]
@@ -24895,7 +24895,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spawn-command"
         }
       ]
@@ -24921,7 +24921,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spdx-correct"
         }
       ]
@@ -24947,7 +24947,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spdx-exceptions"
         }
       ]
@@ -24973,7 +24973,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spdx-expression-parse"
         }
       ]
@@ -24999,7 +24999,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spdx-license-ids"
         }
       ]
@@ -25025,7 +25025,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/split-string"
         }
       ]
@@ -25051,7 +25051,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sprintf-js"
         }
       ]
@@ -25077,7 +25077,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sqlite3"
         }
       ]
@@ -25103,7 +25103,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sshpk"
         }
       ]
@@ -25129,7 +25129,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ssri"
         }
       ]
@@ -25155,7 +25155,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/stack-trace"
         }
       ]
@@ -25181,7 +25181,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/static-extend"
         }
       ],
@@ -25207,7 +25207,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend/node_modules/define-property"
             }
           ]
@@ -25233,7 +25233,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend/node_modules/is-accessor-descriptor"
             }
           ],
@@ -25259,7 +25259,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/static-extend/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
@@ -25287,7 +25287,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend/node_modules/is-data-descriptor"
             }
           ],
@@ -25313,7 +25313,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/static-extend/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
@@ -25341,7 +25341,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend/node_modules/is-descriptor"
             }
           ]
@@ -25367,7 +25367,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend/node_modules/kind-of"
             }
           ]
@@ -25395,7 +25395,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/statuses"
         }
       ]
@@ -25421,7 +25421,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/stream-buffers"
         }
       ]
@@ -25447,7 +25447,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/streamsearch"
         }
       ]
@@ -25473,7 +25473,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strict-uri-encode"
         }
       ]
@@ -25499,7 +25499,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string_decoder"
         }
       ]
@@ -25525,7 +25525,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string-width"
         }
       ]
@@ -25551,7 +25551,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string.fromcodepoint"
         }
       ]
@@ -25577,7 +25577,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string.prototype.codepointat"
         }
       ]
@@ -25603,7 +25603,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string.prototype.trimend"
         }
       ]
@@ -25629,7 +25629,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string.prototype.trimstart"
         }
       ]
@@ -25655,7 +25655,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-ansi"
         }
       ]
@@ -25681,7 +25681,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-bom"
         }
       ]
@@ -25707,7 +25707,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-dirs"
         }
       ]
@@ -25733,7 +25733,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-json-comments"
         }
       ]
@@ -25759,7 +25759,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-outer"
         }
       ]
@@ -25785,7 +25785,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strtok3"
         }
       ]
@@ -25811,7 +25811,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/supports-color"
         }
       ]
@@ -25837,7 +25837,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/supports-preserve-symlinks-flag"
         }
       ]
@@ -25863,7 +25863,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/svg-captcha"
         }
       ]
@@ -25889,7 +25889,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/swagger-ui-dist"
         }
       ]
@@ -25915,7 +25915,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/swagger-ui-express"
         }
       ]
@@ -25941,7 +25941,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tar-fs"
         }
       ],
@@ -25967,7 +25967,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/tar-fs/node_modules/bl"
             }
           ]
@@ -25993,7 +25993,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/tar-fs/node_modules/chownr"
             }
           ]
@@ -26019,7 +26019,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/tar-fs/node_modules/readable-stream"
             }
           ]
@@ -26045,7 +26045,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/tar-fs/node_modules/tar-stream"
             }
           ]
@@ -26073,7 +26073,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tar-stream"
         }
       ]
@@ -26099,7 +26099,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tar"
         }
       ]
@@ -26125,7 +26125,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tdigest"
         }
       ]
@@ -26151,7 +26151,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/text-hex"
         }
       ]
@@ -26177,7 +26177,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/thirty-two"
         }
       ]
@@ -26203,7 +26203,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/through"
         }
       ]
@@ -26229,7 +26229,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/timed-out"
         }
       ]
@@ -26255,7 +26255,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tiny-inflate"
         }
       ]
@@ -26281,7 +26281,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-buffer"
         }
       ]
@@ -26307,7 +26307,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-fast-properties"
         }
       ]
@@ -26333,7 +26333,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-object-path"
         }
       ],
@@ -26359,7 +26359,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/to-object-path/node_modules/kind-of"
             }
           ]
@@ -26387,7 +26387,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-regex-range"
         }
       ]
@@ -26413,7 +26413,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-regex"
         }
       ]
@@ -26439,7 +26439,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/toidentifier"
         }
       ]
@@ -26465,7 +26465,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/token-stream"
         }
       ]
@@ -26491,7 +26491,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/token-types"
         }
       ]
@@ -26517,7 +26517,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/toposort-class"
         }
       ]
@@ -26543,7 +26543,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tough-cookie"
         }
       ]
@@ -26569,7 +26569,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tr46"
         }
       ]
@@ -26595,7 +26595,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/traverse"
         }
       ]
@@ -26621,7 +26621,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tree-kill"
         }
       ]
@@ -26647,7 +26647,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/trim-repeated"
         }
       ]
@@ -26673,7 +26673,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/triple-beam"
         }
       ]
@@ -26699,7 +26699,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/truncate-utf8-bytes"
         }
       ]
@@ -26725,7 +26725,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ts-node-dev"
         }
       ],
@@ -26751,7 +26751,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/ts-node-dev/node_modules/rimraf"
             }
           ]
@@ -26779,7 +26779,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ts-node"
         }
       ]
@@ -26805,7 +26805,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tsconfig"
         }
       ]
@@ -26831,7 +26831,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tslib"
         }
       ]
@@ -26857,7 +26857,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tunnel-agent"
         }
       ]
@@ -26883,7 +26883,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tweetnacl"
         }
       ]
@@ -26909,7 +26909,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/type-check"
         }
       ]
@@ -26935,7 +26935,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/type-is"
         }
       ]
@@ -26961,7 +26961,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/typecast"
         }
       ]
@@ -26987,7 +26987,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/typedarray"
         }
       ]
@@ -27013,7 +27013,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/typescript"
         }
       ]
@@ -27039,7 +27039,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/uglify-js"
         }
       ]
@@ -27065,7 +27065,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unbox-primitive"
         }
       ]
@@ -27091,7 +27091,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unbzip2-stream"
         }
       ]
@@ -27117,7 +27117,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unc-path-regex"
         }
       ]
@@ -27143,7 +27143,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/underscore.string"
         }
       ]
@@ -27169,7 +27169,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unicode-properties"
         }
       ]
@@ -27195,7 +27195,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unicode-trie"
         }
       ]
@@ -27221,7 +27221,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/union-value"
         }
       ],
@@ -27247,7 +27247,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/union-value/node_modules/is-extendable"
             }
           ]
@@ -27275,7 +27275,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unique-filename"
         }
       ]
@@ -27301,7 +27301,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unique-slug"
         }
       ]
@@ -27327,7 +27327,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unit-compare"
         }
       ]
@@ -27353,7 +27353,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/universalify"
         }
       ]
@@ -27379,7 +27379,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unpipe"
         }
       ]
@@ -27405,7 +27405,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unset-value"
         }
       ],
@@ -27431,7 +27431,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/unset-value/node_modules/has-value"
             }
           ],
@@ -27457,7 +27457,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/unset-value/node_modules/has-value/node_modules/isobject"
                 }
               ]
@@ -27485,7 +27485,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/unset-value/node_modules/has-values"
             }
           ]
@@ -27511,7 +27511,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/unset-value/node_modules/isarray"
             }
           ]
@@ -27539,7 +27539,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/untildify"
         }
       ]
@@ -27565,7 +27565,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unzipper"
         }
       ],
@@ -27591,7 +27591,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/unzipper/node_modules/bluebird"
             }
           ]
@@ -27619,7 +27619,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/uri-js"
         }
       ]
@@ -27645,7 +27645,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/urix"
         }
       ]
@@ -27671,7 +27671,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/url-parse-lax"
         }
       ]
@@ -27697,7 +27697,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/url-to-options"
         }
       ]
@@ -27723,7 +27723,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/use"
         }
       ]
@@ -27749,7 +27749,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/utf8-byte-length"
         }
       ]
@@ -27775,7 +27775,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/util-deprecate"
         }
       ]
@@ -27801,7 +27801,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/util"
         }
       ]
@@ -27827,7 +27827,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/utils-merge"
         }
       ]
@@ -27853,7 +27853,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/uuid"
         }
       ]
@@ -27879,7 +27879,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/v8flags"
         }
       ]
@@ -27905,7 +27905,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/validate-npm-package-license"
         }
       ]
@@ -27931,7 +27931,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/validate"
         }
       ]
@@ -27957,7 +27957,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/validator"
         }
       ]
@@ -27983,7 +27983,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/vary"
         }
       ]
@@ -28009,7 +28009,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/verror"
         }
       ],
@@ -28035,7 +28035,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/verror/node_modules/core-util-is"
             }
           ]
@@ -28063,7 +28063,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/vm2"
         }
       ],
@@ -28089,7 +28089,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/vm2/node_modules/acorn"
             }
           ]
@@ -28117,7 +28117,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/void-elements"
         }
       ]
@@ -28143,7 +28143,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/walk"
         }
       ]
@@ -28169,7 +28169,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/walkdir"
         }
       ]
@@ -28195,7 +28195,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/webidl-conversions"
         }
       ]
@@ -28221,7 +28221,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/whatwg-url"
         }
       ]
@@ -28247,7 +28247,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-boxed-primitive"
         }
       ]
@@ -28273,7 +28273,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-collection"
         }
       ]
@@ -28299,7 +28299,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-module"
         }
       ]
@@ -28325,7 +28325,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-pm-runs"
         }
       ]
@@ -28351,7 +28351,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-typed-array"
         }
       ]
@@ -28377,7 +28377,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which"
         }
       ]
@@ -28403,7 +28403,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wide-align"
         }
       ]
@@ -28429,7 +28429,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/winston-transport"
         }
       ],
@@ -28455,7 +28455,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/winston-transport/node_modules/readable-stream"
             }
           ]
@@ -28483,7 +28483,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/winston"
         }
       ],
@@ -28509,7 +28509,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/winston/node_modules/async"
             }
           ]
@@ -28535,7 +28535,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/winston/node_modules/is-stream"
             }
           ]
@@ -28561,7 +28561,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/winston/node_modules/readable-stream"
             }
           ]
@@ -28589,7 +28589,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/with"
         }
       ]
@@ -28615,7 +28615,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wkx"
         }
       ]
@@ -28641,7 +28641,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/word-wrap"
         }
       ]
@@ -28667,7 +28667,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wordwrap"
         }
       ]
@@ -28693,7 +28693,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wrap-ansi"
         }
       ],
@@ -28719,7 +28719,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi/node_modules/ansi-regex"
             }
           ]
@@ -28745,7 +28745,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi/node_modules/emoji-regex"
             }
           ]
@@ -28771,7 +28771,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -28797,7 +28797,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi/node_modules/string-width"
             }
           ]
@@ -28823,7 +28823,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi/node_modules/strip-ansi"
             }
           ]
@@ -28851,7 +28851,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wrappy"
         }
       ]
@@ -28877,7 +28877,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ws"
         }
       ]
@@ -28903,7 +28903,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/xtend"
         }
       ]
@@ -28929,7 +28929,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/y18n"
         }
       ]
@@ -28955,7 +28955,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yallist"
         }
       ]
@@ -28981,7 +28981,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yaml-schema-validator"
         }
       ]
@@ -29007,7 +29007,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yargs-parser"
         }
       ]
@@ -29033,7 +29033,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yargs"
         }
       ],
@@ -29059,7 +29059,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs/node_modules/ansi-regex"
             }
           ]
@@ -29085,7 +29085,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs/node_modules/emoji-regex"
             }
           ]
@@ -29111,7 +29111,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -29137,7 +29137,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs/node_modules/string-width"
             }
           ]
@@ -29163,7 +29163,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs/node_modules/strip-ansi"
             }
           ]
@@ -29191,7 +29191,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yauzl"
         }
       ]
@@ -29217,7 +29217,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yn"
         }
       ]
@@ -29243,7 +29243,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/z85"
         }
       ]
@@ -29269,7 +29269,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/zip-stream"
         }
       ]
@@ -29295,7 +29295,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/zlibjs"
         }
       ]

--- a/tests/_data/sbom_demo-results/juice-shop_npm9_node16_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/juice-shop_npm9_node16_macos-latest.snap.json
@@ -62,6 +62,10 @@
       ],
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -88,6 +92,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@babel/helper-string-parser"
+        }
       ]
     },
     {
@@ -108,6 +118,12 @@
           "url": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@babel/helper-validator-identifier"
         }
       ]
     },
@@ -130,6 +146,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@babel/parser"
+        }
       ]
     },
     {
@@ -150,6 +172,12 @@
           "url": "https://registry.npmjs.org/@babel/types/-/types-7.20.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@babel/types"
         }
       ]
     },
@@ -172,6 +200,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@colors/colors"
+        }
       ]
     },
     {
@@ -193,6 +227,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@dabh/diagnostics"
+        }
       ]
     },
     {
@@ -213,6 +253,12 @@
           "url": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@gar/promisify"
         }
       ]
     },
@@ -236,6 +282,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@mapbox/node-pre-gyp"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -254,6 +306,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/ansi-regex"
             }
           ]
         },
@@ -275,6 +333,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/are-we-there-yet"
+            }
           ]
         },
         {
@@ -294,6 +358,12 @@
               "url": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/detect-libc"
             }
           ]
         },
@@ -315,6 +385,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/gauge"
+            }
           ]
         },
         {
@@ -334,6 +410,12 @@
               "url": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/is-fullwidth-code-point"
             }
           ]
         },
@@ -356,6 +438,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/make-dir"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -374,6 +462,12 @@
                   "url": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/@mapbox/node-pre-gyp/node_modules/make-dir/node_modules/semver"
                 }
               ]
             }
@@ -397,6 +491,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/nopt"
+            }
           ]
         },
         {
@@ -416,6 +516,12 @@
               "url": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/npmlog"
             }
           ]
         },
@@ -437,6 +543,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/readable-stream"
+            }
           ]
         },
         {
@@ -457,6 +569,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/string-width"
+            }
           ]
         },
         {
@@ -476,6 +594,12 @@
               "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/strip-ansi"
             }
           ]
         }
@@ -500,6 +624,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/core-loader"
+        }
       ]
     },
     {
@@ -520,6 +650,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/core/-/core-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/core"
         }
       ]
     },
@@ -542,6 +678,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/evaluator"
+        }
       ]
     },
     {
@@ -562,6 +704,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-all/-/lang-all-4.24.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-all"
         }
       ]
     },
@@ -584,6 +732,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ar"
+        }
       ]
     },
     {
@@ -604,6 +758,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-bn/-/lang-bn-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-bn"
         }
       ]
     },
@@ -626,6 +786,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ca"
+        }
       ]
     },
     {
@@ -646,6 +812,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-cs/-/lang-cs-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-cs"
         }
       ]
     },
@@ -668,6 +840,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-da"
+        }
       ]
     },
     {
@@ -688,6 +866,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-de/-/lang-de-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-de"
         }
       ]
     },
@@ -710,6 +894,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-el"
+        }
       ]
     },
     {
@@ -730,6 +920,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-en-min/-/lang-en-min-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-en-min"
         }
       ]
     },
@@ -752,6 +948,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-en"
+        }
       ]
     },
     {
@@ -772,6 +974,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-es/-/lang-es-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-es"
         }
       ]
     },
@@ -794,6 +1002,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-eu"
+        }
       ]
     },
     {
@@ -814,6 +1028,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-fa/-/lang-fa-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-fa"
         }
       ]
     },
@@ -836,6 +1056,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-fi"
+        }
       ]
     },
     {
@@ -856,6 +1082,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-fr/-/lang-fr-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-fr"
         }
       ]
     },
@@ -878,6 +1110,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ga"
+        }
       ]
     },
     {
@@ -898,6 +1136,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-gl/-/lang-gl-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-gl"
         }
       ]
     },
@@ -920,6 +1164,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-hi"
+        }
       ]
     },
     {
@@ -940,6 +1190,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-hu/-/lang-hu-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-hu"
         }
       ]
     },
@@ -962,6 +1218,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-hy"
+        }
       ]
     },
     {
@@ -982,6 +1244,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-id/-/lang-id-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-id"
         }
       ]
     },
@@ -1004,6 +1272,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-it"
+        }
       ]
     },
     {
@@ -1024,6 +1298,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-ja/-/lang-ja-4.24.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ja"
         }
       ]
     },
@@ -1046,6 +1326,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ko"
+        }
       ]
     },
     {
@@ -1066,6 +1352,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-lt/-/lang-lt-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-lt"
         }
       ]
     },
@@ -1088,6 +1380,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ms"
+        }
       ]
     },
     {
@@ -1108,6 +1406,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-ne/-/lang-ne-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ne"
         }
       ]
     },
@@ -1130,6 +1434,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-nl"
+        }
       ]
     },
     {
@@ -1150,6 +1460,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-no/-/lang-no-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-no"
         }
       ]
     },
@@ -1172,6 +1488,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-pl"
+        }
       ]
     },
     {
@@ -1192,6 +1514,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-pt/-/lang-pt-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-pt"
         }
       ]
     },
@@ -1214,6 +1542,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ro"
+        }
       ]
     },
     {
@@ -1234,6 +1568,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-ru/-/lang-ru-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ru"
         }
       ]
     },
@@ -1256,6 +1596,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-sl"
+        }
       ]
     },
     {
@@ -1276,6 +1622,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-sr/-/lang-sr-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-sr"
         }
       ]
     },
@@ -1298,6 +1650,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-sv"
+        }
       ]
     },
     {
@@ -1318,6 +1676,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-ta/-/lang-ta-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ta"
         }
       ]
     },
@@ -1340,6 +1704,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-th"
+        }
       ]
     },
     {
@@ -1360,6 +1730,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-tl/-/lang-tl-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-tl"
         }
       ]
     },
@@ -1382,6 +1758,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-tr"
+        }
       ]
     },
     {
@@ -1402,6 +1784,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-uk/-/lang-uk-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-uk"
         }
       ]
     },
@@ -1424,6 +1812,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-zh"
+        }
       ]
     },
     {
@@ -1444,6 +1838,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/language-min/-/language-min-4.22.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/language-min"
         }
       ]
     },
@@ -1466,6 +1866,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/language"
+        }
       ]
     },
     {
@@ -1486,6 +1892,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/ner/-/ner-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/ner"
         }
       ]
     },
@@ -1508,6 +1920,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/neural"
+        }
       ]
     },
     {
@@ -1528,6 +1946,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/nlg/-/nlg-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/nlg"
         }
       ]
     },
@@ -1550,6 +1974,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/nlp"
+        }
       ]
     },
     {
@@ -1570,6 +2000,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/nlu/-/nlu-4.23.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/nlu"
         }
       ]
     },
@@ -1592,6 +2028,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/request"
+        }
       ]
     },
     {
@@ -1612,6 +2054,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/sentiment/-/sentiment-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/sentiment"
         }
       ]
     },
@@ -1634,6 +2082,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/similarity"
+        }
       ]
     },
     {
@@ -1654,6 +2108,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/slot/-/slot-4.22.17.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/slot"
         }
       ]
     },
@@ -1676,6 +2136,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@npmcli/fs"
+        }
       ]
     },
     {
@@ -1696,6 +2162,12 @@
           "url": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@npmcli/move-file"
         }
       ]
     },
@@ -1718,6 +2190,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib/core"
+        }
       ]
     },
     {
@@ -1738,6 +2216,12 @@
           "url": "https://registry.npmjs.org/@otplib/plugin-crypto/-/plugin-crypto-12.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib/plugin-crypto"
         }
       ]
     },
@@ -1760,6 +2244,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib/plugin-thirty-two"
+        }
       ]
     },
     {
@@ -1780,6 +2270,12 @@
           "url": "https://registry.npmjs.org/@otplib/preset-default/-/preset-default-12.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib/preset-default"
         }
       ]
     },
@@ -1802,6 +2298,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib/preset-v11"
+        }
       ]
     },
     {
@@ -1822,6 +2324,12 @@
           "url": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@sindresorhus/is"
         }
       ]
     },
@@ -1844,6 +2352,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@swc/helpers"
+        }
       ]
     },
     {
@@ -1864,6 +2378,12 @@
           "url": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@tokenizer/token"
         }
       ]
     },
@@ -1886,6 +2406,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@tootallnate/once"
+        }
       ]
     },
     {
@@ -1906,6 +2432,12 @@
           "url": "https://registry.npmjs.org/@types/component-emitter/-/component-emitter-1.2.11.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/component-emitter"
         }
       ]
     },
@@ -1928,6 +2460,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/cookie"
+        }
       ]
     },
     {
@@ -1948,6 +2486,12 @@
           "url": "https://registry.npmjs.org/@types/cors/-/cors-2.8.12.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/cors"
         }
       ]
     },
@@ -1970,6 +2514,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/debug"
+        }
       ]
     },
     {
@@ -1990,6 +2540,12 @@
           "url": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/ms"
         }
       ]
     },
@@ -2012,6 +2568,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/node"
+        }
       ]
     },
     {
@@ -2032,6 +2594,12 @@
           "url": "https://registry.npmjs.org/@types/strip-bom/-/strip-bom-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/strip-bom"
         }
       ]
     },
@@ -2054,6 +2622,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/strip-json-comments"
+        }
       ]
     },
     {
@@ -2075,6 +2649,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/validator"
+        }
       ]
     },
     {
@@ -2094,6 +2674,12 @@
           "url": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/abbrev"
         }
       ]
     },
@@ -2115,6 +2701,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/accepts"
+        }
       ]
     },
     {
@@ -2135,6 +2727,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/acorn-walk"
+        }
       ]
     },
     {
@@ -2154,6 +2752,12 @@
           "url": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/acorn"
         }
       ]
     },
@@ -2176,6 +2780,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/agent-base"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -2194,6 +2804,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agent-base/node_modules/debug"
             }
           ]
         },
@@ -2214,6 +2830,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agent-base/node_modules/ms"
             }
           ]
         }
@@ -2238,6 +2860,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/agentkeepalive"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -2256,6 +2884,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agentkeepalive/node_modules/debug"
             }
           ]
         },
@@ -2277,6 +2911,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agentkeepalive/node_modules/depd"
+            }
           ]
         },
         {
@@ -2296,6 +2936,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agentkeepalive/node_modules/ms"
             }
           ]
         }
@@ -2319,6 +2965,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/aggregate-error"
+        }
       ]
     },
     {
@@ -2338,6 +2990,12 @@
           "url": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ajv"
         }
       ]
     },
@@ -2359,6 +3017,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ansi-regex"
+        }
       ]
     },
     {
@@ -2378,6 +3042,12 @@
           "url": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ansi-styles"
         }
       ]
     },
@@ -2400,6 +3070,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/anymatch"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -2418,6 +3094,12 @@
               "url": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/anymatch/node_modules/normalize-path"
             }
           ]
         }
@@ -2441,6 +3123,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/append-field"
+        }
       ]
     },
     {
@@ -2460,6 +3148,12 @@
           "url": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/aproba"
         }
       ]
     },
@@ -2482,6 +3176,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/archive-type"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -2500,6 +3200,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-4.4.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/archive-type/node_modules/file-type"
             }
           ]
         }
@@ -2523,6 +3229,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/archiver-utils"
+        }
       ]
     },
     {
@@ -2542,6 +3254,12 @@
           "url": "https://registry.npmjs.org/archiver/-/archiver-1.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/archiver"
         }
       ]
     },
@@ -2563,6 +3281,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/are-we-there-yet"
+        }
       ]
     },
     {
@@ -2582,6 +3306,12 @@
           "url": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/arg"
         }
       ]
     },
@@ -2604,6 +3334,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/argparse"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -2622,6 +3358,12 @@
               "url": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/argparse/node_modules/sprintf-js"
             }
           ]
         }
@@ -2645,6 +3387,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/arr-diff"
+        }
       ]
     },
     {
@@ -2664,6 +3412,12 @@
           "url": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/arr-flatten"
         }
       ]
     },
@@ -2685,6 +3439,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/arr-union"
+        }
       ]
     },
     {
@@ -2704,6 +3464,12 @@
           "url": "https://registry.npmjs.org/array-each/-/array-each-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/array-each"
         }
       ]
     },
@@ -2725,6 +3491,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/array-flatten"
+        }
       ]
     },
     {
@@ -2744,6 +3516,12 @@
           "url": "https://registry.npmjs.org/array-slice/-/array-slice-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/array-slice"
         }
       ]
     },
@@ -2765,6 +3543,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/array-unique"
+        }
       ]
     },
     {
@@ -2784,6 +3568,12 @@
           "url": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/asap"
         }
       ]
     },
@@ -2805,6 +3595,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/asn1"
+        }
       ]
     },
     {
@@ -2824,6 +3620,12 @@
           "url": "https://registry.npmjs.org/assert-never/-/assert-never-1.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/assert-never"
         }
       ]
     },
@@ -2845,6 +3647,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/assert-plus"
+        }
       ]
     },
     {
@@ -2864,6 +3672,12 @@
           "url": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/assign-symbols"
         }
       ]
     },
@@ -2885,6 +3699,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/async"
+        }
       ]
     },
     {
@@ -2904,6 +3724,12 @@
           "url": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/asynckit"
         }
       ]
     },
@@ -2925,6 +3751,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/at-least-node"
+        }
       ]
     },
     {
@@ -2944,6 +3776,12 @@
           "url": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/atob"
         }
       ]
     },
@@ -2965,6 +3803,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/available-typed-arrays"
+        }
       ]
     },
     {
@@ -2984,6 +3828,12 @@
           "url": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/aws-sign2"
         }
       ]
     },
@@ -3005,6 +3855,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/aws4"
+        }
       ]
     },
     {
@@ -3025,6 +3881,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/babel-walk"
+        }
       ]
     },
     {
@@ -3044,6 +3906,12 @@
           "url": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/balanced-match"
         }
       ]
     },
@@ -3066,6 +3934,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -3084,6 +3958,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/base/node_modules/define-property"
             }
           ]
         }
@@ -3107,6 +3987,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base64-arraybuffer"
+        }
       ]
     },
     {
@@ -3126,6 +4012,12 @@
           "url": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base64-js"
         }
       ]
     },
@@ -3147,6 +4039,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base64id"
+        }
       ]
     },
     {
@@ -3166,6 +4064,12 @@
           "url": "https://registry.npmjs.org/base64url/-/base64url-0.0.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base64url"
         }
       ]
     },
@@ -3187,6 +4091,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/basic-auth"
+        }
       ]
     },
     {
@@ -3206,6 +4116,12 @@
           "url": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/batch"
         }
       ]
     },
@@ -3227,6 +4143,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bcrypt-pbkdf"
+        }
       ]
     },
     {
@@ -3246,6 +4168,12 @@
           "url": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/big-integer"
         }
       ]
     },
@@ -3267,6 +4195,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/binary-extensions"
+        }
       ]
     },
     {
@@ -3286,6 +4220,12 @@
           "url": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/binary"
         }
       ]
     },
@@ -3307,6 +4247,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bindings"
+        }
       ]
     },
     {
@@ -3326,6 +4272,12 @@
           "url": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bintrees"
         }
       ]
     },
@@ -3347,6 +4299,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bl"
+        }
       ]
     },
     {
@@ -3367,6 +4325,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bluebird"
+        }
       ]
     },
     {
@@ -3386,6 +4350,12 @@
           "url": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/body-parser"
         }
       ]
     },
@@ -3408,6 +4378,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bower-config"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -3426,6 +4402,12 @@
               "url": "https://registry.npmjs.org/minimist/-/minimist-0.2.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bower-config/node_modules/minimist"
             }
           ]
         }
@@ -3449,6 +4431,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/brace-expansion"
+        }
       ]
     },
     {
@@ -3470,6 +4458,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/braces"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -3488,6 +4482,12 @@
               "url": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/braces/node_modules/extend-shallow"
             }
           ]
         },
@@ -3508,6 +4508,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/braces/node_modules/is-extendable"
             }
           ]
         }
@@ -3531,6 +4537,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/brotli"
+        }
       ]
     },
     {
@@ -3550,6 +4562,12 @@
           "url": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-alloc-unsafe"
         }
       ]
     },
@@ -3571,6 +4589,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-alloc"
+        }
       ]
     },
     {
@@ -3590,6 +4614,12 @@
           "url": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-crc32"
         }
       ]
     },
@@ -3611,6 +4641,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-fill"
+        }
       ]
     },
     {
@@ -3630,6 +4666,12 @@
           "url": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-from"
         }
       ]
     },
@@ -3651,6 +4693,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-indexof-polyfill"
+        }
       ]
     },
     {
@@ -3671,6 +4719,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer"
+        }
       ]
     },
     {
@@ -3690,6 +4744,12 @@
           "url": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffers"
         }
       ]
     },
@@ -3712,6 +4772,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/busboy"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -3730,6 +4796,12 @@
               "url": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/busboy/node_modules/isarray"
             }
           ]
         },
@@ -3751,6 +4823,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/busboy/node_modules/readable-stream"
+            }
           ]
         },
         {
@@ -3770,6 +4848,12 @@
               "url": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/busboy/node_modules/string_decoder"
             }
           ]
         }
@@ -3793,6 +4877,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/byline"
+        }
       ]
     },
     {
@@ -3812,6 +4902,12 @@
           "url": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bytes"
         }
       ]
     },
@@ -3833,6 +4929,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cacache"
+        }
       ]
     },
     {
@@ -3852,6 +4954,12 @@
           "url": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cache-base"
         }
       ]
     },
@@ -3874,6 +4982,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cacheable-request"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -3892,6 +5006,12 @@
               "url": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cacheable-request/node_modules/get-stream"
             }
           ]
         },
@@ -3912,6 +5032,12 @@
               "url": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cacheable-request/node_modules/lowercase-keys"
             }
           ]
         }
@@ -3935,6 +5061,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/call-bind"
+        }
       ]
     },
     {
@@ -3954,6 +5086,12 @@
           "url": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/camelcase"
         }
       ]
     },
@@ -3975,6 +5113,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/caseless"
+        }
       ]
     },
     {
@@ -3994,6 +5138,12 @@
           "url": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/chainsaw"
         }
       ]
     },
@@ -4015,6 +5165,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/chalk"
+        }
       ]
     },
     {
@@ -4034,6 +5190,12 @@
           "url": "https://registry.npmjs.org/character-parser/-/character-parser-2.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/character-parser"
         }
       ]
     },
@@ -4056,6 +5218,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/check-dependencies"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4074,6 +5242,12 @@
               "url": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/check-dependencies/node_modules/semver"
             }
           ]
         }
@@ -4097,6 +5271,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/check-types"
+        }
       ]
     },
     {
@@ -4118,6 +5298,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/chokidar"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4136,6 +5322,12 @@
               "url": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar/node_modules/braces"
             }
           ]
         },
@@ -4157,6 +5349,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar/node_modules/fill-range"
+            }
           ]
         },
         {
@@ -4176,6 +5374,12 @@
               "url": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar/node_modules/is-glob"
             }
           ]
         },
@@ -4197,6 +5401,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar/node_modules/is-number"
+            }
           ]
         },
         {
@@ -4217,6 +5427,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar/node_modules/normalize-path"
+            }
           ]
         },
         {
@@ -4236,6 +5452,12 @@
               "url": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar/node_modules/to-regex-range"
             }
           ]
         }
@@ -4259,6 +5481,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/chownr"
+        }
       ]
     },
     {
@@ -4278,6 +5506,12 @@
           "url": "https://registry.npmjs.org/clarinet/-/clarinet-0.12.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/clarinet"
         }
       ]
     },
@@ -4300,6 +5534,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/class-utils"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4318,6 +5558,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils/node_modules/define-property"
             }
           ]
         },
@@ -4340,6 +5586,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils/node_modules/is-accessor-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -4358,6 +5610,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/class-utils/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -4382,6 +5640,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils/node_modules/is-data-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -4400,6 +5664,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/class-utils/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -4423,6 +5693,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils/node_modules/is-descriptor"
+            }
           ]
         },
         {
@@ -4442,6 +5718,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils/node_modules/kind-of"
             }
           ]
         }
@@ -4465,6 +5747,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/clean-stack"
+        }
       ]
     },
     {
@@ -4486,6 +5774,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cliui"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4504,6 +5798,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui/node_modules/ansi-regex"
             }
           ]
         },
@@ -4525,6 +5825,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui/node_modules/emoji-regex"
+            }
           ]
         },
         {
@@ -4544,6 +5850,12 @@
               "url": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui/node_modules/is-fullwidth-code-point"
             }
           ]
         },
@@ -4565,6 +5877,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui/node_modules/string-width"
+            }
           ]
         },
         {
@@ -4584,6 +5902,12 @@
               "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui/node_modules/strip-ansi"
             }
           ]
         }
@@ -4607,6 +5931,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/clone-response"
+        }
       ]
     },
     {
@@ -4626,6 +5956,12 @@
           "url": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/clone"
         }
       ]
     },
@@ -4647,6 +5983,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/code-point-at"
+        }
       ]
     },
     {
@@ -4666,6 +6008,12 @@
           "url": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/collection-visit"
         }
       ]
     },
@@ -4687,6 +6035,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color-convert"
+        }
       ]
     },
     {
@@ -4706,6 +6060,12 @@
           "url": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color-name"
         }
       ]
     },
@@ -4727,6 +6087,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color-string"
+        }
       ]
     },
     {
@@ -4746,6 +6112,12 @@
           "url": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color-support"
         }
       ]
     },
@@ -4767,6 +6139,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color"
+        }
       ]
     },
     {
@@ -4786,6 +6164,12 @@
           "url": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/colors"
         }
       ]
     },
@@ -4807,6 +6191,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/colorspace"
+        }
       ]
     },
     {
@@ -4826,6 +6216,12 @@
           "url": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/combined-stream"
         }
       ]
     },
@@ -4847,6 +6243,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/commander"
+        }
       ]
     },
     {
@@ -4866,6 +6268,12 @@
           "url": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/component-emitter"
         }
       ]
     },
@@ -4887,6 +6295,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/component-type"
+        }
       ]
     },
     {
@@ -4907,6 +6321,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/compress-commons"
+        }
       ]
     },
     {
@@ -4926,6 +6346,12 @@
           "url": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/compressible"
         }
       ]
     },
@@ -4948,6 +6374,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/compression"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4966,6 +6398,12 @@
               "url": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/compression/node_modules/bytes"
             }
           ]
         }
@@ -4989,6 +6427,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/concat-map"
+        }
       ]
     },
     {
@@ -5008,6 +6452,12 @@
           "url": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/concat-stream"
         }
       ]
     },
@@ -5030,6 +6480,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/concurrently"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5048,6 +6504,12 @@
               "url": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/concurrently/node_modules/supports-color"
             }
           ]
         }
@@ -5071,6 +6533,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/config"
+        }
       ]
     },
     {
@@ -5091,6 +6559,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/console-control-strings"
+        }
       ]
     },
     {
@@ -5110,6 +6584,12 @@
           "url": "https://registry.npmjs.org/constantinople/-/constantinople-4.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/constantinople"
         }
       ]
     },
@@ -5132,6 +6612,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/content-disposition"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5150,6 +6636,12 @@
               "url": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/content-disposition/node_modules/safe-buffer"
             }
           ]
         }
@@ -5173,6 +6665,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/content-type"
+        }
       ]
     },
     {
@@ -5192,6 +6690,12 @@
           "url": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cookie-parser"
         }
       ]
     },
@@ -5213,6 +6717,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cookie-signature"
+        }
       ]
     },
     {
@@ -5232,6 +6742,12 @@
           "url": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cookie"
         }
       ]
     },
@@ -5253,6 +6769,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/copy-descriptor"
+        }
       ]
     },
     {
@@ -5272,6 +6794,12 @@
           "url": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/core-util-is"
         }
       ]
     },
@@ -5293,6 +6821,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cors"
+        }
       ]
     },
     {
@@ -5312,6 +6846,12 @@
           "url": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/crc"
         }
       ]
     },
@@ -5333,6 +6873,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/crc32-stream"
+        }
       ]
     },
     {
@@ -5352,6 +6898,12 @@
           "url": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/create-require"
         }
       ]
     },
@@ -5373,6 +6925,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/crypto-js"
+        }
       ]
     },
     {
@@ -5392,6 +6950,12 @@
           "url": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dashdash"
         }
       ]
     },
@@ -5413,6 +6977,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/date-fns"
+        }
       ]
     },
     {
@@ -5432,6 +7002,12 @@
           "url": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dateformat"
         }
       ]
     },
@@ -5453,6 +7029,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/debug"
+        }
       ]
     },
     {
@@ -5472,6 +7054,12 @@
           "url": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decamelize"
         }
       ]
     },
@@ -5493,6 +7081,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decode-uri-component"
+        }
       ]
     },
     {
@@ -5512,6 +7106,12 @@
           "url": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-response"
         }
       ]
     },
@@ -5534,6 +7134,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-tar"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5552,6 +7158,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-tar/node_modules/file-type"
             }
           ]
         }
@@ -5576,6 +7188,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-tarbz2"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5594,6 +7212,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-6.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-tarbz2/node_modules/file-type"
             }
           ]
         }
@@ -5618,6 +7242,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-targz"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5636,6 +7266,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-targz/node_modules/file-type"
             }
           ]
         }
@@ -5660,6 +7296,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-unzip"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5678,6 +7320,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-unzip/node_modules/file-type"
             }
           ]
         },
@@ -5699,6 +7347,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-unzip/node_modules/get-stream"
+            }
           ]
         },
         {
@@ -5718,6 +7372,12 @@
               "url": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-unzip/node_modules/pify"
             }
           ]
         }
@@ -5742,6 +7402,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5762,6 +7428,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress/node_modules/make-dir"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -5780,6 +7452,12 @@
                   "url": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/decompress/node_modules/make-dir/node_modules/pify"
                 }
               ]
             }
@@ -5803,6 +7481,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress/node_modules/pify"
+            }
           ]
         }
       ]
@@ -5825,6 +7509,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/deep-equal"
+        }
       ]
     },
     {
@@ -5844,6 +7534,12 @@
           "url": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/deep-extend"
         }
       ]
     },
@@ -5865,6 +7561,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/deep-is"
+        }
       ]
     },
     {
@@ -5884,6 +7586,12 @@
           "url": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/define-properties"
         }
       ]
     },
@@ -5905,6 +7613,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/define-property"
+        }
       ]
     },
     {
@@ -5924,6 +7638,12 @@
           "url": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/delayed-stream"
         }
       ]
     },
@@ -5945,6 +7665,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/delegates"
+        }
       ]
     },
     {
@@ -5964,6 +7690,12 @@
           "url": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/depd"
         }
       ]
     },
@@ -5985,6 +7717,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/destroy"
+        }
       ]
     },
     {
@@ -6004,6 +7742,12 @@
           "url": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/detect-file"
         }
       ]
     },
@@ -6025,6 +7769,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/detect-libc"
+        }
       ]
     },
     {
@@ -6044,6 +7794,12 @@
           "url": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dfa"
         }
       ]
     },
@@ -6066,6 +7822,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dicer"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -6084,6 +7846,12 @@
               "url": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/dicer/node_modules/isarray"
             }
           ]
         },
@@ -6105,6 +7873,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/dicer/node_modules/readable-stream"
+            }
           ]
         },
         {
@@ -6124,6 +7898,12 @@
               "url": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/dicer/node_modules/string_decoder"
             }
           ]
         }
@@ -6147,6 +7927,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/diff"
+        }
       ]
     },
     {
@@ -6166,6 +7952,12 @@
           "url": "https://registry.npmjs.org/doctypes/-/doctypes-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/doctypes"
         }
       ]
     },
@@ -6187,6 +7979,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/domelementtype"
+        }
       ]
     },
     {
@@ -6206,6 +8004,12 @@
           "url": "https://registry.npmjs.org/domhandler/-/domhandler-2.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/domhandler"
         }
       ]
     },
@@ -6227,6 +8031,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/domutils"
+        }
       ]
     },
     {
@@ -6246,6 +8056,12 @@
           "url": "https://registry.npmjs.org/dottie/-/dottie-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dottie"
         }
       ]
     },
@@ -6267,6 +8083,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/double-ended-queue"
+        }
       ]
     },
     {
@@ -6286,6 +8108,12 @@
           "url": "https://registry.npmjs.org/doublearray/-/doublearray-0.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/doublearray"
         }
       ]
     },
@@ -6308,6 +8136,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/download"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -6326,6 +8160,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-11.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/download/node_modules/file-type"
             }
           ]
         }
@@ -6349,6 +8189,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/duplexer2"
+        }
       ]
     },
     {
@@ -6368,6 +8214,12 @@
           "url": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/duplexer3"
         }
       ]
     },
@@ -6389,6 +8241,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dynamic-dedupe"
+        }
       ]
     },
     {
@@ -6408,6 +8266,12 @@
           "url": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ecc-jsbn"
         }
       ]
     },
@@ -6429,6 +8293,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ee-first"
+        }
       ]
     },
     {
@@ -6448,6 +8318,12 @@
           "url": "https://registry.npmjs.org/eivindfjeldstad-dot/-/eivindfjeldstad-dot-0.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/eivindfjeldstad-dot"
         }
       ]
     },
@@ -6469,6 +8345,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/emoji-regex"
+        }
       ]
     },
     {
@@ -6489,6 +8371,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/enabled"
+        }
       ]
     },
     {
@@ -6508,6 +8396,12 @@
           "url": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/encodeurl"
         }
       ]
     },
@@ -6530,6 +8424,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/encoding"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -6548,6 +8448,12 @@
               "url": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/encoding/node_modules/iconv-lite"
             }
           ]
         }
@@ -6571,6 +8477,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/end-of-stream"
+        }
       ]
     },
     {
@@ -6590,6 +8502,12 @@
           "url": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-4.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/engine.io-parser"
         }
       ]
     },
@@ -6612,6 +8530,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/engine.io"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -6630,6 +8554,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/engine.io/node_modules/debug"
             }
           ]
         },
@@ -6650,6 +8580,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/engine.io/node_modules/ms"
             }
           ]
         }
@@ -6673,6 +8609,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/env-paths"
+        }
       ]
     },
     {
@@ -6692,6 +8634,12 @@
           "url": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/err-code"
         }
       ]
     },
@@ -6713,6 +8661,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/error-ex"
+        }
       ]
     },
     {
@@ -6732,6 +8686,12 @@
           "url": "https://registry.npmjs.org/errorhandler/-/errorhandler-1.5.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/errorhandler"
         }
       ]
     },
@@ -6753,6 +8713,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/es-abstract"
+        }
       ]
     },
     {
@@ -6772,6 +8738,12 @@
           "url": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/es-get-iterator"
         }
       ]
     },
@@ -6793,6 +8765,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/es-to-primitive"
+        }
       ]
     },
     {
@@ -6812,6 +8790,12 @@
           "url": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/escape-html"
         }
       ]
     },
@@ -6833,6 +8817,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/escape-string-regexp"
+        }
       ]
     },
     {
@@ -6852,6 +8842,12 @@
           "url": "https://registry.npmjs.org/escodegen/-/escodegen-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/escodegen"
         }
       ]
     },
@@ -6873,6 +8869,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/esprima"
+        }
       ]
     },
     {
@@ -6892,6 +8894,12 @@
           "url": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/estraverse"
         }
       ]
     },
@@ -6913,6 +8921,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/esutils"
+        }
       ]
     },
     {
@@ -6932,6 +8946,12 @@
           "url": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/etag"
         }
       ]
     },
@@ -6953,6 +8973,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/eventemitter2"
+        }
       ]
     },
     {
@@ -6972,6 +8998,12 @@
           "url": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/eventemitter3"
         }
       ]
     },
@@ -6993,6 +9025,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/exif"
+        }
       ]
     },
     {
@@ -7012,6 +9050,12 @@
           "url": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/exit"
         }
       ]
     },
@@ -7034,6 +9078,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/expand-brackets"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7052,6 +9102,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/define-property"
             }
           ]
         },
@@ -7072,6 +9128,12 @@
               "url": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/extend-shallow"
             }
           ]
         },
@@ -7094,6 +9156,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/is-accessor-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -7112,6 +9180,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/expand-brackets/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -7136,6 +9210,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/is-data-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -7154,6 +9234,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/expand-brackets/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -7177,6 +9263,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/is-descriptor"
+            }
           ]
         },
         {
@@ -7197,6 +9289,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/is-extendable"
+            }
           ]
         },
         {
@@ -7216,6 +9314,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/kind-of"
             }
           ]
         }
@@ -7239,6 +9343,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/expand-template"
+        }
       ]
     },
     {
@@ -7259,6 +9369,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/expand-tilde"
+        }
       ]
     },
     {
@@ -7278,6 +9394,12 @@
           "url": "https://registry.npmjs.org/express-ipfilter/-/express-ipfilter-1.3.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-ipfilter"
         }
       ]
     },
@@ -7300,6 +9422,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-jwt"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7318,6 +9446,12 @@
               "url": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-0.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/express-jwt/node_modules/jsonwebtoken"
             }
           ]
         },
@@ -7338,6 +9472,12 @@
               "url": "https://registry.npmjs.org/moment/-/moment-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/express-jwt/node_modules/moment"
             }
           ]
         }
@@ -7361,6 +9501,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-rate-limit"
+        }
       ]
     },
     {
@@ -7381,6 +9527,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-robots-txt"
+        }
       ]
     },
     {
@@ -7400,6 +9552,12 @@
           "url": "https://registry.npmjs.org/express-security.txt/-/express-security.txt-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-security.txt"
         }
       ]
     },
@@ -7422,6 +9580,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7440,6 +9604,12 @@
               "url": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/express/node_modules/cookie"
             }
           ]
         },
@@ -7460,6 +9630,12 @@
               "url": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/express/node_modules/safe-buffer"
             }
           ]
         }
@@ -7483,6 +9659,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ext-list"
+        }
       ]
     },
     {
@@ -7502,6 +9684,12 @@
           "url": "https://registry.npmjs.org/ext-name/-/ext-name-5.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ext-name"
         }
       ]
     },
@@ -7523,6 +9711,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/extend-shallow"
+        }
       ]
     },
     {
@@ -7542,6 +9736,12 @@
           "url": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/extend"
         }
       ]
     },
@@ -7564,6 +9764,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/extglob"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7582,6 +9788,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/extglob/node_modules/define-property"
             }
           ]
         },
@@ -7603,6 +9815,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/extglob/node_modules/extend-shallow"
+            }
           ]
         },
         {
@@ -7622,6 +9840,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/extglob/node_modules/is-extendable"
             }
           ]
         }
@@ -7645,6 +9869,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/extsprintf"
+        }
       ]
     },
     {
@@ -7664,6 +9894,12 @@
           "url": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fast-deep-equal"
         }
       ]
     },
@@ -7685,6 +9921,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fast-json-stable-stringify"
+        }
       ]
     },
     {
@@ -7704,6 +9946,12 @@
           "url": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fast-levenshtein"
         }
       ]
     },
@@ -7725,6 +9973,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fast.js"
+        }
       ]
     },
     {
@@ -7744,6 +9998,12 @@
           "url": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fd-slicer"
         }
       ]
     },
@@ -7765,6 +10025,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/feature-policy"
+        }
       ]
     },
     {
@@ -7784,6 +10050,12 @@
           "url": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fecha"
         }
       ]
     },
@@ -7806,6 +10078,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/file-js"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7824,6 +10102,12 @@
               "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/file-js/node_modules/brace-expansion"
             }
           ]
         },
@@ -7844,6 +10128,12 @@
               "url": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/file-js/node_modules/minimatch"
             }
           ]
         }
@@ -7867,6 +10157,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/file-stream-rotator"
+        }
       ]
     },
     {
@@ -7886,6 +10182,12 @@
           "url": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/file-type"
         }
       ]
     },
@@ -7907,6 +10209,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/file-uri-to-path"
+        }
       ]
     },
     {
@@ -7926,6 +10234,12 @@
           "url": "https://registry.npmjs.org/filehound/-/filehound-1.17.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/filehound"
         }
       ]
     },
@@ -7947,6 +10261,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/filename-reserved-regex"
+        }
       ]
     },
     {
@@ -7967,6 +10287,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/filenamify"
+        }
       ]
     },
     {
@@ -7986,6 +10312,12 @@
           "url": "https://registry.npmjs.org/filesniffer/-/filesniffer-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/filesniffer"
         }
       ]
     },
@@ -8008,6 +10340,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fill-range"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -8026,6 +10364,12 @@
               "url": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/fill-range/node_modules/extend-shallow"
             }
           ]
         },
@@ -8046,6 +10390,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/fill-range/node_modules/is-extendable"
             }
           ]
         }
@@ -8069,6 +10419,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/finale-rest"
+        }
       ]
     },
     {
@@ -8088,6 +10444,12 @@
           "url": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/finalhandler"
         }
       ]
     },
@@ -8109,6 +10471,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/find-up"
+        }
       ]
     },
     {
@@ -8128,6 +10496,12 @@
           "url": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/findup-sync"
         }
       ]
     },
@@ -8149,6 +10523,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fined"
+        }
       ]
     },
     {
@@ -8168,6 +10548,12 @@
           "url": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/flagged-respawn"
         }
       ]
     },
@@ -8189,6 +10575,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fn.name"
+        }
       ]
     },
     {
@@ -8208,6 +10600,12 @@
           "url": "https://registry.npmjs.org/fontkit/-/fontkit-1.9.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fontkit"
         }
       ]
     },
@@ -8229,6 +10627,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/for-each"
+        }
       ]
     },
     {
@@ -8248,6 +10652,12 @@
           "url": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/for-in"
         }
       ]
     },
@@ -8269,6 +10679,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/for-own"
+        }
       ]
     },
     {
@@ -8288,6 +10704,12 @@
           "url": "https://registry.npmjs.org/foreachasync/-/foreachasync-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/foreachasync"
         }
       ]
     },
@@ -8309,6 +10731,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/forever-agent"
+        }
       ]
     },
     {
@@ -8328,6 +10756,12 @@
           "url": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/form-data"
         }
       ]
     },
@@ -8349,6 +10783,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/formatio"
+        }
       ]
     },
     {
@@ -8368,6 +10808,12 @@
           "url": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/forwarded"
         }
       ]
     },
@@ -8389,6 +10835,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fragment-cache"
+        }
       ]
     },
     {
@@ -8408,6 +10860,12 @@
           "url": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fresh"
         }
       ]
     },
@@ -8429,6 +10887,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/from2"
+        }
       ]
     },
     {
@@ -8448,6 +10912,12 @@
           "url": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fs-constants"
         }
       ]
     },
@@ -8469,6 +10939,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fs-extra"
+        }
       ]
     },
     {
@@ -8488,6 +10964,12 @@
           "url": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fs-minipass"
         }
       ]
     },
@@ -8509,6 +10991,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fs.realpath"
+        }
       ]
     },
     {
@@ -8528,6 +11016,12 @@
           "url": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fsevents"
         }
       ]
     },
@@ -8550,6 +11044,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fstream"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -8568,6 +11068,12 @@
               "url": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/fstream/node_modules/mkdirp"
             }
           ]
         },
@@ -8588,6 +11094,12 @@
               "url": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/fstream/node_modules/rimraf"
             }
           ]
         }
@@ -8611,6 +11123,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/function-bind"
+        }
       ]
     },
     {
@@ -8630,6 +11148,12 @@
           "url": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/function.prototype.name"
         }
       ]
     },
@@ -8651,6 +11175,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/functions-have-names"
+        }
       ]
     },
     {
@@ -8670,6 +11200,12 @@
           "url": "https://registry.npmjs.org/fuzzball/-/fuzzball-1.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fuzzball"
         }
       ]
     },
@@ -8691,6 +11227,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/gauge"
+        }
       ]
     },
     {
@@ -8710,6 +11252,12 @@
           "url": "https://registry.npmjs.org/geojson-utils/-/geojson-utils-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/geojson-utils"
         }
       ]
     },
@@ -8731,6 +11279,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-caller-file"
+        }
       ]
     },
     {
@@ -8750,6 +11304,12 @@
           "url": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-intrinsic"
         }
       ]
     },
@@ -8771,6 +11331,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-stream"
+        }
       ]
     },
     {
@@ -8790,6 +11356,12 @@
           "url": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-symbol-description"
         }
       ]
     },
@@ -8811,6 +11383,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-value"
+        }
       ]
     },
     {
@@ -8830,6 +11408,12 @@
           "url": "https://registry.npmjs.org/getobject/-/getobject-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/getobject"
         }
       ]
     },
@@ -8851,6 +11435,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/getpass"
+        }
       ]
     },
     {
@@ -8870,6 +11460,12 @@
           "url": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/github-from-package"
         }
       ]
     },
@@ -8892,6 +11488,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/glob-parent"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -8910,6 +11512,12 @@
               "url": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/glob-parent/node_modules/is-glob"
             }
           ]
         }
@@ -8934,6 +11542,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/glob"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -8952,6 +11566,12 @@
               "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/glob/node_modules/brace-expansion"
             }
           ]
         },
@@ -8972,6 +11592,12 @@
               "url": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/glob/node_modules/minimatch"
             }
           ]
         }
@@ -8995,6 +11621,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/global-modules"
+        }
       ]
     },
     {
@@ -9016,6 +11648,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/global-prefix"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9034,6 +11672,12 @@
               "url": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/global-prefix/node_modules/which"
             }
           ]
         }
@@ -9058,6 +11702,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/got"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9076,6 +11726,12 @@
               "url": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/got/node_modules/get-stream"
             }
           ]
         },
@@ -9096,6 +11752,12 @@
               "url": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/got/node_modules/pify"
             }
           ]
         }
@@ -9119,6 +11781,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/graceful-fs"
+        }
       ]
     },
     {
@@ -9140,6 +11808,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-cli"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9158,6 +11832,12 @@
               "url": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-cli/node_modules/nopt"
             }
           ]
         }
@@ -9182,6 +11862,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-contrib-compress"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9200,6 +11886,12 @@
               "url": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-contrib-compress/node_modules/ansi-styles"
             }
           ]
         },
@@ -9221,6 +11913,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-contrib-compress/node_modules/chalk"
+            }
           ]
         },
         {
@@ -9240,6 +11938,12 @@
               "url": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-contrib-compress/node_modules/supports-color"
             }
           ]
         }
@@ -9263,6 +11967,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-known-options"
+        }
       ]
     },
     {
@@ -9284,6 +11994,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-legacy-log-utils"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9302,6 +12018,12 @@
               "url": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils/node_modules/ansi-styles"
             }
           ]
         },
@@ -9323,6 +12045,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils/node_modules/chalk"
+            }
           ]
         },
         {
@@ -9342,6 +12070,12 @@
               "url": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils/node_modules/color-convert"
             }
           ]
         },
@@ -9363,6 +12097,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils/node_modules/color-name"
+            }
           ]
         },
         {
@@ -9383,6 +12123,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils/node_modules/has-flag"
+            }
           ]
         },
         {
@@ -9402,6 +12148,12 @@
               "url": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils/node_modules/supports-color"
             }
           ]
         }
@@ -9426,6 +12178,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-legacy-log"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9444,6 +12202,12 @@
               "url": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log/node_modules/colors"
             }
           ]
         }
@@ -9468,6 +12232,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-legacy-util"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9486,6 +12256,12 @@
               "url": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-util/node_modules/async"
             }
           ]
         }
@@ -9509,6 +12285,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-replace-json"
+        }
       ]
     },
     {
@@ -9530,6 +12312,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9548,6 +12336,12 @@
               "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt/node_modules/brace-expansion"
             }
           ]
         },
@@ -9570,6 +12364,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt/node_modules/findup-sync"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -9588,6 +12388,12 @@
                   "url": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/grunt/node_modules/findup-sync/node_modules/glob"
                 }
               ]
             }
@@ -9611,6 +12417,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt/node_modules/glob"
+            }
           ]
         },
         {
@@ -9630,6 +12442,12 @@
               "url": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.8.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt/node_modules/minimatch"
             }
           ]
         }
@@ -9654,6 +12472,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/handlebars"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9672,6 +12496,12 @@
               "url": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/handlebars/node_modules/wordwrap"
             }
           ]
         }
@@ -9695,6 +12525,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/har-schema"
+        }
       ]
     },
     {
@@ -9714,6 +12550,12 @@
           "url": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/har-validator"
         }
       ]
     },
@@ -9735,6 +12577,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-ansi"
+        }
       ]
     },
     {
@@ -9754,6 +12602,12 @@
           "url": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-bigints"
         }
       ]
     },
@@ -9775,6 +12629,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-flag"
+        }
       ]
     },
     {
@@ -9794,6 +12654,12 @@
           "url": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-property-descriptors"
         }
       ]
     },
@@ -9815,6 +12681,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-symbol-support-x"
+        }
       ]
     },
     {
@@ -9834,6 +12706,12 @@
           "url": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-symbols"
         }
       ]
     },
@@ -9855,6 +12733,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-to-string-tag-x"
+        }
       ]
     },
     {
@@ -9874,6 +12758,12 @@
           "url": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-tostringtag"
         }
       ]
     },
@@ -9895,6 +12785,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-unicode"
+        }
       ]
     },
     {
@@ -9914,6 +12810,12 @@
           "url": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-value"
         }
       ]
     },
@@ -9936,6 +12838,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-values"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9954,6 +12862,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/has-values/node_modules/kind-of"
             }
           ]
         }
@@ -9977,6 +12891,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has"
+        }
       ]
     },
     {
@@ -9996,6 +12916,12 @@
           "url": "https://registry.npmjs.org/hashids/-/hashids-2.2.10.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hashids"
         }
       ]
     },
@@ -10017,6 +12943,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hbs"
+        }
       ]
     },
     {
@@ -10036,6 +12968,12 @@
           "url": "https://registry.npmjs.org/he/-/he-0.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/he"
         }
       ]
     },
@@ -10057,6 +12995,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/heap"
+        }
       ]
     },
     {
@@ -10076,6 +13020,12 @@
           "url": "https://registry.npmjs.org/helmet/-/helmet-4.6.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/helmet"
         }
       ]
     },
@@ -10097,6 +13047,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hoister"
+        }
       ]
     },
     {
@@ -10116,6 +13072,12 @@
           "url": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/homedir-polyfill"
         }
       ]
     },
@@ -10137,6 +13099,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hooker"
+        }
       ]
     },
     {
@@ -10157,6 +13125,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hosted-git-info"
+        }
       ]
     },
     {
@@ -10176,6 +13150,12 @@
           "url": "https://registry.npmjs.org/html-entities/-/html-entities-1.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/html-entities"
         }
       ]
     },
@@ -10198,6 +13178,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/htmlparser2"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -10216,6 +13202,12 @@
               "url": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/htmlparser2/node_modules/isarray"
             }
           ]
         },
@@ -10237,6 +13229,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/htmlparser2/node_modules/readable-stream"
+            }
           ]
         },
         {
@@ -10256,6 +13254,12 @@
               "url": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/htmlparser2/node_modules/string_decoder"
             }
           ]
         }
@@ -10279,6 +13283,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/http-cache-semantics"
+        }
       ]
     },
     {
@@ -10298,6 +13308,12 @@
           "url": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/http-errors"
         }
       ]
     },
@@ -10320,6 +13336,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/http-proxy-agent"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -10338,6 +13360,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/http-proxy-agent/node_modules/debug"
             }
           ]
         },
@@ -10358,6 +13386,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/http-proxy-agent/node_modules/ms"
             }
           ]
         }
@@ -10381,6 +13415,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/http-signature"
+        }
       ]
     },
     {
@@ -10402,6 +13442,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/https-proxy-agent"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -10420,6 +13466,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/https-proxy-agent/node_modules/debug"
             }
           ]
         },
@@ -10440,6 +13492,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/https-proxy-agent/node_modules/ms"
             }
           ]
         }
@@ -10463,6 +13521,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/humanize-ms"
+        }
       ]
     },
     {
@@ -10482,6 +13546,12 @@
           "url": "https://registry.npmjs.org/i18n/-/i18n-0.11.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/i18n"
         }
       ]
     },
@@ -10503,6 +13573,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/iconv-lite"
+        }
       ]
     },
     {
@@ -10522,6 +13598,12 @@
           "url": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ieee754"
         }
       ]
     },
@@ -10544,6 +13626,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ignore-walk"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -10562,6 +13650,12 @@
               "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/ignore-walk/node_modules/brace-expansion"
             }
           ]
         },
@@ -10582,6 +13676,12 @@
               "url": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/ignore-walk/node_modules/minimatch"
             }
           ]
         }
@@ -10605,6 +13705,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/iltorb"
+        }
       ]
     },
     {
@@ -10624,6 +13730,12 @@
           "url": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/imurmurhash"
         }
       ]
     },
@@ -10645,6 +13757,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/indent-string"
+        }
       ]
     },
     {
@@ -10664,6 +13782,12 @@
           "url": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/infer-owner"
         }
       ]
     },
@@ -10685,6 +13809,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/inflection"
+        }
       ]
     },
     {
@@ -10704,6 +13834,12 @@
           "url": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/inflight"
         }
       ]
     },
@@ -10725,6 +13861,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/inherits"
+        }
       ]
     },
     {
@@ -10744,6 +13886,12 @@
           "url": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ini"
         }
       ]
     },
@@ -10765,6 +13913,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/internal-slot"
+        }
       ]
     },
     {
@@ -10784,6 +13938,12 @@
           "url": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/interpret"
         }
       ]
     },
@@ -10805,6 +13965,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/into-stream"
+        }
       ]
     },
     {
@@ -10824,6 +13990,12 @@
           "url": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/invariant"
         }
       ]
     },
@@ -10845,6 +14017,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ip"
+        }
       ]
     },
     {
@@ -10864,6 +14042,12 @@
           "url": "https://registry.npmjs.org/ip6/-/ip6-0.2.10.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ip6"
         }
       ]
     },
@@ -10885,6 +14069,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ipaddr.js"
+        }
       ]
     },
     {
@@ -10904,6 +14094,12 @@
           "url": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-absolute"
         }
       ]
     },
@@ -10925,6 +14121,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-accessor-descriptor"
+        }
       ]
     },
     {
@@ -10944,6 +14146,12 @@
           "url": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-arguments"
         }
       ]
     },
@@ -10965,6 +14173,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-arrayish"
+        }
       ]
     },
     {
@@ -10984,6 +14198,12 @@
           "url": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-bigint"
         }
       ]
     },
@@ -11005,6 +14225,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-binary-path"
+        }
       ]
     },
     {
@@ -11024,6 +14250,12 @@
           "url": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-boolean-object"
         }
       ]
     },
@@ -11045,6 +14277,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-buffer"
+        }
       ]
     },
     {
@@ -11064,6 +14302,12 @@
           "url": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-callable"
         }
       ]
     },
@@ -11085,6 +14329,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-core-module"
+        }
       ]
     },
     {
@@ -11104,6 +14354,12 @@
           "url": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-data-descriptor"
         }
       ]
     },
@@ -11125,6 +14381,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-date-object"
+        }
       ]
     },
     {
@@ -11144,6 +14406,12 @@
           "url": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-descriptor"
         }
       ]
     },
@@ -11165,6 +14433,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-docker"
+        }
       ]
     },
     {
@@ -11184,6 +14458,12 @@
           "url": "https://registry.npmjs.org/is-expression/-/is-expression-4.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-expression"
         }
       ]
     },
@@ -11205,6 +14485,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-extendable"
+        }
       ]
     },
     {
@@ -11224,6 +14510,12 @@
           "url": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-extglob"
         }
       ]
     },
@@ -11245,6 +14537,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-fullwidth-code-point"
+        }
       ]
     },
     {
@@ -11264,6 +14562,12 @@
           "url": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-generator-function"
         }
       ]
     },
@@ -11285,6 +14589,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-glob"
+        }
       ]
     },
     {
@@ -11304,6 +14614,12 @@
           "url": "https://registry.npmjs.org/is-heroku/-/is-heroku-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-heroku"
         }
       ]
     },
@@ -11325,6 +14641,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-lambda"
+        }
       ]
     },
     {
@@ -11344,6 +14666,12 @@
           "url": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-map"
         }
       ]
     },
@@ -11365,6 +14693,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-natural-number"
+        }
       ]
     },
     {
@@ -11384,6 +14718,12 @@
           "url": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-negative-zero"
         }
       ]
     },
@@ -11405,6 +14745,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-number-like"
+        }
       ]
     },
     {
@@ -11424,6 +14770,12 @@
           "url": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-number-object"
         }
       ]
     },
@@ -11446,6 +14798,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-number"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -11464,6 +14822,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/is-number/node_modules/kind-of"
             }
           ]
         }
@@ -11487,6 +14851,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-object"
+        }
       ]
     },
     {
@@ -11506,6 +14876,12 @@
           "url": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-plain-obj"
         }
       ]
     },
@@ -11527,6 +14903,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-plain-object"
+        }
       ]
     },
     {
@@ -11546,6 +14928,12 @@
           "url": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-promise"
         }
       ]
     },
@@ -11567,6 +14955,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-regex"
+        }
       ]
     },
     {
@@ -11586,6 +14980,12 @@
           "url": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-relative"
         }
       ]
     },
@@ -11607,6 +15007,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-retry-allowed"
+        }
       ]
     },
     {
@@ -11626,6 +15032,12 @@
           "url": "https://registry.npmjs.org/is-set/-/is-set-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-set"
         }
       ]
     },
@@ -11647,6 +15059,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-shared-array-buffer"
+        }
       ]
     },
     {
@@ -11666,6 +15084,12 @@
           "url": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-stream"
         }
       ]
     },
@@ -11687,6 +15111,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-string"
+        }
       ]
     },
     {
@@ -11706,6 +15136,12 @@
           "url": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-symbol"
         }
       ]
     },
@@ -11727,6 +15163,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-typed-array"
+        }
       ]
     },
     {
@@ -11746,6 +15188,12 @@
           "url": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-typedarray"
         }
       ]
     },
@@ -11767,6 +15215,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-unc-path"
+        }
       ]
     },
     {
@@ -11786,6 +15240,12 @@
           "url": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-weakmap"
         }
       ]
     },
@@ -11807,6 +15267,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-weakref"
+        }
       ]
     },
     {
@@ -11826,6 +15292,12 @@
           "url": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-weakset"
         }
       ]
     },
@@ -11847,6 +15319,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-windows"
+        }
       ]
     },
     {
@@ -11866,6 +15344,12 @@
           "url": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isarray"
         }
       ]
     },
@@ -11887,6 +15371,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isexe"
+        }
       ]
     },
     {
@@ -11906,6 +15396,12 @@
           "url": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isobject"
         }
       ]
     },
@@ -11927,6 +15423,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isstream"
+        }
       ]
     },
     {
@@ -11946,6 +15448,12 @@
           "url": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isurl"
         }
       ]
     },
@@ -11967,6 +15475,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/js-stringify"
+        }
       ]
     },
     {
@@ -11986,6 +15500,12 @@
           "url": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/js-tokens"
         }
       ]
     },
@@ -12007,6 +15527,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/js-yaml"
+        }
       ]
     },
     {
@@ -12026,6 +15552,12 @@
           "url": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jsbn"
         }
       ]
     },
@@ -12047,6 +15579,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-buffer"
+        }
       ]
     },
     {
@@ -12066,6 +15604,12 @@
           "url": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-parse-better-errors"
         }
       ]
     },
@@ -12087,6 +15631,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-schema-traverse"
+        }
       ]
     },
     {
@@ -12106,6 +15656,12 @@
           "url": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-schema"
         }
       ]
     },
@@ -12127,6 +15683,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-stringify-safe"
+        }
       ]
     },
     {
@@ -12146,6 +15708,12 @@
           "url": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json5"
         }
       ]
     },
@@ -12167,6 +15735,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jsonfile"
+        }
       ]
     },
     {
@@ -12186,6 +15760,12 @@
           "url": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-0.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jsonwebtoken"
         }
       ]
     },
@@ -12207,6 +15787,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jsprim"
+        }
       ]
     },
     {
@@ -12226,6 +15812,12 @@
           "url": "https://registry.npmjs.org/jssha/-/jssha-3.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jssha"
         }
       ]
     },
@@ -12247,6 +15839,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jstransformer"
+        }
       ]
     },
     {
@@ -12266,6 +15864,12 @@
           "url": "https://registry.npmjs.org/juicy-chat-bot/-/juicy-chat-bot-0.6.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/juicy-chat-bot"
         }
       ]
     },
@@ -12287,6 +15891,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jwa"
+        }
       ]
     },
     {
@@ -12306,6 +15916,12 @@
           "url": "https://registry.npmjs.org/jws/-/jws-0.2.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jws"
         }
       ]
     },
@@ -12327,6 +15943,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/keyv"
+        }
       ]
     },
     {
@@ -12346,6 +15968,12 @@
           "url": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/kind-of"
         }
       ]
     },
@@ -12367,6 +15995,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/kuler"
+        }
       ]
     },
     {
@@ -12386,6 +16020,12 @@
           "url": "https://registry.npmjs.org/kuromoji/-/kuromoji-0.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/kuromoji"
         }
       ]
     },
@@ -12407,6 +16047,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lazystream"
+        }
       ]
     },
     {
@@ -12426,6 +16072,12 @@
           "url": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/levn"
         }
       ]
     },
@@ -12448,6 +16100,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/libxmljs2"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12466,6 +16124,12 @@
               "url": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/libxmljs2/node_modules/nan"
             }
           ]
         }
@@ -12490,6 +16154,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/liftup"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12508,6 +16178,12 @@
               "url": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/braces"
             }
           ]
         },
@@ -12529,6 +16205,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/fill-range"
+            }
           ]
         },
         {
@@ -12548,6 +16230,12 @@
               "url": "https://registry.npmjs.org/findup-sync/-/findup-sync-4.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/findup-sync"
             }
           ]
         },
@@ -12569,6 +16257,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/is-glob"
+            }
           ]
         },
         {
@@ -12588,6 +16282,12 @@
               "url": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/is-number"
             }
           ]
         },
@@ -12609,6 +16309,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/micromatch"
+            }
           ]
         },
         {
@@ -12628,6 +16334,12 @@
               "url": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/to-regex-range"
             }
           ]
         }
@@ -12652,6 +16364,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/linebreak"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12670,6 +16388,12 @@
               "url": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/linebreak/node_modules/base64-js"
             }
           ]
         }
@@ -12693,6 +16417,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/listenercount"
+        }
       ]
     },
     {
@@ -12712,6 +16442,12 @@
           "url": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/locate-path"
         }
       ]
     },
@@ -12733,6 +16469,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lodash.camelcase"
+        }
       ]
     },
     {
@@ -12752,6 +16494,12 @@
           "url": "https://registry.npmjs.org/lodash.isfinite/-/lodash.isfinite-3.3.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lodash.isfinite"
         }
       ]
     },
@@ -12773,6 +16521,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lodash.set"
+        }
       ]
     },
     {
@@ -12792,6 +16546,12 @@
           "url": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lodash"
         }
       ]
     },
@@ -12814,6 +16574,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/logform"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12832,6 +16598,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/logform/node_modules/ms"
             }
           ]
         }
@@ -12855,6 +16627,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lolex"
+        }
       ]
     },
     {
@@ -12874,6 +16652,12 @@
           "url": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/loose-envify"
         }
       ]
     },
@@ -12895,6 +16679,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lowercase-keys"
+        }
       ]
     },
     {
@@ -12914,6 +16704,12 @@
           "url": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lru-cache"
         }
       ]
     },
@@ -12936,6 +16732,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-dir"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12954,6 +16756,12 @@
               "url": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-dir/node_modules/semver"
             }
           ]
         }
@@ -12977,6 +16785,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-error"
+        }
       ]
     },
     {
@@ -12996,6 +16810,12 @@
           "url": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-9.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-fetch-happen"
         }
       ],
       "components": [
@@ -13018,6 +16838,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen/node_modules/@tootallnate/once"
+            }
           ]
         },
         {
@@ -13037,6 +16863,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen/node_modules/debug"
             }
           ]
         },
@@ -13058,6 +16890,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen/node_modules/http-cache-semantics"
+            }
           ]
         },
         {
@@ -13078,6 +16916,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen/node_modules/http-proxy-agent"
+            }
           ]
         },
         {
@@ -13097,6 +16941,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen/node_modules/ms"
             }
           ]
         }
@@ -13120,6 +16970,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-iterator"
+        }
       ]
     },
     {
@@ -13139,6 +16995,12 @@
           "url": "https://registry.npmjs.org/make-plural/-/make-plural-6.2.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-plural"
         }
       ]
     },
@@ -13160,6 +17022,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/map-cache"
+        }
       ]
     },
     {
@@ -13179,6 +17047,12 @@
           "url": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/map-visit"
         }
       ]
     },
@@ -13200,6 +17074,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/marsdb"
+        }
       ]
     },
     {
@@ -13219,6 +17099,12 @@
           "url": "https://registry.npmjs.org/math-interval-parser/-/math-interval-parser-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/math-interval-parser"
         }
       ]
     },
@@ -13240,6 +17126,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/media-typer"
+        }
       ]
     },
     {
@@ -13259,6 +17151,12 @@
           "url": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/merge-descriptors"
         }
       ]
     },
@@ -13280,6 +17178,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/messageformat-formatters"
+        }
       ]
     },
     {
@@ -13299,6 +17203,12 @@
           "url": "https://registry.npmjs.org/messageformat-parser/-/messageformat-parser-4.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/messageformat-parser"
         }
       ]
     },
@@ -13321,6 +17231,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/messageformat"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -13339,6 +17255,12 @@
               "url": "https://registry.npmjs.org/make-plural/-/make-plural-4.3.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/messageformat/node_modules/make-plural"
             }
           ]
         }
@@ -13362,6 +17284,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/methods"
+        }
       ]
     },
     {
@@ -13381,6 +17309,12 @@
           "url": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/micromatch"
         }
       ]
     },
@@ -13402,6 +17336,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mime-db"
+        }
       ]
     },
     {
@@ -13421,6 +17361,12 @@
           "url": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mime-types"
         }
       ]
     },
@@ -13442,6 +17388,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mime"
+        }
       ]
     },
     {
@@ -13461,6 +17413,12 @@
           "url": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mimic-response"
         }
       ]
     },
@@ -13482,6 +17440,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minimatch"
+        }
       ]
     },
     {
@@ -13501,6 +17465,12 @@
           "url": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minimist"
         }
       ]
     },
@@ -13522,6 +17492,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-collect"
+        }
       ]
     },
     {
@@ -13541,6 +17517,12 @@
           "url": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-1.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-fetch"
         }
       ]
     },
@@ -13562,6 +17544,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-flush"
+        }
       ]
     },
     {
@@ -13581,6 +17569,12 @@
           "url": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-pipeline"
         }
       ]
     },
@@ -13602,6 +17596,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-sized"
+        }
       ]
     },
     {
@@ -13621,6 +17621,12 @@
           "url": "https://registry.npmjs.org/minipass/-/minipass-3.3.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass"
         }
       ]
     },
@@ -13642,6 +17648,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minizlib"
+        }
       ]
     },
     {
@@ -13661,6 +17673,12 @@
           "url": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mixin-deep"
         }
       ]
     },
@@ -13682,6 +17700,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mkdirp-classic"
+        }
       ]
     },
     {
@@ -13701,6 +17725,12 @@
           "url": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mkdirp"
         }
       ]
     },
@@ -13722,6 +17752,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/moment-timezone"
+        }
       ]
     },
     {
@@ -13741,6 +17777,12 @@
           "url": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/moment"
         }
       ]
     },
@@ -13763,6 +17805,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/morgan"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -13781,6 +17829,12 @@
               "url": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/morgan/node_modules/on-finished"
             }
           ]
         }
@@ -13804,6 +17858,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mout"
+        }
       ]
     },
     {
@@ -13823,6 +17883,12 @@
           "url": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ms"
         }
       ]
     },
@@ -13845,6 +17911,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/multer"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -13863,6 +17935,12 @@
               "url": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/multer/node_modules/mkdirp"
             }
           ]
         }
@@ -13886,6 +17964,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mustache"
+        }
       ]
     },
     {
@@ -13905,6 +17989,12 @@
           "url": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/nan"
         }
       ]
     },
@@ -13926,6 +18016,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/nanomatch"
+        }
       ]
     },
     {
@@ -13945,6 +18041,12 @@
           "url": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/napi-build-utils"
         }
       ]
     },
@@ -13967,6 +18069,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/needle"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -13985,6 +18093,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/needle/node_modules/debug"
             }
           ]
         },
@@ -14005,6 +18119,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/needle/node_modules/ms"
             }
           ]
         }
@@ -14028,6 +18148,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/negotiator"
+        }
       ]
     },
     {
@@ -14047,6 +18173,12 @@
           "url": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/neo-async"
         }
       ]
     },
@@ -14069,6 +18201,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-abi"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14087,6 +18225,12 @@
               "url": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-abi/node_modules/semver"
             }
           ]
         }
@@ -14110,6 +18254,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-addon-api"
+        }
       ]
     },
     {
@@ -14129,6 +18279,12 @@
           "url": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-fetch"
         }
       ]
     },
@@ -14151,6 +18307,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-gyp"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14169,6 +18331,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/ansi-regex"
             }
           ]
         },
@@ -14190,6 +18358,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/are-we-there-yet"
+            }
           ]
         },
         {
@@ -14209,6 +18383,12 @@
               "url": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/gauge"
             }
           ]
         },
@@ -14230,6 +18410,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/is-fullwidth-code-point"
+            }
           ]
         },
         {
@@ -14249,6 +18435,12 @@
               "url": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/nopt"
             }
           ]
         },
@@ -14270,6 +18462,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/npmlog"
+            }
           ]
         },
         {
@@ -14289,6 +18487,12 @@
               "url": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/readable-stream"
             }
           ]
         },
@@ -14310,6 +18514,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/string-width"
+            }
           ]
         },
         {
@@ -14329,6 +18539,12 @@
               "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/strip-ansi"
             }
           ]
         }
@@ -14353,6 +18569,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-pre-gyp"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14371,6 +18593,12 @@
               "url": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/chownr"
             }
           ]
         },
@@ -14392,6 +18620,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/fs-minipass"
+            }
           ]
         },
         {
@@ -14411,6 +18645,12 @@
               "url": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/minipass"
             }
           ]
         },
@@ -14432,6 +18672,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/minizlib"
+            }
           ]
         },
         {
@@ -14451,6 +18697,12 @@
               "url": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/mkdirp"
             }
           ]
         },
@@ -14472,6 +18724,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/nopt"
+            }
           ]
         },
         {
@@ -14491,6 +18749,12 @@
               "url": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/rimraf"
             }
           ]
         },
@@ -14512,6 +18776,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/safe-buffer"
+            }
           ]
         },
         {
@@ -14531,6 +18801,12 @@
               "url": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/semver"
             }
           ]
         },
@@ -14552,6 +18828,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/tar"
+            }
           ]
         },
         {
@@ -14571,6 +18853,12 @@
               "url": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/yallist"
             }
           ]
         }
@@ -14594,6 +18882,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/noop-logger"
+        }
       ]
     },
     {
@@ -14613,6 +18907,12 @@
           "url": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/nopt"
         }
       ]
     },
@@ -14635,6 +18935,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/normalize-package-data"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14653,6 +18959,12 @@
               "url": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/normalize-package-data/node_modules/semver"
             }
           ]
         }
@@ -14676,6 +18988,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/normalize-path"
+        }
       ]
     },
     {
@@ -14695,6 +19013,12 @@
           "url": "https://registry.npmjs.org/normalize-url/-/normalize-url-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/normalize-url"
         }
       ]
     },
@@ -14717,6 +19041,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/notevil"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14735,6 +19065,12 @@
               "url": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/notevil/node_modules/esprima"
             }
           ]
         }
@@ -14758,6 +19094,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/npm-bundled"
+        }
       ]
     },
     {
@@ -14777,6 +19119,12 @@
           "url": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/npm-normalize-package-bin"
         }
       ]
     },
@@ -14798,6 +19146,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/npm-packlist"
+        }
       ]
     },
     {
@@ -14817,6 +19171,12 @@
           "url": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/npmlog"
         }
       ]
     },
@@ -14838,6 +19198,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/number-is-nan"
+        }
       ]
     },
     {
@@ -14858,6 +19224,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/oauth-sign"
+        }
       ]
     },
     {
@@ -14877,6 +19249,12 @@
           "url": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-assign"
         }
       ]
     },
@@ -14899,6 +19277,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-copy"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14917,6 +19301,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy/node_modules/define-property"
             }
           ]
         },
@@ -14938,6 +19328,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy/node_modules/is-accessor-descriptor"
+            }
           ]
         },
         {
@@ -14957,6 +19353,12 @@
               "url": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy/node_modules/is-data-descriptor"
             }
           ]
         },
@@ -14979,6 +19381,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy/node_modules/is-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -14997,6 +19405,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/object-copy/node_modules/is-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -15020,6 +19434,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy/node_modules/kind-of"
+            }
           ]
         }
       ]
@@ -15042,6 +19462,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-inspect"
+        }
       ]
     },
     {
@@ -15061,6 +19487,12 @@
           "url": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-is"
         }
       ]
     },
@@ -15082,6 +19514,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-keys"
+        }
       ]
     },
     {
@@ -15101,6 +19539,12 @@
           "url": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-visit"
         }
       ]
     },
@@ -15122,6 +19566,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object.assign"
+        }
       ]
     },
     {
@@ -15141,6 +19591,12 @@
           "url": "https://registry.npmjs.org/object.defaults/-/object.defaults-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object.defaults"
         }
       ]
     },
@@ -15162,6 +19618,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object.map"
+        }
       ]
     },
     {
@@ -15181,6 +19643,12 @@
           "url": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object.pick"
         }
       ]
     },
@@ -15202,6 +19670,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/on-finished"
+        }
       ]
     },
     {
@@ -15221,6 +19695,12 @@
           "url": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/on-headers"
         }
       ]
     },
@@ -15242,6 +19722,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/once"
+        }
       ]
     },
     {
@@ -15261,6 +19747,12 @@
           "url": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/one-time"
         }
       ]
     },
@@ -15282,6 +19774,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/opentype.js"
+        }
       ]
     },
     {
@@ -15301,6 +19799,12 @@
           "url": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/optionator"
         }
       ]
     },
@@ -15322,6 +19826,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/os-homedir"
+        }
       ]
     },
     {
@@ -15341,6 +19851,12 @@
           "url": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/os-tmpdir"
         }
       ]
     },
@@ -15362,6 +19878,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/osenv"
+        }
       ]
     },
     {
@@ -15381,6 +19903,12 @@
           "url": "https://registry.npmjs.org/otplib/-/otplib-12.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/otplib"
         }
       ]
     },
@@ -15402,6 +19930,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-cancelable"
+        }
       ]
     },
     {
@@ -15421,6 +19955,12 @@
           "url": "https://registry.npmjs.org/p-event/-/p-event-2.3.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-event"
         }
       ]
     },
@@ -15442,6 +19982,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-finally"
+        }
       ]
     },
     {
@@ -15461,6 +20007,12 @@
           "url": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-is-promise"
         }
       ]
     },
@@ -15482,6 +20034,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-limit"
+        }
       ]
     },
     {
@@ -15501,6 +20059,12 @@
           "url": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-locate"
         }
       ]
     },
@@ -15522,6 +20086,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-map"
+        }
       ]
     },
     {
@@ -15541,6 +20111,12 @@
           "url": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-timeout"
         }
       ]
     },
@@ -15562,6 +20138,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-try"
+        }
       ]
     },
     {
@@ -15581,6 +20163,12 @@
           "url": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pako"
         }
       ]
     },
@@ -15602,6 +20190,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/parse-filepath"
+        }
       ]
     },
     {
@@ -15621,6 +20215,12 @@
           "url": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/parse-json"
         }
       ]
     },
@@ -15642,6 +20242,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/parse-passwd"
+        }
       ]
     },
     {
@@ -15661,6 +20267,12 @@
           "url": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/parseurl"
         }
       ]
     },
@@ -15682,6 +20294,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pascalcase"
+        }
       ]
     },
     {
@@ -15701,6 +20319,12 @@
           "url": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-exists"
         }
       ]
     },
@@ -15722,6 +20346,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-is-absolute"
+        }
       ]
     },
     {
@@ -15741,6 +20371,12 @@
           "url": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-parse"
         }
       ]
     },
@@ -15762,6 +20398,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-root-regex"
+        }
       ]
     },
     {
@@ -15781,6 +20423,12 @@
           "url": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-root"
         }
       ]
     },
@@ -15802,6 +20450,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-to-regexp"
+        }
       ]
     },
     {
@@ -15821,6 +20475,12 @@
           "url": "https://registry.npmjs.org/pdfkit/-/pdfkit-0.11.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pdfkit"
         }
       ]
     },
@@ -15842,6 +20502,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/peek-readable"
+        }
       ]
     },
     {
@@ -15861,6 +20527,12 @@
           "url": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pend"
         }
       ]
     },
@@ -15882,6 +20554,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/performance-now"
+        }
       ]
     },
     {
@@ -15901,6 +20579,12 @@
           "url": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.5.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pg-connection-string"
         }
       ]
     },
@@ -15922,6 +20606,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/picomatch"
+        }
       ]
     },
     {
@@ -15941,6 +20631,12 @@
           "url": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pify"
         }
       ]
     },
@@ -15962,6 +20658,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pinkie-promise"
+        }
       ]
     },
     {
@@ -15981,6 +20683,12 @@
           "url": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pinkie"
         }
       ]
     },
@@ -16002,6 +20710,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/png-js"
+        }
       ]
     },
     {
@@ -16021,6 +20735,12 @@
           "url": "https://registry.npmjs.org/portscanner/-/portscanner-2.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/portscanner"
         }
       ]
     },
@@ -16042,6 +20762,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/posix-character-classes"
+        }
       ]
     },
     {
@@ -16061,6 +20787,12 @@
           "url": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.3.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/prebuild-install"
         }
       ]
     },
@@ -16082,6 +20814,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/prelude-ls"
+        }
       ]
     },
     {
@@ -16101,6 +20839,12 @@
           "url": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/prepend-http"
         }
       ]
     },
@@ -16122,6 +20866,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pretty-bytes"
+        }
       ]
     },
     {
@@ -16141,6 +20891,12 @@
           "url": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/process-nextick-args"
         }
       ]
     },
@@ -16162,6 +20918,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/prom-client"
+        }
       ]
     },
     {
@@ -16181,6 +20943,12 @@
           "url": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/promise-inflight"
         }
       ]
     },
@@ -16203,6 +20971,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/promise-retry"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -16221,6 +20995,12 @@
               "url": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/promise-retry/node_modules/err-code"
             }
           ]
         },
@@ -16241,6 +21021,12 @@
               "url": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/promise-retry/node_modules/retry"
             }
           ]
         }
@@ -16264,6 +21050,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/promise"
+        }
       ]
     },
     {
@@ -16283,6 +21075,12 @@
           "url": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/proper-lockfile"
         }
       ]
     },
@@ -16304,6 +21102,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/proxy-addr"
+        }
       ]
     },
     {
@@ -16323,6 +21127,12 @@
           "url": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/psl"
         }
       ]
     },
@@ -16344,6 +21154,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-attrs"
+        }
       ]
     },
     {
@@ -16363,6 +21179,12 @@
           "url": "https://registry.npmjs.org/pug-code-gen/-/pug-code-gen-3.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-code-gen"
         }
       ]
     },
@@ -16384,6 +21206,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-error"
+        }
       ]
     },
     {
@@ -16403,6 +21231,12 @@
           "url": "https://registry.npmjs.org/pug-filters/-/pug-filters-4.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-filters"
         }
       ]
     },
@@ -16424,6 +21258,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-lexer"
+        }
       ]
     },
     {
@@ -16443,6 +21283,12 @@
           "url": "https://registry.npmjs.org/pug-linker/-/pug-linker-4.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-linker"
         }
       ]
     },
@@ -16464,6 +21310,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-load"
+        }
       ]
     },
     {
@@ -16483,6 +21335,12 @@
           "url": "https://registry.npmjs.org/pug-parser/-/pug-parser-6.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-parser"
         }
       ]
     },
@@ -16504,6 +21362,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-runtime"
+        }
       ]
     },
     {
@@ -16523,6 +21387,12 @@
           "url": "https://registry.npmjs.org/pug-strip-comments/-/pug-strip-comments-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-strip-comments"
         }
       ]
     },
@@ -16544,6 +21414,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-walk"
+        }
       ]
     },
     {
@@ -16563,6 +21439,12 @@
           "url": "https://registry.npmjs.org/pug/-/pug-3.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug"
         }
       ]
     },
@@ -16584,6 +21466,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pump"
+        }
       ]
     },
     {
@@ -16603,6 +21491,12 @@
           "url": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/punycode"
         }
       ]
     },
@@ -16624,6 +21518,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/qs"
+        }
       ]
     },
     {
@@ -16643,6 +21543,12 @@
           "url": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/query-string"
         }
       ]
     },
@@ -16664,6 +21570,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/range_check"
+        }
       ]
     },
     {
@@ -16683,6 +21595,12 @@
           "url": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/range-parser"
         }
       ]
     },
@@ -16704,6 +21622,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/raw-body"
+        }
       ]
     },
     {
@@ -16723,6 +21647,12 @@
           "url": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/rc"
         }
       ]
     },
@@ -16745,6 +21675,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/read-pkg"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -16763,6 +21699,12 @@
               "url": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/read-pkg/node_modules/pify"
             }
           ]
         }
@@ -16787,6 +21729,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/readable-stream"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -16805,6 +21753,12 @@
               "url": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/readable-stream/node_modules/isarray"
             }
           ]
         }
@@ -16829,6 +21783,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/readable-web-to-node-stream"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -16847,6 +21807,12 @@
               "url": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/readable-web-to-node-stream/node_modules/readable-stream"
             }
           ]
         }
@@ -16870,6 +21836,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/readdirp"
+        }
       ]
     },
     {
@@ -16889,6 +21861,12 @@
           "url": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/rechoir"
         }
       ]
     },
@@ -16910,6 +21888,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/regex-not"
+        }
       ]
     },
     {
@@ -16929,6 +21913,12 @@
           "url": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/regexp.prototype.flags"
         }
       ]
     },
@@ -16950,6 +21940,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/remove-trailing-separator"
+        }
       ]
     },
     {
@@ -16970,6 +21966,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/repeat-element"
+        }
       ]
     },
     {
@@ -16989,6 +21991,12 @@
           "url": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/repeat-string"
         }
       ]
     },
@@ -17011,6 +22019,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/replace"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17029,6 +22043,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/ansi-regex"
             }
           ]
         },
@@ -17050,6 +22070,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/ansi-styles"
+            }
           ]
         },
         {
@@ -17069,6 +22095,12 @@
               "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/brace-expansion"
             }
           ]
         },
@@ -17090,6 +22122,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/cliui"
+            }
           ]
         },
         {
@@ -17109,6 +22147,12 @@
               "url": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/color-convert"
             }
           ]
         },
@@ -17130,6 +22174,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/color-name"
+            }
           ]
         },
         {
@@ -17149,6 +22199,12 @@
               "url": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/find-up"
             }
           ]
         },
@@ -17170,6 +22226,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/is-fullwidth-code-point"
+            }
           ]
         },
         {
@@ -17189,6 +22251,12 @@
               "url": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/locate-path"
             }
           ]
         },
@@ -17210,6 +22278,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/minimatch"
+            }
           ]
         },
         {
@@ -17229,6 +22303,12 @@
               "url": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/p-locate"
             }
           ]
         },
@@ -17250,6 +22330,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/path-exists"
+            }
           ]
         },
         {
@@ -17269,6 +22355,12 @@
               "url": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/string-width"
             }
           ]
         },
@@ -17290,6 +22382,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/strip-ansi"
+            }
           ]
         },
         {
@@ -17309,6 +22407,12 @@
               "url": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/wrap-ansi"
             }
           ]
         },
@@ -17330,6 +22434,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/yargs-parser"
+            }
           ]
         },
         {
@@ -17349,6 +22459,12 @@
               "url": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/yargs"
             }
           ]
         }
@@ -17373,6 +22489,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/request"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17391,6 +22513,12 @@
               "url": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/request/node_modules/qs"
             }
           ]
         }
@@ -17414,6 +22542,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/require-directory"
+        }
       ]
     },
     {
@@ -17433,6 +22567,12 @@
           "url": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/require-main-filename"
         }
       ]
     },
@@ -17454,6 +22594,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/resolve-dir"
+        }
       ]
     },
     {
@@ -17473,6 +22619,12 @@
           "url": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/resolve-url"
         }
       ]
     },
@@ -17494,6 +22646,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/resolve"
+        }
       ]
     },
     {
@@ -17513,6 +22671,12 @@
           "url": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/responselike"
         }
       ]
     },
@@ -17534,6 +22698,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/restructure"
+        }
       ]
     },
     {
@@ -17553,6 +22723,12 @@
           "url": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ret"
         }
       ]
     },
@@ -17574,6 +22750,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/retry-as-promised"
+        }
       ]
     },
     {
@@ -17594,6 +22776,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/retry"
+        }
       ]
     },
     {
@@ -17613,6 +22801,12 @@
           "url": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/rimraf"
         }
       ]
     },
@@ -17635,6 +22829,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/rxjs"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17653,6 +22853,12 @@
               "url": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/rxjs/node_modules/tslib"
             }
           ]
         }
@@ -17676,6 +22882,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safe-buffer"
+        }
       ]
     },
     {
@@ -17695,6 +22907,12 @@
           "url": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safe-regex-test"
         }
       ]
     },
@@ -17716,6 +22934,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safe-regex"
+        }
       ]
     },
     {
@@ -17735,6 +22959,12 @@
           "url": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safe-stable-stringify"
         }
       ]
     },
@@ -17756,6 +22986,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safer-buffer"
+        }
       ]
     },
     {
@@ -17776,6 +23012,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/samsam"
+        }
       ]
     },
     {
@@ -17795,6 +23037,12 @@
           "url": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sanitize-filename"
         }
       ]
     },
@@ -17817,6 +23065,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sanitize-html"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17835,6 +23089,12 @@
               "url": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sanitize-html/node_modules/lodash"
             }
           ]
         }
@@ -17858,6 +23118,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sax"
+        }
       ]
     },
     {
@@ -17878,6 +23144,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/seek-bzip"
+        }
       ]
     },
     {
@@ -17897,6 +23169,12 @@
           "url": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/semver"
         }
       ]
     },
@@ -17919,6 +23197,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/send"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17937,6 +23221,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/send/node_modules/ms"
             }
           ]
         }
@@ -17960,6 +23250,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sequelize-pool"
+        }
       ]
     },
     {
@@ -17981,6 +23277,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sequelize"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17999,6 +23301,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sequelize/node_modules/debug"
             }
           ]
         },
@@ -18020,6 +23328,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sequelize/node_modules/ms"
+            }
           ]
         },
         {
@@ -18039,6 +23353,12 @@
               "url": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sequelize/node_modules/uuid"
             }
           ]
         }
@@ -18063,6 +23383,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/serve-index"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18081,6 +23407,12 @@
               "url": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index/node_modules/depd"
             }
           ]
         },
@@ -18102,6 +23434,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index/node_modules/http-errors"
+            }
           ]
         },
         {
@@ -18121,6 +23459,12 @@
               "url": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index/node_modules/inherits"
             }
           ]
         },
@@ -18142,6 +23486,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index/node_modules/setprototypeof"
+            }
           ]
         },
         {
@@ -18161,6 +23511,12 @@
               "url": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index/node_modules/statuses"
             }
           ]
         }
@@ -18184,6 +23540,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/serve-static"
+        }
       ]
     },
     {
@@ -18203,6 +23565,12 @@
           "url": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/set-blocking"
         }
       ]
     },
@@ -18225,6 +23593,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/set-value"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18243,6 +23617,12 @@
               "url": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/set-value/node_modules/extend-shallow"
             }
           ]
         },
@@ -18263,6 +23643,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/set-value/node_modules/is-extendable"
             }
           ]
         }
@@ -18286,6 +23672,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/setimmediate"
+        }
       ]
     },
     {
@@ -18305,6 +23697,12 @@
           "url": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/setprototypeof"
         }
       ]
     },
@@ -18326,6 +23724,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/side-channel"
+        }
       ]
     },
     {
@@ -18346,6 +23750,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/signal-exit"
+        }
       ]
     },
     {
@@ -18365,6 +23775,12 @@
           "url": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/simple-concat"
         }
       ]
     },
@@ -18387,6 +23803,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/simple-get"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18405,6 +23827,12 @@
               "url": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/simple-get/node_modules/decompress-response"
             }
           ]
         },
@@ -18425,6 +23853,12 @@
               "url": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/simple-get/node_modules/mimic-response"
             }
           ]
         }
@@ -18449,6 +23883,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/simple-swizzle"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18467,6 +23907,12 @@
               "url": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/simple-swizzle/node_modules/is-arrayish"
             }
           ]
         }
@@ -18490,6 +23936,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sinon"
+        }
       ]
     },
     {
@@ -18509,6 +23961,12 @@
           "url": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/smart-buffer"
         }
       ]
     },
@@ -18531,6 +23989,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/snapdragon-node"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18549,6 +24013,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon-node/node_modules/define-property"
             }
           ]
         }
@@ -18573,6 +24043,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/snapdragon-util"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18591,6 +24067,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon-util/node_modules/kind-of"
             }
           ]
         }
@@ -18615,6 +24097,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/snapdragon"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18633,6 +24121,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/define-property"
             }
           ]
         },
@@ -18653,6 +24147,12 @@
               "url": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/extend-shallow"
             }
           ]
         },
@@ -18675,6 +24175,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/is-accessor-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -18693,6 +24199,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/snapdragon/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -18717,6 +24229,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/is-data-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -18735,6 +24253,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/snapdragon/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -18758,6 +24282,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/is-descriptor"
+            }
           ]
         },
         {
@@ -18777,6 +24307,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/is-extendable"
             }
           ]
         },
@@ -18798,6 +24334,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/kind-of"
+            }
           ]
         },
         {
@@ -18817,6 +24359,12 @@
               "url": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/source-map"
             }
           ]
         }
@@ -18840,6 +24388,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socket.io-adapter"
+        }
       ]
     },
     {
@@ -18861,6 +24415,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socket.io-parser"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18879,6 +24439,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socket.io-parser/node_modules/debug"
             }
           ]
         },
@@ -18899,6 +24465,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socket.io-parser/node_modules/ms"
             }
           ]
         }
@@ -18923,6 +24495,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socket.io"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18941,6 +24519,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socket.io/node_modules/debug"
             }
           ]
         },
@@ -18961,6 +24545,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socket.io/node_modules/ms"
             }
           ]
         }
@@ -18985,6 +24575,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socks-proxy-agent"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -19003,6 +24599,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socks-proxy-agent/node_modules/debug"
             }
           ]
         },
@@ -19023,6 +24625,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socks-proxy-agent/node_modules/ms"
             }
           ]
         }
@@ -19047,6 +24655,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socks"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -19065,6 +24679,12 @@
               "url": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socks/node_modules/ip"
             }
           ]
         }
@@ -19089,6 +24709,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sort-keys-length"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -19107,6 +24733,12 @@
               "url": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sort-keys-length/node_modules/sort-keys"
             }
           ]
         }
@@ -19130,6 +24762,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sort-keys"
+        }
       ]
     },
     {
@@ -19149,6 +24787,12 @@
           "url": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/source-map-resolve"
         }
       ]
     },
@@ -19170,6 +24814,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/source-map-support"
+        }
       ]
     },
     {
@@ -19189,6 +24839,12 @@
           "url": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/source-map-url"
         }
       ]
     },
@@ -19210,6 +24866,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/source-map"
+        }
       ]
     },
     {
@@ -19229,6 +24891,12 @@
           "url": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2-1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spawn-command"
         }
       ]
     },
@@ -19250,6 +24918,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spdx-correct"
+        }
       ]
     },
     {
@@ -19269,6 +24943,12 @@
           "url": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spdx-exceptions"
         }
       ]
     },
@@ -19290,6 +24970,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spdx-expression-parse"
+        }
       ]
     },
     {
@@ -19309,6 +24995,12 @@
           "url": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.12.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spdx-license-ids"
         }
       ]
     },
@@ -19330,6 +25022,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/split-string"
+        }
       ]
     },
     {
@@ -19349,6 +25047,12 @@
           "url": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sprintf-js"
         }
       ]
     },
@@ -19370,6 +25074,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sqlite3"
+        }
       ]
     },
     {
@@ -19389,6 +25099,12 @@
           "url": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sshpk"
         }
       ]
     },
@@ -19410,6 +25126,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ssri"
+        }
       ]
     },
     {
@@ -19429,6 +25151,12 @@
           "url": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/stack-trace"
         }
       ]
     },
@@ -19451,6 +25179,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/static-extend"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -19469,6 +25203,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend/node_modules/define-property"
             }
           ]
         },
@@ -19491,6 +25231,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend/node_modules/is-accessor-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -19509,6 +25255,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/static-extend/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -19533,6 +25285,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend/node_modules/is-data-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -19551,6 +25309,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/static-extend/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -19574,6 +25338,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend/node_modules/is-descriptor"
+            }
           ]
         },
         {
@@ -19593,6 +25363,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend/node_modules/kind-of"
             }
           ]
         }
@@ -19616,6 +25392,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/statuses"
+        }
       ]
     },
     {
@@ -19635,6 +25417,12 @@
           "url": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-2.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/stream-buffers"
         }
       ]
     },
@@ -19656,6 +25444,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/streamsearch"
+        }
       ]
     },
     {
@@ -19675,6 +25469,12 @@
           "url": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strict-uri-encode"
         }
       ]
     },
@@ -19696,6 +25496,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string_decoder"
+        }
       ]
     },
     {
@@ -19715,6 +25521,12 @@
           "url": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string-width"
         }
       ]
     },
@@ -19736,6 +25548,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string.fromcodepoint"
+        }
       ]
     },
     {
@@ -19755,6 +25573,12 @@
           "url": "https://registry.npmjs.org/string.prototype.codepointat/-/string.prototype.codepointat-0.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string.prototype.codepointat"
         }
       ]
     },
@@ -19776,6 +25600,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string.prototype.trimend"
+        }
       ]
     },
     {
@@ -19795,6 +25625,12 @@
           "url": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string.prototype.trimstart"
         }
       ]
     },
@@ -19816,6 +25652,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-ansi"
+        }
       ]
     },
     {
@@ -19835,6 +25677,12 @@
           "url": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-bom"
         }
       ]
     },
@@ -19856,6 +25704,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-dirs"
+        }
       ]
     },
     {
@@ -19875,6 +25729,12 @@
           "url": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-json-comments"
         }
       ]
     },
@@ -19896,6 +25756,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-outer"
+        }
       ]
     },
     {
@@ -19915,6 +25781,12 @@
           "url": "https://registry.npmjs.org/strtok3/-/strtok3-6.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strtok3"
         }
       ]
     },
@@ -19936,6 +25808,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/supports-color"
+        }
       ]
     },
     {
@@ -19955,6 +25833,12 @@
           "url": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/supports-preserve-symlinks-flag"
         }
       ]
     },
@@ -19976,6 +25860,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/svg-captcha"
+        }
       ]
     },
     {
@@ -19996,6 +25886,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/swagger-ui-dist"
+        }
       ]
     },
     {
@@ -20015,6 +25911,12 @@
           "url": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-4.5.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/swagger-ui-express"
         }
       ]
     },
@@ -20037,6 +25939,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tar-fs"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -20055,6 +25963,12 @@
               "url": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/tar-fs/node_modules/bl"
             }
           ]
         },
@@ -20076,6 +25990,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/tar-fs/node_modules/chownr"
+            }
           ]
         },
         {
@@ -20096,6 +26016,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/tar-fs/node_modules/readable-stream"
+            }
           ]
         },
         {
@@ -20115,6 +26041,12 @@
               "url": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/tar-fs/node_modules/tar-stream"
             }
           ]
         }
@@ -20138,6 +26070,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tar-stream"
+        }
       ]
     },
     {
@@ -20157,6 +26095,12 @@
           "url": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tar"
         }
       ]
     },
@@ -20178,6 +26122,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tdigest"
+        }
       ]
     },
     {
@@ -20197,6 +26147,12 @@
           "url": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/text-hex"
         }
       ]
     },
@@ -20218,6 +26174,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/thirty-two"
+        }
       ]
     },
     {
@@ -20237,6 +26199,12 @@
           "url": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/through"
         }
       ]
     },
@@ -20258,6 +26226,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/timed-out"
+        }
       ]
     },
     {
@@ -20277,6 +26251,12 @@
           "url": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tiny-inflate"
         }
       ]
     },
@@ -20298,6 +26278,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-buffer"
+        }
       ]
     },
     {
@@ -20317,6 +26303,12 @@
           "url": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-fast-properties"
         }
       ]
     },
@@ -20339,6 +26331,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-object-path"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -20357,6 +26355,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/to-object-path/node_modules/kind-of"
             }
           ]
         }
@@ -20380,6 +26384,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-regex-range"
+        }
       ]
     },
     {
@@ -20399,6 +26409,12 @@
           "url": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-regex"
         }
       ]
     },
@@ -20420,6 +26436,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/toidentifier"
+        }
       ]
     },
     {
@@ -20439,6 +26461,12 @@
           "url": "https://registry.npmjs.org/token-stream/-/token-stream-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/token-stream"
         }
       ]
     },
@@ -20460,6 +26488,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/token-types"
+        }
       ]
     },
     {
@@ -20479,6 +26513,12 @@
           "url": "https://registry.npmjs.org/toposort-class/-/toposort-class-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/toposort-class"
         }
       ]
     },
@@ -20500,6 +26540,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tough-cookie"
+        }
       ]
     },
     {
@@ -20519,6 +26565,12 @@
           "url": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tr46"
         }
       ]
     },
@@ -20540,6 +26592,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/traverse"
+        }
       ]
     },
     {
@@ -20559,6 +26617,12 @@
           "url": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tree-kill"
         }
       ]
     },
@@ -20580,6 +26644,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/trim-repeated"
+        }
       ]
     },
     {
@@ -20600,6 +26670,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/triple-beam"
+        }
       ]
     },
     {
@@ -20619,6 +26695,12 @@
           "url": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/truncate-utf8-bytes"
         }
       ]
     },
@@ -20641,6 +26723,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ts-node-dev"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -20659,6 +26747,12 @@
               "url": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/ts-node-dev/node_modules/rimraf"
             }
           ]
         }
@@ -20682,6 +26776,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ts-node"
+        }
       ]
     },
     {
@@ -20701,6 +26801,12 @@
           "url": "https://registry.npmjs.org/tsconfig/-/tsconfig-7.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tsconfig"
         }
       ]
     },
@@ -20722,6 +26828,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tslib"
+        }
       ]
     },
     {
@@ -20741,6 +26853,12 @@
           "url": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tunnel-agent"
         }
       ]
     },
@@ -20762,6 +26880,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tweetnacl"
+        }
       ]
     },
     {
@@ -20781,6 +26905,12 @@
           "url": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/type-check"
         }
       ]
     },
@@ -20802,6 +26932,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/type-is"
+        }
       ]
     },
     {
@@ -20821,6 +26957,12 @@
           "url": "https://registry.npmjs.org/typecast/-/typecast-0.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/typecast"
         }
       ]
     },
@@ -20842,6 +26984,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/typedarray"
+        }
       ]
     },
     {
@@ -20861,6 +27009,12 @@
           "url": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/typescript"
         }
       ]
     },
@@ -20882,6 +27036,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/uglify-js"
+        }
       ]
     },
     {
@@ -20901,6 +27061,12 @@
           "url": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unbox-primitive"
         }
       ]
     },
@@ -20922,6 +27088,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unbzip2-stream"
+        }
       ]
     },
     {
@@ -20941,6 +27113,12 @@
           "url": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unc-path-regex"
         }
       ]
     },
@@ -20962,6 +27140,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/underscore.string"
+        }
       ]
     },
     {
@@ -20982,6 +27166,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unicode-properties"
+        }
       ]
     },
     {
@@ -21001,6 +27191,12 @@
           "url": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unicode-trie"
         }
       ]
     },
@@ -21023,6 +27219,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/union-value"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21041,6 +27243,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/union-value/node_modules/is-extendable"
             }
           ]
         }
@@ -21064,6 +27272,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unique-filename"
+        }
       ]
     },
     {
@@ -21083,6 +27297,12 @@
           "url": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unique-slug"
         }
       ]
     },
@@ -21104,6 +27324,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unit-compare"
+        }
       ]
     },
     {
@@ -21124,6 +27350,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/universalify"
+        }
       ]
     },
     {
@@ -21143,6 +27375,12 @@
           "url": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unpipe"
         }
       ]
     },
@@ -21165,6 +27403,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unset-value"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21185,6 +27429,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/unset-value/node_modules/has-value"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -21203,6 +27453,12 @@
                   "url": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/unset-value/node_modules/has-value/node_modules/isobject"
                 }
               ]
             }
@@ -21226,6 +27482,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/unset-value/node_modules/has-values"
+            }
           ]
         },
         {
@@ -21245,6 +27507,12 @@
               "url": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/unset-value/node_modules/isarray"
             }
           ]
         }
@@ -21268,6 +27536,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/untildify"
+        }
       ]
     },
     {
@@ -21289,6 +27563,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unzipper"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21307,6 +27587,12 @@
               "url": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/unzipper/node_modules/bluebird"
             }
           ]
         }
@@ -21330,6 +27616,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/uri-js"
+        }
       ]
     },
     {
@@ -21349,6 +27641,12 @@
           "url": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/urix"
         }
       ]
     },
@@ -21370,6 +27668,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/url-parse-lax"
+        }
       ]
     },
     {
@@ -21389,6 +27693,12 @@
           "url": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/url-to-options"
         }
       ]
     },
@@ -21410,6 +27720,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/use"
+        }
       ]
     },
     {
@@ -21429,6 +27745,12 @@
           "url": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/utf8-byte-length"
         }
       ]
     },
@@ -21450,6 +27772,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/util-deprecate"
+        }
       ]
     },
     {
@@ -21469,6 +27797,12 @@
           "url": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/util"
         }
       ]
     },
@@ -21490,6 +27824,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/utils-merge"
+        }
       ]
     },
     {
@@ -21509,6 +27849,12 @@
           "url": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/uuid"
         }
       ]
     },
@@ -21530,6 +27876,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/v8flags"
+        }
       ]
     },
     {
@@ -21549,6 +27901,12 @@
           "url": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/validate-npm-package-license"
         }
       ]
     },
@@ -21570,6 +27928,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/validate"
+        }
       ]
     },
     {
@@ -21590,6 +27954,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/validator"
+        }
       ]
     },
     {
@@ -21609,6 +27979,12 @@
           "url": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/vary"
         }
       ]
     },
@@ -21631,6 +28007,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/verror"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21649,6 +28031,12 @@
               "url": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/verror/node_modules/core-util-is"
             }
           ]
         }
@@ -21673,6 +28061,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/vm2"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21691,6 +28085,12 @@
               "url": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/vm2/node_modules/acorn"
             }
           ]
         }
@@ -21714,6 +28114,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/void-elements"
+        }
       ]
     },
     {
@@ -21733,6 +28139,12 @@
           "url": "https://registry.npmjs.org/walk/-/walk-2.3.15.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/walk"
         }
       ]
     },
@@ -21754,6 +28166,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/walkdir"
+        }
       ]
     },
     {
@@ -21773,6 +28191,12 @@
           "url": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/webidl-conversions"
         }
       ]
     },
@@ -21794,6 +28218,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/whatwg-url"
+        }
       ]
     },
     {
@@ -21813,6 +28243,12 @@
           "url": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-boxed-primitive"
         }
       ]
     },
@@ -21834,6 +28270,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-collection"
+        }
       ]
     },
     {
@@ -21853,6 +28295,12 @@
           "url": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-module"
         }
       ]
     },
@@ -21874,6 +28322,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-pm-runs"
+        }
       ]
     },
     {
@@ -21893,6 +28347,12 @@
           "url": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-typed-array"
         }
       ]
     },
@@ -21914,6 +28374,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which"
+        }
       ]
     },
     {
@@ -21933,6 +28399,12 @@
           "url": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wide-align"
         }
       ]
     },
@@ -21955,6 +28427,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/winston-transport"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21973,6 +28451,12 @@
               "url": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/winston-transport/node_modules/readable-stream"
             }
           ]
         }
@@ -21997,6 +28481,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/winston"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -22015,6 +28505,12 @@
               "url": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/winston/node_modules/async"
             }
           ]
         },
@@ -22036,6 +28532,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/winston/node_modules/is-stream"
+            }
           ]
         },
         {
@@ -22055,6 +28557,12 @@
               "url": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/winston/node_modules/readable-stream"
             }
           ]
         }
@@ -22078,6 +28586,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/with"
+        }
       ]
     },
     {
@@ -22097,6 +28611,12 @@
           "url": "https://registry.npmjs.org/wkx/-/wkx-0.5.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wkx"
         }
       ]
     },
@@ -22118,6 +28638,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/word-wrap"
+        }
       ]
     },
     {
@@ -22137,6 +28663,12 @@
           "url": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wordwrap"
         }
       ]
     },
@@ -22159,6 +28691,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wrap-ansi"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -22177,6 +28715,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi/node_modules/ansi-regex"
             }
           ]
         },
@@ -22198,6 +28742,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi/node_modules/emoji-regex"
+            }
           ]
         },
         {
@@ -22217,6 +28767,12 @@
               "url": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi/node_modules/is-fullwidth-code-point"
             }
           ]
         },
@@ -22238,6 +28794,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi/node_modules/string-width"
+            }
           ]
         },
         {
@@ -22257,6 +28819,12 @@
               "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi/node_modules/strip-ansi"
             }
           ]
         }
@@ -22280,6 +28848,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wrappy"
+        }
       ]
     },
     {
@@ -22299,6 +28873,12 @@
           "url": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ws"
         }
       ]
     },
@@ -22320,6 +28900,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/xtend"
+        }
       ]
     },
     {
@@ -22339,6 +28925,12 @@
           "url": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/y18n"
         }
       ]
     },
@@ -22360,6 +28952,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yallist"
+        }
       ]
     },
     {
@@ -22380,6 +28978,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yaml-schema-validator"
+        }
       ]
     },
     {
@@ -22399,6 +29003,12 @@
           "url": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yargs-parser"
         }
       ]
     },
@@ -22421,6 +29031,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yargs"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -22439,6 +29055,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs/node_modules/ansi-regex"
             }
           ]
         },
@@ -22460,6 +29082,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs/node_modules/emoji-regex"
+            }
           ]
         },
         {
@@ -22479,6 +29107,12 @@
               "url": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs/node_modules/is-fullwidth-code-point"
             }
           ]
         },
@@ -22500,6 +29134,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs/node_modules/string-width"
+            }
           ]
         },
         {
@@ -22519,6 +29159,12 @@
               "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs/node_modules/strip-ansi"
             }
           ]
         }
@@ -22542,6 +29188,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yauzl"
+        }
       ]
     },
     {
@@ -22561,6 +29213,12 @@
           "url": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yn"
         }
       ]
     },
@@ -22582,6 +29240,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/z85"
+        }
       ]
     },
     {
@@ -22602,6 +29266,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/zip-stream"
+        }
       ]
     },
     {
@@ -22621,6 +29291,12 @@
           "url": "https://registry.npmjs.org/zlibjs/-/zlibjs-0.3.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/zlibjs"
         }
       ]
     }

--- a/tests/_data/sbom_demo-results/juice-shop_npm9_node16_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/juice-shop_npm9_node16_ubuntu-latest.snap.json
@@ -62,6 +62,10 @@
       ],
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -88,6 +92,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@babel/helper-string-parser"
+        }
       ]
     },
     {
@@ -108,6 +118,12 @@
           "url": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@babel/helper-validator-identifier"
         }
       ]
     },
@@ -130,6 +146,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@babel/parser"
+        }
       ]
     },
     {
@@ -150,6 +172,12 @@
           "url": "https://registry.npmjs.org/@babel/types/-/types-7.20.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@babel/types"
         }
       ]
     },
@@ -172,6 +200,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@colors/colors"
+        }
       ]
     },
     {
@@ -193,6 +227,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@dabh/diagnostics"
+        }
       ]
     },
     {
@@ -213,6 +253,12 @@
           "url": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@gar/promisify"
         }
       ]
     },
@@ -236,6 +282,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@mapbox/node-pre-gyp"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -254,6 +306,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/ansi-regex"
             }
           ]
         },
@@ -275,6 +333,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/are-we-there-yet"
+            }
           ]
         },
         {
@@ -294,6 +358,12 @@
               "url": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/detect-libc"
             }
           ]
         },
@@ -315,6 +385,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/gauge"
+            }
           ]
         },
         {
@@ -334,6 +410,12 @@
               "url": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/is-fullwidth-code-point"
             }
           ]
         },
@@ -356,6 +438,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/make-dir"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -374,6 +462,12 @@
                   "url": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/@mapbox/node-pre-gyp/node_modules/make-dir/node_modules/semver"
                 }
               ]
             }
@@ -397,6 +491,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/nopt"
+            }
           ]
         },
         {
@@ -416,6 +516,12 @@
               "url": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/npmlog"
             }
           ]
         },
@@ -437,6 +543,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/readable-stream"
+            }
           ]
         },
         {
@@ -457,6 +569,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/string-width"
+            }
           ]
         },
         {
@@ -476,6 +594,12 @@
               "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/strip-ansi"
             }
           ]
         }
@@ -500,6 +624,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/core-loader"
+        }
       ]
     },
     {
@@ -520,6 +650,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/core/-/core-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/core"
         }
       ]
     },
@@ -542,6 +678,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/evaluator"
+        }
       ]
     },
     {
@@ -562,6 +704,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-all/-/lang-all-4.24.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-all"
         }
       ]
     },
@@ -584,6 +732,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ar"
+        }
       ]
     },
     {
@@ -604,6 +758,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-bn/-/lang-bn-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-bn"
         }
       ]
     },
@@ -626,6 +786,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ca"
+        }
       ]
     },
     {
@@ -646,6 +812,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-cs/-/lang-cs-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-cs"
         }
       ]
     },
@@ -668,6 +840,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-da"
+        }
       ]
     },
     {
@@ -688,6 +866,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-de/-/lang-de-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-de"
         }
       ]
     },
@@ -710,6 +894,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-el"
+        }
       ]
     },
     {
@@ -730,6 +920,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-en-min/-/lang-en-min-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-en-min"
         }
       ]
     },
@@ -752,6 +948,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-en"
+        }
       ]
     },
     {
@@ -772,6 +974,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-es/-/lang-es-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-es"
         }
       ]
     },
@@ -794,6 +1002,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-eu"
+        }
       ]
     },
     {
@@ -814,6 +1028,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-fa/-/lang-fa-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-fa"
         }
       ]
     },
@@ -836,6 +1056,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-fi"
+        }
       ]
     },
     {
@@ -856,6 +1082,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-fr/-/lang-fr-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-fr"
         }
       ]
     },
@@ -878,6 +1110,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ga"
+        }
       ]
     },
     {
@@ -898,6 +1136,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-gl/-/lang-gl-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-gl"
         }
       ]
     },
@@ -920,6 +1164,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-hi"
+        }
       ]
     },
     {
@@ -940,6 +1190,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-hu/-/lang-hu-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-hu"
         }
       ]
     },
@@ -962,6 +1218,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-hy"
+        }
       ]
     },
     {
@@ -982,6 +1244,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-id/-/lang-id-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-id"
         }
       ]
     },
@@ -1004,6 +1272,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-it"
+        }
       ]
     },
     {
@@ -1024,6 +1298,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-ja/-/lang-ja-4.24.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ja"
         }
       ]
     },
@@ -1046,6 +1326,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ko"
+        }
       ]
     },
     {
@@ -1066,6 +1352,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-lt/-/lang-lt-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-lt"
         }
       ]
     },
@@ -1088,6 +1380,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ms"
+        }
       ]
     },
     {
@@ -1108,6 +1406,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-ne/-/lang-ne-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ne"
         }
       ]
     },
@@ -1130,6 +1434,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-nl"
+        }
       ]
     },
     {
@@ -1150,6 +1460,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-no/-/lang-no-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-no"
         }
       ]
     },
@@ -1172,6 +1488,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-pl"
+        }
       ]
     },
     {
@@ -1192,6 +1514,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-pt/-/lang-pt-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-pt"
         }
       ]
     },
@@ -1214,6 +1542,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ro"
+        }
       ]
     },
     {
@@ -1234,6 +1568,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-ru/-/lang-ru-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ru"
         }
       ]
     },
@@ -1256,6 +1596,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-sl"
+        }
       ]
     },
     {
@@ -1276,6 +1622,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-sr/-/lang-sr-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-sr"
         }
       ]
     },
@@ -1298,6 +1650,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-sv"
+        }
       ]
     },
     {
@@ -1318,6 +1676,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-ta/-/lang-ta-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ta"
         }
       ]
     },
@@ -1340,6 +1704,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-th"
+        }
       ]
     },
     {
@@ -1360,6 +1730,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-tl/-/lang-tl-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-tl"
         }
       ]
     },
@@ -1382,6 +1758,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-tr"
+        }
       ]
     },
     {
@@ -1402,6 +1784,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-uk/-/lang-uk-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-uk"
         }
       ]
     },
@@ -1424,6 +1812,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-zh"
+        }
       ]
     },
     {
@@ -1444,6 +1838,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/language-min/-/language-min-4.22.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/language-min"
         }
       ]
     },
@@ -1466,6 +1866,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/language"
+        }
       ]
     },
     {
@@ -1486,6 +1892,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/ner/-/ner-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/ner"
         }
       ]
     },
@@ -1508,6 +1920,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/neural"
+        }
       ]
     },
     {
@@ -1528,6 +1946,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/nlg/-/nlg-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/nlg"
         }
       ]
     },
@@ -1550,6 +1974,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/nlp"
+        }
       ]
     },
     {
@@ -1570,6 +2000,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/nlu/-/nlu-4.23.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/nlu"
         }
       ]
     },
@@ -1592,6 +2028,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/request"
+        }
       ]
     },
     {
@@ -1612,6 +2054,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/sentiment/-/sentiment-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/sentiment"
         }
       ]
     },
@@ -1634,6 +2082,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/similarity"
+        }
       ]
     },
     {
@@ -1654,6 +2108,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/slot/-/slot-4.22.17.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/slot"
         }
       ]
     },
@@ -1676,6 +2136,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@npmcli/fs"
+        }
       ]
     },
     {
@@ -1696,6 +2162,12 @@
           "url": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@npmcli/move-file"
         }
       ]
     },
@@ -1718,6 +2190,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib/core"
+        }
       ]
     },
     {
@@ -1738,6 +2216,12 @@
           "url": "https://registry.npmjs.org/@otplib/plugin-crypto/-/plugin-crypto-12.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib/plugin-crypto"
         }
       ]
     },
@@ -1760,6 +2244,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib/plugin-thirty-two"
+        }
       ]
     },
     {
@@ -1780,6 +2270,12 @@
           "url": "https://registry.npmjs.org/@otplib/preset-default/-/preset-default-12.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib/preset-default"
         }
       ]
     },
@@ -1802,6 +2298,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib/preset-v11"
+        }
       ]
     },
     {
@@ -1822,6 +2324,12 @@
           "url": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@sindresorhus/is"
         }
       ]
     },
@@ -1844,6 +2352,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@swc/helpers"
+        }
       ]
     },
     {
@@ -1864,6 +2378,12 @@
           "url": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@tokenizer/token"
         }
       ]
     },
@@ -1886,6 +2406,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@tootallnate/once"
+        }
       ]
     },
     {
@@ -1906,6 +2432,12 @@
           "url": "https://registry.npmjs.org/@types/component-emitter/-/component-emitter-1.2.11.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/component-emitter"
         }
       ]
     },
@@ -1928,6 +2460,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/cookie"
+        }
       ]
     },
     {
@@ -1948,6 +2486,12 @@
           "url": "https://registry.npmjs.org/@types/cors/-/cors-2.8.12.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/cors"
         }
       ]
     },
@@ -1970,6 +2514,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/debug"
+        }
       ]
     },
     {
@@ -1990,6 +2540,12 @@
           "url": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/ms"
         }
       ]
     },
@@ -2012,6 +2568,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/node"
+        }
       ]
     },
     {
@@ -2032,6 +2594,12 @@
           "url": "https://registry.npmjs.org/@types/strip-bom/-/strip-bom-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/strip-bom"
         }
       ]
     },
@@ -2054,6 +2622,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/strip-json-comments"
+        }
       ]
     },
     {
@@ -2075,6 +2649,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/validator"
+        }
       ]
     },
     {
@@ -2094,6 +2674,12 @@
           "url": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/abbrev"
         }
       ]
     },
@@ -2115,6 +2701,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/accepts"
+        }
       ]
     },
     {
@@ -2135,6 +2727,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/acorn-walk"
+        }
       ]
     },
     {
@@ -2154,6 +2752,12 @@
           "url": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/acorn"
         }
       ]
     },
@@ -2176,6 +2780,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/agent-base"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -2194,6 +2804,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agent-base/node_modules/debug"
             }
           ]
         },
@@ -2214,6 +2830,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agent-base/node_modules/ms"
             }
           ]
         }
@@ -2238,6 +2860,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/agentkeepalive"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -2256,6 +2884,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agentkeepalive/node_modules/debug"
             }
           ]
         },
@@ -2277,6 +2911,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agentkeepalive/node_modules/depd"
+            }
           ]
         },
         {
@@ -2296,6 +2936,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agentkeepalive/node_modules/ms"
             }
           ]
         }
@@ -2319,6 +2965,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/aggregate-error"
+        }
       ]
     },
     {
@@ -2338,6 +2990,12 @@
           "url": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ajv"
         }
       ]
     },
@@ -2359,6 +3017,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ansi-regex"
+        }
       ]
     },
     {
@@ -2378,6 +3042,12 @@
           "url": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ansi-styles"
         }
       ]
     },
@@ -2400,6 +3070,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/anymatch"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -2418,6 +3094,12 @@
               "url": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/anymatch/node_modules/normalize-path"
             }
           ]
         }
@@ -2441,6 +3123,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/append-field"
+        }
       ]
     },
     {
@@ -2460,6 +3148,12 @@
           "url": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/aproba"
         }
       ]
     },
@@ -2482,6 +3176,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/archive-type"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -2500,6 +3200,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-4.4.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/archive-type/node_modules/file-type"
             }
           ]
         }
@@ -2523,6 +3229,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/archiver-utils"
+        }
       ]
     },
     {
@@ -2542,6 +3254,12 @@
           "url": "https://registry.npmjs.org/archiver/-/archiver-1.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/archiver"
         }
       ]
     },
@@ -2563,6 +3281,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/are-we-there-yet"
+        }
       ]
     },
     {
@@ -2582,6 +3306,12 @@
           "url": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/arg"
         }
       ]
     },
@@ -2604,6 +3334,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/argparse"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -2622,6 +3358,12 @@
               "url": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/argparse/node_modules/sprintf-js"
             }
           ]
         }
@@ -2645,6 +3387,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/arr-diff"
+        }
       ]
     },
     {
@@ -2664,6 +3412,12 @@
           "url": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/arr-flatten"
         }
       ]
     },
@@ -2685,6 +3439,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/arr-union"
+        }
       ]
     },
     {
@@ -2704,6 +3464,12 @@
           "url": "https://registry.npmjs.org/array-each/-/array-each-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/array-each"
         }
       ]
     },
@@ -2725,6 +3491,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/array-flatten"
+        }
       ]
     },
     {
@@ -2744,6 +3516,12 @@
           "url": "https://registry.npmjs.org/array-slice/-/array-slice-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/array-slice"
         }
       ]
     },
@@ -2765,6 +3543,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/array-unique"
+        }
       ]
     },
     {
@@ -2784,6 +3568,12 @@
           "url": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/asap"
         }
       ]
     },
@@ -2805,6 +3595,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/asn1"
+        }
       ]
     },
     {
@@ -2824,6 +3620,12 @@
           "url": "https://registry.npmjs.org/assert-never/-/assert-never-1.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/assert-never"
         }
       ]
     },
@@ -2845,6 +3647,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/assert-plus"
+        }
       ]
     },
     {
@@ -2864,6 +3672,12 @@
           "url": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/assign-symbols"
         }
       ]
     },
@@ -2885,6 +3699,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/async"
+        }
       ]
     },
     {
@@ -2904,6 +3724,12 @@
           "url": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/asynckit"
         }
       ]
     },
@@ -2925,6 +3751,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/at-least-node"
+        }
       ]
     },
     {
@@ -2944,6 +3776,12 @@
           "url": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/atob"
         }
       ]
     },
@@ -2965,6 +3803,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/available-typed-arrays"
+        }
       ]
     },
     {
@@ -2984,6 +3828,12 @@
           "url": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/aws-sign2"
         }
       ]
     },
@@ -3005,6 +3855,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/aws4"
+        }
       ]
     },
     {
@@ -3025,6 +3881,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/babel-walk"
+        }
       ]
     },
     {
@@ -3044,6 +3906,12 @@
           "url": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/balanced-match"
         }
       ]
     },
@@ -3066,6 +3934,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -3084,6 +3958,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/base/node_modules/define-property"
             }
           ]
         }
@@ -3107,6 +3987,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base64-arraybuffer"
+        }
       ]
     },
     {
@@ -3126,6 +4012,12 @@
           "url": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base64-js"
         }
       ]
     },
@@ -3147,6 +4039,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base64id"
+        }
       ]
     },
     {
@@ -3166,6 +4064,12 @@
           "url": "https://registry.npmjs.org/base64url/-/base64url-0.0.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base64url"
         }
       ]
     },
@@ -3187,6 +4091,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/basic-auth"
+        }
       ]
     },
     {
@@ -3206,6 +4116,12 @@
           "url": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/batch"
         }
       ]
     },
@@ -3227,6 +4143,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bcrypt-pbkdf"
+        }
       ]
     },
     {
@@ -3246,6 +4168,12 @@
           "url": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/big-integer"
         }
       ]
     },
@@ -3267,6 +4195,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/binary-extensions"
+        }
       ]
     },
     {
@@ -3286,6 +4220,12 @@
           "url": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/binary"
         }
       ]
     },
@@ -3307,6 +4247,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bindings"
+        }
       ]
     },
     {
@@ -3326,6 +4272,12 @@
           "url": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bintrees"
         }
       ]
     },
@@ -3347,6 +4299,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bl"
+        }
       ]
     },
     {
@@ -3367,6 +4325,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bluebird"
+        }
       ]
     },
     {
@@ -3386,6 +4350,12 @@
           "url": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/body-parser"
         }
       ]
     },
@@ -3408,6 +4378,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bower-config"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -3426,6 +4402,12 @@
               "url": "https://registry.npmjs.org/minimist/-/minimist-0.2.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bower-config/node_modules/minimist"
             }
           ]
         }
@@ -3449,6 +4431,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/brace-expansion"
+        }
       ]
     },
     {
@@ -3470,6 +4458,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/braces"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -3488,6 +4482,12 @@
               "url": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/braces/node_modules/extend-shallow"
             }
           ]
         },
@@ -3508,6 +4508,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/braces/node_modules/is-extendable"
             }
           ]
         }
@@ -3531,6 +4537,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/brotli"
+        }
       ]
     },
     {
@@ -3550,6 +4562,12 @@
           "url": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-alloc-unsafe"
         }
       ]
     },
@@ -3571,6 +4589,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-alloc"
+        }
       ]
     },
     {
@@ -3590,6 +4614,12 @@
           "url": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-crc32"
         }
       ]
     },
@@ -3611,6 +4641,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-fill"
+        }
       ]
     },
     {
@@ -3630,6 +4666,12 @@
           "url": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-from"
         }
       ]
     },
@@ -3651,6 +4693,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-indexof-polyfill"
+        }
       ]
     },
     {
@@ -3671,6 +4719,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer"
+        }
       ]
     },
     {
@@ -3690,6 +4744,12 @@
           "url": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffers"
         }
       ]
     },
@@ -3712,6 +4772,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/busboy"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -3730,6 +4796,12 @@
               "url": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/busboy/node_modules/isarray"
             }
           ]
         },
@@ -3751,6 +4823,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/busboy/node_modules/readable-stream"
+            }
           ]
         },
         {
@@ -3770,6 +4848,12 @@
               "url": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/busboy/node_modules/string_decoder"
             }
           ]
         }
@@ -3793,6 +4877,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/byline"
+        }
       ]
     },
     {
@@ -3812,6 +4902,12 @@
           "url": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bytes"
         }
       ]
     },
@@ -3833,6 +4929,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cacache"
+        }
       ]
     },
     {
@@ -3852,6 +4954,12 @@
           "url": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cache-base"
         }
       ]
     },
@@ -3874,6 +4982,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cacheable-request"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -3892,6 +5006,12 @@
               "url": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cacheable-request/node_modules/get-stream"
             }
           ]
         },
@@ -3912,6 +5032,12 @@
               "url": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cacheable-request/node_modules/lowercase-keys"
             }
           ]
         }
@@ -3935,6 +5061,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/call-bind"
+        }
       ]
     },
     {
@@ -3954,6 +5086,12 @@
           "url": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/camelcase"
         }
       ]
     },
@@ -3975,6 +5113,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/caseless"
+        }
       ]
     },
     {
@@ -3994,6 +5138,12 @@
           "url": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/chainsaw"
         }
       ]
     },
@@ -4015,6 +5165,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/chalk"
+        }
       ]
     },
     {
@@ -4034,6 +5190,12 @@
           "url": "https://registry.npmjs.org/character-parser/-/character-parser-2.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/character-parser"
         }
       ]
     },
@@ -4056,6 +5218,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/check-dependencies"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4074,6 +5242,12 @@
               "url": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/check-dependencies/node_modules/semver"
             }
           ]
         }
@@ -4097,6 +5271,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/check-types"
+        }
       ]
     },
     {
@@ -4118,6 +5298,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/chokidar"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4136,6 +5322,12 @@
               "url": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar/node_modules/braces"
             }
           ]
         },
@@ -4157,6 +5349,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar/node_modules/fill-range"
+            }
           ]
         },
         {
@@ -4176,6 +5374,12 @@
               "url": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar/node_modules/is-glob"
             }
           ]
         },
@@ -4197,6 +5401,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar/node_modules/is-number"
+            }
           ]
         },
         {
@@ -4217,6 +5427,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar/node_modules/normalize-path"
+            }
           ]
         },
         {
@@ -4236,6 +5452,12 @@
               "url": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar/node_modules/to-regex-range"
             }
           ]
         }
@@ -4259,6 +5481,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/chownr"
+        }
       ]
     },
     {
@@ -4278,6 +5506,12 @@
           "url": "https://registry.npmjs.org/clarinet/-/clarinet-0.12.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/clarinet"
         }
       ]
     },
@@ -4300,6 +5534,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/class-utils"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4318,6 +5558,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils/node_modules/define-property"
             }
           ]
         },
@@ -4340,6 +5586,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils/node_modules/is-accessor-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -4358,6 +5610,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/class-utils/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -4382,6 +5640,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils/node_modules/is-data-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -4400,6 +5664,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/class-utils/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -4423,6 +5693,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils/node_modules/is-descriptor"
+            }
           ]
         },
         {
@@ -4442,6 +5718,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils/node_modules/kind-of"
             }
           ]
         }
@@ -4465,6 +5747,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/clean-stack"
+        }
       ]
     },
     {
@@ -4486,6 +5774,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cliui"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4504,6 +5798,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui/node_modules/ansi-regex"
             }
           ]
         },
@@ -4525,6 +5825,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui/node_modules/emoji-regex"
+            }
           ]
         },
         {
@@ -4544,6 +5850,12 @@
               "url": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui/node_modules/is-fullwidth-code-point"
             }
           ]
         },
@@ -4565,6 +5877,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui/node_modules/string-width"
+            }
           ]
         },
         {
@@ -4584,6 +5902,12 @@
               "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui/node_modules/strip-ansi"
             }
           ]
         }
@@ -4607,6 +5931,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/clone-response"
+        }
       ]
     },
     {
@@ -4626,6 +5956,12 @@
           "url": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/clone"
         }
       ]
     },
@@ -4647,6 +5983,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/code-point-at"
+        }
       ]
     },
     {
@@ -4666,6 +6008,12 @@
           "url": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/collection-visit"
         }
       ]
     },
@@ -4687,6 +6035,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color-convert"
+        }
       ]
     },
     {
@@ -4706,6 +6060,12 @@
           "url": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color-name"
         }
       ]
     },
@@ -4727,6 +6087,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color-string"
+        }
       ]
     },
     {
@@ -4746,6 +6112,12 @@
           "url": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color-support"
         }
       ]
     },
@@ -4767,6 +6139,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color"
+        }
       ]
     },
     {
@@ -4786,6 +6164,12 @@
           "url": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/colors"
         }
       ]
     },
@@ -4807,6 +6191,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/colorspace"
+        }
       ]
     },
     {
@@ -4826,6 +6216,12 @@
           "url": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/combined-stream"
         }
       ]
     },
@@ -4847,6 +6243,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/commander"
+        }
       ]
     },
     {
@@ -4866,6 +6268,12 @@
           "url": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/component-emitter"
         }
       ]
     },
@@ -4887,6 +6295,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/component-type"
+        }
       ]
     },
     {
@@ -4907,6 +6321,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/compress-commons"
+        }
       ]
     },
     {
@@ -4926,6 +6346,12 @@
           "url": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/compressible"
         }
       ]
     },
@@ -4948,6 +6374,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/compression"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4966,6 +6398,12 @@
               "url": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/compression/node_modules/bytes"
             }
           ]
         }
@@ -4989,6 +6427,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/concat-map"
+        }
       ]
     },
     {
@@ -5008,6 +6452,12 @@
           "url": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/concat-stream"
         }
       ]
     },
@@ -5030,6 +6480,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/concurrently"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5048,6 +6504,12 @@
               "url": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/concurrently/node_modules/supports-color"
             }
           ]
         }
@@ -5071,6 +6533,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/config"
+        }
       ]
     },
     {
@@ -5091,6 +6559,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/console-control-strings"
+        }
       ]
     },
     {
@@ -5110,6 +6584,12 @@
           "url": "https://registry.npmjs.org/constantinople/-/constantinople-4.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/constantinople"
         }
       ]
     },
@@ -5132,6 +6612,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/content-disposition"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5150,6 +6636,12 @@
               "url": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/content-disposition/node_modules/safe-buffer"
             }
           ]
         }
@@ -5173,6 +6665,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/content-type"
+        }
       ]
     },
     {
@@ -5192,6 +6690,12 @@
           "url": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cookie-parser"
         }
       ]
     },
@@ -5213,6 +6717,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cookie-signature"
+        }
       ]
     },
     {
@@ -5232,6 +6742,12 @@
           "url": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cookie"
         }
       ]
     },
@@ -5253,6 +6769,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/copy-descriptor"
+        }
       ]
     },
     {
@@ -5272,6 +6794,12 @@
           "url": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/core-util-is"
         }
       ]
     },
@@ -5293,6 +6821,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cors"
+        }
       ]
     },
     {
@@ -5312,6 +6846,12 @@
           "url": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/crc"
         }
       ]
     },
@@ -5333,6 +6873,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/crc32-stream"
+        }
       ]
     },
     {
@@ -5352,6 +6898,12 @@
           "url": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/create-require"
         }
       ]
     },
@@ -5373,6 +6925,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/crypto-js"
+        }
       ]
     },
     {
@@ -5392,6 +6950,12 @@
           "url": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dashdash"
         }
       ]
     },
@@ -5413,6 +6977,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/date-fns"
+        }
       ]
     },
     {
@@ -5432,6 +7002,12 @@
           "url": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dateformat"
         }
       ]
     },
@@ -5453,6 +7029,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/debug"
+        }
       ]
     },
     {
@@ -5472,6 +7054,12 @@
           "url": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decamelize"
         }
       ]
     },
@@ -5493,6 +7081,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decode-uri-component"
+        }
       ]
     },
     {
@@ -5512,6 +7106,12 @@
           "url": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-response"
         }
       ]
     },
@@ -5534,6 +7134,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-tar"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5552,6 +7158,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-tar/node_modules/file-type"
             }
           ]
         }
@@ -5576,6 +7188,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-tarbz2"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5594,6 +7212,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-6.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-tarbz2/node_modules/file-type"
             }
           ]
         }
@@ -5618,6 +7242,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-targz"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5636,6 +7266,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-targz/node_modules/file-type"
             }
           ]
         }
@@ -5660,6 +7296,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-unzip"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5678,6 +7320,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-unzip/node_modules/file-type"
             }
           ]
         },
@@ -5699,6 +7347,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-unzip/node_modules/get-stream"
+            }
           ]
         },
         {
@@ -5718,6 +7372,12 @@
               "url": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-unzip/node_modules/pify"
             }
           ]
         }
@@ -5742,6 +7402,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5762,6 +7428,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress/node_modules/make-dir"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -5780,6 +7452,12 @@
                   "url": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/decompress/node_modules/make-dir/node_modules/pify"
                 }
               ]
             }
@@ -5803,6 +7481,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress/node_modules/pify"
+            }
           ]
         }
       ]
@@ -5825,6 +7509,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/deep-equal"
+        }
       ]
     },
     {
@@ -5844,6 +7534,12 @@
           "url": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/deep-extend"
         }
       ]
     },
@@ -5865,6 +7561,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/deep-is"
+        }
       ]
     },
     {
@@ -5884,6 +7586,12 @@
           "url": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/define-properties"
         }
       ]
     },
@@ -5905,6 +7613,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/define-property"
+        }
       ]
     },
     {
@@ -5924,6 +7638,12 @@
           "url": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/delayed-stream"
         }
       ]
     },
@@ -5945,6 +7665,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/delegates"
+        }
       ]
     },
     {
@@ -5964,6 +7690,12 @@
           "url": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/depd"
         }
       ]
     },
@@ -5985,6 +7717,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/destroy"
+        }
       ]
     },
     {
@@ -6004,6 +7742,12 @@
           "url": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/detect-file"
         }
       ]
     },
@@ -6025,6 +7769,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/detect-libc"
+        }
       ]
     },
     {
@@ -6044,6 +7794,12 @@
           "url": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dfa"
         }
       ]
     },
@@ -6066,6 +7822,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dicer"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -6084,6 +7846,12 @@
               "url": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/dicer/node_modules/isarray"
             }
           ]
         },
@@ -6105,6 +7873,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/dicer/node_modules/readable-stream"
+            }
           ]
         },
         {
@@ -6124,6 +7898,12 @@
               "url": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/dicer/node_modules/string_decoder"
             }
           ]
         }
@@ -6147,6 +7927,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/diff"
+        }
       ]
     },
     {
@@ -6166,6 +7952,12 @@
           "url": "https://registry.npmjs.org/doctypes/-/doctypes-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/doctypes"
         }
       ]
     },
@@ -6187,6 +7979,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/domelementtype"
+        }
       ]
     },
     {
@@ -6206,6 +8004,12 @@
           "url": "https://registry.npmjs.org/domhandler/-/domhandler-2.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/domhandler"
         }
       ]
     },
@@ -6227,6 +8031,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/domutils"
+        }
       ]
     },
     {
@@ -6246,6 +8056,12 @@
           "url": "https://registry.npmjs.org/dottie/-/dottie-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dottie"
         }
       ]
     },
@@ -6267,6 +8083,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/double-ended-queue"
+        }
       ]
     },
     {
@@ -6286,6 +8108,12 @@
           "url": "https://registry.npmjs.org/doublearray/-/doublearray-0.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/doublearray"
         }
       ]
     },
@@ -6308,6 +8136,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/download"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -6326,6 +8160,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-11.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/download/node_modules/file-type"
             }
           ]
         }
@@ -6349,6 +8189,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/duplexer2"
+        }
       ]
     },
     {
@@ -6368,6 +8214,12 @@
           "url": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/duplexer3"
         }
       ]
     },
@@ -6389,6 +8241,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dynamic-dedupe"
+        }
       ]
     },
     {
@@ -6408,6 +8266,12 @@
           "url": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ecc-jsbn"
         }
       ]
     },
@@ -6429,6 +8293,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ee-first"
+        }
       ]
     },
     {
@@ -6448,6 +8318,12 @@
           "url": "https://registry.npmjs.org/eivindfjeldstad-dot/-/eivindfjeldstad-dot-0.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/eivindfjeldstad-dot"
         }
       ]
     },
@@ -6469,6 +8345,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/emoji-regex"
+        }
       ]
     },
     {
@@ -6489,6 +8371,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/enabled"
+        }
       ]
     },
     {
@@ -6508,6 +8396,12 @@
           "url": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/encodeurl"
         }
       ]
     },
@@ -6530,6 +8424,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/encoding"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -6548,6 +8448,12 @@
               "url": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/encoding/node_modules/iconv-lite"
             }
           ]
         }
@@ -6571,6 +8477,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/end-of-stream"
+        }
       ]
     },
     {
@@ -6590,6 +8502,12 @@
           "url": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-4.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/engine.io-parser"
         }
       ]
     },
@@ -6612,6 +8530,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/engine.io"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -6630,6 +8554,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/engine.io/node_modules/debug"
             }
           ]
         },
@@ -6650,6 +8580,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/engine.io/node_modules/ms"
             }
           ]
         }
@@ -6673,6 +8609,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/env-paths"
+        }
       ]
     },
     {
@@ -6692,6 +8634,12 @@
           "url": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/err-code"
         }
       ]
     },
@@ -6713,6 +8661,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/error-ex"
+        }
       ]
     },
     {
@@ -6732,6 +8686,12 @@
           "url": "https://registry.npmjs.org/errorhandler/-/errorhandler-1.5.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/errorhandler"
         }
       ]
     },
@@ -6753,6 +8713,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/es-abstract"
+        }
       ]
     },
     {
@@ -6772,6 +8738,12 @@
           "url": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/es-get-iterator"
         }
       ]
     },
@@ -6793,6 +8765,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/es-to-primitive"
+        }
       ]
     },
     {
@@ -6812,6 +8790,12 @@
           "url": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/escape-html"
         }
       ]
     },
@@ -6833,6 +8817,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/escape-string-regexp"
+        }
       ]
     },
     {
@@ -6852,6 +8842,12 @@
           "url": "https://registry.npmjs.org/escodegen/-/escodegen-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/escodegen"
         }
       ]
     },
@@ -6873,6 +8869,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/esprima"
+        }
       ]
     },
     {
@@ -6892,6 +8894,12 @@
           "url": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/estraverse"
         }
       ]
     },
@@ -6913,6 +8921,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/esutils"
+        }
       ]
     },
     {
@@ -6932,6 +8946,12 @@
           "url": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/etag"
         }
       ]
     },
@@ -6953,6 +8973,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/eventemitter2"
+        }
       ]
     },
     {
@@ -6972,6 +8998,12 @@
           "url": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/eventemitter3"
         }
       ]
     },
@@ -6993,6 +9025,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/exif"
+        }
       ]
     },
     {
@@ -7012,6 +9050,12 @@
           "url": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/exit"
         }
       ]
     },
@@ -7034,6 +9078,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/expand-brackets"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7052,6 +9102,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/define-property"
             }
           ]
         },
@@ -7072,6 +9128,12 @@
               "url": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/extend-shallow"
             }
           ]
         },
@@ -7094,6 +9156,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/is-accessor-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -7112,6 +9180,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/expand-brackets/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -7136,6 +9210,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/is-data-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -7154,6 +9234,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/expand-brackets/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -7177,6 +9263,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/is-descriptor"
+            }
           ]
         },
         {
@@ -7197,6 +9289,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/is-extendable"
+            }
           ]
         },
         {
@@ -7216,6 +9314,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/kind-of"
             }
           ]
         }
@@ -7239,6 +9343,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/expand-template"
+        }
       ]
     },
     {
@@ -7259,6 +9369,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/expand-tilde"
+        }
       ]
     },
     {
@@ -7278,6 +9394,12 @@
           "url": "https://registry.npmjs.org/express-ipfilter/-/express-ipfilter-1.3.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-ipfilter"
         }
       ]
     },
@@ -7300,6 +9422,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-jwt"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7318,6 +9446,12 @@
               "url": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-0.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/express-jwt/node_modules/jsonwebtoken"
             }
           ]
         },
@@ -7338,6 +9472,12 @@
               "url": "https://registry.npmjs.org/moment/-/moment-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/express-jwt/node_modules/moment"
             }
           ]
         }
@@ -7361,6 +9501,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-rate-limit"
+        }
       ]
     },
     {
@@ -7381,6 +9527,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-robots-txt"
+        }
       ]
     },
     {
@@ -7400,6 +9552,12 @@
           "url": "https://registry.npmjs.org/express-security.txt/-/express-security.txt-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-security.txt"
         }
       ]
     },
@@ -7422,6 +9580,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7440,6 +9604,12 @@
               "url": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/express/node_modules/cookie"
             }
           ]
         },
@@ -7460,6 +9630,12 @@
               "url": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/express/node_modules/safe-buffer"
             }
           ]
         }
@@ -7483,6 +9659,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ext-list"
+        }
       ]
     },
     {
@@ -7502,6 +9684,12 @@
           "url": "https://registry.npmjs.org/ext-name/-/ext-name-5.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ext-name"
         }
       ]
     },
@@ -7523,6 +9711,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/extend-shallow"
+        }
       ]
     },
     {
@@ -7542,6 +9736,12 @@
           "url": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/extend"
         }
       ]
     },
@@ -7564,6 +9764,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/extglob"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7582,6 +9788,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/extglob/node_modules/define-property"
             }
           ]
         },
@@ -7603,6 +9815,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/extglob/node_modules/extend-shallow"
+            }
           ]
         },
         {
@@ -7622,6 +9840,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/extglob/node_modules/is-extendable"
             }
           ]
         }
@@ -7645,6 +9869,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/extsprintf"
+        }
       ]
     },
     {
@@ -7664,6 +9894,12 @@
           "url": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fast-deep-equal"
         }
       ]
     },
@@ -7685,6 +9921,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fast-json-stable-stringify"
+        }
       ]
     },
     {
@@ -7704,6 +9946,12 @@
           "url": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fast-levenshtein"
         }
       ]
     },
@@ -7725,6 +9973,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fast.js"
+        }
       ]
     },
     {
@@ -7744,6 +9998,12 @@
           "url": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fd-slicer"
         }
       ]
     },
@@ -7765,6 +10025,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/feature-policy"
+        }
       ]
     },
     {
@@ -7784,6 +10050,12 @@
           "url": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fecha"
         }
       ]
     },
@@ -7806,6 +10078,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/file-js"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7824,6 +10102,12 @@
               "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/file-js/node_modules/brace-expansion"
             }
           ]
         },
@@ -7844,6 +10128,12 @@
               "url": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/file-js/node_modules/minimatch"
             }
           ]
         }
@@ -7867,6 +10157,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/file-stream-rotator"
+        }
       ]
     },
     {
@@ -7886,6 +10182,12 @@
           "url": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/file-type"
         }
       ]
     },
@@ -7907,6 +10209,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/file-uri-to-path"
+        }
       ]
     },
     {
@@ -7926,6 +10234,12 @@
           "url": "https://registry.npmjs.org/filehound/-/filehound-1.17.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/filehound"
         }
       ]
     },
@@ -7947,6 +10261,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/filename-reserved-regex"
+        }
       ]
     },
     {
@@ -7967,6 +10287,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/filenamify"
+        }
       ]
     },
     {
@@ -7986,6 +10312,12 @@
           "url": "https://registry.npmjs.org/filesniffer/-/filesniffer-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/filesniffer"
         }
       ]
     },
@@ -8008,6 +10340,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fill-range"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -8026,6 +10364,12 @@
               "url": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/fill-range/node_modules/extend-shallow"
             }
           ]
         },
@@ -8046,6 +10390,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/fill-range/node_modules/is-extendable"
             }
           ]
         }
@@ -8069,6 +10419,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/finale-rest"
+        }
       ]
     },
     {
@@ -8088,6 +10444,12 @@
           "url": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/finalhandler"
         }
       ]
     },
@@ -8109,6 +10471,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/find-up"
+        }
       ]
     },
     {
@@ -8128,6 +10496,12 @@
           "url": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/findup-sync"
         }
       ]
     },
@@ -8149,6 +10523,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fined"
+        }
       ]
     },
     {
@@ -8168,6 +10548,12 @@
           "url": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/flagged-respawn"
         }
       ]
     },
@@ -8189,6 +10575,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fn.name"
+        }
       ]
     },
     {
@@ -8208,6 +10600,12 @@
           "url": "https://registry.npmjs.org/fontkit/-/fontkit-1.9.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fontkit"
         }
       ]
     },
@@ -8229,6 +10627,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/for-each"
+        }
       ]
     },
     {
@@ -8248,6 +10652,12 @@
           "url": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/for-in"
         }
       ]
     },
@@ -8269,6 +10679,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/for-own"
+        }
       ]
     },
     {
@@ -8288,6 +10704,12 @@
           "url": "https://registry.npmjs.org/foreachasync/-/foreachasync-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/foreachasync"
         }
       ]
     },
@@ -8309,6 +10731,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/forever-agent"
+        }
       ]
     },
     {
@@ -8328,6 +10756,12 @@
           "url": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/form-data"
         }
       ]
     },
@@ -8349,6 +10783,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/formatio"
+        }
       ]
     },
     {
@@ -8368,6 +10808,12 @@
           "url": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/forwarded"
         }
       ]
     },
@@ -8389,6 +10835,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fragment-cache"
+        }
       ]
     },
     {
@@ -8408,6 +10860,12 @@
           "url": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fresh"
         }
       ]
     },
@@ -8429,6 +10887,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/from2"
+        }
       ]
     },
     {
@@ -8448,6 +10912,12 @@
           "url": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fs-constants"
         }
       ]
     },
@@ -8469,6 +10939,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fs-extra"
+        }
       ]
     },
     {
@@ -8489,6 +10965,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fs-minipass"
+        }
       ]
     },
     {
@@ -8508,6 +10990,12 @@
           "url": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fs.realpath"
         }
       ]
     },
@@ -8530,6 +11018,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fstream"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -8548,6 +11042,12 @@
               "url": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/fstream/node_modules/mkdirp"
             }
           ]
         },
@@ -8568,6 +11068,12 @@
               "url": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/fstream/node_modules/rimraf"
             }
           ]
         }
@@ -8591,6 +11097,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/function-bind"
+        }
       ]
     },
     {
@@ -8610,6 +11122,12 @@
           "url": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/function.prototype.name"
         }
       ]
     },
@@ -8631,6 +11149,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/functions-have-names"
+        }
       ]
     },
     {
@@ -8650,6 +11174,12 @@
           "url": "https://registry.npmjs.org/fuzzball/-/fuzzball-1.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fuzzball"
         }
       ]
     },
@@ -8671,6 +11201,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/gauge"
+        }
       ]
     },
     {
@@ -8690,6 +11226,12 @@
           "url": "https://registry.npmjs.org/geojson-utils/-/geojson-utils-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/geojson-utils"
         }
       ]
     },
@@ -8711,6 +11253,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-caller-file"
+        }
       ]
     },
     {
@@ -8730,6 +11278,12 @@
           "url": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-intrinsic"
         }
       ]
     },
@@ -8751,6 +11305,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-stream"
+        }
       ]
     },
     {
@@ -8770,6 +11330,12 @@
           "url": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-symbol-description"
         }
       ]
     },
@@ -8791,6 +11357,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-value"
+        }
       ]
     },
     {
@@ -8810,6 +11382,12 @@
           "url": "https://registry.npmjs.org/getobject/-/getobject-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/getobject"
         }
       ]
     },
@@ -8831,6 +11409,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/getpass"
+        }
       ]
     },
     {
@@ -8850,6 +11434,12 @@
           "url": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/github-from-package"
         }
       ]
     },
@@ -8872,6 +11462,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/glob-parent"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -8890,6 +11486,12 @@
               "url": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/glob-parent/node_modules/is-glob"
             }
           ]
         }
@@ -8914,6 +11516,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/glob"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -8932,6 +11540,12 @@
               "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/glob/node_modules/brace-expansion"
             }
           ]
         },
@@ -8952,6 +11566,12 @@
               "url": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/glob/node_modules/minimatch"
             }
           ]
         }
@@ -8975,6 +11595,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/global-modules"
+        }
       ]
     },
     {
@@ -8996,6 +11622,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/global-prefix"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9014,6 +11646,12 @@
               "url": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/global-prefix/node_modules/which"
             }
           ]
         }
@@ -9038,6 +11676,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/got"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9056,6 +11700,12 @@
               "url": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/got/node_modules/get-stream"
             }
           ]
         },
@@ -9076,6 +11726,12 @@
               "url": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/got/node_modules/pify"
             }
           ]
         }
@@ -9099,6 +11755,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/graceful-fs"
+        }
       ]
     },
     {
@@ -9120,6 +11782,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-cli"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9138,6 +11806,12 @@
               "url": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-cli/node_modules/nopt"
             }
           ]
         }
@@ -9162,6 +11836,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-contrib-compress"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9180,6 +11860,12 @@
               "url": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-contrib-compress/node_modules/ansi-styles"
             }
           ]
         },
@@ -9201,6 +11887,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-contrib-compress/node_modules/chalk"
+            }
           ]
         },
         {
@@ -9220,6 +11912,12 @@
               "url": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-contrib-compress/node_modules/supports-color"
             }
           ]
         }
@@ -9243,6 +11941,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-known-options"
+        }
       ]
     },
     {
@@ -9264,6 +11968,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-legacy-log-utils"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9282,6 +11992,12 @@
               "url": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils/node_modules/ansi-styles"
             }
           ]
         },
@@ -9303,6 +12019,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils/node_modules/chalk"
+            }
           ]
         },
         {
@@ -9322,6 +12044,12 @@
               "url": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils/node_modules/color-convert"
             }
           ]
         },
@@ -9343,6 +12071,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils/node_modules/color-name"
+            }
           ]
         },
         {
@@ -9363,6 +12097,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils/node_modules/has-flag"
+            }
           ]
         },
         {
@@ -9382,6 +12122,12 @@
               "url": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils/node_modules/supports-color"
             }
           ]
         }
@@ -9406,6 +12152,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-legacy-log"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9424,6 +12176,12 @@
               "url": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log/node_modules/colors"
             }
           ]
         }
@@ -9448,6 +12206,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-legacy-util"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9466,6 +12230,12 @@
               "url": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-util/node_modules/async"
             }
           ]
         }
@@ -9489,6 +12259,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-replace-json"
+        }
       ]
     },
     {
@@ -9510,6 +12286,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9528,6 +12310,12 @@
               "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt/node_modules/brace-expansion"
             }
           ]
         },
@@ -9550,6 +12338,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt/node_modules/findup-sync"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -9568,6 +12362,12 @@
                   "url": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/grunt/node_modules/findup-sync/node_modules/glob"
                 }
               ]
             }
@@ -9591,6 +12391,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt/node_modules/glob"
+            }
           ]
         },
         {
@@ -9610,6 +12416,12 @@
               "url": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.8.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt/node_modules/minimatch"
             }
           ]
         }
@@ -9634,6 +12446,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/handlebars"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9652,6 +12470,12 @@
               "url": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/handlebars/node_modules/wordwrap"
             }
           ]
         }
@@ -9675,6 +12499,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/har-schema"
+        }
       ]
     },
     {
@@ -9694,6 +12524,12 @@
           "url": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/har-validator"
         }
       ]
     },
@@ -9715,6 +12551,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-ansi"
+        }
       ]
     },
     {
@@ -9734,6 +12576,12 @@
           "url": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-bigints"
         }
       ]
     },
@@ -9755,6 +12603,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-flag"
+        }
       ]
     },
     {
@@ -9774,6 +12628,12 @@
           "url": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-property-descriptors"
         }
       ]
     },
@@ -9795,6 +12655,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-symbol-support-x"
+        }
       ]
     },
     {
@@ -9814,6 +12680,12 @@
           "url": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-symbols"
         }
       ]
     },
@@ -9835,6 +12707,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-to-string-tag-x"
+        }
       ]
     },
     {
@@ -9854,6 +12732,12 @@
           "url": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-tostringtag"
         }
       ]
     },
@@ -9875,6 +12759,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-unicode"
+        }
       ]
     },
     {
@@ -9894,6 +12784,12 @@
           "url": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-value"
         }
       ]
     },
@@ -9916,6 +12812,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-values"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9934,6 +12836,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/has-values/node_modules/kind-of"
             }
           ]
         }
@@ -9957,6 +12865,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has"
+        }
       ]
     },
     {
@@ -9976,6 +12890,12 @@
           "url": "https://registry.npmjs.org/hashids/-/hashids-2.2.10.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hashids"
         }
       ]
     },
@@ -9997,6 +12917,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hbs"
+        }
       ]
     },
     {
@@ -10016,6 +12942,12 @@
           "url": "https://registry.npmjs.org/he/-/he-0.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/he"
         }
       ]
     },
@@ -10037,6 +12969,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/heap"
+        }
       ]
     },
     {
@@ -10056,6 +12994,12 @@
           "url": "https://registry.npmjs.org/helmet/-/helmet-4.6.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/helmet"
         }
       ]
     },
@@ -10077,6 +13021,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hoister"
+        }
       ]
     },
     {
@@ -10096,6 +13046,12 @@
           "url": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/homedir-polyfill"
         }
       ]
     },
@@ -10117,6 +13073,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hooker"
+        }
       ]
     },
     {
@@ -10137,6 +13099,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hosted-git-info"
+        }
       ]
     },
     {
@@ -10156,6 +13124,12 @@
           "url": "https://registry.npmjs.org/html-entities/-/html-entities-1.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/html-entities"
         }
       ]
     },
@@ -10178,6 +13152,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/htmlparser2"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -10196,6 +13176,12 @@
               "url": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/htmlparser2/node_modules/isarray"
             }
           ]
         },
@@ -10217,6 +13203,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/htmlparser2/node_modules/readable-stream"
+            }
           ]
         },
         {
@@ -10236,6 +13228,12 @@
               "url": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/htmlparser2/node_modules/string_decoder"
             }
           ]
         }
@@ -10259,6 +13257,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/http-cache-semantics"
+        }
       ]
     },
     {
@@ -10278,6 +13282,12 @@
           "url": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/http-errors"
         }
       ]
     },
@@ -10300,6 +13310,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/http-proxy-agent"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -10318,6 +13334,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/http-proxy-agent/node_modules/debug"
             }
           ]
         },
@@ -10338,6 +13360,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/http-proxy-agent/node_modules/ms"
             }
           ]
         }
@@ -10361,6 +13389,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/http-signature"
+        }
       ]
     },
     {
@@ -10382,6 +13416,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/https-proxy-agent"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -10400,6 +13440,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/https-proxy-agent/node_modules/debug"
             }
           ]
         },
@@ -10420,6 +13466,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/https-proxy-agent/node_modules/ms"
             }
           ]
         }
@@ -10443,6 +13495,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/humanize-ms"
+        }
       ]
     },
     {
@@ -10462,6 +13520,12 @@
           "url": "https://registry.npmjs.org/i18n/-/i18n-0.11.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/i18n"
         }
       ]
     },
@@ -10483,6 +13547,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/iconv-lite"
+        }
       ]
     },
     {
@@ -10502,6 +13572,12 @@
           "url": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ieee754"
         }
       ]
     },
@@ -10524,6 +13600,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ignore-walk"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -10542,6 +13624,12 @@
               "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/ignore-walk/node_modules/brace-expansion"
             }
           ]
         },
@@ -10562,6 +13650,12 @@
               "url": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/ignore-walk/node_modules/minimatch"
             }
           ]
         }
@@ -10585,6 +13679,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/iltorb"
+        }
       ]
     },
     {
@@ -10604,6 +13704,12 @@
           "url": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/imurmurhash"
         }
       ]
     },
@@ -10625,6 +13731,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/indent-string"
+        }
       ]
     },
     {
@@ -10644,6 +13756,12 @@
           "url": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/infer-owner"
         }
       ]
     },
@@ -10665,6 +13783,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/inflection"
+        }
       ]
     },
     {
@@ -10684,6 +13808,12 @@
           "url": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/inflight"
         }
       ]
     },
@@ -10705,6 +13835,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/inherits"
+        }
       ]
     },
     {
@@ -10724,6 +13860,12 @@
           "url": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ini"
         }
       ]
     },
@@ -10745,6 +13887,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/internal-slot"
+        }
       ]
     },
     {
@@ -10764,6 +13912,12 @@
           "url": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/interpret"
         }
       ]
     },
@@ -10785,6 +13939,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/into-stream"
+        }
       ]
     },
     {
@@ -10804,6 +13964,12 @@
           "url": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/invariant"
         }
       ]
     },
@@ -10825,6 +13991,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ip"
+        }
       ]
     },
     {
@@ -10844,6 +14016,12 @@
           "url": "https://registry.npmjs.org/ip6/-/ip6-0.2.10.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ip6"
         }
       ]
     },
@@ -10865,6 +14043,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ipaddr.js"
+        }
       ]
     },
     {
@@ -10884,6 +14068,12 @@
           "url": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-absolute"
         }
       ]
     },
@@ -10905,6 +14095,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-accessor-descriptor"
+        }
       ]
     },
     {
@@ -10924,6 +14120,12 @@
           "url": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-arguments"
         }
       ]
     },
@@ -10945,6 +14147,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-arrayish"
+        }
       ]
     },
     {
@@ -10964,6 +14172,12 @@
           "url": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-bigint"
         }
       ]
     },
@@ -10985,6 +14199,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-binary-path"
+        }
       ]
     },
     {
@@ -11004,6 +14224,12 @@
           "url": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-boolean-object"
         }
       ]
     },
@@ -11025,6 +14251,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-buffer"
+        }
       ]
     },
     {
@@ -11044,6 +14276,12 @@
           "url": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-callable"
         }
       ]
     },
@@ -11065,6 +14303,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-core-module"
+        }
       ]
     },
     {
@@ -11084,6 +14328,12 @@
           "url": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-data-descriptor"
         }
       ]
     },
@@ -11105,6 +14355,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-date-object"
+        }
       ]
     },
     {
@@ -11124,6 +14380,12 @@
           "url": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-descriptor"
         }
       ]
     },
@@ -11145,6 +14407,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-docker"
+        }
       ]
     },
     {
@@ -11164,6 +14432,12 @@
           "url": "https://registry.npmjs.org/is-expression/-/is-expression-4.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-expression"
         }
       ]
     },
@@ -11185,6 +14459,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-extendable"
+        }
       ]
     },
     {
@@ -11204,6 +14484,12 @@
           "url": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-extglob"
         }
       ]
     },
@@ -11225,6 +14511,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-fullwidth-code-point"
+        }
       ]
     },
     {
@@ -11244,6 +14536,12 @@
           "url": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-generator-function"
         }
       ]
     },
@@ -11265,6 +14563,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-glob"
+        }
       ]
     },
     {
@@ -11284,6 +14588,12 @@
           "url": "https://registry.npmjs.org/is-heroku/-/is-heroku-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-heroku"
         }
       ]
     },
@@ -11305,6 +14615,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-lambda"
+        }
       ]
     },
     {
@@ -11324,6 +14640,12 @@
           "url": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-map"
         }
       ]
     },
@@ -11345,6 +14667,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-natural-number"
+        }
       ]
     },
     {
@@ -11364,6 +14692,12 @@
           "url": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-negative-zero"
         }
       ]
     },
@@ -11385,6 +14719,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-number-like"
+        }
       ]
     },
     {
@@ -11404,6 +14744,12 @@
           "url": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-number-object"
         }
       ]
     },
@@ -11426,6 +14772,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-number"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -11444,6 +14796,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/is-number/node_modules/kind-of"
             }
           ]
         }
@@ -11467,6 +14825,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-object"
+        }
       ]
     },
     {
@@ -11486,6 +14850,12 @@
           "url": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-plain-obj"
         }
       ]
     },
@@ -11507,6 +14877,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-plain-object"
+        }
       ]
     },
     {
@@ -11526,6 +14902,12 @@
           "url": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-promise"
         }
       ]
     },
@@ -11547,6 +14929,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-regex"
+        }
       ]
     },
     {
@@ -11566,6 +14954,12 @@
           "url": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-relative"
         }
       ]
     },
@@ -11587,6 +14981,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-retry-allowed"
+        }
       ]
     },
     {
@@ -11606,6 +15006,12 @@
           "url": "https://registry.npmjs.org/is-set/-/is-set-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-set"
         }
       ]
     },
@@ -11627,6 +15033,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-shared-array-buffer"
+        }
       ]
     },
     {
@@ -11646,6 +15058,12 @@
           "url": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-stream"
         }
       ]
     },
@@ -11667,6 +15085,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-string"
+        }
       ]
     },
     {
@@ -11686,6 +15110,12 @@
           "url": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-symbol"
         }
       ]
     },
@@ -11707,6 +15137,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-typed-array"
+        }
       ]
     },
     {
@@ -11726,6 +15162,12 @@
           "url": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-typedarray"
         }
       ]
     },
@@ -11747,6 +15189,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-unc-path"
+        }
       ]
     },
     {
@@ -11766,6 +15214,12 @@
           "url": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-weakmap"
         }
       ]
     },
@@ -11787,6 +15241,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-weakref"
+        }
       ]
     },
     {
@@ -11806,6 +15266,12 @@
           "url": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-weakset"
         }
       ]
     },
@@ -11827,6 +15293,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-windows"
+        }
       ]
     },
     {
@@ -11846,6 +15318,12 @@
           "url": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isarray"
         }
       ]
     },
@@ -11867,6 +15345,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isexe"
+        }
       ]
     },
     {
@@ -11886,6 +15370,12 @@
           "url": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isobject"
         }
       ]
     },
@@ -11907,6 +15397,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isstream"
+        }
       ]
     },
     {
@@ -11926,6 +15422,12 @@
           "url": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isurl"
         }
       ]
     },
@@ -11947,6 +15449,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/js-stringify"
+        }
       ]
     },
     {
@@ -11966,6 +15474,12 @@
           "url": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/js-tokens"
         }
       ]
     },
@@ -11987,6 +15501,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/js-yaml"
+        }
       ]
     },
     {
@@ -12006,6 +15526,12 @@
           "url": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jsbn"
         }
       ]
     },
@@ -12027,6 +15553,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-buffer"
+        }
       ]
     },
     {
@@ -12046,6 +15578,12 @@
           "url": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-parse-better-errors"
         }
       ]
     },
@@ -12067,6 +15605,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-schema-traverse"
+        }
       ]
     },
     {
@@ -12086,6 +15630,12 @@
           "url": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-schema"
         }
       ]
     },
@@ -12107,6 +15657,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-stringify-safe"
+        }
       ]
     },
     {
@@ -12126,6 +15682,12 @@
           "url": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json5"
         }
       ]
     },
@@ -12147,6 +15709,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jsonfile"
+        }
       ]
     },
     {
@@ -12166,6 +15734,12 @@
           "url": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-0.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jsonwebtoken"
         }
       ]
     },
@@ -12187,6 +15761,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jsprim"
+        }
       ]
     },
     {
@@ -12206,6 +15786,12 @@
           "url": "https://registry.npmjs.org/jssha/-/jssha-3.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jssha"
         }
       ]
     },
@@ -12227,6 +15813,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jstransformer"
+        }
       ]
     },
     {
@@ -12246,6 +15838,12 @@
           "url": "https://registry.npmjs.org/juicy-chat-bot/-/juicy-chat-bot-0.6.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/juicy-chat-bot"
         }
       ]
     },
@@ -12267,6 +15865,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jwa"
+        }
       ]
     },
     {
@@ -12286,6 +15890,12 @@
           "url": "https://registry.npmjs.org/jws/-/jws-0.2.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jws"
         }
       ]
     },
@@ -12307,6 +15917,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/keyv"
+        }
       ]
     },
     {
@@ -12326,6 +15942,12 @@
           "url": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/kind-of"
         }
       ]
     },
@@ -12347,6 +15969,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/kuler"
+        }
       ]
     },
     {
@@ -12366,6 +15994,12 @@
           "url": "https://registry.npmjs.org/kuromoji/-/kuromoji-0.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/kuromoji"
         }
       ]
     },
@@ -12387,6 +16021,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lazystream"
+        }
       ]
     },
     {
@@ -12406,6 +16046,12 @@
           "url": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/levn"
         }
       ]
     },
@@ -12428,6 +16074,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/libxmljs2"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12446,6 +16098,12 @@
               "url": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/libxmljs2/node_modules/nan"
             }
           ]
         }
@@ -12470,6 +16128,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/liftup"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12488,6 +16152,12 @@
               "url": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/braces"
             }
           ]
         },
@@ -12509,6 +16179,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/fill-range"
+            }
           ]
         },
         {
@@ -12528,6 +16204,12 @@
               "url": "https://registry.npmjs.org/findup-sync/-/findup-sync-4.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/findup-sync"
             }
           ]
         },
@@ -12549,6 +16231,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/is-glob"
+            }
           ]
         },
         {
@@ -12568,6 +16256,12 @@
               "url": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/is-number"
             }
           ]
         },
@@ -12589,6 +16283,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/micromatch"
+            }
           ]
         },
         {
@@ -12608,6 +16308,12 @@
               "url": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/to-regex-range"
             }
           ]
         }
@@ -12632,6 +16338,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/linebreak"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12650,6 +16362,12 @@
               "url": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/linebreak/node_modules/base64-js"
             }
           ]
         }
@@ -12673,6 +16391,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/listenercount"
+        }
       ]
     },
     {
@@ -12692,6 +16416,12 @@
           "url": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/locate-path"
         }
       ]
     },
@@ -12713,6 +16443,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lodash.camelcase"
+        }
       ]
     },
     {
@@ -12732,6 +16468,12 @@
           "url": "https://registry.npmjs.org/lodash.isfinite/-/lodash.isfinite-3.3.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lodash.isfinite"
         }
       ]
     },
@@ -12753,6 +16495,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lodash.set"
+        }
       ]
     },
     {
@@ -12772,6 +16520,12 @@
           "url": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lodash"
         }
       ]
     },
@@ -12794,6 +16548,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/logform"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12812,6 +16572,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/logform/node_modules/ms"
             }
           ]
         }
@@ -12835,6 +16601,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lolex"
+        }
       ]
     },
     {
@@ -12854,6 +16626,12 @@
           "url": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/loose-envify"
         }
       ]
     },
@@ -12875,6 +16653,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lowercase-keys"
+        }
       ]
     },
     {
@@ -12894,6 +16678,12 @@
           "url": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lru-cache"
         }
       ]
     },
@@ -12916,6 +16706,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-dir"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12934,6 +16730,12 @@
               "url": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-dir/node_modules/semver"
             }
           ]
         }
@@ -12957,6 +16759,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-error"
+        }
       ]
     },
     {
@@ -12976,6 +16784,12 @@
           "url": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-9.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-fetch-happen"
         }
       ],
       "components": [
@@ -12998,6 +16812,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen/node_modules/@tootallnate/once"
+            }
           ]
         },
         {
@@ -13017,6 +16837,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen/node_modules/debug"
             }
           ]
         },
@@ -13038,6 +16864,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen/node_modules/http-cache-semantics"
+            }
           ]
         },
         {
@@ -13058,6 +16890,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen/node_modules/http-proxy-agent"
+            }
           ]
         },
         {
@@ -13077,6 +16915,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen/node_modules/ms"
             }
           ]
         }
@@ -13100,6 +16944,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-iterator"
+        }
       ]
     },
     {
@@ -13119,6 +16969,12 @@
           "url": "https://registry.npmjs.org/make-plural/-/make-plural-6.2.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-plural"
         }
       ]
     },
@@ -13140,6 +16996,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/map-cache"
+        }
       ]
     },
     {
@@ -13159,6 +17021,12 @@
           "url": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/map-visit"
         }
       ]
     },
@@ -13180,6 +17048,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/marsdb"
+        }
       ]
     },
     {
@@ -13199,6 +17073,12 @@
           "url": "https://registry.npmjs.org/math-interval-parser/-/math-interval-parser-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/math-interval-parser"
         }
       ]
     },
@@ -13220,6 +17100,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/media-typer"
+        }
       ]
     },
     {
@@ -13239,6 +17125,12 @@
           "url": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/merge-descriptors"
         }
       ]
     },
@@ -13260,6 +17152,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/messageformat-formatters"
+        }
       ]
     },
     {
@@ -13279,6 +17177,12 @@
           "url": "https://registry.npmjs.org/messageformat-parser/-/messageformat-parser-4.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/messageformat-parser"
         }
       ]
     },
@@ -13301,6 +17205,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/messageformat"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -13319,6 +17229,12 @@
               "url": "https://registry.npmjs.org/make-plural/-/make-plural-4.3.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/messageformat/node_modules/make-plural"
             }
           ]
         }
@@ -13342,6 +17258,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/methods"
+        }
       ]
     },
     {
@@ -13361,6 +17283,12 @@
           "url": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/micromatch"
         }
       ]
     },
@@ -13382,6 +17310,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mime-db"
+        }
       ]
     },
     {
@@ -13401,6 +17335,12 @@
           "url": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mime-types"
         }
       ]
     },
@@ -13422,6 +17362,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mime"
+        }
       ]
     },
     {
@@ -13441,6 +17387,12 @@
           "url": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mimic-response"
         }
       ]
     },
@@ -13462,6 +17414,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minimatch"
+        }
       ]
     },
     {
@@ -13481,6 +17439,12 @@
           "url": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minimist"
         }
       ]
     },
@@ -13502,6 +17466,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-collect"
+        }
       ]
     },
     {
@@ -13521,6 +17491,12 @@
           "url": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-1.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-fetch"
         }
       ]
     },
@@ -13542,6 +17518,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-flush"
+        }
       ]
     },
     {
@@ -13561,6 +17543,12 @@
           "url": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-pipeline"
         }
       ]
     },
@@ -13582,6 +17570,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-sized"
+        }
       ]
     },
     {
@@ -13601,6 +17595,12 @@
           "url": "https://registry.npmjs.org/minipass/-/minipass-3.3.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass"
         }
       ]
     },
@@ -13622,6 +17622,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minizlib"
+        }
       ]
     },
     {
@@ -13641,6 +17647,12 @@
           "url": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mixin-deep"
         }
       ]
     },
@@ -13662,6 +17674,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mkdirp-classic"
+        }
       ]
     },
     {
@@ -13681,6 +17699,12 @@
           "url": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mkdirp"
         }
       ]
     },
@@ -13702,6 +17726,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/moment-timezone"
+        }
       ]
     },
     {
@@ -13721,6 +17751,12 @@
           "url": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/moment"
         }
       ]
     },
@@ -13743,6 +17779,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/morgan"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -13761,6 +17803,12 @@
               "url": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/morgan/node_modules/on-finished"
             }
           ]
         }
@@ -13784,6 +17832,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mout"
+        }
       ]
     },
     {
@@ -13803,6 +17857,12 @@
           "url": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ms"
         }
       ]
     },
@@ -13825,6 +17885,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/multer"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -13843,6 +17909,12 @@
               "url": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/multer/node_modules/mkdirp"
             }
           ]
         }
@@ -13866,6 +17938,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mustache"
+        }
       ]
     },
     {
@@ -13885,6 +17963,12 @@
           "url": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/nan"
         }
       ]
     },
@@ -13906,6 +17990,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/nanomatch"
+        }
       ]
     },
     {
@@ -13925,6 +18015,12 @@
           "url": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/napi-build-utils"
         }
       ]
     },
@@ -13947,6 +18043,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/needle"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -13965,6 +18067,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/needle/node_modules/debug"
             }
           ]
         },
@@ -13985,6 +18093,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/needle/node_modules/ms"
             }
           ]
         }
@@ -14008,6 +18122,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/negotiator"
+        }
       ]
     },
     {
@@ -14027,6 +18147,12 @@
           "url": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/neo-async"
         }
       ]
     },
@@ -14049,6 +18175,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-abi"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14067,6 +18199,12 @@
               "url": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-abi/node_modules/semver"
             }
           ]
         }
@@ -14090,6 +18228,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-addon-api"
+        }
       ]
     },
     {
@@ -14109,6 +18253,12 @@
           "url": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-fetch"
         }
       ]
     },
@@ -14131,6 +18281,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-gyp"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14149,6 +18305,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/ansi-regex"
             }
           ]
         },
@@ -14170,6 +18332,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/are-we-there-yet"
+            }
           ]
         },
         {
@@ -14189,6 +18357,12 @@
               "url": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/gauge"
             }
           ]
         },
@@ -14210,6 +18384,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/is-fullwidth-code-point"
+            }
           ]
         },
         {
@@ -14229,6 +18409,12 @@
               "url": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/nopt"
             }
           ]
         },
@@ -14250,6 +18436,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/npmlog"
+            }
           ]
         },
         {
@@ -14269,6 +18461,12 @@
               "url": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/readable-stream"
             }
           ]
         },
@@ -14290,6 +18488,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/string-width"
+            }
           ]
         },
         {
@@ -14309,6 +18513,12 @@
               "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/strip-ansi"
             }
           ]
         }
@@ -14333,6 +18543,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-pre-gyp"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14351,6 +18567,12 @@
               "url": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/chownr"
             }
           ]
         },
@@ -14372,6 +18594,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/fs-minipass"
+            }
           ]
         },
         {
@@ -14391,6 +18619,12 @@
               "url": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/minipass"
             }
           ]
         },
@@ -14412,6 +18646,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/minizlib"
+            }
           ]
         },
         {
@@ -14431,6 +18671,12 @@
               "url": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/mkdirp"
             }
           ]
         },
@@ -14452,6 +18698,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/nopt"
+            }
           ]
         },
         {
@@ -14471,6 +18723,12 @@
               "url": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/rimraf"
             }
           ]
         },
@@ -14492,6 +18750,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/safe-buffer"
+            }
           ]
         },
         {
@@ -14511,6 +18775,12 @@
               "url": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/semver"
             }
           ]
         },
@@ -14532,6 +18802,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/tar"
+            }
           ]
         },
         {
@@ -14551,6 +18827,12 @@
               "url": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/yallist"
             }
           ]
         }
@@ -14574,6 +18856,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/noop-logger"
+        }
       ]
     },
     {
@@ -14593,6 +18881,12 @@
           "url": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/nopt"
         }
       ]
     },
@@ -14615,6 +18909,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/normalize-package-data"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14633,6 +18933,12 @@
               "url": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/normalize-package-data/node_modules/semver"
             }
           ]
         }
@@ -14656,6 +18962,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/normalize-path"
+        }
       ]
     },
     {
@@ -14675,6 +18987,12 @@
           "url": "https://registry.npmjs.org/normalize-url/-/normalize-url-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/normalize-url"
         }
       ]
     },
@@ -14697,6 +19015,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/notevil"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14715,6 +19039,12 @@
               "url": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/notevil/node_modules/esprima"
             }
           ]
         }
@@ -14738,6 +19068,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/npm-bundled"
+        }
       ]
     },
     {
@@ -14757,6 +19093,12 @@
           "url": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/npm-normalize-package-bin"
         }
       ]
     },
@@ -14778,6 +19120,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/npm-packlist"
+        }
       ]
     },
     {
@@ -14797,6 +19145,12 @@
           "url": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/npmlog"
         }
       ]
     },
@@ -14818,6 +19172,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/number-is-nan"
+        }
       ]
     },
     {
@@ -14838,6 +19198,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/oauth-sign"
+        }
       ]
     },
     {
@@ -14857,6 +19223,12 @@
           "url": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-assign"
         }
       ]
     },
@@ -14879,6 +19251,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-copy"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14897,6 +19275,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy/node_modules/define-property"
             }
           ]
         },
@@ -14918,6 +19302,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy/node_modules/is-accessor-descriptor"
+            }
           ]
         },
         {
@@ -14937,6 +19327,12 @@
               "url": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy/node_modules/is-data-descriptor"
             }
           ]
         },
@@ -14959,6 +19355,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy/node_modules/is-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -14977,6 +19379,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/object-copy/node_modules/is-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -15000,6 +19408,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy/node_modules/kind-of"
+            }
           ]
         }
       ]
@@ -15022,6 +19436,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-inspect"
+        }
       ]
     },
     {
@@ -15041,6 +19461,12 @@
           "url": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-is"
         }
       ]
     },
@@ -15062,6 +19488,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-keys"
+        }
       ]
     },
     {
@@ -15081,6 +19513,12 @@
           "url": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-visit"
         }
       ]
     },
@@ -15102,6 +19540,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object.assign"
+        }
       ]
     },
     {
@@ -15121,6 +19565,12 @@
           "url": "https://registry.npmjs.org/object.defaults/-/object.defaults-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object.defaults"
         }
       ]
     },
@@ -15142,6 +19592,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object.map"
+        }
       ]
     },
     {
@@ -15161,6 +19617,12 @@
           "url": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object.pick"
         }
       ]
     },
@@ -15182,6 +19644,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/on-finished"
+        }
       ]
     },
     {
@@ -15201,6 +19669,12 @@
           "url": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/on-headers"
         }
       ]
     },
@@ -15222,6 +19696,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/once"
+        }
       ]
     },
     {
@@ -15241,6 +19721,12 @@
           "url": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/one-time"
         }
       ]
     },
@@ -15262,6 +19748,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/opentype.js"
+        }
       ]
     },
     {
@@ -15281,6 +19773,12 @@
           "url": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/optionator"
         }
       ]
     },
@@ -15302,6 +19800,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/os-homedir"
+        }
       ]
     },
     {
@@ -15321,6 +19825,12 @@
           "url": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/os-tmpdir"
         }
       ]
     },
@@ -15342,6 +19852,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/osenv"
+        }
       ]
     },
     {
@@ -15361,6 +19877,12 @@
           "url": "https://registry.npmjs.org/otplib/-/otplib-12.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/otplib"
         }
       ]
     },
@@ -15382,6 +19904,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-cancelable"
+        }
       ]
     },
     {
@@ -15401,6 +19929,12 @@
           "url": "https://registry.npmjs.org/p-event/-/p-event-2.3.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-event"
         }
       ]
     },
@@ -15422,6 +19956,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-finally"
+        }
       ]
     },
     {
@@ -15441,6 +19981,12 @@
           "url": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-is-promise"
         }
       ]
     },
@@ -15462,6 +20008,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-limit"
+        }
       ]
     },
     {
@@ -15481,6 +20033,12 @@
           "url": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-locate"
         }
       ]
     },
@@ -15502,6 +20060,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-map"
+        }
       ]
     },
     {
@@ -15521,6 +20085,12 @@
           "url": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-timeout"
         }
       ]
     },
@@ -15542,6 +20112,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-try"
+        }
       ]
     },
     {
@@ -15561,6 +20137,12 @@
           "url": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pako"
         }
       ]
     },
@@ -15582,6 +20164,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/parse-filepath"
+        }
       ]
     },
     {
@@ -15601,6 +20189,12 @@
           "url": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/parse-json"
         }
       ]
     },
@@ -15622,6 +20216,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/parse-passwd"
+        }
       ]
     },
     {
@@ -15641,6 +20241,12 @@
           "url": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/parseurl"
         }
       ]
     },
@@ -15662,6 +20268,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pascalcase"
+        }
       ]
     },
     {
@@ -15681,6 +20293,12 @@
           "url": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-exists"
         }
       ]
     },
@@ -15702,6 +20320,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-is-absolute"
+        }
       ]
     },
     {
@@ -15721,6 +20345,12 @@
           "url": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-parse"
         }
       ]
     },
@@ -15742,6 +20372,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-root-regex"
+        }
       ]
     },
     {
@@ -15761,6 +20397,12 @@
           "url": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-root"
         }
       ]
     },
@@ -15782,6 +20424,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-to-regexp"
+        }
       ]
     },
     {
@@ -15801,6 +20449,12 @@
           "url": "https://registry.npmjs.org/pdfkit/-/pdfkit-0.11.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pdfkit"
         }
       ]
     },
@@ -15822,6 +20476,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/peek-readable"
+        }
       ]
     },
     {
@@ -15841,6 +20501,12 @@
           "url": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pend"
         }
       ]
     },
@@ -15862,6 +20528,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/performance-now"
+        }
       ]
     },
     {
@@ -15881,6 +20553,12 @@
           "url": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.5.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pg-connection-string"
         }
       ]
     },
@@ -15902,6 +20580,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/picomatch"
+        }
       ]
     },
     {
@@ -15921,6 +20605,12 @@
           "url": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pify"
         }
       ]
     },
@@ -15942,6 +20632,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pinkie-promise"
+        }
       ]
     },
     {
@@ -15961,6 +20657,12 @@
           "url": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pinkie"
         }
       ]
     },
@@ -15982,6 +20684,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/png-js"
+        }
       ]
     },
     {
@@ -16001,6 +20709,12 @@
           "url": "https://registry.npmjs.org/portscanner/-/portscanner-2.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/portscanner"
         }
       ]
     },
@@ -16022,6 +20736,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/posix-character-classes"
+        }
       ]
     },
     {
@@ -16041,6 +20761,12 @@
           "url": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.3.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/prebuild-install"
         }
       ]
     },
@@ -16062,6 +20788,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/prelude-ls"
+        }
       ]
     },
     {
@@ -16081,6 +20813,12 @@
           "url": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/prepend-http"
         }
       ]
     },
@@ -16102,6 +20840,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pretty-bytes"
+        }
       ]
     },
     {
@@ -16121,6 +20865,12 @@
           "url": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/process-nextick-args"
         }
       ]
     },
@@ -16142,6 +20892,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/prom-client"
+        }
       ]
     },
     {
@@ -16161,6 +20917,12 @@
           "url": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/promise-inflight"
         }
       ]
     },
@@ -16183,6 +20945,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/promise-retry"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -16201,6 +20969,12 @@
               "url": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/promise-retry/node_modules/err-code"
             }
           ]
         },
@@ -16221,6 +20995,12 @@
               "url": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/promise-retry/node_modules/retry"
             }
           ]
         }
@@ -16244,6 +21024,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/promise"
+        }
       ]
     },
     {
@@ -16263,6 +21049,12 @@
           "url": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/proper-lockfile"
         }
       ]
     },
@@ -16284,6 +21076,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/proxy-addr"
+        }
       ]
     },
     {
@@ -16303,6 +21101,12 @@
           "url": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/psl"
         }
       ]
     },
@@ -16324,6 +21128,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-attrs"
+        }
       ]
     },
     {
@@ -16343,6 +21153,12 @@
           "url": "https://registry.npmjs.org/pug-code-gen/-/pug-code-gen-3.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-code-gen"
         }
       ]
     },
@@ -16364,6 +21180,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-error"
+        }
       ]
     },
     {
@@ -16383,6 +21205,12 @@
           "url": "https://registry.npmjs.org/pug-filters/-/pug-filters-4.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-filters"
         }
       ]
     },
@@ -16404,6 +21232,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-lexer"
+        }
       ]
     },
     {
@@ -16423,6 +21257,12 @@
           "url": "https://registry.npmjs.org/pug-linker/-/pug-linker-4.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-linker"
         }
       ]
     },
@@ -16444,6 +21284,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-load"
+        }
       ]
     },
     {
@@ -16463,6 +21309,12 @@
           "url": "https://registry.npmjs.org/pug-parser/-/pug-parser-6.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-parser"
         }
       ]
     },
@@ -16484,6 +21336,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-runtime"
+        }
       ]
     },
     {
@@ -16503,6 +21361,12 @@
           "url": "https://registry.npmjs.org/pug-strip-comments/-/pug-strip-comments-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-strip-comments"
         }
       ]
     },
@@ -16524,6 +21388,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-walk"
+        }
       ]
     },
     {
@@ -16543,6 +21413,12 @@
           "url": "https://registry.npmjs.org/pug/-/pug-3.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug"
         }
       ]
     },
@@ -16564,6 +21440,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pump"
+        }
       ]
     },
     {
@@ -16583,6 +21465,12 @@
           "url": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/punycode"
         }
       ]
     },
@@ -16604,6 +21492,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/qs"
+        }
       ]
     },
     {
@@ -16623,6 +21517,12 @@
           "url": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/query-string"
         }
       ]
     },
@@ -16644,6 +21544,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/range_check"
+        }
       ]
     },
     {
@@ -16663,6 +21569,12 @@
           "url": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/range-parser"
         }
       ]
     },
@@ -16684,6 +21596,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/raw-body"
+        }
       ]
     },
     {
@@ -16703,6 +21621,12 @@
           "url": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/rc"
         }
       ]
     },
@@ -16725,6 +21649,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/read-pkg"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -16743,6 +21673,12 @@
               "url": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/read-pkg/node_modules/pify"
             }
           ]
         }
@@ -16767,6 +21703,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/readable-stream"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -16785,6 +21727,12 @@
               "url": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/readable-stream/node_modules/isarray"
             }
           ]
         }
@@ -16809,6 +21757,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/readable-web-to-node-stream"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -16827,6 +21781,12 @@
               "url": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/readable-web-to-node-stream/node_modules/readable-stream"
             }
           ]
         }
@@ -16850,6 +21810,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/readdirp"
+        }
       ]
     },
     {
@@ -16869,6 +21835,12 @@
           "url": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/rechoir"
         }
       ]
     },
@@ -16890,6 +21862,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/regex-not"
+        }
       ]
     },
     {
@@ -16909,6 +21887,12 @@
           "url": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/regexp.prototype.flags"
         }
       ]
     },
@@ -16930,6 +21914,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/remove-trailing-separator"
+        }
       ]
     },
     {
@@ -16950,6 +21940,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/repeat-element"
+        }
       ]
     },
     {
@@ -16969,6 +21965,12 @@
           "url": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/repeat-string"
         }
       ]
     },
@@ -16991,6 +21993,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/replace"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17009,6 +22017,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/ansi-regex"
             }
           ]
         },
@@ -17030,6 +22044,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/ansi-styles"
+            }
           ]
         },
         {
@@ -17049,6 +22069,12 @@
               "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/brace-expansion"
             }
           ]
         },
@@ -17070,6 +22096,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/cliui"
+            }
           ]
         },
         {
@@ -17089,6 +22121,12 @@
               "url": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/color-convert"
             }
           ]
         },
@@ -17110,6 +22148,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/color-name"
+            }
           ]
         },
         {
@@ -17129,6 +22173,12 @@
               "url": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/find-up"
             }
           ]
         },
@@ -17150,6 +22200,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/is-fullwidth-code-point"
+            }
           ]
         },
         {
@@ -17169,6 +22225,12 @@
               "url": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/locate-path"
             }
           ]
         },
@@ -17190,6 +22252,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/minimatch"
+            }
           ]
         },
         {
@@ -17209,6 +22277,12 @@
               "url": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/p-locate"
             }
           ]
         },
@@ -17230,6 +22304,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/path-exists"
+            }
           ]
         },
         {
@@ -17249,6 +22329,12 @@
               "url": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/string-width"
             }
           ]
         },
@@ -17270,6 +22356,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/strip-ansi"
+            }
           ]
         },
         {
@@ -17289,6 +22381,12 @@
               "url": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/wrap-ansi"
             }
           ]
         },
@@ -17310,6 +22408,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/yargs-parser"
+            }
           ]
         },
         {
@@ -17329,6 +22433,12 @@
               "url": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/yargs"
             }
           ]
         }
@@ -17353,6 +22463,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/request"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17371,6 +22487,12 @@
               "url": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/request/node_modules/qs"
             }
           ]
         }
@@ -17394,6 +22516,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/require-directory"
+        }
       ]
     },
     {
@@ -17413,6 +22541,12 @@
           "url": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/require-main-filename"
         }
       ]
     },
@@ -17434,6 +22568,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/resolve-dir"
+        }
       ]
     },
     {
@@ -17453,6 +22593,12 @@
           "url": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/resolve-url"
         }
       ]
     },
@@ -17474,6 +22620,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/resolve"
+        }
       ]
     },
     {
@@ -17493,6 +22645,12 @@
           "url": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/responselike"
         }
       ]
     },
@@ -17514,6 +22672,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/restructure"
+        }
       ]
     },
     {
@@ -17533,6 +22697,12 @@
           "url": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ret"
         }
       ]
     },
@@ -17554,6 +22724,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/retry-as-promised"
+        }
       ]
     },
     {
@@ -17574,6 +22750,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/retry"
+        }
       ]
     },
     {
@@ -17593,6 +22775,12 @@
           "url": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/rimraf"
         }
       ]
     },
@@ -17615,6 +22803,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/rxjs"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17633,6 +22827,12 @@
               "url": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/rxjs/node_modules/tslib"
             }
           ]
         }
@@ -17656,6 +22856,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safe-buffer"
+        }
       ]
     },
     {
@@ -17675,6 +22881,12 @@
           "url": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safe-regex-test"
         }
       ]
     },
@@ -17696,6 +22908,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safe-regex"
+        }
       ]
     },
     {
@@ -17715,6 +22933,12 @@
           "url": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safe-stable-stringify"
         }
       ]
     },
@@ -17736,6 +22960,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safer-buffer"
+        }
       ]
     },
     {
@@ -17756,6 +22986,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/samsam"
+        }
       ]
     },
     {
@@ -17775,6 +23011,12 @@
           "url": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sanitize-filename"
         }
       ]
     },
@@ -17797,6 +23039,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sanitize-html"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17815,6 +23063,12 @@
               "url": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sanitize-html/node_modules/lodash"
             }
           ]
         }
@@ -17838,6 +23092,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sax"
+        }
       ]
     },
     {
@@ -17858,6 +23118,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/seek-bzip"
+        }
       ]
     },
     {
@@ -17877,6 +23143,12 @@
           "url": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/semver"
         }
       ]
     },
@@ -17899,6 +23171,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/send"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17917,6 +23195,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/send/node_modules/ms"
             }
           ]
         }
@@ -17940,6 +23224,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sequelize-pool"
+        }
       ]
     },
     {
@@ -17961,6 +23251,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sequelize"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17979,6 +23275,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sequelize/node_modules/debug"
             }
           ]
         },
@@ -18000,6 +23302,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sequelize/node_modules/ms"
+            }
           ]
         },
         {
@@ -18019,6 +23327,12 @@
               "url": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sequelize/node_modules/uuid"
             }
           ]
         }
@@ -18043,6 +23357,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/serve-index"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18061,6 +23381,12 @@
               "url": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index/node_modules/depd"
             }
           ]
         },
@@ -18082,6 +23408,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index/node_modules/http-errors"
+            }
           ]
         },
         {
@@ -18101,6 +23433,12 @@
               "url": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index/node_modules/inherits"
             }
           ]
         },
@@ -18122,6 +23460,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index/node_modules/setprototypeof"
+            }
           ]
         },
         {
@@ -18141,6 +23485,12 @@
               "url": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index/node_modules/statuses"
             }
           ]
         }
@@ -18164,6 +23514,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/serve-static"
+        }
       ]
     },
     {
@@ -18183,6 +23539,12 @@
           "url": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/set-blocking"
         }
       ]
     },
@@ -18205,6 +23567,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/set-value"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18223,6 +23591,12 @@
               "url": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/set-value/node_modules/extend-shallow"
             }
           ]
         },
@@ -18243,6 +23617,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/set-value/node_modules/is-extendable"
             }
           ]
         }
@@ -18266,6 +23646,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/setimmediate"
+        }
       ]
     },
     {
@@ -18285,6 +23671,12 @@
           "url": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/setprototypeof"
         }
       ]
     },
@@ -18306,6 +23698,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/side-channel"
+        }
       ]
     },
     {
@@ -18326,6 +23724,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/signal-exit"
+        }
       ]
     },
     {
@@ -18345,6 +23749,12 @@
           "url": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/simple-concat"
         }
       ]
     },
@@ -18367,6 +23777,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/simple-get"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18385,6 +23801,12 @@
               "url": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/simple-get/node_modules/decompress-response"
             }
           ]
         },
@@ -18405,6 +23827,12 @@
               "url": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/simple-get/node_modules/mimic-response"
             }
           ]
         }
@@ -18429,6 +23857,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/simple-swizzle"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18447,6 +23881,12 @@
               "url": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/simple-swizzle/node_modules/is-arrayish"
             }
           ]
         }
@@ -18470,6 +23910,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sinon"
+        }
       ]
     },
     {
@@ -18489,6 +23935,12 @@
           "url": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/smart-buffer"
         }
       ]
     },
@@ -18511,6 +23963,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/snapdragon-node"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18529,6 +23987,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon-node/node_modules/define-property"
             }
           ]
         }
@@ -18553,6 +24017,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/snapdragon-util"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18571,6 +24041,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon-util/node_modules/kind-of"
             }
           ]
         }
@@ -18595,6 +24071,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/snapdragon"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18613,6 +24095,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/define-property"
             }
           ]
         },
@@ -18633,6 +24121,12 @@
               "url": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/extend-shallow"
             }
           ]
         },
@@ -18655,6 +24149,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/is-accessor-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -18673,6 +24173,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/snapdragon/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -18697,6 +24203,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/is-data-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -18715,6 +24227,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/snapdragon/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -18738,6 +24256,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/is-descriptor"
+            }
           ]
         },
         {
@@ -18757,6 +24281,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/is-extendable"
             }
           ]
         },
@@ -18778,6 +24308,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/kind-of"
+            }
           ]
         },
         {
@@ -18797,6 +24333,12 @@
               "url": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/source-map"
             }
           ]
         }
@@ -18820,6 +24362,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socket.io-adapter"
+        }
       ]
     },
     {
@@ -18841,6 +24389,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socket.io-parser"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18859,6 +24413,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socket.io-parser/node_modules/debug"
             }
           ]
         },
@@ -18879,6 +24439,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socket.io-parser/node_modules/ms"
             }
           ]
         }
@@ -18903,6 +24469,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socket.io"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18921,6 +24493,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socket.io/node_modules/debug"
             }
           ]
         },
@@ -18941,6 +24519,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socket.io/node_modules/ms"
             }
           ]
         }
@@ -18965,6 +24549,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socks-proxy-agent"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18983,6 +24573,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socks-proxy-agent/node_modules/debug"
             }
           ]
         },
@@ -19003,6 +24599,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socks-proxy-agent/node_modules/ms"
             }
           ]
         }
@@ -19027,6 +24629,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socks"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -19045,6 +24653,12 @@
               "url": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socks/node_modules/ip"
             }
           ]
         }
@@ -19069,6 +24683,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sort-keys-length"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -19087,6 +24707,12 @@
               "url": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sort-keys-length/node_modules/sort-keys"
             }
           ]
         }
@@ -19110,6 +24736,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sort-keys"
+        }
       ]
     },
     {
@@ -19129,6 +24761,12 @@
           "url": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/source-map-resolve"
         }
       ]
     },
@@ -19150,6 +24788,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/source-map-support"
+        }
       ]
     },
     {
@@ -19169,6 +24813,12 @@
           "url": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/source-map-url"
         }
       ]
     },
@@ -19190,6 +24840,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/source-map"
+        }
       ]
     },
     {
@@ -19209,6 +24865,12 @@
           "url": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2-1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spawn-command"
         }
       ]
     },
@@ -19230,6 +24892,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spdx-correct"
+        }
       ]
     },
     {
@@ -19249,6 +24917,12 @@
           "url": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spdx-exceptions"
         }
       ]
     },
@@ -19270,6 +24944,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spdx-expression-parse"
+        }
       ]
     },
     {
@@ -19289,6 +24969,12 @@
           "url": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.12.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spdx-license-ids"
         }
       ]
     },
@@ -19310,6 +24996,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/split-string"
+        }
       ]
     },
     {
@@ -19329,6 +25021,12 @@
           "url": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sprintf-js"
         }
       ]
     },
@@ -19350,6 +25048,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sqlite3"
+        }
       ]
     },
     {
@@ -19369,6 +25073,12 @@
           "url": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sshpk"
         }
       ]
     },
@@ -19390,6 +25100,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ssri"
+        }
       ]
     },
     {
@@ -19409,6 +25125,12 @@
           "url": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/stack-trace"
         }
       ]
     },
@@ -19431,6 +25153,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/static-extend"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -19449,6 +25177,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend/node_modules/define-property"
             }
           ]
         },
@@ -19471,6 +25205,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend/node_modules/is-accessor-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -19489,6 +25229,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/static-extend/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -19513,6 +25259,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend/node_modules/is-data-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -19531,6 +25283,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/static-extend/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -19554,6 +25312,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend/node_modules/is-descriptor"
+            }
           ]
         },
         {
@@ -19573,6 +25337,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend/node_modules/kind-of"
             }
           ]
         }
@@ -19596,6 +25366,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/statuses"
+        }
       ]
     },
     {
@@ -19615,6 +25391,12 @@
           "url": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-2.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/stream-buffers"
         }
       ]
     },
@@ -19636,6 +25418,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/streamsearch"
+        }
       ]
     },
     {
@@ -19655,6 +25443,12 @@
           "url": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strict-uri-encode"
         }
       ]
     },
@@ -19676,6 +25470,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string_decoder"
+        }
       ]
     },
     {
@@ -19695,6 +25495,12 @@
           "url": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string-width"
         }
       ]
     },
@@ -19716,6 +25522,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string.fromcodepoint"
+        }
       ]
     },
     {
@@ -19735,6 +25547,12 @@
           "url": "https://registry.npmjs.org/string.prototype.codepointat/-/string.prototype.codepointat-0.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string.prototype.codepointat"
         }
       ]
     },
@@ -19756,6 +25574,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string.prototype.trimend"
+        }
       ]
     },
     {
@@ -19775,6 +25599,12 @@
           "url": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string.prototype.trimstart"
         }
       ]
     },
@@ -19796,6 +25626,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-ansi"
+        }
       ]
     },
     {
@@ -19815,6 +25651,12 @@
           "url": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-bom"
         }
       ]
     },
@@ -19836,6 +25678,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-dirs"
+        }
       ]
     },
     {
@@ -19855,6 +25703,12 @@
           "url": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-json-comments"
         }
       ]
     },
@@ -19876,6 +25730,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-outer"
+        }
       ]
     },
     {
@@ -19895,6 +25755,12 @@
           "url": "https://registry.npmjs.org/strtok3/-/strtok3-6.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strtok3"
         }
       ]
     },
@@ -19916,6 +25782,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/supports-color"
+        }
       ]
     },
     {
@@ -19935,6 +25807,12 @@
           "url": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/supports-preserve-symlinks-flag"
         }
       ]
     },
@@ -19956,6 +25834,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/svg-captcha"
+        }
       ]
     },
     {
@@ -19976,6 +25860,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/swagger-ui-dist"
+        }
       ]
     },
     {
@@ -19995,6 +25885,12 @@
           "url": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-4.5.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/swagger-ui-express"
         }
       ]
     },
@@ -20017,6 +25913,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tar-fs"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -20035,6 +25937,12 @@
               "url": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/tar-fs/node_modules/bl"
             }
           ]
         },
@@ -20056,6 +25964,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/tar-fs/node_modules/chownr"
+            }
           ]
         },
         {
@@ -20076,6 +25990,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/tar-fs/node_modules/readable-stream"
+            }
           ]
         },
         {
@@ -20095,6 +26015,12 @@
               "url": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/tar-fs/node_modules/tar-stream"
             }
           ]
         }
@@ -20118,6 +26044,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tar-stream"
+        }
       ]
     },
     {
@@ -20137,6 +26069,12 @@
           "url": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tar"
         }
       ]
     },
@@ -20158,6 +26096,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tdigest"
+        }
       ]
     },
     {
@@ -20177,6 +26121,12 @@
           "url": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/text-hex"
         }
       ]
     },
@@ -20198,6 +26148,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/thirty-two"
+        }
       ]
     },
     {
@@ -20217,6 +26173,12 @@
           "url": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/through"
         }
       ]
     },
@@ -20238,6 +26200,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/timed-out"
+        }
       ]
     },
     {
@@ -20257,6 +26225,12 @@
           "url": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tiny-inflate"
         }
       ]
     },
@@ -20278,6 +26252,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-buffer"
+        }
       ]
     },
     {
@@ -20297,6 +26277,12 @@
           "url": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-fast-properties"
         }
       ]
     },
@@ -20319,6 +26305,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-object-path"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -20337,6 +26329,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/to-object-path/node_modules/kind-of"
             }
           ]
         }
@@ -20360,6 +26358,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-regex-range"
+        }
       ]
     },
     {
@@ -20379,6 +26383,12 @@
           "url": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-regex"
         }
       ]
     },
@@ -20400,6 +26410,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/toidentifier"
+        }
       ]
     },
     {
@@ -20419,6 +26435,12 @@
           "url": "https://registry.npmjs.org/token-stream/-/token-stream-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/token-stream"
         }
       ]
     },
@@ -20440,6 +26462,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/token-types"
+        }
       ]
     },
     {
@@ -20459,6 +26487,12 @@
           "url": "https://registry.npmjs.org/toposort-class/-/toposort-class-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/toposort-class"
         }
       ]
     },
@@ -20480,6 +26514,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tough-cookie"
+        }
       ]
     },
     {
@@ -20499,6 +26539,12 @@
           "url": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tr46"
         }
       ]
     },
@@ -20520,6 +26566,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/traverse"
+        }
       ]
     },
     {
@@ -20539,6 +26591,12 @@
           "url": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tree-kill"
         }
       ]
     },
@@ -20560,6 +26618,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/trim-repeated"
+        }
       ]
     },
     {
@@ -20580,6 +26644,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/triple-beam"
+        }
       ]
     },
     {
@@ -20599,6 +26669,12 @@
           "url": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/truncate-utf8-bytes"
         }
       ]
     },
@@ -20621,6 +26697,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ts-node-dev"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -20639,6 +26721,12 @@
               "url": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/ts-node-dev/node_modules/rimraf"
             }
           ]
         }
@@ -20662,6 +26750,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ts-node"
+        }
       ]
     },
     {
@@ -20681,6 +26775,12 @@
           "url": "https://registry.npmjs.org/tsconfig/-/tsconfig-7.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tsconfig"
         }
       ]
     },
@@ -20702,6 +26802,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tslib"
+        }
       ]
     },
     {
@@ -20721,6 +26827,12 @@
           "url": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tunnel-agent"
         }
       ]
     },
@@ -20742,6 +26854,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tweetnacl"
+        }
       ]
     },
     {
@@ -20761,6 +26879,12 @@
           "url": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/type-check"
         }
       ]
     },
@@ -20782,6 +26906,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/type-is"
+        }
       ]
     },
     {
@@ -20801,6 +26931,12 @@
           "url": "https://registry.npmjs.org/typecast/-/typecast-0.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/typecast"
         }
       ]
     },
@@ -20822,6 +26958,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/typedarray"
+        }
       ]
     },
     {
@@ -20841,6 +26983,12 @@
           "url": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/typescript"
         }
       ]
     },
@@ -20862,6 +27010,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/uglify-js"
+        }
       ]
     },
     {
@@ -20881,6 +27035,12 @@
           "url": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unbox-primitive"
         }
       ]
     },
@@ -20902,6 +27062,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unbzip2-stream"
+        }
       ]
     },
     {
@@ -20921,6 +27087,12 @@
           "url": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unc-path-regex"
         }
       ]
     },
@@ -20942,6 +27114,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/underscore.string"
+        }
       ]
     },
     {
@@ -20962,6 +27140,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unicode-properties"
+        }
       ]
     },
     {
@@ -20981,6 +27165,12 @@
           "url": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unicode-trie"
         }
       ]
     },
@@ -21003,6 +27193,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/union-value"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21021,6 +27217,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/union-value/node_modules/is-extendable"
             }
           ]
         }
@@ -21044,6 +27246,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unique-filename"
+        }
       ]
     },
     {
@@ -21063,6 +27271,12 @@
           "url": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unique-slug"
         }
       ]
     },
@@ -21084,6 +27298,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unit-compare"
+        }
       ]
     },
     {
@@ -21104,6 +27324,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/universalify"
+        }
       ]
     },
     {
@@ -21123,6 +27349,12 @@
           "url": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unpipe"
         }
       ]
     },
@@ -21145,6 +27377,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unset-value"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21165,6 +27403,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/unset-value/node_modules/has-value"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -21183,6 +27427,12 @@
                   "url": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/unset-value/node_modules/has-value/node_modules/isobject"
                 }
               ]
             }
@@ -21206,6 +27456,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/unset-value/node_modules/has-values"
+            }
           ]
         },
         {
@@ -21225,6 +27481,12 @@
               "url": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/unset-value/node_modules/isarray"
             }
           ]
         }
@@ -21248,6 +27510,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/untildify"
+        }
       ]
     },
     {
@@ -21269,6 +27537,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unzipper"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21287,6 +27561,12 @@
               "url": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/unzipper/node_modules/bluebird"
             }
           ]
         }
@@ -21310,6 +27590,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/uri-js"
+        }
       ]
     },
     {
@@ -21329,6 +27615,12 @@
           "url": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/urix"
         }
       ]
     },
@@ -21350,6 +27642,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/url-parse-lax"
+        }
       ]
     },
     {
@@ -21369,6 +27667,12 @@
           "url": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/url-to-options"
         }
       ]
     },
@@ -21390,6 +27694,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/use"
+        }
       ]
     },
     {
@@ -21409,6 +27719,12 @@
           "url": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/utf8-byte-length"
         }
       ]
     },
@@ -21430,6 +27746,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/util-deprecate"
+        }
       ]
     },
     {
@@ -21449,6 +27771,12 @@
           "url": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/util"
         }
       ]
     },
@@ -21470,6 +27798,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/utils-merge"
+        }
       ]
     },
     {
@@ -21489,6 +27823,12 @@
           "url": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/uuid"
         }
       ]
     },
@@ -21510,6 +27850,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/v8flags"
+        }
       ]
     },
     {
@@ -21529,6 +27875,12 @@
           "url": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/validate-npm-package-license"
         }
       ]
     },
@@ -21550,6 +27902,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/validate"
+        }
       ]
     },
     {
@@ -21570,6 +27928,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/validator"
+        }
       ]
     },
     {
@@ -21589,6 +27953,12 @@
           "url": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/vary"
         }
       ]
     },
@@ -21611,6 +27981,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/verror"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21629,6 +28005,12 @@
               "url": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/verror/node_modules/core-util-is"
             }
           ]
         }
@@ -21653,6 +28035,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/vm2"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21671,6 +28059,12 @@
               "url": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/vm2/node_modules/acorn"
             }
           ]
         }
@@ -21694,6 +28088,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/void-elements"
+        }
       ]
     },
     {
@@ -21713,6 +28113,12 @@
           "url": "https://registry.npmjs.org/walk/-/walk-2.3.15.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/walk"
         }
       ]
     },
@@ -21734,6 +28140,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/walkdir"
+        }
       ]
     },
     {
@@ -21753,6 +28165,12 @@
           "url": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/webidl-conversions"
         }
       ]
     },
@@ -21774,6 +28192,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/whatwg-url"
+        }
       ]
     },
     {
@@ -21793,6 +28217,12 @@
           "url": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-boxed-primitive"
         }
       ]
     },
@@ -21814,6 +28244,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-collection"
+        }
       ]
     },
     {
@@ -21833,6 +28269,12 @@
           "url": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-module"
         }
       ]
     },
@@ -21854,6 +28296,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-pm-runs"
+        }
       ]
     },
     {
@@ -21873,6 +28321,12 @@
           "url": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-typed-array"
         }
       ]
     },
@@ -21894,6 +28348,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which"
+        }
       ]
     },
     {
@@ -21913,6 +28373,12 @@
           "url": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wide-align"
         }
       ]
     },
@@ -21935,6 +28401,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/winston-transport"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21953,6 +28425,12 @@
               "url": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/winston-transport/node_modules/readable-stream"
             }
           ]
         }
@@ -21977,6 +28455,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/winston"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21995,6 +28479,12 @@
               "url": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/winston/node_modules/async"
             }
           ]
         },
@@ -22016,6 +28506,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/winston/node_modules/is-stream"
+            }
           ]
         },
         {
@@ -22035,6 +28531,12 @@
               "url": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/winston/node_modules/readable-stream"
             }
           ]
         }
@@ -22058,6 +28560,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/with"
+        }
       ]
     },
     {
@@ -22077,6 +28585,12 @@
           "url": "https://registry.npmjs.org/wkx/-/wkx-0.5.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wkx"
         }
       ]
     },
@@ -22098,6 +28612,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/word-wrap"
+        }
       ]
     },
     {
@@ -22117,6 +28637,12 @@
           "url": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wordwrap"
         }
       ]
     },
@@ -22139,6 +28665,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wrap-ansi"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -22157,6 +28689,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi/node_modules/ansi-regex"
             }
           ]
         },
@@ -22178,6 +28716,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi/node_modules/emoji-regex"
+            }
           ]
         },
         {
@@ -22197,6 +28741,12 @@
               "url": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi/node_modules/is-fullwidth-code-point"
             }
           ]
         },
@@ -22218,6 +28768,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi/node_modules/string-width"
+            }
           ]
         },
         {
@@ -22237,6 +28793,12 @@
               "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi/node_modules/strip-ansi"
             }
           ]
         }
@@ -22260,6 +28822,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wrappy"
+        }
       ]
     },
     {
@@ -22279,6 +28847,12 @@
           "url": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ws"
         }
       ]
     },
@@ -22300,6 +28874,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/xtend"
+        }
       ]
     },
     {
@@ -22319,6 +28899,12 @@
           "url": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/y18n"
         }
       ]
     },
@@ -22340,6 +28926,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yallist"
+        }
       ]
     },
     {
@@ -22360,6 +28952,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yaml-schema-validator"
+        }
       ]
     },
     {
@@ -22379,6 +28977,12 @@
           "url": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yargs-parser"
         }
       ]
     },
@@ -22401,6 +29005,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yargs"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -22419,6 +29029,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs/node_modules/ansi-regex"
             }
           ]
         },
@@ -22440,6 +29056,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs/node_modules/emoji-regex"
+            }
           ]
         },
         {
@@ -22459,6 +29081,12 @@
               "url": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs/node_modules/is-fullwidth-code-point"
             }
           ]
         },
@@ -22480,6 +29108,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs/node_modules/string-width"
+            }
           ]
         },
         {
@@ -22499,6 +29133,12 @@
               "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs/node_modules/strip-ansi"
             }
           ]
         }
@@ -22522,6 +29162,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yauzl"
+        }
       ]
     },
     {
@@ -22541,6 +29187,12 @@
           "url": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yn"
         }
       ]
     },
@@ -22562,6 +29214,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/z85"
+        }
       ]
     },
     {
@@ -22582,6 +29240,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/zip-stream"
+        }
       ]
     },
     {
@@ -22601,6 +29265,12 @@
           "url": "https://registry.npmjs.org/zlibjs/-/zlibjs-0.3.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/zlibjs"
         }
       ]
     }

--- a/tests/_data/sbom_demo-results/juice-shop_npm9_node16_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/juice-shop_npm9_node16_ubuntu-latest.snap.json
@@ -62,7 +62,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -95,7 +95,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@babel/helper-string-parser"
         }
       ]
@@ -122,7 +122,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@babel/helper-validator-identifier"
         }
       ]
@@ -149,7 +149,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@babel/parser"
         }
       ]
@@ -176,7 +176,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@babel/types"
         }
       ]
@@ -203,7 +203,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@colors/colors"
         }
       ]
@@ -230,7 +230,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@dabh/diagnostics"
         }
       ]
@@ -257,7 +257,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@gar/promisify"
         }
       ]
@@ -284,7 +284,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@mapbox/node-pre-gyp"
         }
       ],
@@ -310,7 +310,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/ansi-regex"
             }
           ]
@@ -336,7 +336,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/are-we-there-yet"
             }
           ]
@@ -362,7 +362,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/detect-libc"
             }
           ]
@@ -388,7 +388,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/gauge"
             }
           ]
@@ -414,7 +414,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -440,7 +440,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/make-dir"
             }
           ],
@@ -466,7 +466,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/@mapbox/node-pre-gyp/node_modules/make-dir/node_modules/semver"
                 }
               ]
@@ -494,7 +494,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/nopt"
             }
           ]
@@ -520,7 +520,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/npmlog"
             }
           ]
@@ -546,7 +546,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/readable-stream"
             }
           ]
@@ -572,7 +572,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/string-width"
             }
           ]
@@ -598,7 +598,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/strip-ansi"
             }
           ]
@@ -627,7 +627,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/core-loader"
         }
       ]
@@ -654,7 +654,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/core"
         }
       ]
@@ -681,7 +681,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/evaluator"
         }
       ]
@@ -708,7 +708,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-all"
         }
       ]
@@ -735,7 +735,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ar"
         }
       ]
@@ -762,7 +762,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-bn"
         }
       ]
@@ -789,7 +789,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ca"
         }
       ]
@@ -816,7 +816,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-cs"
         }
       ]
@@ -843,7 +843,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-da"
         }
       ]
@@ -870,7 +870,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-de"
         }
       ]
@@ -897,7 +897,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-el"
         }
       ]
@@ -924,7 +924,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-en-min"
         }
       ]
@@ -951,7 +951,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-en"
         }
       ]
@@ -978,7 +978,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-es"
         }
       ]
@@ -1005,7 +1005,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-eu"
         }
       ]
@@ -1032,7 +1032,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-fa"
         }
       ]
@@ -1059,7 +1059,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-fi"
         }
       ]
@@ -1086,7 +1086,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-fr"
         }
       ]
@@ -1113,7 +1113,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ga"
         }
       ]
@@ -1140,7 +1140,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-gl"
         }
       ]
@@ -1167,7 +1167,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-hi"
         }
       ]
@@ -1194,7 +1194,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-hu"
         }
       ]
@@ -1221,7 +1221,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-hy"
         }
       ]
@@ -1248,7 +1248,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-id"
         }
       ]
@@ -1275,7 +1275,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-it"
         }
       ]
@@ -1302,7 +1302,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ja"
         }
       ]
@@ -1329,7 +1329,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ko"
         }
       ]
@@ -1356,7 +1356,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-lt"
         }
       ]
@@ -1383,7 +1383,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ms"
         }
       ]
@@ -1410,7 +1410,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ne"
         }
       ]
@@ -1437,7 +1437,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-nl"
         }
       ]
@@ -1464,7 +1464,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-no"
         }
       ]
@@ -1491,7 +1491,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-pl"
         }
       ]
@@ -1518,7 +1518,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-pt"
         }
       ]
@@ -1545,7 +1545,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ro"
         }
       ]
@@ -1572,7 +1572,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ru"
         }
       ]
@@ -1599,7 +1599,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-sl"
         }
       ]
@@ -1626,7 +1626,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-sr"
         }
       ]
@@ -1653,7 +1653,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-sv"
         }
       ]
@@ -1680,7 +1680,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ta"
         }
       ]
@@ -1707,7 +1707,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-th"
         }
       ]
@@ -1734,7 +1734,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-tl"
         }
       ]
@@ -1761,7 +1761,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-tr"
         }
       ]
@@ -1788,7 +1788,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-uk"
         }
       ]
@@ -1815,7 +1815,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-zh"
         }
       ]
@@ -1842,7 +1842,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/language-min"
         }
       ]
@@ -1869,7 +1869,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/language"
         }
       ]
@@ -1896,7 +1896,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/ner"
         }
       ]
@@ -1923,7 +1923,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/neural"
         }
       ]
@@ -1950,7 +1950,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/nlg"
         }
       ]
@@ -1977,7 +1977,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/nlp"
         }
       ]
@@ -2004,7 +2004,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/nlu"
         }
       ]
@@ -2031,7 +2031,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/request"
         }
       ]
@@ -2058,7 +2058,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/sentiment"
         }
       ]
@@ -2085,7 +2085,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/similarity"
         }
       ]
@@ -2112,7 +2112,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/slot"
         }
       ]
@@ -2139,7 +2139,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@npmcli/fs"
         }
       ]
@@ -2166,7 +2166,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@npmcli/move-file"
         }
       ]
@@ -2193,7 +2193,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib/core"
         }
       ]
@@ -2220,7 +2220,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib/plugin-crypto"
         }
       ]
@@ -2247,7 +2247,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib/plugin-thirty-two"
         }
       ]
@@ -2274,7 +2274,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib/preset-default"
         }
       ]
@@ -2301,7 +2301,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib/preset-v11"
         }
       ]
@@ -2328,7 +2328,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@sindresorhus/is"
         }
       ]
@@ -2355,7 +2355,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@swc/helpers"
         }
       ]
@@ -2382,7 +2382,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@tokenizer/token"
         }
       ]
@@ -2409,7 +2409,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@tootallnate/once"
         }
       ]
@@ -2436,7 +2436,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/component-emitter"
         }
       ]
@@ -2463,7 +2463,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/cookie"
         }
       ]
@@ -2490,7 +2490,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/cors"
         }
       ]
@@ -2517,7 +2517,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/debug"
         }
       ]
@@ -2544,7 +2544,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/ms"
         }
       ]
@@ -2571,7 +2571,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/node"
         }
       ]
@@ -2598,7 +2598,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/strip-bom"
         }
       ]
@@ -2625,7 +2625,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/strip-json-comments"
         }
       ]
@@ -2652,7 +2652,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/validator"
         }
       ]
@@ -2678,7 +2678,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/abbrev"
         }
       ]
@@ -2704,7 +2704,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/accepts"
         }
       ]
@@ -2730,7 +2730,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/acorn-walk"
         }
       ]
@@ -2756,7 +2756,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/acorn"
         }
       ]
@@ -2782,7 +2782,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/agent-base"
         }
       ],
@@ -2808,7 +2808,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agent-base/node_modules/debug"
             }
           ]
@@ -2834,7 +2834,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agent-base/node_modules/ms"
             }
           ]
@@ -2862,7 +2862,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/agentkeepalive"
         }
       ],
@@ -2888,7 +2888,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agentkeepalive/node_modules/debug"
             }
           ]
@@ -2914,7 +2914,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agentkeepalive/node_modules/depd"
             }
           ]
@@ -2940,7 +2940,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agentkeepalive/node_modules/ms"
             }
           ]
@@ -2968,7 +2968,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/aggregate-error"
         }
       ]
@@ -2994,7 +2994,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ajv"
         }
       ]
@@ -3020,7 +3020,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ansi-regex"
         }
       ]
@@ -3046,7 +3046,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ansi-styles"
         }
       ]
@@ -3072,7 +3072,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/anymatch"
         }
       ],
@@ -3098,7 +3098,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/anymatch/node_modules/normalize-path"
             }
           ]
@@ -3126,7 +3126,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/append-field"
         }
       ]
@@ -3152,7 +3152,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/aproba"
         }
       ]
@@ -3178,7 +3178,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/archive-type"
         }
       ],
@@ -3204,7 +3204,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/archive-type/node_modules/file-type"
             }
           ]
@@ -3232,7 +3232,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/archiver-utils"
         }
       ]
@@ -3258,7 +3258,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/archiver"
         }
       ]
@@ -3284,7 +3284,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/are-we-there-yet"
         }
       ]
@@ -3310,7 +3310,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/arg"
         }
       ]
@@ -3336,7 +3336,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/argparse"
         }
       ],
@@ -3362,7 +3362,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/argparse/node_modules/sprintf-js"
             }
           ]
@@ -3390,7 +3390,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/arr-diff"
         }
       ]
@@ -3416,7 +3416,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/arr-flatten"
         }
       ]
@@ -3442,7 +3442,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/arr-union"
         }
       ]
@@ -3468,7 +3468,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/array-each"
         }
       ]
@@ -3494,7 +3494,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/array-flatten"
         }
       ]
@@ -3520,7 +3520,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/array-slice"
         }
       ]
@@ -3546,7 +3546,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/array-unique"
         }
       ]
@@ -3572,7 +3572,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/asap"
         }
       ]
@@ -3598,7 +3598,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/asn1"
         }
       ]
@@ -3624,7 +3624,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/assert-never"
         }
       ]
@@ -3650,7 +3650,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/assert-plus"
         }
       ]
@@ -3676,7 +3676,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/assign-symbols"
         }
       ]
@@ -3702,7 +3702,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/async"
         }
       ]
@@ -3728,7 +3728,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/asynckit"
         }
       ]
@@ -3754,7 +3754,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/at-least-node"
         }
       ]
@@ -3780,7 +3780,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/atob"
         }
       ]
@@ -3806,7 +3806,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/available-typed-arrays"
         }
       ]
@@ -3832,7 +3832,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/aws-sign2"
         }
       ]
@@ -3858,7 +3858,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/aws4"
         }
       ]
@@ -3884,7 +3884,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/babel-walk"
         }
       ]
@@ -3910,7 +3910,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/balanced-match"
         }
       ]
@@ -3936,7 +3936,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base"
         }
       ],
@@ -3962,7 +3962,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/base/node_modules/define-property"
             }
           ]
@@ -3990,7 +3990,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base64-arraybuffer"
         }
       ]
@@ -4016,7 +4016,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base64-js"
         }
       ]
@@ -4042,7 +4042,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base64id"
         }
       ]
@@ -4068,7 +4068,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base64url"
         }
       ]
@@ -4094,7 +4094,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/basic-auth"
         }
       ]
@@ -4120,7 +4120,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/batch"
         }
       ]
@@ -4146,7 +4146,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bcrypt-pbkdf"
         }
       ]
@@ -4172,7 +4172,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/big-integer"
         }
       ]
@@ -4198,7 +4198,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/binary-extensions"
         }
       ]
@@ -4224,7 +4224,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/binary"
         }
       ]
@@ -4250,7 +4250,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bindings"
         }
       ]
@@ -4276,7 +4276,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bintrees"
         }
       ]
@@ -4302,7 +4302,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bl"
         }
       ]
@@ -4328,7 +4328,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bluebird"
         }
       ]
@@ -4354,7 +4354,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/body-parser"
         }
       ]
@@ -4380,7 +4380,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bower-config"
         }
       ],
@@ -4406,7 +4406,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bower-config/node_modules/minimist"
             }
           ]
@@ -4434,7 +4434,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/brace-expansion"
         }
       ]
@@ -4460,7 +4460,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/braces"
         }
       ],
@@ -4486,7 +4486,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/braces/node_modules/extend-shallow"
             }
           ]
@@ -4512,7 +4512,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/braces/node_modules/is-extendable"
             }
           ]
@@ -4540,7 +4540,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/brotli"
         }
       ]
@@ -4566,7 +4566,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-alloc-unsafe"
         }
       ]
@@ -4592,7 +4592,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-alloc"
         }
       ]
@@ -4618,7 +4618,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-crc32"
         }
       ]
@@ -4644,7 +4644,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-fill"
         }
       ]
@@ -4670,7 +4670,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-from"
         }
       ]
@@ -4696,7 +4696,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-indexof-polyfill"
         }
       ]
@@ -4722,7 +4722,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer"
         }
       ]
@@ -4748,7 +4748,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffers"
         }
       ]
@@ -4774,7 +4774,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/busboy"
         }
       ],
@@ -4800,7 +4800,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/busboy/node_modules/isarray"
             }
           ]
@@ -4826,7 +4826,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/busboy/node_modules/readable-stream"
             }
           ]
@@ -4852,7 +4852,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/busboy/node_modules/string_decoder"
             }
           ]
@@ -4880,7 +4880,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/byline"
         }
       ]
@@ -4906,7 +4906,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bytes"
         }
       ]
@@ -4932,7 +4932,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cacache"
         }
       ]
@@ -4958,7 +4958,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cache-base"
         }
       ]
@@ -4984,7 +4984,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cacheable-request"
         }
       ],
@@ -5010,7 +5010,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cacheable-request/node_modules/get-stream"
             }
           ]
@@ -5036,7 +5036,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cacheable-request/node_modules/lowercase-keys"
             }
           ]
@@ -5064,7 +5064,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/call-bind"
         }
       ]
@@ -5090,7 +5090,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/camelcase"
         }
       ]
@@ -5116,7 +5116,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/caseless"
         }
       ]
@@ -5142,7 +5142,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/chainsaw"
         }
       ]
@@ -5168,7 +5168,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/chalk"
         }
       ]
@@ -5194,7 +5194,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/character-parser"
         }
       ]
@@ -5220,7 +5220,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/check-dependencies"
         }
       ],
@@ -5246,7 +5246,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/check-dependencies/node_modules/semver"
             }
           ]
@@ -5274,7 +5274,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/check-types"
         }
       ]
@@ -5300,7 +5300,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/chokidar"
         }
       ],
@@ -5326,7 +5326,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar/node_modules/braces"
             }
           ]
@@ -5352,7 +5352,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar/node_modules/fill-range"
             }
           ]
@@ -5378,7 +5378,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar/node_modules/is-glob"
             }
           ]
@@ -5404,7 +5404,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar/node_modules/is-number"
             }
           ]
@@ -5430,7 +5430,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar/node_modules/normalize-path"
             }
           ]
@@ -5456,7 +5456,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar/node_modules/to-regex-range"
             }
           ]
@@ -5484,7 +5484,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/chownr"
         }
       ]
@@ -5510,7 +5510,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/clarinet"
         }
       ]
@@ -5536,7 +5536,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/class-utils"
         }
       ],
@@ -5562,7 +5562,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils/node_modules/define-property"
             }
           ]
@@ -5588,7 +5588,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils/node_modules/is-accessor-descriptor"
             }
           ],
@@ -5614,7 +5614,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/class-utils/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
@@ -5642,7 +5642,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils/node_modules/is-data-descriptor"
             }
           ],
@@ -5668,7 +5668,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/class-utils/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
@@ -5696,7 +5696,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils/node_modules/is-descriptor"
             }
           ]
@@ -5722,7 +5722,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils/node_modules/kind-of"
             }
           ]
@@ -5750,7 +5750,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/clean-stack"
         }
       ]
@@ -5776,7 +5776,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cliui"
         }
       ],
@@ -5802,7 +5802,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui/node_modules/ansi-regex"
             }
           ]
@@ -5828,7 +5828,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui/node_modules/emoji-regex"
             }
           ]
@@ -5854,7 +5854,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -5880,7 +5880,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui/node_modules/string-width"
             }
           ]
@@ -5906,7 +5906,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui/node_modules/strip-ansi"
             }
           ]
@@ -5934,7 +5934,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/clone-response"
         }
       ]
@@ -5960,7 +5960,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/clone"
         }
       ]
@@ -5986,7 +5986,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/code-point-at"
         }
       ]
@@ -6012,7 +6012,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/collection-visit"
         }
       ]
@@ -6038,7 +6038,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color-convert"
         }
       ]
@@ -6064,7 +6064,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color-name"
         }
       ]
@@ -6090,7 +6090,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color-string"
         }
       ]
@@ -6116,7 +6116,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color-support"
         }
       ]
@@ -6142,7 +6142,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color"
         }
       ]
@@ -6168,7 +6168,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/colors"
         }
       ]
@@ -6194,7 +6194,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/colorspace"
         }
       ]
@@ -6220,7 +6220,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/combined-stream"
         }
       ]
@@ -6246,7 +6246,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/commander"
         }
       ]
@@ -6272,7 +6272,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/component-emitter"
         }
       ]
@@ -6298,7 +6298,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/component-type"
         }
       ]
@@ -6324,7 +6324,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/compress-commons"
         }
       ]
@@ -6350,7 +6350,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/compressible"
         }
       ]
@@ -6376,7 +6376,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/compression"
         }
       ],
@@ -6402,7 +6402,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/compression/node_modules/bytes"
             }
           ]
@@ -6430,7 +6430,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/concat-map"
         }
       ]
@@ -6456,7 +6456,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/concat-stream"
         }
       ]
@@ -6482,7 +6482,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/concurrently"
         }
       ],
@@ -6508,7 +6508,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/concurrently/node_modules/supports-color"
             }
           ]
@@ -6536,7 +6536,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/config"
         }
       ]
@@ -6562,7 +6562,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/console-control-strings"
         }
       ]
@@ -6588,7 +6588,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/constantinople"
         }
       ]
@@ -6614,7 +6614,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/content-disposition"
         }
       ],
@@ -6640,7 +6640,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/content-disposition/node_modules/safe-buffer"
             }
           ]
@@ -6668,7 +6668,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/content-type"
         }
       ]
@@ -6694,7 +6694,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cookie-parser"
         }
       ]
@@ -6720,7 +6720,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cookie-signature"
         }
       ]
@@ -6746,7 +6746,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cookie"
         }
       ]
@@ -6772,7 +6772,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/copy-descriptor"
         }
       ]
@@ -6798,7 +6798,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/core-util-is"
         }
       ]
@@ -6824,7 +6824,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cors"
         }
       ]
@@ -6850,7 +6850,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/crc"
         }
       ]
@@ -6876,7 +6876,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/crc32-stream"
         }
       ]
@@ -6902,7 +6902,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/create-require"
         }
       ]
@@ -6928,7 +6928,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/crypto-js"
         }
       ]
@@ -6954,7 +6954,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dashdash"
         }
       ]
@@ -6980,7 +6980,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/date-fns"
         }
       ]
@@ -7006,7 +7006,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dateformat"
         }
       ]
@@ -7032,7 +7032,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/debug"
         }
       ]
@@ -7058,7 +7058,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decamelize"
         }
       ]
@@ -7084,7 +7084,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decode-uri-component"
         }
       ]
@@ -7110,7 +7110,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-response"
         }
       ]
@@ -7136,7 +7136,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-tar"
         }
       ],
@@ -7162,7 +7162,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-tar/node_modules/file-type"
             }
           ]
@@ -7190,7 +7190,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-tarbz2"
         }
       ],
@@ -7216,7 +7216,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-tarbz2/node_modules/file-type"
             }
           ]
@@ -7244,7 +7244,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-targz"
         }
       ],
@@ -7270,7 +7270,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-targz/node_modules/file-type"
             }
           ]
@@ -7298,7 +7298,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-unzip"
         }
       ],
@@ -7324,7 +7324,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-unzip/node_modules/file-type"
             }
           ]
@@ -7350,7 +7350,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-unzip/node_modules/get-stream"
             }
           ]
@@ -7376,7 +7376,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-unzip/node_modules/pify"
             }
           ]
@@ -7404,7 +7404,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress"
         }
       ],
@@ -7430,7 +7430,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress/node_modules/make-dir"
             }
           ],
@@ -7456,7 +7456,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/decompress/node_modules/make-dir/node_modules/pify"
                 }
               ]
@@ -7484,7 +7484,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress/node_modules/pify"
             }
           ]
@@ -7512,7 +7512,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/deep-equal"
         }
       ]
@@ -7538,7 +7538,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/deep-extend"
         }
       ]
@@ -7564,7 +7564,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/deep-is"
         }
       ]
@@ -7590,7 +7590,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/define-properties"
         }
       ]
@@ -7616,7 +7616,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/define-property"
         }
       ]
@@ -7642,7 +7642,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/delayed-stream"
         }
       ]
@@ -7668,7 +7668,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/delegates"
         }
       ]
@@ -7694,7 +7694,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/depd"
         }
       ]
@@ -7720,7 +7720,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/destroy"
         }
       ]
@@ -7746,7 +7746,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/detect-file"
         }
       ]
@@ -7772,7 +7772,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/detect-libc"
         }
       ]
@@ -7798,7 +7798,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dfa"
         }
       ]
@@ -7824,7 +7824,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dicer"
         }
       ],
@@ -7850,7 +7850,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/dicer/node_modules/isarray"
             }
           ]
@@ -7876,7 +7876,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/dicer/node_modules/readable-stream"
             }
           ]
@@ -7902,7 +7902,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/dicer/node_modules/string_decoder"
             }
           ]
@@ -7930,7 +7930,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/diff"
         }
       ]
@@ -7956,7 +7956,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/doctypes"
         }
       ]
@@ -7982,7 +7982,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/domelementtype"
         }
       ]
@@ -8008,7 +8008,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/domhandler"
         }
       ]
@@ -8034,7 +8034,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/domutils"
         }
       ]
@@ -8060,7 +8060,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dottie"
         }
       ]
@@ -8086,7 +8086,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/double-ended-queue"
         }
       ]
@@ -8112,7 +8112,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/doublearray"
         }
       ]
@@ -8138,7 +8138,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/download"
         }
       ],
@@ -8164,7 +8164,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/download/node_modules/file-type"
             }
           ]
@@ -8192,7 +8192,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/duplexer2"
         }
       ]
@@ -8218,7 +8218,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/duplexer3"
         }
       ]
@@ -8244,7 +8244,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dynamic-dedupe"
         }
       ]
@@ -8270,7 +8270,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ecc-jsbn"
         }
       ]
@@ -8296,7 +8296,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ee-first"
         }
       ]
@@ -8322,7 +8322,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/eivindfjeldstad-dot"
         }
       ]
@@ -8348,7 +8348,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/emoji-regex"
         }
       ]
@@ -8374,7 +8374,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/enabled"
         }
       ]
@@ -8400,7 +8400,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/encodeurl"
         }
       ]
@@ -8426,7 +8426,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/encoding"
         }
       ],
@@ -8452,7 +8452,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/encoding/node_modules/iconv-lite"
             }
           ]
@@ -8480,7 +8480,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/end-of-stream"
         }
       ]
@@ -8506,7 +8506,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/engine.io-parser"
         }
       ]
@@ -8532,7 +8532,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/engine.io"
         }
       ],
@@ -8558,7 +8558,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/engine.io/node_modules/debug"
             }
           ]
@@ -8584,7 +8584,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/engine.io/node_modules/ms"
             }
           ]
@@ -8612,7 +8612,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/env-paths"
         }
       ]
@@ -8638,7 +8638,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/err-code"
         }
       ]
@@ -8664,7 +8664,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/error-ex"
         }
       ]
@@ -8690,7 +8690,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/errorhandler"
         }
       ]
@@ -8716,7 +8716,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/es-abstract"
         }
       ]
@@ -8742,7 +8742,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/es-get-iterator"
         }
       ]
@@ -8768,7 +8768,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/es-to-primitive"
         }
       ]
@@ -8794,7 +8794,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/escape-html"
         }
       ]
@@ -8820,7 +8820,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/escape-string-regexp"
         }
       ]
@@ -8846,7 +8846,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/escodegen"
         }
       ]
@@ -8872,7 +8872,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/esprima"
         }
       ]
@@ -8898,7 +8898,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/estraverse"
         }
       ]
@@ -8924,7 +8924,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/esutils"
         }
       ]
@@ -8950,7 +8950,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/etag"
         }
       ]
@@ -8976,7 +8976,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/eventemitter2"
         }
       ]
@@ -9002,7 +9002,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/eventemitter3"
         }
       ]
@@ -9028,7 +9028,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/exif"
         }
       ]
@@ -9054,7 +9054,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/exit"
         }
       ]
@@ -9080,7 +9080,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/expand-brackets"
         }
       ],
@@ -9106,7 +9106,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/define-property"
             }
           ]
@@ -9132,7 +9132,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/extend-shallow"
             }
           ]
@@ -9158,7 +9158,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/is-accessor-descriptor"
             }
           ],
@@ -9184,7 +9184,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/expand-brackets/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
@@ -9212,7 +9212,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/is-data-descriptor"
             }
           ],
@@ -9238,7 +9238,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/expand-brackets/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
@@ -9266,7 +9266,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/is-descriptor"
             }
           ]
@@ -9292,7 +9292,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/is-extendable"
             }
           ]
@@ -9318,7 +9318,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/kind-of"
             }
           ]
@@ -9346,7 +9346,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/expand-template"
         }
       ]
@@ -9372,7 +9372,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/expand-tilde"
         }
       ]
@@ -9398,7 +9398,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-ipfilter"
         }
       ]
@@ -9424,7 +9424,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-jwt"
         }
       ],
@@ -9450,7 +9450,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/express-jwt/node_modules/jsonwebtoken"
             }
           ]
@@ -9476,7 +9476,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/express-jwt/node_modules/moment"
             }
           ]
@@ -9504,7 +9504,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-rate-limit"
         }
       ]
@@ -9530,7 +9530,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-robots-txt"
         }
       ]
@@ -9556,7 +9556,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-security.txt"
         }
       ]
@@ -9582,7 +9582,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express"
         }
       ],
@@ -9608,7 +9608,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/express/node_modules/cookie"
             }
           ]
@@ -9634,7 +9634,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/express/node_modules/safe-buffer"
             }
           ]
@@ -9662,7 +9662,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ext-list"
         }
       ]
@@ -9688,7 +9688,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ext-name"
         }
       ]
@@ -9714,7 +9714,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/extend-shallow"
         }
       ]
@@ -9740,7 +9740,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/extend"
         }
       ]
@@ -9766,7 +9766,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/extglob"
         }
       ],
@@ -9792,7 +9792,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/extglob/node_modules/define-property"
             }
           ]
@@ -9818,7 +9818,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/extglob/node_modules/extend-shallow"
             }
           ]
@@ -9844,7 +9844,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/extglob/node_modules/is-extendable"
             }
           ]
@@ -9872,7 +9872,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/extsprintf"
         }
       ]
@@ -9898,7 +9898,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fast-deep-equal"
         }
       ]
@@ -9924,7 +9924,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fast-json-stable-stringify"
         }
       ]
@@ -9950,7 +9950,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fast-levenshtein"
         }
       ]
@@ -9976,7 +9976,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fast.js"
         }
       ]
@@ -10002,7 +10002,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fd-slicer"
         }
       ]
@@ -10028,7 +10028,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/feature-policy"
         }
       ]
@@ -10054,7 +10054,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fecha"
         }
       ]
@@ -10080,7 +10080,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/file-js"
         }
       ],
@@ -10106,7 +10106,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/file-js/node_modules/brace-expansion"
             }
           ]
@@ -10132,7 +10132,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/file-js/node_modules/minimatch"
             }
           ]
@@ -10160,7 +10160,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/file-stream-rotator"
         }
       ]
@@ -10186,7 +10186,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/file-type"
         }
       ]
@@ -10212,7 +10212,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/file-uri-to-path"
         }
       ]
@@ -10238,7 +10238,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/filehound"
         }
       ]
@@ -10264,7 +10264,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/filename-reserved-regex"
         }
       ]
@@ -10290,7 +10290,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/filenamify"
         }
       ]
@@ -10316,7 +10316,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/filesniffer"
         }
       ]
@@ -10342,7 +10342,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fill-range"
         }
       ],
@@ -10368,7 +10368,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/fill-range/node_modules/extend-shallow"
             }
           ]
@@ -10394,7 +10394,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/fill-range/node_modules/is-extendable"
             }
           ]
@@ -10422,7 +10422,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/finale-rest"
         }
       ]
@@ -10448,7 +10448,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/finalhandler"
         }
       ]
@@ -10474,7 +10474,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/find-up"
         }
       ]
@@ -10500,7 +10500,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/findup-sync"
         }
       ]
@@ -10526,7 +10526,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fined"
         }
       ]
@@ -10552,7 +10552,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/flagged-respawn"
         }
       ]
@@ -10578,7 +10578,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fn.name"
         }
       ]
@@ -10604,7 +10604,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fontkit"
         }
       ]
@@ -10630,7 +10630,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/for-each"
         }
       ]
@@ -10656,7 +10656,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/for-in"
         }
       ]
@@ -10682,7 +10682,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/for-own"
         }
       ]
@@ -10708,7 +10708,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/foreachasync"
         }
       ]
@@ -10734,7 +10734,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/forever-agent"
         }
       ]
@@ -10760,7 +10760,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/form-data"
         }
       ]
@@ -10786,7 +10786,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/formatio"
         }
       ]
@@ -10812,7 +10812,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/forwarded"
         }
       ]
@@ -10838,7 +10838,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fragment-cache"
         }
       ]
@@ -10864,7 +10864,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fresh"
         }
       ]
@@ -10890,7 +10890,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/from2"
         }
       ]
@@ -10916,7 +10916,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fs-constants"
         }
       ]
@@ -10942,7 +10942,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fs-extra"
         }
       ]
@@ -10968,7 +10968,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fs-minipass"
         }
       ]
@@ -10994,7 +10994,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fs.realpath"
         }
       ]
@@ -11020,7 +11020,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fstream"
         }
       ],
@@ -11046,7 +11046,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/fstream/node_modules/mkdirp"
             }
           ]
@@ -11072,7 +11072,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/fstream/node_modules/rimraf"
             }
           ]
@@ -11100,7 +11100,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/function-bind"
         }
       ]
@@ -11126,7 +11126,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/function.prototype.name"
         }
       ]
@@ -11152,7 +11152,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/functions-have-names"
         }
       ]
@@ -11178,7 +11178,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fuzzball"
         }
       ]
@@ -11204,7 +11204,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/gauge"
         }
       ]
@@ -11230,7 +11230,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/geojson-utils"
         }
       ]
@@ -11256,7 +11256,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-caller-file"
         }
       ]
@@ -11282,7 +11282,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-intrinsic"
         }
       ]
@@ -11308,7 +11308,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-stream"
         }
       ]
@@ -11334,7 +11334,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-symbol-description"
         }
       ]
@@ -11360,7 +11360,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-value"
         }
       ]
@@ -11386,7 +11386,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/getobject"
         }
       ]
@@ -11412,7 +11412,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/getpass"
         }
       ]
@@ -11438,7 +11438,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/github-from-package"
         }
       ]
@@ -11464,7 +11464,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/glob-parent"
         }
       ],
@@ -11490,7 +11490,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/glob-parent/node_modules/is-glob"
             }
           ]
@@ -11518,7 +11518,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/glob"
         }
       ],
@@ -11544,7 +11544,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/glob/node_modules/brace-expansion"
             }
           ]
@@ -11570,7 +11570,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/glob/node_modules/minimatch"
             }
           ]
@@ -11598,7 +11598,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/global-modules"
         }
       ]
@@ -11624,7 +11624,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/global-prefix"
         }
       ],
@@ -11650,7 +11650,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/global-prefix/node_modules/which"
             }
           ]
@@ -11678,7 +11678,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/got"
         }
       ],
@@ -11704,7 +11704,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/got/node_modules/get-stream"
             }
           ]
@@ -11730,7 +11730,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/got/node_modules/pify"
             }
           ]
@@ -11758,7 +11758,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/graceful-fs"
         }
       ]
@@ -11784,7 +11784,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-cli"
         }
       ],
@@ -11810,7 +11810,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-cli/node_modules/nopt"
             }
           ]
@@ -11838,7 +11838,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-contrib-compress"
         }
       ],
@@ -11864,7 +11864,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-contrib-compress/node_modules/ansi-styles"
             }
           ]
@@ -11890,7 +11890,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-contrib-compress/node_modules/chalk"
             }
           ]
@@ -11916,7 +11916,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-contrib-compress/node_modules/supports-color"
             }
           ]
@@ -11944,7 +11944,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-known-options"
         }
       ]
@@ -11970,7 +11970,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-legacy-log-utils"
         }
       ],
@@ -11996,7 +11996,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils/node_modules/ansi-styles"
             }
           ]
@@ -12022,7 +12022,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils/node_modules/chalk"
             }
           ]
@@ -12048,7 +12048,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils/node_modules/color-convert"
             }
           ]
@@ -12074,7 +12074,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils/node_modules/color-name"
             }
           ]
@@ -12100,7 +12100,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils/node_modules/has-flag"
             }
           ]
@@ -12126,7 +12126,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils/node_modules/supports-color"
             }
           ]
@@ -12154,7 +12154,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-legacy-log"
         }
       ],
@@ -12180,7 +12180,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log/node_modules/colors"
             }
           ]
@@ -12208,7 +12208,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-legacy-util"
         }
       ],
@@ -12234,7 +12234,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-util/node_modules/async"
             }
           ]
@@ -12262,7 +12262,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-replace-json"
         }
       ]
@@ -12288,7 +12288,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt"
         }
       ],
@@ -12314,7 +12314,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt/node_modules/brace-expansion"
             }
           ]
@@ -12340,7 +12340,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt/node_modules/findup-sync"
             }
           ],
@@ -12366,7 +12366,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/grunt/node_modules/findup-sync/node_modules/glob"
                 }
               ]
@@ -12394,7 +12394,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt/node_modules/glob"
             }
           ]
@@ -12420,7 +12420,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt/node_modules/minimatch"
             }
           ]
@@ -12448,7 +12448,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/handlebars"
         }
       ],
@@ -12474,7 +12474,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/handlebars/node_modules/wordwrap"
             }
           ]
@@ -12502,7 +12502,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/har-schema"
         }
       ]
@@ -12528,7 +12528,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/har-validator"
         }
       ]
@@ -12554,7 +12554,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-ansi"
         }
       ]
@@ -12580,7 +12580,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-bigints"
         }
       ]
@@ -12606,7 +12606,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-flag"
         }
       ]
@@ -12632,7 +12632,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-property-descriptors"
         }
       ]
@@ -12658,7 +12658,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-symbol-support-x"
         }
       ]
@@ -12684,7 +12684,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-symbols"
         }
       ]
@@ -12710,7 +12710,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-to-string-tag-x"
         }
       ]
@@ -12736,7 +12736,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-tostringtag"
         }
       ]
@@ -12762,7 +12762,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-unicode"
         }
       ]
@@ -12788,7 +12788,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-value"
         }
       ]
@@ -12814,7 +12814,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-values"
         }
       ],
@@ -12840,7 +12840,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/has-values/node_modules/kind-of"
             }
           ]
@@ -12868,7 +12868,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has"
         }
       ]
@@ -12894,7 +12894,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hashids"
         }
       ]
@@ -12920,7 +12920,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hbs"
         }
       ]
@@ -12946,7 +12946,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/he"
         }
       ]
@@ -12972,7 +12972,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/heap"
         }
       ]
@@ -12998,7 +12998,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/helmet"
         }
       ]
@@ -13024,7 +13024,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hoister"
         }
       ]
@@ -13050,7 +13050,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/homedir-polyfill"
         }
       ]
@@ -13076,7 +13076,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hooker"
         }
       ]
@@ -13102,7 +13102,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hosted-git-info"
         }
       ]
@@ -13128,7 +13128,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/html-entities"
         }
       ]
@@ -13154,7 +13154,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/htmlparser2"
         }
       ],
@@ -13180,7 +13180,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/htmlparser2/node_modules/isarray"
             }
           ]
@@ -13206,7 +13206,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/htmlparser2/node_modules/readable-stream"
             }
           ]
@@ -13232,7 +13232,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/htmlparser2/node_modules/string_decoder"
             }
           ]
@@ -13260,7 +13260,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/http-cache-semantics"
         }
       ]
@@ -13286,7 +13286,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/http-errors"
         }
       ]
@@ -13312,7 +13312,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/http-proxy-agent"
         }
       ],
@@ -13338,7 +13338,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/http-proxy-agent/node_modules/debug"
             }
           ]
@@ -13364,7 +13364,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/http-proxy-agent/node_modules/ms"
             }
           ]
@@ -13392,7 +13392,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/http-signature"
         }
       ]
@@ -13418,7 +13418,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/https-proxy-agent"
         }
       ],
@@ -13444,7 +13444,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/https-proxy-agent/node_modules/debug"
             }
           ]
@@ -13470,7 +13470,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/https-proxy-agent/node_modules/ms"
             }
           ]
@@ -13498,7 +13498,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/humanize-ms"
         }
       ]
@@ -13524,7 +13524,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/i18n"
         }
       ]
@@ -13550,7 +13550,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/iconv-lite"
         }
       ]
@@ -13576,7 +13576,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ieee754"
         }
       ]
@@ -13602,7 +13602,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ignore-walk"
         }
       ],
@@ -13628,7 +13628,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/ignore-walk/node_modules/brace-expansion"
             }
           ]
@@ -13654,7 +13654,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/ignore-walk/node_modules/minimatch"
             }
           ]
@@ -13682,7 +13682,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/iltorb"
         }
       ]
@@ -13708,7 +13708,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/imurmurhash"
         }
       ]
@@ -13734,7 +13734,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/indent-string"
         }
       ]
@@ -13760,7 +13760,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/infer-owner"
         }
       ]
@@ -13786,7 +13786,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/inflection"
         }
       ]
@@ -13812,7 +13812,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/inflight"
         }
       ]
@@ -13838,7 +13838,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/inherits"
         }
       ]
@@ -13864,7 +13864,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ini"
         }
       ]
@@ -13890,7 +13890,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/internal-slot"
         }
       ]
@@ -13916,7 +13916,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/interpret"
         }
       ]
@@ -13942,7 +13942,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/into-stream"
         }
       ]
@@ -13968,7 +13968,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/invariant"
         }
       ]
@@ -13994,7 +13994,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ip"
         }
       ]
@@ -14020,7 +14020,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ip6"
         }
       ]
@@ -14046,7 +14046,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ipaddr.js"
         }
       ]
@@ -14072,7 +14072,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-absolute"
         }
       ]
@@ -14098,7 +14098,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-accessor-descriptor"
         }
       ]
@@ -14124,7 +14124,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-arguments"
         }
       ]
@@ -14150,7 +14150,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-arrayish"
         }
       ]
@@ -14176,7 +14176,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-bigint"
         }
       ]
@@ -14202,7 +14202,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-binary-path"
         }
       ]
@@ -14228,7 +14228,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-boolean-object"
         }
       ]
@@ -14254,7 +14254,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-buffer"
         }
       ]
@@ -14280,7 +14280,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-callable"
         }
       ]
@@ -14306,7 +14306,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-core-module"
         }
       ]
@@ -14332,7 +14332,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-data-descriptor"
         }
       ]
@@ -14358,7 +14358,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-date-object"
         }
       ]
@@ -14384,7 +14384,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-descriptor"
         }
       ]
@@ -14410,7 +14410,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-docker"
         }
       ]
@@ -14436,7 +14436,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-expression"
         }
       ]
@@ -14462,7 +14462,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-extendable"
         }
       ]
@@ -14488,7 +14488,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-extglob"
         }
       ]
@@ -14514,7 +14514,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-fullwidth-code-point"
         }
       ]
@@ -14540,7 +14540,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-generator-function"
         }
       ]
@@ -14566,7 +14566,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-glob"
         }
       ]
@@ -14592,7 +14592,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-heroku"
         }
       ]
@@ -14618,7 +14618,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-lambda"
         }
       ]
@@ -14644,7 +14644,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-map"
         }
       ]
@@ -14670,7 +14670,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-natural-number"
         }
       ]
@@ -14696,7 +14696,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-negative-zero"
         }
       ]
@@ -14722,7 +14722,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-number-like"
         }
       ]
@@ -14748,7 +14748,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-number-object"
         }
       ]
@@ -14774,7 +14774,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-number"
         }
       ],
@@ -14800,7 +14800,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/is-number/node_modules/kind-of"
             }
           ]
@@ -14828,7 +14828,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-object"
         }
       ]
@@ -14854,7 +14854,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-plain-obj"
         }
       ]
@@ -14880,7 +14880,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-plain-object"
         }
       ]
@@ -14906,7 +14906,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-promise"
         }
       ]
@@ -14932,7 +14932,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-regex"
         }
       ]
@@ -14958,7 +14958,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-relative"
         }
       ]
@@ -14984,7 +14984,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-retry-allowed"
         }
       ]
@@ -15010,7 +15010,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-set"
         }
       ]
@@ -15036,7 +15036,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-shared-array-buffer"
         }
       ]
@@ -15062,7 +15062,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-stream"
         }
       ]
@@ -15088,7 +15088,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-string"
         }
       ]
@@ -15114,7 +15114,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-symbol"
         }
       ]
@@ -15140,7 +15140,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-typed-array"
         }
       ]
@@ -15166,7 +15166,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-typedarray"
         }
       ]
@@ -15192,7 +15192,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-unc-path"
         }
       ]
@@ -15218,7 +15218,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-weakmap"
         }
       ]
@@ -15244,7 +15244,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-weakref"
         }
       ]
@@ -15270,7 +15270,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-weakset"
         }
       ]
@@ -15296,7 +15296,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-windows"
         }
       ]
@@ -15322,7 +15322,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isarray"
         }
       ]
@@ -15348,7 +15348,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isexe"
         }
       ]
@@ -15374,7 +15374,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isobject"
         }
       ]
@@ -15400,7 +15400,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isstream"
         }
       ]
@@ -15426,7 +15426,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isurl"
         }
       ]
@@ -15452,7 +15452,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/js-stringify"
         }
       ]
@@ -15478,7 +15478,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/js-tokens"
         }
       ]
@@ -15504,7 +15504,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/js-yaml"
         }
       ]
@@ -15530,7 +15530,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jsbn"
         }
       ]
@@ -15556,7 +15556,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-buffer"
         }
       ]
@@ -15582,7 +15582,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-parse-better-errors"
         }
       ]
@@ -15608,7 +15608,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-schema-traverse"
         }
       ]
@@ -15634,7 +15634,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-schema"
         }
       ]
@@ -15660,7 +15660,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-stringify-safe"
         }
       ]
@@ -15686,7 +15686,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json5"
         }
       ]
@@ -15712,7 +15712,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jsonfile"
         }
       ]
@@ -15738,7 +15738,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jsonwebtoken"
         }
       ]
@@ -15764,7 +15764,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jsprim"
         }
       ]
@@ -15790,7 +15790,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jssha"
         }
       ]
@@ -15816,7 +15816,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jstransformer"
         }
       ]
@@ -15842,7 +15842,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/juicy-chat-bot"
         }
       ]
@@ -15868,7 +15868,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jwa"
         }
       ]
@@ -15894,7 +15894,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jws"
         }
       ]
@@ -15920,7 +15920,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/keyv"
         }
       ]
@@ -15946,7 +15946,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/kind-of"
         }
       ]
@@ -15972,7 +15972,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/kuler"
         }
       ]
@@ -15998,7 +15998,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/kuromoji"
         }
       ]
@@ -16024,7 +16024,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lazystream"
         }
       ]
@@ -16050,7 +16050,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/levn"
         }
       ]
@@ -16076,7 +16076,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/libxmljs2"
         }
       ],
@@ -16102,7 +16102,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/libxmljs2/node_modules/nan"
             }
           ]
@@ -16130,7 +16130,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/liftup"
         }
       ],
@@ -16156,7 +16156,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/braces"
             }
           ]
@@ -16182,7 +16182,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/fill-range"
             }
           ]
@@ -16208,7 +16208,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/findup-sync"
             }
           ]
@@ -16234,7 +16234,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/is-glob"
             }
           ]
@@ -16260,7 +16260,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/is-number"
             }
           ]
@@ -16286,7 +16286,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/micromatch"
             }
           ]
@@ -16312,7 +16312,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/to-regex-range"
             }
           ]
@@ -16340,7 +16340,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/linebreak"
         }
       ],
@@ -16366,7 +16366,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/linebreak/node_modules/base64-js"
             }
           ]
@@ -16394,7 +16394,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/listenercount"
         }
       ]
@@ -16420,7 +16420,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/locate-path"
         }
       ]
@@ -16446,7 +16446,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lodash.camelcase"
         }
       ]
@@ -16472,7 +16472,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lodash.isfinite"
         }
       ]
@@ -16498,7 +16498,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lodash.set"
         }
       ]
@@ -16524,7 +16524,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lodash"
         }
       ]
@@ -16550,7 +16550,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/logform"
         }
       ],
@@ -16576,7 +16576,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/logform/node_modules/ms"
             }
           ]
@@ -16604,7 +16604,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lolex"
         }
       ]
@@ -16630,7 +16630,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/loose-envify"
         }
       ]
@@ -16656,7 +16656,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lowercase-keys"
         }
       ]
@@ -16682,7 +16682,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lru-cache"
         }
       ]
@@ -16708,7 +16708,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-dir"
         }
       ],
@@ -16734,7 +16734,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-dir/node_modules/semver"
             }
           ]
@@ -16762,7 +16762,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-error"
         }
       ]
@@ -16788,7 +16788,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-fetch-happen"
         }
       ],
@@ -16815,7 +16815,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen/node_modules/@tootallnate/once"
             }
           ]
@@ -16841,7 +16841,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen/node_modules/debug"
             }
           ]
@@ -16867,7 +16867,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen/node_modules/http-cache-semantics"
             }
           ]
@@ -16893,7 +16893,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen/node_modules/http-proxy-agent"
             }
           ]
@@ -16919,7 +16919,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen/node_modules/ms"
             }
           ]
@@ -16947,7 +16947,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-iterator"
         }
       ]
@@ -16973,7 +16973,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-plural"
         }
       ]
@@ -16999,7 +16999,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/map-cache"
         }
       ]
@@ -17025,7 +17025,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/map-visit"
         }
       ]
@@ -17051,7 +17051,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/marsdb"
         }
       ]
@@ -17077,7 +17077,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/math-interval-parser"
         }
       ]
@@ -17103,7 +17103,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/media-typer"
         }
       ]
@@ -17129,7 +17129,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/merge-descriptors"
         }
       ]
@@ -17155,7 +17155,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/messageformat-formatters"
         }
       ]
@@ -17181,7 +17181,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/messageformat-parser"
         }
       ]
@@ -17207,7 +17207,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/messageformat"
         }
       ],
@@ -17233,7 +17233,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/messageformat/node_modules/make-plural"
             }
           ]
@@ -17261,7 +17261,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/methods"
         }
       ]
@@ -17287,7 +17287,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/micromatch"
         }
       ]
@@ -17313,7 +17313,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mime-db"
         }
       ]
@@ -17339,7 +17339,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mime-types"
         }
       ]
@@ -17365,7 +17365,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mime"
         }
       ]
@@ -17391,7 +17391,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mimic-response"
         }
       ]
@@ -17417,7 +17417,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minimatch"
         }
       ]
@@ -17443,7 +17443,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minimist"
         }
       ]
@@ -17469,7 +17469,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-collect"
         }
       ]
@@ -17495,7 +17495,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-fetch"
         }
       ]
@@ -17521,7 +17521,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-flush"
         }
       ]
@@ -17547,7 +17547,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-pipeline"
         }
       ]
@@ -17573,7 +17573,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-sized"
         }
       ]
@@ -17599,7 +17599,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass"
         }
       ]
@@ -17625,7 +17625,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minizlib"
         }
       ]
@@ -17651,7 +17651,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mixin-deep"
         }
       ]
@@ -17677,7 +17677,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mkdirp-classic"
         }
       ]
@@ -17703,7 +17703,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mkdirp"
         }
       ]
@@ -17729,7 +17729,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/moment-timezone"
         }
       ]
@@ -17755,7 +17755,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/moment"
         }
       ]
@@ -17781,7 +17781,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/morgan"
         }
       ],
@@ -17807,7 +17807,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/morgan/node_modules/on-finished"
             }
           ]
@@ -17835,7 +17835,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mout"
         }
       ]
@@ -17861,7 +17861,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ms"
         }
       ]
@@ -17887,7 +17887,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/multer"
         }
       ],
@@ -17913,7 +17913,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/multer/node_modules/mkdirp"
             }
           ]
@@ -17941,7 +17941,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mustache"
         }
       ]
@@ -17967,7 +17967,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/nan"
         }
       ]
@@ -17993,7 +17993,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/nanomatch"
         }
       ]
@@ -18019,7 +18019,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/napi-build-utils"
         }
       ]
@@ -18045,7 +18045,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/needle"
         }
       ],
@@ -18071,7 +18071,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/needle/node_modules/debug"
             }
           ]
@@ -18097,7 +18097,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/needle/node_modules/ms"
             }
           ]
@@ -18125,7 +18125,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/negotiator"
         }
       ]
@@ -18151,7 +18151,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/neo-async"
         }
       ]
@@ -18177,7 +18177,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-abi"
         }
       ],
@@ -18203,7 +18203,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-abi/node_modules/semver"
             }
           ]
@@ -18231,7 +18231,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-addon-api"
         }
       ]
@@ -18257,7 +18257,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-fetch"
         }
       ]
@@ -18283,7 +18283,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-gyp"
         }
       ],
@@ -18309,7 +18309,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/ansi-regex"
             }
           ]
@@ -18335,7 +18335,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/are-we-there-yet"
             }
           ]
@@ -18361,7 +18361,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/gauge"
             }
           ]
@@ -18387,7 +18387,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -18413,7 +18413,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/nopt"
             }
           ]
@@ -18439,7 +18439,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/npmlog"
             }
           ]
@@ -18465,7 +18465,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/readable-stream"
             }
           ]
@@ -18491,7 +18491,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/string-width"
             }
           ]
@@ -18517,7 +18517,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/strip-ansi"
             }
           ]
@@ -18545,7 +18545,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-pre-gyp"
         }
       ],
@@ -18571,7 +18571,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/chownr"
             }
           ]
@@ -18597,7 +18597,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/fs-minipass"
             }
           ]
@@ -18623,7 +18623,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/minipass"
             }
           ]
@@ -18649,7 +18649,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/minizlib"
             }
           ]
@@ -18675,7 +18675,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/mkdirp"
             }
           ]
@@ -18701,7 +18701,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/nopt"
             }
           ]
@@ -18727,7 +18727,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/rimraf"
             }
           ]
@@ -18753,7 +18753,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/safe-buffer"
             }
           ]
@@ -18779,7 +18779,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/semver"
             }
           ]
@@ -18805,7 +18805,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/tar"
             }
           ]
@@ -18831,7 +18831,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/yallist"
             }
           ]
@@ -18859,7 +18859,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/noop-logger"
         }
       ]
@@ -18885,7 +18885,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/nopt"
         }
       ]
@@ -18911,7 +18911,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/normalize-package-data"
         }
       ],
@@ -18937,7 +18937,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/normalize-package-data/node_modules/semver"
             }
           ]
@@ -18965,7 +18965,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/normalize-path"
         }
       ]
@@ -18991,7 +18991,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/normalize-url"
         }
       ]
@@ -19017,7 +19017,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/notevil"
         }
       ],
@@ -19043,7 +19043,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/notevil/node_modules/esprima"
             }
           ]
@@ -19071,7 +19071,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/npm-bundled"
         }
       ]
@@ -19097,7 +19097,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/npm-normalize-package-bin"
         }
       ]
@@ -19123,7 +19123,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/npm-packlist"
         }
       ]
@@ -19149,7 +19149,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/npmlog"
         }
       ]
@@ -19175,7 +19175,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/number-is-nan"
         }
       ]
@@ -19201,7 +19201,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/oauth-sign"
         }
       ]
@@ -19227,7 +19227,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-assign"
         }
       ]
@@ -19253,7 +19253,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-copy"
         }
       ],
@@ -19279,7 +19279,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy/node_modules/define-property"
             }
           ]
@@ -19305,7 +19305,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy/node_modules/is-accessor-descriptor"
             }
           ]
@@ -19331,7 +19331,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy/node_modules/is-data-descriptor"
             }
           ]
@@ -19357,7 +19357,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy/node_modules/is-descriptor"
             }
           ],
@@ -19383,7 +19383,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/object-copy/node_modules/is-descriptor/node_modules/kind-of"
                 }
               ]
@@ -19411,7 +19411,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy/node_modules/kind-of"
             }
           ]
@@ -19439,7 +19439,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-inspect"
         }
       ]
@@ -19465,7 +19465,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-is"
         }
       ]
@@ -19491,7 +19491,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-keys"
         }
       ]
@@ -19517,7 +19517,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-visit"
         }
       ]
@@ -19543,7 +19543,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object.assign"
         }
       ]
@@ -19569,7 +19569,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object.defaults"
         }
       ]
@@ -19595,7 +19595,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object.map"
         }
       ]
@@ -19621,7 +19621,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object.pick"
         }
       ]
@@ -19647,7 +19647,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/on-finished"
         }
       ]
@@ -19673,7 +19673,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/on-headers"
         }
       ]
@@ -19699,7 +19699,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/once"
         }
       ]
@@ -19725,7 +19725,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/one-time"
         }
       ]
@@ -19751,7 +19751,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/opentype.js"
         }
       ]
@@ -19777,7 +19777,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/optionator"
         }
       ]
@@ -19803,7 +19803,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/os-homedir"
         }
       ]
@@ -19829,7 +19829,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/os-tmpdir"
         }
       ]
@@ -19855,7 +19855,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/osenv"
         }
       ]
@@ -19881,7 +19881,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/otplib"
         }
       ]
@@ -19907,7 +19907,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-cancelable"
         }
       ]
@@ -19933,7 +19933,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-event"
         }
       ]
@@ -19959,7 +19959,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-finally"
         }
       ]
@@ -19985,7 +19985,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-is-promise"
         }
       ]
@@ -20011,7 +20011,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-limit"
         }
       ]
@@ -20037,7 +20037,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-locate"
         }
       ]
@@ -20063,7 +20063,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-map"
         }
       ]
@@ -20089,7 +20089,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-timeout"
         }
       ]
@@ -20115,7 +20115,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-try"
         }
       ]
@@ -20141,7 +20141,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pako"
         }
       ]
@@ -20167,7 +20167,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/parse-filepath"
         }
       ]
@@ -20193,7 +20193,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/parse-json"
         }
       ]
@@ -20219,7 +20219,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/parse-passwd"
         }
       ]
@@ -20245,7 +20245,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/parseurl"
         }
       ]
@@ -20271,7 +20271,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pascalcase"
         }
       ]
@@ -20297,7 +20297,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-exists"
         }
       ]
@@ -20323,7 +20323,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-is-absolute"
         }
       ]
@@ -20349,7 +20349,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-parse"
         }
       ]
@@ -20375,7 +20375,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-root-regex"
         }
       ]
@@ -20401,7 +20401,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-root"
         }
       ]
@@ -20427,7 +20427,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-to-regexp"
         }
       ]
@@ -20453,7 +20453,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pdfkit"
         }
       ]
@@ -20479,7 +20479,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/peek-readable"
         }
       ]
@@ -20505,7 +20505,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pend"
         }
       ]
@@ -20531,7 +20531,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/performance-now"
         }
       ]
@@ -20557,7 +20557,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pg-connection-string"
         }
       ]
@@ -20583,7 +20583,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/picomatch"
         }
       ]
@@ -20609,7 +20609,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pify"
         }
       ]
@@ -20635,7 +20635,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pinkie-promise"
         }
       ]
@@ -20661,7 +20661,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pinkie"
         }
       ]
@@ -20687,7 +20687,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/png-js"
         }
       ]
@@ -20713,7 +20713,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/portscanner"
         }
       ]
@@ -20739,7 +20739,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/posix-character-classes"
         }
       ]
@@ -20765,7 +20765,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/prebuild-install"
         }
       ]
@@ -20791,7 +20791,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/prelude-ls"
         }
       ]
@@ -20817,7 +20817,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/prepend-http"
         }
       ]
@@ -20843,7 +20843,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pretty-bytes"
         }
       ]
@@ -20869,7 +20869,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/process-nextick-args"
         }
       ]
@@ -20895,7 +20895,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/prom-client"
         }
       ]
@@ -20921,7 +20921,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/promise-inflight"
         }
       ]
@@ -20947,7 +20947,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/promise-retry"
         }
       ],
@@ -20973,7 +20973,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/promise-retry/node_modules/err-code"
             }
           ]
@@ -20999,7 +20999,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/promise-retry/node_modules/retry"
             }
           ]
@@ -21027,7 +21027,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/promise"
         }
       ]
@@ -21053,7 +21053,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/proper-lockfile"
         }
       ]
@@ -21079,7 +21079,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/proxy-addr"
         }
       ]
@@ -21105,7 +21105,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/psl"
         }
       ]
@@ -21131,7 +21131,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-attrs"
         }
       ]
@@ -21157,7 +21157,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-code-gen"
         }
       ]
@@ -21183,7 +21183,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-error"
         }
       ]
@@ -21209,7 +21209,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-filters"
         }
       ]
@@ -21235,7 +21235,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-lexer"
         }
       ]
@@ -21261,7 +21261,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-linker"
         }
       ]
@@ -21287,7 +21287,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-load"
         }
       ]
@@ -21313,7 +21313,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-parser"
         }
       ]
@@ -21339,7 +21339,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-runtime"
         }
       ]
@@ -21365,7 +21365,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-strip-comments"
         }
       ]
@@ -21391,7 +21391,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-walk"
         }
       ]
@@ -21417,7 +21417,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug"
         }
       ]
@@ -21443,7 +21443,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pump"
         }
       ]
@@ -21469,7 +21469,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/punycode"
         }
       ]
@@ -21495,7 +21495,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/qs"
         }
       ]
@@ -21521,7 +21521,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/query-string"
         }
       ]
@@ -21547,7 +21547,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/range_check"
         }
       ]
@@ -21573,7 +21573,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/range-parser"
         }
       ]
@@ -21599,7 +21599,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/raw-body"
         }
       ]
@@ -21625,7 +21625,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/rc"
         }
       ]
@@ -21651,7 +21651,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/read-pkg"
         }
       ],
@@ -21677,7 +21677,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/read-pkg/node_modules/pify"
             }
           ]
@@ -21705,7 +21705,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/readable-stream"
         }
       ],
@@ -21731,7 +21731,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/readable-stream/node_modules/isarray"
             }
           ]
@@ -21759,7 +21759,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/readable-web-to-node-stream"
         }
       ],
@@ -21785,7 +21785,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/readable-web-to-node-stream/node_modules/readable-stream"
             }
           ]
@@ -21813,7 +21813,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/readdirp"
         }
       ]
@@ -21839,7 +21839,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/rechoir"
         }
       ]
@@ -21865,7 +21865,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/regex-not"
         }
       ]
@@ -21891,7 +21891,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/regexp.prototype.flags"
         }
       ]
@@ -21917,7 +21917,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/remove-trailing-separator"
         }
       ]
@@ -21943,7 +21943,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/repeat-element"
         }
       ]
@@ -21969,7 +21969,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/repeat-string"
         }
       ]
@@ -21995,7 +21995,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/replace"
         }
       ],
@@ -22021,7 +22021,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/ansi-regex"
             }
           ]
@@ -22047,7 +22047,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/ansi-styles"
             }
           ]
@@ -22073,7 +22073,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/brace-expansion"
             }
           ]
@@ -22099,7 +22099,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/cliui"
             }
           ]
@@ -22125,7 +22125,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/color-convert"
             }
           ]
@@ -22151,7 +22151,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/color-name"
             }
           ]
@@ -22177,7 +22177,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/find-up"
             }
           ]
@@ -22203,7 +22203,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -22229,7 +22229,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/locate-path"
             }
           ]
@@ -22255,7 +22255,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/minimatch"
             }
           ]
@@ -22281,7 +22281,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/p-locate"
             }
           ]
@@ -22307,7 +22307,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/path-exists"
             }
           ]
@@ -22333,7 +22333,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/string-width"
             }
           ]
@@ -22359,7 +22359,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/strip-ansi"
             }
           ]
@@ -22385,7 +22385,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/wrap-ansi"
             }
           ]
@@ -22411,7 +22411,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/yargs-parser"
             }
           ]
@@ -22437,7 +22437,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/yargs"
             }
           ]
@@ -22465,7 +22465,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/request"
         }
       ],
@@ -22491,7 +22491,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/request/node_modules/qs"
             }
           ]
@@ -22519,7 +22519,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/require-directory"
         }
       ]
@@ -22545,7 +22545,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/require-main-filename"
         }
       ]
@@ -22571,7 +22571,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/resolve-dir"
         }
       ]
@@ -22597,7 +22597,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/resolve-url"
         }
       ]
@@ -22623,7 +22623,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/resolve"
         }
       ]
@@ -22649,7 +22649,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/responselike"
         }
       ]
@@ -22675,7 +22675,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/restructure"
         }
       ]
@@ -22701,7 +22701,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ret"
         }
       ]
@@ -22727,7 +22727,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/retry-as-promised"
         }
       ]
@@ -22753,7 +22753,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/retry"
         }
       ]
@@ -22779,7 +22779,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/rimraf"
         }
       ]
@@ -22805,7 +22805,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/rxjs"
         }
       ],
@@ -22831,7 +22831,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/rxjs/node_modules/tslib"
             }
           ]
@@ -22859,7 +22859,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safe-buffer"
         }
       ]
@@ -22885,7 +22885,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safe-regex-test"
         }
       ]
@@ -22911,7 +22911,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safe-regex"
         }
       ]
@@ -22937,7 +22937,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safe-stable-stringify"
         }
       ]
@@ -22963,7 +22963,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safer-buffer"
         }
       ]
@@ -22989,7 +22989,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/samsam"
         }
       ]
@@ -23015,7 +23015,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sanitize-filename"
         }
       ]
@@ -23041,7 +23041,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sanitize-html"
         }
       ],
@@ -23067,7 +23067,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sanitize-html/node_modules/lodash"
             }
           ]
@@ -23095,7 +23095,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sax"
         }
       ]
@@ -23121,7 +23121,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/seek-bzip"
         }
       ]
@@ -23147,7 +23147,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/semver"
         }
       ]
@@ -23173,7 +23173,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/send"
         }
       ],
@@ -23199,7 +23199,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/send/node_modules/ms"
             }
           ]
@@ -23227,7 +23227,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sequelize-pool"
         }
       ]
@@ -23253,7 +23253,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sequelize"
         }
       ],
@@ -23279,7 +23279,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sequelize/node_modules/debug"
             }
           ]
@@ -23305,7 +23305,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sequelize/node_modules/ms"
             }
           ]
@@ -23331,7 +23331,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sequelize/node_modules/uuid"
             }
           ]
@@ -23359,7 +23359,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/serve-index"
         }
       ],
@@ -23385,7 +23385,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index/node_modules/depd"
             }
           ]
@@ -23411,7 +23411,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index/node_modules/http-errors"
             }
           ]
@@ -23437,7 +23437,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index/node_modules/inherits"
             }
           ]
@@ -23463,7 +23463,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index/node_modules/setprototypeof"
             }
           ]
@@ -23489,7 +23489,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index/node_modules/statuses"
             }
           ]
@@ -23517,7 +23517,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/serve-static"
         }
       ]
@@ -23543,7 +23543,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/set-blocking"
         }
       ]
@@ -23569,7 +23569,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/set-value"
         }
       ],
@@ -23595,7 +23595,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/set-value/node_modules/extend-shallow"
             }
           ]
@@ -23621,7 +23621,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/set-value/node_modules/is-extendable"
             }
           ]
@@ -23649,7 +23649,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/setimmediate"
         }
       ]
@@ -23675,7 +23675,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/setprototypeof"
         }
       ]
@@ -23701,7 +23701,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/side-channel"
         }
       ]
@@ -23727,7 +23727,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/signal-exit"
         }
       ]
@@ -23753,7 +23753,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/simple-concat"
         }
       ]
@@ -23779,7 +23779,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/simple-get"
         }
       ],
@@ -23805,7 +23805,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/simple-get/node_modules/decompress-response"
             }
           ]
@@ -23831,7 +23831,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/simple-get/node_modules/mimic-response"
             }
           ]
@@ -23859,7 +23859,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/simple-swizzle"
         }
       ],
@@ -23885,7 +23885,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/simple-swizzle/node_modules/is-arrayish"
             }
           ]
@@ -23913,7 +23913,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sinon"
         }
       ]
@@ -23939,7 +23939,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/smart-buffer"
         }
       ]
@@ -23965,7 +23965,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/snapdragon-node"
         }
       ],
@@ -23991,7 +23991,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon-node/node_modules/define-property"
             }
           ]
@@ -24019,7 +24019,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/snapdragon-util"
         }
       ],
@@ -24045,7 +24045,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon-util/node_modules/kind-of"
             }
           ]
@@ -24073,7 +24073,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/snapdragon"
         }
       ],
@@ -24099,7 +24099,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/define-property"
             }
           ]
@@ -24125,7 +24125,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/extend-shallow"
             }
           ]
@@ -24151,7 +24151,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/is-accessor-descriptor"
             }
           ],
@@ -24177,7 +24177,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/snapdragon/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
@@ -24205,7 +24205,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/is-data-descriptor"
             }
           ],
@@ -24231,7 +24231,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/snapdragon/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
@@ -24259,7 +24259,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/is-descriptor"
             }
           ]
@@ -24285,7 +24285,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/is-extendable"
             }
           ]
@@ -24311,7 +24311,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/kind-of"
             }
           ]
@@ -24337,7 +24337,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/source-map"
             }
           ]
@@ -24365,7 +24365,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socket.io-adapter"
         }
       ]
@@ -24391,7 +24391,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socket.io-parser"
         }
       ],
@@ -24417,7 +24417,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socket.io-parser/node_modules/debug"
             }
           ]
@@ -24443,7 +24443,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socket.io-parser/node_modules/ms"
             }
           ]
@@ -24471,7 +24471,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socket.io"
         }
       ],
@@ -24497,7 +24497,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socket.io/node_modules/debug"
             }
           ]
@@ -24523,7 +24523,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socket.io/node_modules/ms"
             }
           ]
@@ -24551,7 +24551,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socks-proxy-agent"
         }
       ],
@@ -24577,7 +24577,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socks-proxy-agent/node_modules/debug"
             }
           ]
@@ -24603,7 +24603,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socks-proxy-agent/node_modules/ms"
             }
           ]
@@ -24631,7 +24631,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socks"
         }
       ],
@@ -24657,7 +24657,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socks/node_modules/ip"
             }
           ]
@@ -24685,7 +24685,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sort-keys-length"
         }
       ],
@@ -24711,7 +24711,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sort-keys-length/node_modules/sort-keys"
             }
           ]
@@ -24739,7 +24739,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sort-keys"
         }
       ]
@@ -24765,7 +24765,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/source-map-resolve"
         }
       ]
@@ -24791,7 +24791,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/source-map-support"
         }
       ]
@@ -24817,7 +24817,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/source-map-url"
         }
       ]
@@ -24843,7 +24843,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/source-map"
         }
       ]
@@ -24869,7 +24869,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spawn-command"
         }
       ]
@@ -24895,7 +24895,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spdx-correct"
         }
       ]
@@ -24921,7 +24921,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spdx-exceptions"
         }
       ]
@@ -24947,7 +24947,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spdx-expression-parse"
         }
       ]
@@ -24973,7 +24973,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spdx-license-ids"
         }
       ]
@@ -24999,7 +24999,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/split-string"
         }
       ]
@@ -25025,7 +25025,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sprintf-js"
         }
       ]
@@ -25051,7 +25051,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sqlite3"
         }
       ]
@@ -25077,7 +25077,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sshpk"
         }
       ]
@@ -25103,7 +25103,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ssri"
         }
       ]
@@ -25129,7 +25129,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/stack-trace"
         }
       ]
@@ -25155,7 +25155,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/static-extend"
         }
       ],
@@ -25181,7 +25181,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend/node_modules/define-property"
             }
           ]
@@ -25207,7 +25207,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend/node_modules/is-accessor-descriptor"
             }
           ],
@@ -25233,7 +25233,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/static-extend/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
@@ -25261,7 +25261,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend/node_modules/is-data-descriptor"
             }
           ],
@@ -25287,7 +25287,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/static-extend/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
@@ -25315,7 +25315,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend/node_modules/is-descriptor"
             }
           ]
@@ -25341,7 +25341,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend/node_modules/kind-of"
             }
           ]
@@ -25369,7 +25369,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/statuses"
         }
       ]
@@ -25395,7 +25395,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/stream-buffers"
         }
       ]
@@ -25421,7 +25421,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/streamsearch"
         }
       ]
@@ -25447,7 +25447,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strict-uri-encode"
         }
       ]
@@ -25473,7 +25473,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string_decoder"
         }
       ]
@@ -25499,7 +25499,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string-width"
         }
       ]
@@ -25525,7 +25525,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string.fromcodepoint"
         }
       ]
@@ -25551,7 +25551,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string.prototype.codepointat"
         }
       ]
@@ -25577,7 +25577,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string.prototype.trimend"
         }
       ]
@@ -25603,7 +25603,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string.prototype.trimstart"
         }
       ]
@@ -25629,7 +25629,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-ansi"
         }
       ]
@@ -25655,7 +25655,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-bom"
         }
       ]
@@ -25681,7 +25681,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-dirs"
         }
       ]
@@ -25707,7 +25707,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-json-comments"
         }
       ]
@@ -25733,7 +25733,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-outer"
         }
       ]
@@ -25759,7 +25759,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strtok3"
         }
       ]
@@ -25785,7 +25785,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/supports-color"
         }
       ]
@@ -25811,7 +25811,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/supports-preserve-symlinks-flag"
         }
       ]
@@ -25837,7 +25837,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/svg-captcha"
         }
       ]
@@ -25863,7 +25863,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/swagger-ui-dist"
         }
       ]
@@ -25889,7 +25889,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/swagger-ui-express"
         }
       ]
@@ -25915,7 +25915,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tar-fs"
         }
       ],
@@ -25941,7 +25941,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/tar-fs/node_modules/bl"
             }
           ]
@@ -25967,7 +25967,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/tar-fs/node_modules/chownr"
             }
           ]
@@ -25993,7 +25993,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/tar-fs/node_modules/readable-stream"
             }
           ]
@@ -26019,7 +26019,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/tar-fs/node_modules/tar-stream"
             }
           ]
@@ -26047,7 +26047,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tar-stream"
         }
       ]
@@ -26073,7 +26073,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tar"
         }
       ]
@@ -26099,7 +26099,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tdigest"
         }
       ]
@@ -26125,7 +26125,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/text-hex"
         }
       ]
@@ -26151,7 +26151,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/thirty-two"
         }
       ]
@@ -26177,7 +26177,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/through"
         }
       ]
@@ -26203,7 +26203,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/timed-out"
         }
       ]
@@ -26229,7 +26229,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tiny-inflate"
         }
       ]
@@ -26255,7 +26255,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-buffer"
         }
       ]
@@ -26281,7 +26281,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-fast-properties"
         }
       ]
@@ -26307,7 +26307,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-object-path"
         }
       ],
@@ -26333,7 +26333,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/to-object-path/node_modules/kind-of"
             }
           ]
@@ -26361,7 +26361,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-regex-range"
         }
       ]
@@ -26387,7 +26387,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-regex"
         }
       ]
@@ -26413,7 +26413,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/toidentifier"
         }
       ]
@@ -26439,7 +26439,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/token-stream"
         }
       ]
@@ -26465,7 +26465,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/token-types"
         }
       ]
@@ -26491,7 +26491,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/toposort-class"
         }
       ]
@@ -26517,7 +26517,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tough-cookie"
         }
       ]
@@ -26543,7 +26543,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tr46"
         }
       ]
@@ -26569,7 +26569,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/traverse"
         }
       ]
@@ -26595,7 +26595,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tree-kill"
         }
       ]
@@ -26621,7 +26621,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/trim-repeated"
         }
       ]
@@ -26647,7 +26647,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/triple-beam"
         }
       ]
@@ -26673,7 +26673,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/truncate-utf8-bytes"
         }
       ]
@@ -26699,7 +26699,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ts-node-dev"
         }
       ],
@@ -26725,7 +26725,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/ts-node-dev/node_modules/rimraf"
             }
           ]
@@ -26753,7 +26753,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ts-node"
         }
       ]
@@ -26779,7 +26779,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tsconfig"
         }
       ]
@@ -26805,7 +26805,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tslib"
         }
       ]
@@ -26831,7 +26831,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tunnel-agent"
         }
       ]
@@ -26857,7 +26857,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tweetnacl"
         }
       ]
@@ -26883,7 +26883,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/type-check"
         }
       ]
@@ -26909,7 +26909,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/type-is"
         }
       ]
@@ -26935,7 +26935,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/typecast"
         }
       ]
@@ -26961,7 +26961,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/typedarray"
         }
       ]
@@ -26987,7 +26987,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/typescript"
         }
       ]
@@ -27013,7 +27013,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/uglify-js"
         }
       ]
@@ -27039,7 +27039,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unbox-primitive"
         }
       ]
@@ -27065,7 +27065,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unbzip2-stream"
         }
       ]
@@ -27091,7 +27091,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unc-path-regex"
         }
       ]
@@ -27117,7 +27117,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/underscore.string"
         }
       ]
@@ -27143,7 +27143,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unicode-properties"
         }
       ]
@@ -27169,7 +27169,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unicode-trie"
         }
       ]
@@ -27195,7 +27195,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/union-value"
         }
       ],
@@ -27221,7 +27221,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/union-value/node_modules/is-extendable"
             }
           ]
@@ -27249,7 +27249,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unique-filename"
         }
       ]
@@ -27275,7 +27275,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unique-slug"
         }
       ]
@@ -27301,7 +27301,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unit-compare"
         }
       ]
@@ -27327,7 +27327,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/universalify"
         }
       ]
@@ -27353,7 +27353,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unpipe"
         }
       ]
@@ -27379,7 +27379,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unset-value"
         }
       ],
@@ -27405,7 +27405,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/unset-value/node_modules/has-value"
             }
           ],
@@ -27431,7 +27431,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/unset-value/node_modules/has-value/node_modules/isobject"
                 }
               ]
@@ -27459,7 +27459,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/unset-value/node_modules/has-values"
             }
           ]
@@ -27485,7 +27485,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/unset-value/node_modules/isarray"
             }
           ]
@@ -27513,7 +27513,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/untildify"
         }
       ]
@@ -27539,7 +27539,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unzipper"
         }
       ],
@@ -27565,7 +27565,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/unzipper/node_modules/bluebird"
             }
           ]
@@ -27593,7 +27593,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/uri-js"
         }
       ]
@@ -27619,7 +27619,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/urix"
         }
       ]
@@ -27645,7 +27645,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/url-parse-lax"
         }
       ]
@@ -27671,7 +27671,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/url-to-options"
         }
       ]
@@ -27697,7 +27697,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/use"
         }
       ]
@@ -27723,7 +27723,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/utf8-byte-length"
         }
       ]
@@ -27749,7 +27749,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/util-deprecate"
         }
       ]
@@ -27775,7 +27775,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/util"
         }
       ]
@@ -27801,7 +27801,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/utils-merge"
         }
       ]
@@ -27827,7 +27827,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/uuid"
         }
       ]
@@ -27853,7 +27853,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/v8flags"
         }
       ]
@@ -27879,7 +27879,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/validate-npm-package-license"
         }
       ]
@@ -27905,7 +27905,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/validate"
         }
       ]
@@ -27931,7 +27931,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/validator"
         }
       ]
@@ -27957,7 +27957,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/vary"
         }
       ]
@@ -27983,7 +27983,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/verror"
         }
       ],
@@ -28009,7 +28009,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/verror/node_modules/core-util-is"
             }
           ]
@@ -28037,7 +28037,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/vm2"
         }
       ],
@@ -28063,7 +28063,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/vm2/node_modules/acorn"
             }
           ]
@@ -28091,7 +28091,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/void-elements"
         }
       ]
@@ -28117,7 +28117,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/walk"
         }
       ]
@@ -28143,7 +28143,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/walkdir"
         }
       ]
@@ -28169,7 +28169,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/webidl-conversions"
         }
       ]
@@ -28195,7 +28195,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/whatwg-url"
         }
       ]
@@ -28221,7 +28221,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-boxed-primitive"
         }
       ]
@@ -28247,7 +28247,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-collection"
         }
       ]
@@ -28273,7 +28273,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-module"
         }
       ]
@@ -28299,7 +28299,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-pm-runs"
         }
       ]
@@ -28325,7 +28325,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-typed-array"
         }
       ]
@@ -28351,7 +28351,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which"
         }
       ]
@@ -28377,7 +28377,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wide-align"
         }
       ]
@@ -28403,7 +28403,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/winston-transport"
         }
       ],
@@ -28429,7 +28429,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/winston-transport/node_modules/readable-stream"
             }
           ]
@@ -28457,7 +28457,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/winston"
         }
       ],
@@ -28483,7 +28483,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/winston/node_modules/async"
             }
           ]
@@ -28509,7 +28509,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/winston/node_modules/is-stream"
             }
           ]
@@ -28535,7 +28535,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/winston/node_modules/readable-stream"
             }
           ]
@@ -28563,7 +28563,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/with"
         }
       ]
@@ -28589,7 +28589,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wkx"
         }
       ]
@@ -28615,7 +28615,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/word-wrap"
         }
       ]
@@ -28641,7 +28641,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wordwrap"
         }
       ]
@@ -28667,7 +28667,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wrap-ansi"
         }
       ],
@@ -28693,7 +28693,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi/node_modules/ansi-regex"
             }
           ]
@@ -28719,7 +28719,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi/node_modules/emoji-regex"
             }
           ]
@@ -28745,7 +28745,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -28771,7 +28771,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi/node_modules/string-width"
             }
           ]
@@ -28797,7 +28797,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi/node_modules/strip-ansi"
             }
           ]
@@ -28825,7 +28825,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wrappy"
         }
       ]
@@ -28851,7 +28851,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ws"
         }
       ]
@@ -28877,7 +28877,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/xtend"
         }
       ]
@@ -28903,7 +28903,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/y18n"
         }
       ]
@@ -28929,7 +28929,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yallist"
         }
       ]
@@ -28955,7 +28955,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yaml-schema-validator"
         }
       ]
@@ -28981,7 +28981,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yargs-parser"
         }
       ]
@@ -29007,7 +29007,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yargs"
         }
       ],
@@ -29033,7 +29033,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs/node_modules/ansi-regex"
             }
           ]
@@ -29059,7 +29059,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs/node_modules/emoji-regex"
             }
           ]
@@ -29085,7 +29085,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -29111,7 +29111,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs/node_modules/string-width"
             }
           ]
@@ -29137,7 +29137,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs/node_modules/strip-ansi"
             }
           ]
@@ -29165,7 +29165,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yauzl"
         }
       ]
@@ -29191,7 +29191,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yn"
         }
       ]
@@ -29217,7 +29217,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/z85"
         }
       ]
@@ -29243,7 +29243,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/zip-stream"
         }
       ]
@@ -29269,7 +29269,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/zlibjs"
         }
       ]

--- a/tests/_data/sbom_demo-results/juice-shop_npm9_node16_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/juice-shop_npm9_node16_windows-latest.snap.json
@@ -62,6 +62,10 @@
       ],
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -88,6 +92,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@babel\\helper-string-parser"
+        }
       ]
     },
     {
@@ -108,6 +118,12 @@
           "url": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@babel\\helper-validator-identifier"
         }
       ]
     },
@@ -130,6 +146,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@babel\\parser"
+        }
       ]
     },
     {
@@ -150,6 +172,12 @@
           "url": "https://registry.npmjs.org/@babel/types/-/types-7.20.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@babel\\types"
         }
       ]
     },
@@ -172,6 +200,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@colors\\colors"
+        }
       ]
     },
     {
@@ -193,6 +227,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@dabh\\diagnostics"
+        }
       ]
     },
     {
@@ -213,6 +253,12 @@
           "url": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@gar\\promisify"
         }
       ]
     },
@@ -236,6 +282,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@mapbox\\node-pre-gyp"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -254,6 +306,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\ansi-regex"
             }
           ]
         },
@@ -275,6 +333,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\are-we-there-yet"
+            }
           ]
         },
         {
@@ -294,6 +358,12 @@
               "url": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\detect-libc"
             }
           ]
         },
@@ -315,6 +385,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\gauge"
+            }
           ]
         },
         {
@@ -334,6 +410,12 @@
               "url": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\is-fullwidth-code-point"
             }
           ]
         },
@@ -356,6 +438,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\make-dir"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -374,6 +462,12 @@
                   "url": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\make-dir\\node_modules\\semver"
                 }
               ]
             }
@@ -397,6 +491,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\nopt"
+            }
           ]
         },
         {
@@ -416,6 +516,12 @@
               "url": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\npmlog"
             }
           ]
         },
@@ -437,6 +543,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\readable-stream"
+            }
           ]
         },
         {
@@ -457,6 +569,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\string-width"
+            }
           ]
         },
         {
@@ -476,6 +594,12 @@
               "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\strip-ansi"
             }
           ]
         }
@@ -500,6 +624,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\core-loader"
+        }
       ]
     },
     {
@@ -520,6 +650,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/core/-/core-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\core"
         }
       ]
     },
@@ -542,6 +678,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\evaluator"
+        }
       ]
     },
     {
@@ -562,6 +704,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-all/-/lang-all-4.24.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-all"
         }
       ]
     },
@@ -584,6 +732,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-ar"
+        }
       ]
     },
     {
@@ -604,6 +758,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-bn/-/lang-bn-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-bn"
         }
       ]
     },
@@ -626,6 +786,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-ca"
+        }
       ]
     },
     {
@@ -646,6 +812,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-cs/-/lang-cs-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-cs"
         }
       ]
     },
@@ -668,6 +840,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-da"
+        }
       ]
     },
     {
@@ -688,6 +866,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-de/-/lang-de-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-de"
         }
       ]
     },
@@ -710,6 +894,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-el"
+        }
       ]
     },
     {
@@ -730,6 +920,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-en-min/-/lang-en-min-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-en-min"
         }
       ]
     },
@@ -752,6 +948,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-en"
+        }
       ]
     },
     {
@@ -772,6 +974,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-es/-/lang-es-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-es"
         }
       ]
     },
@@ -794,6 +1002,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-eu"
+        }
       ]
     },
     {
@@ -814,6 +1028,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-fa/-/lang-fa-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-fa"
         }
       ]
     },
@@ -836,6 +1056,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-fi"
+        }
       ]
     },
     {
@@ -856,6 +1082,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-fr/-/lang-fr-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-fr"
         }
       ]
     },
@@ -878,6 +1110,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-ga"
+        }
       ]
     },
     {
@@ -898,6 +1136,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-gl/-/lang-gl-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-gl"
         }
       ]
     },
@@ -920,6 +1164,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-hi"
+        }
       ]
     },
     {
@@ -940,6 +1190,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-hu/-/lang-hu-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-hu"
         }
       ]
     },
@@ -962,6 +1218,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-hy"
+        }
       ]
     },
     {
@@ -982,6 +1244,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-id/-/lang-id-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-id"
         }
       ]
     },
@@ -1004,6 +1272,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-it"
+        }
       ]
     },
     {
@@ -1024,6 +1298,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-ja/-/lang-ja-4.24.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-ja"
         }
       ]
     },
@@ -1046,6 +1326,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-ko"
+        }
       ]
     },
     {
@@ -1066,6 +1352,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-lt/-/lang-lt-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-lt"
         }
       ]
     },
@@ -1088,6 +1380,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-ms"
+        }
       ]
     },
     {
@@ -1108,6 +1406,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-ne/-/lang-ne-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-ne"
         }
       ]
     },
@@ -1130,6 +1434,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-nl"
+        }
       ]
     },
     {
@@ -1150,6 +1460,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-no/-/lang-no-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-no"
         }
       ]
     },
@@ -1172,6 +1488,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-pl"
+        }
       ]
     },
     {
@@ -1192,6 +1514,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-pt/-/lang-pt-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-pt"
         }
       ]
     },
@@ -1214,6 +1542,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-ro"
+        }
       ]
     },
     {
@@ -1234,6 +1568,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-ru/-/lang-ru-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-ru"
         }
       ]
     },
@@ -1256,6 +1596,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-sl"
+        }
       ]
     },
     {
@@ -1276,6 +1622,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-sr/-/lang-sr-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-sr"
         }
       ]
     },
@@ -1298,6 +1650,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-sv"
+        }
       ]
     },
     {
@@ -1318,6 +1676,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-ta/-/lang-ta-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-ta"
         }
       ]
     },
@@ -1340,6 +1704,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-th"
+        }
       ]
     },
     {
@@ -1360,6 +1730,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-tl/-/lang-tl-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-tl"
         }
       ]
     },
@@ -1382,6 +1758,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-tr"
+        }
       ]
     },
     {
@@ -1402,6 +1784,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-uk/-/lang-uk-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-uk"
         }
       ]
     },
@@ -1424,6 +1812,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-zh"
+        }
       ]
     },
     {
@@ -1444,6 +1838,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/language-min/-/language-min-4.22.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\language-min"
         }
       ]
     },
@@ -1466,6 +1866,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\language"
+        }
       ]
     },
     {
@@ -1486,6 +1892,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/ner/-/ner-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\ner"
         }
       ]
     },
@@ -1508,6 +1920,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\neural"
+        }
       ]
     },
     {
@@ -1528,6 +1946,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/nlg/-/nlg-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\nlg"
         }
       ]
     },
@@ -1550,6 +1974,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\nlp"
+        }
       ]
     },
     {
@@ -1570,6 +2000,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/nlu/-/nlu-4.23.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\nlu"
         }
       ]
     },
@@ -1592,6 +2028,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\request"
+        }
       ]
     },
     {
@@ -1612,6 +2054,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/sentiment/-/sentiment-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\sentiment"
         }
       ]
     },
@@ -1634,6 +2082,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\similarity"
+        }
       ]
     },
     {
@@ -1654,6 +2108,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/slot/-/slot-4.22.17.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\slot"
         }
       ]
     },
@@ -1676,6 +2136,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@npmcli\\fs"
+        }
       ]
     },
     {
@@ -1696,6 +2162,12 @@
           "url": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@npmcli\\move-file"
         }
       ]
     },
@@ -1718,6 +2190,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib\\core"
+        }
       ]
     },
     {
@@ -1738,6 +2216,12 @@
           "url": "https://registry.npmjs.org/@otplib/plugin-crypto/-/plugin-crypto-12.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib\\plugin-crypto"
         }
       ]
     },
@@ -1760,6 +2244,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib\\plugin-thirty-two"
+        }
       ]
     },
     {
@@ -1780,6 +2270,12 @@
           "url": "https://registry.npmjs.org/@otplib/preset-default/-/preset-default-12.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib\\preset-default"
         }
       ]
     },
@@ -1802,6 +2298,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib\\preset-v11"
+        }
       ]
     },
     {
@@ -1822,6 +2324,12 @@
           "url": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@sindresorhus\\is"
         }
       ]
     },
@@ -1844,6 +2352,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@swc\\helpers"
+        }
       ]
     },
     {
@@ -1864,6 +2378,12 @@
           "url": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@tokenizer\\token"
         }
       ]
     },
@@ -1886,6 +2406,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@tootallnate\\once"
+        }
       ]
     },
     {
@@ -1906,6 +2432,12 @@
           "url": "https://registry.npmjs.org/@types/component-emitter/-/component-emitter-1.2.11.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types\\component-emitter"
         }
       ]
     },
@@ -1928,6 +2460,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types\\cookie"
+        }
       ]
     },
     {
@@ -1948,6 +2486,12 @@
           "url": "https://registry.npmjs.org/@types/cors/-/cors-2.8.12.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types\\cors"
         }
       ]
     },
@@ -1970,6 +2514,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types\\debug"
+        }
       ]
     },
     {
@@ -1990,6 +2540,12 @@
           "url": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types\\ms"
         }
       ]
     },
@@ -2012,6 +2568,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types\\node"
+        }
       ]
     },
     {
@@ -2032,6 +2594,12 @@
           "url": "https://registry.npmjs.org/@types/strip-bom/-/strip-bom-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types\\strip-bom"
         }
       ]
     },
@@ -2054,6 +2622,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types\\strip-json-comments"
+        }
       ]
     },
     {
@@ -2075,6 +2649,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types\\validator"
+        }
       ]
     },
     {
@@ -2094,6 +2674,12 @@
           "url": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/abbrev"
         }
       ]
     },
@@ -2115,6 +2701,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/accepts"
+        }
       ]
     },
     {
@@ -2135,6 +2727,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/acorn-walk"
+        }
       ]
     },
     {
@@ -2154,6 +2752,12 @@
           "url": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/acorn"
         }
       ]
     },
@@ -2176,6 +2780,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/agent-base"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -2194,6 +2804,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agent-base\\node_modules\\debug"
             }
           ]
         },
@@ -2214,6 +2830,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agent-base\\node_modules\\ms"
             }
           ]
         }
@@ -2238,6 +2860,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/agentkeepalive"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -2256,6 +2884,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agentkeepalive\\node_modules\\debug"
             }
           ]
         },
@@ -2277,6 +2911,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agentkeepalive\\node_modules\\depd"
+            }
           ]
         },
         {
@@ -2296,6 +2936,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agentkeepalive\\node_modules\\ms"
             }
           ]
         }
@@ -2319,6 +2965,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/aggregate-error"
+        }
       ]
     },
     {
@@ -2338,6 +2990,12 @@
           "url": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ajv"
         }
       ]
     },
@@ -2359,6 +3017,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ansi-regex"
+        }
       ]
     },
     {
@@ -2378,6 +3042,12 @@
           "url": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ansi-styles"
         }
       ]
     },
@@ -2400,6 +3070,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/anymatch"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -2418,6 +3094,12 @@
               "url": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/anymatch\\node_modules\\normalize-path"
             }
           ]
         }
@@ -2441,6 +3123,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/append-field"
+        }
       ]
     },
     {
@@ -2460,6 +3148,12 @@
           "url": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/aproba"
         }
       ]
     },
@@ -2482,6 +3176,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/archive-type"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -2500,6 +3200,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-4.4.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/archive-type\\node_modules\\file-type"
             }
           ]
         }
@@ -2523,6 +3229,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/archiver-utils"
+        }
       ]
     },
     {
@@ -2542,6 +3254,12 @@
           "url": "https://registry.npmjs.org/archiver/-/archiver-1.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/archiver"
         }
       ]
     },
@@ -2563,6 +3281,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/are-we-there-yet"
+        }
       ]
     },
     {
@@ -2582,6 +3306,12 @@
           "url": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/arg"
         }
       ]
     },
@@ -2604,6 +3334,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/argparse"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -2622,6 +3358,12 @@
               "url": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/argparse\\node_modules\\sprintf-js"
             }
           ]
         }
@@ -2645,6 +3387,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/arr-diff"
+        }
       ]
     },
     {
@@ -2664,6 +3412,12 @@
           "url": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/arr-flatten"
         }
       ]
     },
@@ -2685,6 +3439,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/arr-union"
+        }
       ]
     },
     {
@@ -2704,6 +3464,12 @@
           "url": "https://registry.npmjs.org/array-each/-/array-each-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/array-each"
         }
       ]
     },
@@ -2725,6 +3491,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/array-flatten"
+        }
       ]
     },
     {
@@ -2744,6 +3516,12 @@
           "url": "https://registry.npmjs.org/array-slice/-/array-slice-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/array-slice"
         }
       ]
     },
@@ -2765,6 +3543,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/array-unique"
+        }
       ]
     },
     {
@@ -2784,6 +3568,12 @@
           "url": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/asap"
         }
       ]
     },
@@ -2805,6 +3595,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/asn1"
+        }
       ]
     },
     {
@@ -2824,6 +3620,12 @@
           "url": "https://registry.npmjs.org/assert-never/-/assert-never-1.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/assert-never"
         }
       ]
     },
@@ -2845,6 +3647,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/assert-plus"
+        }
       ]
     },
     {
@@ -2864,6 +3672,12 @@
           "url": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/assign-symbols"
         }
       ]
     },
@@ -2885,6 +3699,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/async"
+        }
       ]
     },
     {
@@ -2904,6 +3724,12 @@
           "url": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/asynckit"
         }
       ]
     },
@@ -2925,6 +3751,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/at-least-node"
+        }
       ]
     },
     {
@@ -2944,6 +3776,12 @@
           "url": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/atob"
         }
       ]
     },
@@ -2965,6 +3803,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/available-typed-arrays"
+        }
       ]
     },
     {
@@ -2984,6 +3828,12 @@
           "url": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/aws-sign2"
         }
       ]
     },
@@ -3005,6 +3855,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/aws4"
+        }
       ]
     },
     {
@@ -3025,6 +3881,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/babel-walk"
+        }
       ]
     },
     {
@@ -3044,6 +3906,12 @@
           "url": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/balanced-match"
         }
       ]
     },
@@ -3066,6 +3934,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -3084,6 +3958,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/base\\node_modules\\define-property"
             }
           ]
         }
@@ -3107,6 +3987,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base64-arraybuffer"
+        }
       ]
     },
     {
@@ -3126,6 +4012,12 @@
           "url": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base64-js"
         }
       ]
     },
@@ -3147,6 +4039,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base64id"
+        }
       ]
     },
     {
@@ -3166,6 +4064,12 @@
           "url": "https://registry.npmjs.org/base64url/-/base64url-0.0.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base64url"
         }
       ]
     },
@@ -3187,6 +4091,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/basic-auth"
+        }
       ]
     },
     {
@@ -3206,6 +4116,12 @@
           "url": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/batch"
         }
       ]
     },
@@ -3227,6 +4143,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bcrypt-pbkdf"
+        }
       ]
     },
     {
@@ -3246,6 +4168,12 @@
           "url": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/big-integer"
         }
       ]
     },
@@ -3267,6 +4195,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/binary-extensions"
+        }
       ]
     },
     {
@@ -3286,6 +4220,12 @@
           "url": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/binary"
         }
       ]
     },
@@ -3307,6 +4247,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bindings"
+        }
       ]
     },
     {
@@ -3326,6 +4272,12 @@
           "url": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bintrees"
         }
       ]
     },
@@ -3347,6 +4299,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bl"
+        }
       ]
     },
     {
@@ -3367,6 +4325,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bluebird"
+        }
       ]
     },
     {
@@ -3386,6 +4350,12 @@
           "url": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/body-parser"
         }
       ]
     },
@@ -3408,6 +4378,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bower-config"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -3426,6 +4402,12 @@
               "url": "https://registry.npmjs.org/minimist/-/minimist-0.2.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bower-config\\node_modules\\minimist"
             }
           ]
         }
@@ -3449,6 +4431,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/brace-expansion"
+        }
       ]
     },
     {
@@ -3470,6 +4458,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/braces"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -3488,6 +4482,12 @@
               "url": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/braces\\node_modules\\extend-shallow"
             }
           ]
         },
@@ -3508,6 +4508,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/braces\\node_modules\\is-extendable"
             }
           ]
         }
@@ -3531,6 +4537,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/brotli"
+        }
       ]
     },
     {
@@ -3550,6 +4562,12 @@
           "url": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-alloc-unsafe"
         }
       ]
     },
@@ -3571,6 +4589,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-alloc"
+        }
       ]
     },
     {
@@ -3590,6 +4614,12 @@
           "url": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-crc32"
         }
       ]
     },
@@ -3611,6 +4641,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-fill"
+        }
       ]
     },
     {
@@ -3630,6 +4666,12 @@
           "url": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-from"
         }
       ]
     },
@@ -3651,6 +4693,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-indexof-polyfill"
+        }
       ]
     },
     {
@@ -3671,6 +4719,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer"
+        }
       ]
     },
     {
@@ -3690,6 +4744,12 @@
           "url": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffers"
         }
       ]
     },
@@ -3712,6 +4772,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/busboy"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -3730,6 +4796,12 @@
               "url": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/busboy\\node_modules\\isarray"
             }
           ]
         },
@@ -3751,6 +4823,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/busboy\\node_modules\\readable-stream"
+            }
           ]
         },
         {
@@ -3770,6 +4848,12 @@
               "url": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/busboy\\node_modules\\string_decoder"
             }
           ]
         }
@@ -3793,6 +4877,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/byline"
+        }
       ]
     },
     {
@@ -3812,6 +4902,12 @@
           "url": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bytes"
         }
       ]
     },
@@ -3833,6 +4929,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cacache"
+        }
       ]
     },
     {
@@ -3852,6 +4954,12 @@
           "url": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cache-base"
         }
       ]
     },
@@ -3874,6 +4982,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cacheable-request"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -3892,6 +5006,12 @@
               "url": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cacheable-request\\node_modules\\get-stream"
             }
           ]
         },
@@ -3912,6 +5032,12 @@
               "url": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cacheable-request\\node_modules\\lowercase-keys"
             }
           ]
         }
@@ -3935,6 +5061,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/call-bind"
+        }
       ]
     },
     {
@@ -3954,6 +5086,12 @@
           "url": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/camelcase"
         }
       ]
     },
@@ -3975,6 +5113,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/caseless"
+        }
       ]
     },
     {
@@ -3994,6 +5138,12 @@
           "url": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/chainsaw"
         }
       ]
     },
@@ -4015,6 +5165,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/chalk"
+        }
       ]
     },
     {
@@ -4034,6 +5190,12 @@
           "url": "https://registry.npmjs.org/character-parser/-/character-parser-2.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/character-parser"
         }
       ]
     },
@@ -4056,6 +5218,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/check-dependencies"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4074,6 +5242,12 @@
               "url": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/check-dependencies\\node_modules\\semver"
             }
           ]
         }
@@ -4097,6 +5271,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/check-types"
+        }
       ]
     },
     {
@@ -4118,6 +5298,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/chokidar"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4136,6 +5322,12 @@
               "url": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar\\node_modules\\braces"
             }
           ]
         },
@@ -4157,6 +5349,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar\\node_modules\\fill-range"
+            }
           ]
         },
         {
@@ -4176,6 +5374,12 @@
               "url": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar\\node_modules\\is-glob"
             }
           ]
         },
@@ -4197,6 +5401,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar\\node_modules\\is-number"
+            }
           ]
         },
         {
@@ -4217,6 +5427,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar\\node_modules\\normalize-path"
+            }
           ]
         },
         {
@@ -4236,6 +5452,12 @@
               "url": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar\\node_modules\\to-regex-range"
             }
           ]
         }
@@ -4259,6 +5481,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/chownr"
+        }
       ]
     },
     {
@@ -4278,6 +5506,12 @@
           "url": "https://registry.npmjs.org/clarinet/-/clarinet-0.12.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/clarinet"
         }
       ]
     },
@@ -4300,6 +5534,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/class-utils"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4318,6 +5558,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils\\node_modules\\define-property"
             }
           ]
         },
@@ -4340,6 +5586,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils\\node_modules\\is-accessor-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -4358,6 +5610,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/class-utils\\node_modules\\is-accessor-descriptor\\node_modules\\kind-of"
                 }
               ]
             }
@@ -4382,6 +5640,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils\\node_modules\\is-data-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -4400,6 +5664,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/class-utils\\node_modules\\is-data-descriptor\\node_modules\\kind-of"
                 }
               ]
             }
@@ -4423,6 +5693,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils\\node_modules\\is-descriptor"
+            }
           ]
         },
         {
@@ -4442,6 +5718,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils\\node_modules\\kind-of"
             }
           ]
         }
@@ -4465,6 +5747,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/clean-stack"
+        }
       ]
     },
     {
@@ -4486,6 +5774,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cliui"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4504,6 +5798,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui\\node_modules\\ansi-regex"
             }
           ]
         },
@@ -4525,6 +5825,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui\\node_modules\\emoji-regex"
+            }
           ]
         },
         {
@@ -4544,6 +5850,12 @@
               "url": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui\\node_modules\\is-fullwidth-code-point"
             }
           ]
         },
@@ -4565,6 +5877,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui\\node_modules\\string-width"
+            }
           ]
         },
         {
@@ -4584,6 +5902,12 @@
               "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui\\node_modules\\strip-ansi"
             }
           ]
         }
@@ -4607,6 +5931,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/clone-response"
+        }
       ]
     },
     {
@@ -4626,6 +5956,12 @@
           "url": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/clone"
         }
       ]
     },
@@ -4647,6 +5983,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/code-point-at"
+        }
       ]
     },
     {
@@ -4666,6 +6008,12 @@
           "url": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/collection-visit"
         }
       ]
     },
@@ -4687,6 +6035,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color-convert"
+        }
       ]
     },
     {
@@ -4706,6 +6060,12 @@
           "url": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color-name"
         }
       ]
     },
@@ -4727,6 +6087,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color-string"
+        }
       ]
     },
     {
@@ -4746,6 +6112,12 @@
           "url": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color-support"
         }
       ]
     },
@@ -4767,6 +6139,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color"
+        }
       ]
     },
     {
@@ -4786,6 +6164,12 @@
           "url": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/colors"
         }
       ]
     },
@@ -4807,6 +6191,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/colorspace"
+        }
       ]
     },
     {
@@ -4826,6 +6216,12 @@
           "url": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/combined-stream"
         }
       ]
     },
@@ -4847,6 +6243,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/commander"
+        }
       ]
     },
     {
@@ -4866,6 +6268,12 @@
           "url": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/component-emitter"
         }
       ]
     },
@@ -4887,6 +6295,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/component-type"
+        }
       ]
     },
     {
@@ -4907,6 +6321,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/compress-commons"
+        }
       ]
     },
     {
@@ -4926,6 +6346,12 @@
           "url": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/compressible"
         }
       ]
     },
@@ -4948,6 +6374,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/compression"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4966,6 +6398,12 @@
               "url": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/compression\\node_modules\\bytes"
             }
           ]
         }
@@ -4989,6 +6427,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/concat-map"
+        }
       ]
     },
     {
@@ -5008,6 +6452,12 @@
           "url": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/concat-stream"
         }
       ]
     },
@@ -5030,6 +6480,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/concurrently"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5048,6 +6504,12 @@
               "url": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/concurrently\\node_modules\\supports-color"
             }
           ]
         }
@@ -5071,6 +6533,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/config"
+        }
       ]
     },
     {
@@ -5091,6 +6559,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/console-control-strings"
+        }
       ]
     },
     {
@@ -5110,6 +6584,12 @@
           "url": "https://registry.npmjs.org/constantinople/-/constantinople-4.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/constantinople"
         }
       ]
     },
@@ -5132,6 +6612,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/content-disposition"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5150,6 +6636,12 @@
               "url": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/content-disposition\\node_modules\\safe-buffer"
             }
           ]
         }
@@ -5173,6 +6665,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/content-type"
+        }
       ]
     },
     {
@@ -5192,6 +6690,12 @@
           "url": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cookie-parser"
         }
       ]
     },
@@ -5213,6 +6717,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cookie-signature"
+        }
       ]
     },
     {
@@ -5232,6 +6742,12 @@
           "url": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cookie"
         }
       ]
     },
@@ -5253,6 +6769,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/copy-descriptor"
+        }
       ]
     },
     {
@@ -5272,6 +6794,12 @@
           "url": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/core-util-is"
         }
       ]
     },
@@ -5293,6 +6821,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cors"
+        }
       ]
     },
     {
@@ -5312,6 +6846,12 @@
           "url": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/crc"
         }
       ]
     },
@@ -5333,6 +6873,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/crc32-stream"
+        }
       ]
     },
     {
@@ -5352,6 +6898,12 @@
           "url": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/create-require"
         }
       ]
     },
@@ -5373,6 +6925,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/crypto-js"
+        }
       ]
     },
     {
@@ -5392,6 +6950,12 @@
           "url": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dashdash"
         }
       ]
     },
@@ -5413,6 +6977,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/date-fns"
+        }
       ]
     },
     {
@@ -5432,6 +7002,12 @@
           "url": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dateformat"
         }
       ]
     },
@@ -5453,6 +7029,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/debug"
+        }
       ]
     },
     {
@@ -5472,6 +7054,12 @@
           "url": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decamelize"
         }
       ]
     },
@@ -5493,6 +7081,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decode-uri-component"
+        }
       ]
     },
     {
@@ -5512,6 +7106,12 @@
           "url": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-response"
         }
       ]
     },
@@ -5534,6 +7134,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-tar"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5552,6 +7158,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-tar\\node_modules\\file-type"
             }
           ]
         }
@@ -5576,6 +7188,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-tarbz2"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5594,6 +7212,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-6.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-tarbz2\\node_modules\\file-type"
             }
           ]
         }
@@ -5618,6 +7242,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-targz"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5636,6 +7266,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-targz\\node_modules\\file-type"
             }
           ]
         }
@@ -5660,6 +7296,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-unzip"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5678,6 +7320,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-unzip\\node_modules\\file-type"
             }
           ]
         },
@@ -5699,6 +7347,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-unzip\\node_modules\\get-stream"
+            }
           ]
         },
         {
@@ -5718,6 +7372,12 @@
               "url": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-unzip\\node_modules\\pify"
             }
           ]
         }
@@ -5742,6 +7402,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5762,6 +7428,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress\\node_modules\\make-dir"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -5780,6 +7452,12 @@
                   "url": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/decompress\\node_modules\\make-dir\\node_modules\\pify"
                 }
               ]
             }
@@ -5803,6 +7481,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress\\node_modules\\pify"
+            }
           ]
         }
       ]
@@ -5825,6 +7509,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/deep-equal"
+        }
       ]
     },
     {
@@ -5844,6 +7534,12 @@
           "url": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/deep-extend"
         }
       ]
     },
@@ -5865,6 +7561,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/deep-is"
+        }
       ]
     },
     {
@@ -5884,6 +7586,12 @@
           "url": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/define-properties"
         }
       ]
     },
@@ -5905,6 +7613,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/define-property"
+        }
       ]
     },
     {
@@ -5924,6 +7638,12 @@
           "url": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/delayed-stream"
         }
       ]
     },
@@ -5945,6 +7665,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/delegates"
+        }
       ]
     },
     {
@@ -5964,6 +7690,12 @@
           "url": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/depd"
         }
       ]
     },
@@ -5985,6 +7717,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/destroy"
+        }
       ]
     },
     {
@@ -6004,6 +7742,12 @@
           "url": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/detect-file"
         }
       ]
     },
@@ -6025,6 +7769,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/detect-libc"
+        }
       ]
     },
     {
@@ -6044,6 +7794,12 @@
           "url": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dfa"
         }
       ]
     },
@@ -6066,6 +7822,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dicer"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -6084,6 +7846,12 @@
               "url": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/dicer\\node_modules\\isarray"
             }
           ]
         },
@@ -6105,6 +7873,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/dicer\\node_modules\\readable-stream"
+            }
           ]
         },
         {
@@ -6124,6 +7898,12 @@
               "url": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/dicer\\node_modules\\string_decoder"
             }
           ]
         }
@@ -6147,6 +7927,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/diff"
+        }
       ]
     },
     {
@@ -6166,6 +7952,12 @@
           "url": "https://registry.npmjs.org/doctypes/-/doctypes-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/doctypes"
         }
       ]
     },
@@ -6187,6 +7979,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/domelementtype"
+        }
       ]
     },
     {
@@ -6206,6 +8004,12 @@
           "url": "https://registry.npmjs.org/domhandler/-/domhandler-2.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/domhandler"
         }
       ]
     },
@@ -6227,6 +8031,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/domutils"
+        }
       ]
     },
     {
@@ -6246,6 +8056,12 @@
           "url": "https://registry.npmjs.org/dottie/-/dottie-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dottie"
         }
       ]
     },
@@ -6267,6 +8083,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/double-ended-queue"
+        }
       ]
     },
     {
@@ -6286,6 +8108,12 @@
           "url": "https://registry.npmjs.org/doublearray/-/doublearray-0.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/doublearray"
         }
       ]
     },
@@ -6308,6 +8136,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/download"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -6326,6 +8160,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-11.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/download\\node_modules\\file-type"
             }
           ]
         }
@@ -6349,6 +8189,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/duplexer2"
+        }
       ]
     },
     {
@@ -6368,6 +8214,12 @@
           "url": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/duplexer3"
         }
       ]
     },
@@ -6389,6 +8241,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dynamic-dedupe"
+        }
       ]
     },
     {
@@ -6408,6 +8266,12 @@
           "url": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ecc-jsbn"
         }
       ]
     },
@@ -6429,6 +8293,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ee-first"
+        }
       ]
     },
     {
@@ -6448,6 +8318,12 @@
           "url": "https://registry.npmjs.org/eivindfjeldstad-dot/-/eivindfjeldstad-dot-0.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/eivindfjeldstad-dot"
         }
       ]
     },
@@ -6469,6 +8345,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/emoji-regex"
+        }
       ]
     },
     {
@@ -6489,6 +8371,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/enabled"
+        }
       ]
     },
     {
@@ -6508,6 +8396,12 @@
           "url": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/encodeurl"
         }
       ]
     },
@@ -6530,6 +8424,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/encoding"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -6548,6 +8448,12 @@
               "url": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/encoding\\node_modules\\iconv-lite"
             }
           ]
         }
@@ -6571,6 +8477,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/end-of-stream"
+        }
       ]
     },
     {
@@ -6590,6 +8502,12 @@
           "url": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-4.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/engine.io-parser"
         }
       ]
     },
@@ -6612,6 +8530,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/engine.io"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -6630,6 +8554,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/engine.io\\node_modules\\debug"
             }
           ]
         },
@@ -6650,6 +8580,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/engine.io\\node_modules\\ms"
             }
           ]
         }
@@ -6673,6 +8609,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/env-paths"
+        }
       ]
     },
     {
@@ -6692,6 +8634,12 @@
           "url": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/err-code"
         }
       ]
     },
@@ -6713,6 +8661,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/error-ex"
+        }
       ]
     },
     {
@@ -6732,6 +8686,12 @@
           "url": "https://registry.npmjs.org/errorhandler/-/errorhandler-1.5.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/errorhandler"
         }
       ]
     },
@@ -6753,6 +8713,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/es-abstract"
+        }
       ]
     },
     {
@@ -6772,6 +8738,12 @@
           "url": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/es-get-iterator"
         }
       ]
     },
@@ -6793,6 +8765,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/es-to-primitive"
+        }
       ]
     },
     {
@@ -6812,6 +8790,12 @@
           "url": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/escape-html"
         }
       ]
     },
@@ -6833,6 +8817,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/escape-string-regexp"
+        }
       ]
     },
     {
@@ -6852,6 +8842,12 @@
           "url": "https://registry.npmjs.org/escodegen/-/escodegen-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/escodegen"
         }
       ]
     },
@@ -6873,6 +8869,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/esprima"
+        }
       ]
     },
     {
@@ -6892,6 +8894,12 @@
           "url": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/estraverse"
         }
       ]
     },
@@ -6913,6 +8921,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/esutils"
+        }
       ]
     },
     {
@@ -6932,6 +8946,12 @@
           "url": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/etag"
         }
       ]
     },
@@ -6953,6 +8973,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/eventemitter2"
+        }
       ]
     },
     {
@@ -6972,6 +8998,12 @@
           "url": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/eventemitter3"
         }
       ]
     },
@@ -6993,6 +9025,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/exif"
+        }
       ]
     },
     {
@@ -7012,6 +9050,12 @@
           "url": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/exit"
         }
       ]
     },
@@ -7034,6 +9078,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/expand-brackets"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7052,6 +9102,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets\\node_modules\\define-property"
             }
           ]
         },
@@ -7072,6 +9128,12 @@
               "url": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets\\node_modules\\extend-shallow"
             }
           ]
         },
@@ -7094,6 +9156,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets\\node_modules\\is-accessor-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -7112,6 +9180,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/expand-brackets\\node_modules\\is-accessor-descriptor\\node_modules\\kind-of"
                 }
               ]
             }
@@ -7136,6 +9210,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets\\node_modules\\is-data-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -7154,6 +9234,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/expand-brackets\\node_modules\\is-data-descriptor\\node_modules\\kind-of"
                 }
               ]
             }
@@ -7177,6 +9263,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets\\node_modules\\is-descriptor"
+            }
           ]
         },
         {
@@ -7197,6 +9289,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets\\node_modules\\is-extendable"
+            }
           ]
         },
         {
@@ -7216,6 +9314,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets\\node_modules\\kind-of"
             }
           ]
         }
@@ -7239,6 +9343,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/expand-template"
+        }
       ]
     },
     {
@@ -7259,6 +9369,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/expand-tilde"
+        }
       ]
     },
     {
@@ -7278,6 +9394,12 @@
           "url": "https://registry.npmjs.org/express-ipfilter/-/express-ipfilter-1.3.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-ipfilter"
         }
       ]
     },
@@ -7300,6 +9422,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-jwt"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7318,6 +9446,12 @@
               "url": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-0.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/express-jwt\\node_modules\\jsonwebtoken"
             }
           ]
         },
@@ -7338,6 +9472,12 @@
               "url": "https://registry.npmjs.org/moment/-/moment-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/express-jwt\\node_modules\\moment"
             }
           ]
         }
@@ -7361,6 +9501,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-rate-limit"
+        }
       ]
     },
     {
@@ -7381,6 +9527,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-robots-txt"
+        }
       ]
     },
     {
@@ -7400,6 +9552,12 @@
           "url": "https://registry.npmjs.org/express-security.txt/-/express-security.txt-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-security.txt"
         }
       ]
     },
@@ -7422,6 +9580,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7440,6 +9604,12 @@
               "url": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/express\\node_modules\\cookie"
             }
           ]
         },
@@ -7460,6 +9630,12 @@
               "url": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/express\\node_modules\\safe-buffer"
             }
           ]
         }
@@ -7483,6 +9659,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ext-list"
+        }
       ]
     },
     {
@@ -7502,6 +9684,12 @@
           "url": "https://registry.npmjs.org/ext-name/-/ext-name-5.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ext-name"
         }
       ]
     },
@@ -7523,6 +9711,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/extend-shallow"
+        }
       ]
     },
     {
@@ -7542,6 +9736,12 @@
           "url": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/extend"
         }
       ]
     },
@@ -7564,6 +9764,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/extglob"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7582,6 +9788,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/extglob\\node_modules\\define-property"
             }
           ]
         },
@@ -7603,6 +9815,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/extglob\\node_modules\\extend-shallow"
+            }
           ]
         },
         {
@@ -7622,6 +9840,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/extglob\\node_modules\\is-extendable"
             }
           ]
         }
@@ -7645,6 +9869,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/extsprintf"
+        }
       ]
     },
     {
@@ -7664,6 +9894,12 @@
           "url": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fast-deep-equal"
         }
       ]
     },
@@ -7685,6 +9921,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fast-json-stable-stringify"
+        }
       ]
     },
     {
@@ -7704,6 +9946,12 @@
           "url": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fast-levenshtein"
         }
       ]
     },
@@ -7725,6 +9973,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fast.js"
+        }
       ]
     },
     {
@@ -7744,6 +9998,12 @@
           "url": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fd-slicer"
         }
       ]
     },
@@ -7765,6 +10025,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/feature-policy"
+        }
       ]
     },
     {
@@ -7784,6 +10050,12 @@
           "url": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fecha"
         }
       ]
     },
@@ -7806,6 +10078,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/file-js"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7824,6 +10102,12 @@
               "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/file-js\\node_modules\\brace-expansion"
             }
           ]
         },
@@ -7844,6 +10128,12 @@
               "url": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/file-js\\node_modules\\minimatch"
             }
           ]
         }
@@ -7867,6 +10157,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/file-stream-rotator"
+        }
       ]
     },
     {
@@ -7886,6 +10182,12 @@
           "url": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/file-type"
         }
       ]
     },
@@ -7907,6 +10209,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/file-uri-to-path"
+        }
       ]
     },
     {
@@ -7926,6 +10234,12 @@
           "url": "https://registry.npmjs.org/filehound/-/filehound-1.17.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/filehound"
         }
       ]
     },
@@ -7947,6 +10261,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/filename-reserved-regex"
+        }
       ]
     },
     {
@@ -7967,6 +10287,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/filenamify"
+        }
       ]
     },
     {
@@ -7986,6 +10312,12 @@
           "url": "https://registry.npmjs.org/filesniffer/-/filesniffer-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/filesniffer"
         }
       ]
     },
@@ -8008,6 +10340,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fill-range"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -8026,6 +10364,12 @@
               "url": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/fill-range\\node_modules\\extend-shallow"
             }
           ]
         },
@@ -8046,6 +10390,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/fill-range\\node_modules\\is-extendable"
             }
           ]
         }
@@ -8069,6 +10419,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/finale-rest"
+        }
       ]
     },
     {
@@ -8088,6 +10444,12 @@
           "url": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/finalhandler"
         }
       ]
     },
@@ -8109,6 +10471,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/find-up"
+        }
       ]
     },
     {
@@ -8128,6 +10496,12 @@
           "url": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/findup-sync"
         }
       ]
     },
@@ -8149,6 +10523,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fined"
+        }
       ]
     },
     {
@@ -8168,6 +10548,12 @@
           "url": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/flagged-respawn"
         }
       ]
     },
@@ -8189,6 +10575,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fn.name"
+        }
       ]
     },
     {
@@ -8208,6 +10600,12 @@
           "url": "https://registry.npmjs.org/fontkit/-/fontkit-1.9.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fontkit"
         }
       ]
     },
@@ -8229,6 +10627,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/for-each"
+        }
       ]
     },
     {
@@ -8248,6 +10652,12 @@
           "url": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/for-in"
         }
       ]
     },
@@ -8269,6 +10679,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/for-own"
+        }
       ]
     },
     {
@@ -8288,6 +10704,12 @@
           "url": "https://registry.npmjs.org/foreachasync/-/foreachasync-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/foreachasync"
         }
       ]
     },
@@ -8309,6 +10731,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/forever-agent"
+        }
       ]
     },
     {
@@ -8328,6 +10756,12 @@
           "url": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/form-data"
         }
       ]
     },
@@ -8349,6 +10783,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/formatio"
+        }
       ]
     },
     {
@@ -8368,6 +10808,12 @@
           "url": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/forwarded"
         }
       ]
     },
@@ -8389,6 +10835,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fragment-cache"
+        }
       ]
     },
     {
@@ -8408,6 +10860,12 @@
           "url": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fresh"
         }
       ]
     },
@@ -8429,6 +10887,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/from2"
+        }
       ]
     },
     {
@@ -8448,6 +10912,12 @@
           "url": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fs-constants"
         }
       ]
     },
@@ -8469,6 +10939,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fs-extra"
+        }
       ]
     },
     {
@@ -8489,6 +10965,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fs-minipass"
+        }
       ]
     },
     {
@@ -8508,6 +10990,12 @@
           "url": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fs.realpath"
         }
       ]
     },
@@ -8530,6 +11018,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fstream"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -8548,6 +11042,12 @@
               "url": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/fstream\\node_modules\\mkdirp"
             }
           ]
         },
@@ -8568,6 +11068,12 @@
               "url": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/fstream\\node_modules\\rimraf"
             }
           ]
         }
@@ -8591,6 +11097,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/function-bind"
+        }
       ]
     },
     {
@@ -8610,6 +11122,12 @@
           "url": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/function.prototype.name"
         }
       ]
     },
@@ -8631,6 +11149,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/functions-have-names"
+        }
       ]
     },
     {
@@ -8650,6 +11174,12 @@
           "url": "https://registry.npmjs.org/fuzzball/-/fuzzball-1.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fuzzball"
         }
       ]
     },
@@ -8671,6 +11201,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/gauge"
+        }
       ]
     },
     {
@@ -8690,6 +11226,12 @@
           "url": "https://registry.npmjs.org/geojson-utils/-/geojson-utils-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/geojson-utils"
         }
       ]
     },
@@ -8711,6 +11253,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-caller-file"
+        }
       ]
     },
     {
@@ -8730,6 +11278,12 @@
           "url": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-intrinsic"
         }
       ]
     },
@@ -8751,6 +11305,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-stream"
+        }
       ]
     },
     {
@@ -8770,6 +11330,12 @@
           "url": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-symbol-description"
         }
       ]
     },
@@ -8791,6 +11357,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-value"
+        }
       ]
     },
     {
@@ -8810,6 +11382,12 @@
           "url": "https://registry.npmjs.org/getobject/-/getobject-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/getobject"
         }
       ]
     },
@@ -8831,6 +11409,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/getpass"
+        }
       ]
     },
     {
@@ -8850,6 +11434,12 @@
           "url": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/github-from-package"
         }
       ]
     },
@@ -8872,6 +11462,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/glob-parent"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -8890,6 +11486,12 @@
               "url": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/glob-parent\\node_modules\\is-glob"
             }
           ]
         }
@@ -8914,6 +11516,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/glob"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -8932,6 +11540,12 @@
               "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/glob\\node_modules\\brace-expansion"
             }
           ]
         },
@@ -8952,6 +11566,12 @@
               "url": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/glob\\node_modules\\minimatch"
             }
           ]
         }
@@ -8975,6 +11595,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/global-modules"
+        }
       ]
     },
     {
@@ -8996,6 +11622,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/global-prefix"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9014,6 +11646,12 @@
               "url": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/global-prefix\\node_modules\\which"
             }
           ]
         }
@@ -9038,6 +11676,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/got"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9056,6 +11700,12 @@
               "url": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/got\\node_modules\\get-stream"
             }
           ]
         },
@@ -9076,6 +11726,12 @@
               "url": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/got\\node_modules\\pify"
             }
           ]
         }
@@ -9099,6 +11755,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/graceful-fs"
+        }
       ]
     },
     {
@@ -9120,6 +11782,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-cli"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9138,6 +11806,12 @@
               "url": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-cli\\node_modules\\nopt"
             }
           ]
         }
@@ -9162,6 +11836,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-contrib-compress"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9180,6 +11860,12 @@
               "url": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-contrib-compress\\node_modules\\ansi-styles"
             }
           ]
         },
@@ -9201,6 +11887,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-contrib-compress\\node_modules\\chalk"
+            }
           ]
         },
         {
@@ -9220,6 +11912,12 @@
               "url": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-contrib-compress\\node_modules\\supports-color"
             }
           ]
         }
@@ -9243,6 +11941,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-known-options"
+        }
       ]
     },
     {
@@ -9264,6 +11968,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-legacy-log-utils"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9282,6 +11992,12 @@
               "url": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils\\node_modules\\ansi-styles"
             }
           ]
         },
@@ -9303,6 +12019,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils\\node_modules\\chalk"
+            }
           ]
         },
         {
@@ -9322,6 +12044,12 @@
               "url": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils\\node_modules\\color-convert"
             }
           ]
         },
@@ -9343,6 +12071,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils\\node_modules\\color-name"
+            }
           ]
         },
         {
@@ -9363,6 +12097,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils\\node_modules\\has-flag"
+            }
           ]
         },
         {
@@ -9382,6 +12122,12 @@
               "url": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils\\node_modules\\supports-color"
             }
           ]
         }
@@ -9406,6 +12152,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-legacy-log"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9424,6 +12176,12 @@
               "url": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log\\node_modules\\colors"
             }
           ]
         }
@@ -9448,6 +12206,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-legacy-util"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9466,6 +12230,12 @@
               "url": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-util\\node_modules\\async"
             }
           ]
         }
@@ -9489,6 +12259,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-replace-json"
+        }
       ]
     },
     {
@@ -9510,6 +12286,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9528,6 +12310,12 @@
               "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt\\node_modules\\brace-expansion"
             }
           ]
         },
@@ -9550,6 +12338,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt\\node_modules\\findup-sync"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -9568,6 +12362,12 @@
                   "url": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/grunt\\node_modules\\findup-sync\\node_modules\\glob"
                 }
               ]
             }
@@ -9591,6 +12391,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt\\node_modules\\glob"
+            }
           ]
         },
         {
@@ -9610,6 +12416,12 @@
               "url": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.8.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt\\node_modules\\minimatch"
             }
           ]
         }
@@ -9634,6 +12446,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/handlebars"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9652,6 +12470,12 @@
               "url": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/handlebars\\node_modules\\wordwrap"
             }
           ]
         }
@@ -9675,6 +12499,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/har-schema"
+        }
       ]
     },
     {
@@ -9694,6 +12524,12 @@
           "url": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/har-validator"
         }
       ]
     },
@@ -9715,6 +12551,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-ansi"
+        }
       ]
     },
     {
@@ -9734,6 +12576,12 @@
           "url": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-bigints"
         }
       ]
     },
@@ -9755,6 +12603,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-flag"
+        }
       ]
     },
     {
@@ -9774,6 +12628,12 @@
           "url": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-property-descriptors"
         }
       ]
     },
@@ -9795,6 +12655,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-symbol-support-x"
+        }
       ]
     },
     {
@@ -9814,6 +12680,12 @@
           "url": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-symbols"
         }
       ]
     },
@@ -9835,6 +12707,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-to-string-tag-x"
+        }
       ]
     },
     {
@@ -9854,6 +12732,12 @@
           "url": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-tostringtag"
         }
       ]
     },
@@ -9875,6 +12759,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-unicode"
+        }
       ]
     },
     {
@@ -9894,6 +12784,12 @@
           "url": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-value"
         }
       ]
     },
@@ -9916,6 +12812,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-values"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9934,6 +12836,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/has-values\\node_modules\\kind-of"
             }
           ]
         }
@@ -9957,6 +12865,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has"
+        }
       ]
     },
     {
@@ -9976,6 +12890,12 @@
           "url": "https://registry.npmjs.org/hashids/-/hashids-2.2.10.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hashids"
         }
       ]
     },
@@ -9997,6 +12917,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hbs"
+        }
       ]
     },
     {
@@ -10016,6 +12942,12 @@
           "url": "https://registry.npmjs.org/he/-/he-0.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/he"
         }
       ]
     },
@@ -10037,6 +12969,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/heap"
+        }
       ]
     },
     {
@@ -10056,6 +12994,12 @@
           "url": "https://registry.npmjs.org/helmet/-/helmet-4.6.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/helmet"
         }
       ]
     },
@@ -10077,6 +13021,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hoister"
+        }
       ]
     },
     {
@@ -10096,6 +13046,12 @@
           "url": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/homedir-polyfill"
         }
       ]
     },
@@ -10117,6 +13073,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hooker"
+        }
       ]
     },
     {
@@ -10137,6 +13099,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hosted-git-info"
+        }
       ]
     },
     {
@@ -10156,6 +13124,12 @@
           "url": "https://registry.npmjs.org/html-entities/-/html-entities-1.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/html-entities"
         }
       ]
     },
@@ -10178,6 +13152,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/htmlparser2"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -10196,6 +13176,12 @@
               "url": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/htmlparser2\\node_modules\\isarray"
             }
           ]
         },
@@ -10217,6 +13203,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/htmlparser2\\node_modules\\readable-stream"
+            }
           ]
         },
         {
@@ -10236,6 +13228,12 @@
               "url": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/htmlparser2\\node_modules\\string_decoder"
             }
           ]
         }
@@ -10259,6 +13257,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/http-cache-semantics"
+        }
       ]
     },
     {
@@ -10278,6 +13282,12 @@
           "url": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/http-errors"
         }
       ]
     },
@@ -10300,6 +13310,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/http-proxy-agent"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -10318,6 +13334,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/http-proxy-agent\\node_modules\\debug"
             }
           ]
         },
@@ -10338,6 +13360,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/http-proxy-agent\\node_modules\\ms"
             }
           ]
         }
@@ -10361,6 +13389,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/http-signature"
+        }
       ]
     },
     {
@@ -10382,6 +13416,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/https-proxy-agent"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -10400,6 +13440,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/https-proxy-agent\\node_modules\\debug"
             }
           ]
         },
@@ -10420,6 +13466,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/https-proxy-agent\\node_modules\\ms"
             }
           ]
         }
@@ -10443,6 +13495,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/humanize-ms"
+        }
       ]
     },
     {
@@ -10462,6 +13520,12 @@
           "url": "https://registry.npmjs.org/i18n/-/i18n-0.11.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/i18n"
         }
       ]
     },
@@ -10483,6 +13547,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/iconv-lite"
+        }
       ]
     },
     {
@@ -10502,6 +13572,12 @@
           "url": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ieee754"
         }
       ]
     },
@@ -10524,6 +13600,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ignore-walk"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -10542,6 +13624,12 @@
               "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/ignore-walk\\node_modules\\brace-expansion"
             }
           ]
         },
@@ -10562,6 +13650,12 @@
               "url": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/ignore-walk\\node_modules\\minimatch"
             }
           ]
         }
@@ -10585,6 +13679,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/iltorb"
+        }
       ]
     },
     {
@@ -10604,6 +13704,12 @@
           "url": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/imurmurhash"
         }
       ]
     },
@@ -10625,6 +13731,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/indent-string"
+        }
       ]
     },
     {
@@ -10644,6 +13756,12 @@
           "url": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/infer-owner"
         }
       ]
     },
@@ -10665,6 +13783,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/inflection"
+        }
       ]
     },
     {
@@ -10684,6 +13808,12 @@
           "url": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/inflight"
         }
       ]
     },
@@ -10705,6 +13835,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/inherits"
+        }
       ]
     },
     {
@@ -10724,6 +13860,12 @@
           "url": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ini"
         }
       ]
     },
@@ -10745,6 +13887,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/internal-slot"
+        }
       ]
     },
     {
@@ -10764,6 +13912,12 @@
           "url": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/interpret"
         }
       ]
     },
@@ -10785,6 +13939,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/into-stream"
+        }
       ]
     },
     {
@@ -10804,6 +13964,12 @@
           "url": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/invariant"
         }
       ]
     },
@@ -10825,6 +13991,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ip"
+        }
       ]
     },
     {
@@ -10844,6 +14016,12 @@
           "url": "https://registry.npmjs.org/ip6/-/ip6-0.2.10.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ip6"
         }
       ]
     },
@@ -10865,6 +14043,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ipaddr.js"
+        }
       ]
     },
     {
@@ -10884,6 +14068,12 @@
           "url": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-absolute"
         }
       ]
     },
@@ -10905,6 +14095,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-accessor-descriptor"
+        }
       ]
     },
     {
@@ -10924,6 +14120,12 @@
           "url": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-arguments"
         }
       ]
     },
@@ -10945,6 +14147,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-arrayish"
+        }
       ]
     },
     {
@@ -10964,6 +14172,12 @@
           "url": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-bigint"
         }
       ]
     },
@@ -10985,6 +14199,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-binary-path"
+        }
       ]
     },
     {
@@ -11004,6 +14224,12 @@
           "url": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-boolean-object"
         }
       ]
     },
@@ -11025,6 +14251,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-buffer"
+        }
       ]
     },
     {
@@ -11044,6 +14276,12 @@
           "url": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-callable"
         }
       ]
     },
@@ -11065,6 +14303,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-core-module"
+        }
       ]
     },
     {
@@ -11084,6 +14328,12 @@
           "url": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-data-descriptor"
         }
       ]
     },
@@ -11105,6 +14355,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-date-object"
+        }
       ]
     },
     {
@@ -11124,6 +14380,12 @@
           "url": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-descriptor"
         }
       ]
     },
@@ -11145,6 +14407,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-docker"
+        }
       ]
     },
     {
@@ -11164,6 +14432,12 @@
           "url": "https://registry.npmjs.org/is-expression/-/is-expression-4.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-expression"
         }
       ]
     },
@@ -11185,6 +14459,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-extendable"
+        }
       ]
     },
     {
@@ -11204,6 +14484,12 @@
           "url": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-extglob"
         }
       ]
     },
@@ -11225,6 +14511,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-fullwidth-code-point"
+        }
       ]
     },
     {
@@ -11244,6 +14536,12 @@
           "url": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-generator-function"
         }
       ]
     },
@@ -11265,6 +14563,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-glob"
+        }
       ]
     },
     {
@@ -11284,6 +14588,12 @@
           "url": "https://registry.npmjs.org/is-heroku/-/is-heroku-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-heroku"
         }
       ]
     },
@@ -11305,6 +14615,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-lambda"
+        }
       ]
     },
     {
@@ -11324,6 +14640,12 @@
           "url": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-map"
         }
       ]
     },
@@ -11345,6 +14667,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-natural-number"
+        }
       ]
     },
     {
@@ -11364,6 +14692,12 @@
           "url": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-negative-zero"
         }
       ]
     },
@@ -11385,6 +14719,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-number-like"
+        }
       ]
     },
     {
@@ -11404,6 +14744,12 @@
           "url": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-number-object"
         }
       ]
     },
@@ -11426,6 +14772,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-number"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -11444,6 +14796,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/is-number\\node_modules\\kind-of"
             }
           ]
         }
@@ -11467,6 +14825,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-object"
+        }
       ]
     },
     {
@@ -11486,6 +14850,12 @@
           "url": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-plain-obj"
         }
       ]
     },
@@ -11507,6 +14877,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-plain-object"
+        }
       ]
     },
     {
@@ -11526,6 +14902,12 @@
           "url": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-promise"
         }
       ]
     },
@@ -11547,6 +14929,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-regex"
+        }
       ]
     },
     {
@@ -11566,6 +14954,12 @@
           "url": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-relative"
         }
       ]
     },
@@ -11587,6 +14981,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-retry-allowed"
+        }
       ]
     },
     {
@@ -11606,6 +15006,12 @@
           "url": "https://registry.npmjs.org/is-set/-/is-set-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-set"
         }
       ]
     },
@@ -11627,6 +15033,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-shared-array-buffer"
+        }
       ]
     },
     {
@@ -11646,6 +15058,12 @@
           "url": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-stream"
         }
       ]
     },
@@ -11667,6 +15085,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-string"
+        }
       ]
     },
     {
@@ -11686,6 +15110,12 @@
           "url": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-symbol"
         }
       ]
     },
@@ -11707,6 +15137,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-typed-array"
+        }
       ]
     },
     {
@@ -11726,6 +15162,12 @@
           "url": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-typedarray"
         }
       ]
     },
@@ -11747,6 +15189,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-unc-path"
+        }
       ]
     },
     {
@@ -11766,6 +15214,12 @@
           "url": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-weakmap"
         }
       ]
     },
@@ -11787,6 +15241,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-weakref"
+        }
       ]
     },
     {
@@ -11806,6 +15266,12 @@
           "url": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-weakset"
         }
       ]
     },
@@ -11827,6 +15293,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-windows"
+        }
       ]
     },
     {
@@ -11846,6 +15318,12 @@
           "url": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isarray"
         }
       ]
     },
@@ -11867,6 +15345,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isexe"
+        }
       ]
     },
     {
@@ -11886,6 +15370,12 @@
           "url": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isobject"
         }
       ]
     },
@@ -11907,6 +15397,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isstream"
+        }
       ]
     },
     {
@@ -11926,6 +15422,12 @@
           "url": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isurl"
         }
       ]
     },
@@ -11947,6 +15449,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/js-stringify"
+        }
       ]
     },
     {
@@ -11966,6 +15474,12 @@
           "url": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/js-tokens"
         }
       ]
     },
@@ -11987,6 +15501,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/js-yaml"
+        }
       ]
     },
     {
@@ -12006,6 +15526,12 @@
           "url": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jsbn"
         }
       ]
     },
@@ -12027,6 +15553,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-buffer"
+        }
       ]
     },
     {
@@ -12046,6 +15578,12 @@
           "url": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-parse-better-errors"
         }
       ]
     },
@@ -12067,6 +15605,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-schema-traverse"
+        }
       ]
     },
     {
@@ -12086,6 +15630,12 @@
           "url": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-schema"
         }
       ]
     },
@@ -12107,6 +15657,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-stringify-safe"
+        }
       ]
     },
     {
@@ -12126,6 +15682,12 @@
           "url": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json5"
         }
       ]
     },
@@ -12147,6 +15709,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jsonfile"
+        }
       ]
     },
     {
@@ -12166,6 +15734,12 @@
           "url": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-0.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jsonwebtoken"
         }
       ]
     },
@@ -12187,6 +15761,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jsprim"
+        }
       ]
     },
     {
@@ -12206,6 +15786,12 @@
           "url": "https://registry.npmjs.org/jssha/-/jssha-3.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jssha"
         }
       ]
     },
@@ -12227,6 +15813,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jstransformer"
+        }
       ]
     },
     {
@@ -12246,6 +15838,12 @@
           "url": "https://registry.npmjs.org/juicy-chat-bot/-/juicy-chat-bot-0.6.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/juicy-chat-bot"
         }
       ]
     },
@@ -12267,6 +15865,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jwa"
+        }
       ]
     },
     {
@@ -12286,6 +15890,12 @@
           "url": "https://registry.npmjs.org/jws/-/jws-0.2.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jws"
         }
       ]
     },
@@ -12307,6 +15917,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/keyv"
+        }
       ]
     },
     {
@@ -12326,6 +15942,12 @@
           "url": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/kind-of"
         }
       ]
     },
@@ -12347,6 +15969,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/kuler"
+        }
       ]
     },
     {
@@ -12366,6 +15994,12 @@
           "url": "https://registry.npmjs.org/kuromoji/-/kuromoji-0.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/kuromoji"
         }
       ]
     },
@@ -12387,6 +16021,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lazystream"
+        }
       ]
     },
     {
@@ -12406,6 +16046,12 @@
           "url": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/levn"
         }
       ]
     },
@@ -12428,6 +16074,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/libxmljs2"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12446,6 +16098,12 @@
               "url": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/libxmljs2\\node_modules\\nan"
             }
           ]
         }
@@ -12470,6 +16128,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/liftup"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12488,6 +16152,12 @@
               "url": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup\\node_modules\\braces"
             }
           ]
         },
@@ -12509,6 +16179,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup\\node_modules\\fill-range"
+            }
           ]
         },
         {
@@ -12528,6 +16204,12 @@
               "url": "https://registry.npmjs.org/findup-sync/-/findup-sync-4.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup\\node_modules\\findup-sync"
             }
           ]
         },
@@ -12549,6 +16231,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup\\node_modules\\is-glob"
+            }
           ]
         },
         {
@@ -12568,6 +16256,12 @@
               "url": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup\\node_modules\\is-number"
             }
           ]
         },
@@ -12589,6 +16283,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup\\node_modules\\micromatch"
+            }
           ]
         },
         {
@@ -12608,6 +16308,12 @@
               "url": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup\\node_modules\\to-regex-range"
             }
           ]
         }
@@ -12632,6 +16338,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/linebreak"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12650,6 +16362,12 @@
               "url": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/linebreak\\node_modules\\base64-js"
             }
           ]
         }
@@ -12673,6 +16391,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/listenercount"
+        }
       ]
     },
     {
@@ -12692,6 +16416,12 @@
           "url": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/locate-path"
         }
       ]
     },
@@ -12713,6 +16443,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lodash.camelcase"
+        }
       ]
     },
     {
@@ -12732,6 +16468,12 @@
           "url": "https://registry.npmjs.org/lodash.isfinite/-/lodash.isfinite-3.3.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lodash.isfinite"
         }
       ]
     },
@@ -12753,6 +16495,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lodash.set"
+        }
       ]
     },
     {
@@ -12772,6 +16520,12 @@
           "url": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lodash"
         }
       ]
     },
@@ -12794,6 +16548,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/logform"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12812,6 +16572,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/logform\\node_modules\\ms"
             }
           ]
         }
@@ -12835,6 +16601,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lolex"
+        }
       ]
     },
     {
@@ -12854,6 +16626,12 @@
           "url": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/loose-envify"
         }
       ]
     },
@@ -12875,6 +16653,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lowercase-keys"
+        }
       ]
     },
     {
@@ -12894,6 +16678,12 @@
           "url": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lru-cache"
         }
       ]
     },
@@ -12916,6 +16706,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-dir"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12934,6 +16730,12 @@
               "url": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-dir\\node_modules\\semver"
             }
           ]
         }
@@ -12957,6 +16759,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-error"
+        }
       ]
     },
     {
@@ -12976,6 +16784,12 @@
           "url": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-9.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-fetch-happen"
         }
       ],
       "components": [
@@ -12998,6 +16812,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen\\node_modules\\@tootallnate\\once"
+            }
           ]
         },
         {
@@ -13017,6 +16837,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen\\node_modules\\debug"
             }
           ]
         },
@@ -13038,6 +16864,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen\\node_modules\\http-cache-semantics"
+            }
           ]
         },
         {
@@ -13058,6 +16890,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen\\node_modules\\http-proxy-agent"
+            }
           ]
         },
         {
@@ -13077,6 +16915,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen\\node_modules\\ms"
             }
           ]
         }
@@ -13100,6 +16944,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-iterator"
+        }
       ]
     },
     {
@@ -13119,6 +16969,12 @@
           "url": "https://registry.npmjs.org/make-plural/-/make-plural-6.2.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-plural"
         }
       ]
     },
@@ -13140,6 +16996,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/map-cache"
+        }
       ]
     },
     {
@@ -13159,6 +17021,12 @@
           "url": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/map-visit"
         }
       ]
     },
@@ -13180,6 +17048,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/marsdb"
+        }
       ]
     },
     {
@@ -13199,6 +17073,12 @@
           "url": "https://registry.npmjs.org/math-interval-parser/-/math-interval-parser-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/math-interval-parser"
         }
       ]
     },
@@ -13220,6 +17100,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/media-typer"
+        }
       ]
     },
     {
@@ -13239,6 +17125,12 @@
           "url": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/merge-descriptors"
         }
       ]
     },
@@ -13260,6 +17152,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/messageformat-formatters"
+        }
       ]
     },
     {
@@ -13279,6 +17177,12 @@
           "url": "https://registry.npmjs.org/messageformat-parser/-/messageformat-parser-4.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/messageformat-parser"
         }
       ]
     },
@@ -13301,6 +17205,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/messageformat"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -13319,6 +17229,12 @@
               "url": "https://registry.npmjs.org/make-plural/-/make-plural-4.3.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/messageformat\\node_modules\\make-plural"
             }
           ]
         }
@@ -13342,6 +17258,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/methods"
+        }
       ]
     },
     {
@@ -13361,6 +17283,12 @@
           "url": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/micromatch"
         }
       ]
     },
@@ -13382,6 +17310,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mime-db"
+        }
       ]
     },
     {
@@ -13401,6 +17335,12 @@
           "url": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mime-types"
         }
       ]
     },
@@ -13422,6 +17362,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mime"
+        }
       ]
     },
     {
@@ -13441,6 +17387,12 @@
           "url": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mimic-response"
         }
       ]
     },
@@ -13462,6 +17414,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minimatch"
+        }
       ]
     },
     {
@@ -13481,6 +17439,12 @@
           "url": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minimist"
         }
       ]
     },
@@ -13502,6 +17466,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-collect"
+        }
       ]
     },
     {
@@ -13521,6 +17491,12 @@
           "url": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-1.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-fetch"
         }
       ]
     },
@@ -13542,6 +17518,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-flush"
+        }
       ]
     },
     {
@@ -13561,6 +17543,12 @@
           "url": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-pipeline"
         }
       ]
     },
@@ -13582,6 +17570,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-sized"
+        }
       ]
     },
     {
@@ -13601,6 +17595,12 @@
           "url": "https://registry.npmjs.org/minipass/-/minipass-3.3.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass"
         }
       ]
     },
@@ -13622,6 +17622,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minizlib"
+        }
       ]
     },
     {
@@ -13641,6 +17647,12 @@
           "url": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mixin-deep"
         }
       ]
     },
@@ -13662,6 +17674,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mkdirp-classic"
+        }
       ]
     },
     {
@@ -13681,6 +17699,12 @@
           "url": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mkdirp"
         }
       ]
     },
@@ -13702,6 +17726,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/moment-timezone"
+        }
       ]
     },
     {
@@ -13721,6 +17751,12 @@
           "url": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/moment"
         }
       ]
     },
@@ -13743,6 +17779,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/morgan"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -13761,6 +17803,12 @@
               "url": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/morgan\\node_modules\\on-finished"
             }
           ]
         }
@@ -13784,6 +17832,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mout"
+        }
       ]
     },
     {
@@ -13803,6 +17857,12 @@
           "url": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ms"
         }
       ]
     },
@@ -13825,6 +17885,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/multer"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -13843,6 +17909,12 @@
               "url": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/multer\\node_modules\\mkdirp"
             }
           ]
         }
@@ -13866,6 +17938,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mustache"
+        }
       ]
     },
     {
@@ -13885,6 +17963,12 @@
           "url": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/nan"
         }
       ]
     },
@@ -13906,6 +17990,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/nanomatch"
+        }
       ]
     },
     {
@@ -13925,6 +18015,12 @@
           "url": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/napi-build-utils"
         }
       ]
     },
@@ -13947,6 +18043,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/needle"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -13965,6 +18067,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/needle\\node_modules\\debug"
             }
           ]
         },
@@ -13985,6 +18093,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/needle\\node_modules\\ms"
             }
           ]
         }
@@ -14008,6 +18122,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/negotiator"
+        }
       ]
     },
     {
@@ -14027,6 +18147,12 @@
           "url": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/neo-async"
         }
       ]
     },
@@ -14049,6 +18175,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-abi"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14067,6 +18199,12 @@
               "url": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-abi\\node_modules\\semver"
             }
           ]
         }
@@ -14090,6 +18228,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-addon-api"
+        }
       ]
     },
     {
@@ -14109,6 +18253,12 @@
           "url": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-fetch"
         }
       ]
     },
@@ -14131,6 +18281,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-gyp"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14149,6 +18305,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp\\node_modules\\ansi-regex"
             }
           ]
         },
@@ -14170,6 +18332,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp\\node_modules\\are-we-there-yet"
+            }
           ]
         },
         {
@@ -14189,6 +18357,12 @@
               "url": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp\\node_modules\\gauge"
             }
           ]
         },
@@ -14210,6 +18384,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp\\node_modules\\is-fullwidth-code-point"
+            }
           ]
         },
         {
@@ -14229,6 +18409,12 @@
               "url": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp\\node_modules\\nopt"
             }
           ]
         },
@@ -14250,6 +18436,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp\\node_modules\\npmlog"
+            }
           ]
         },
         {
@@ -14269,6 +18461,12 @@
               "url": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp\\node_modules\\readable-stream"
             }
           ]
         },
@@ -14290,6 +18488,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp\\node_modules\\string-width"
+            }
           ]
         },
         {
@@ -14309,6 +18513,12 @@
               "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp\\node_modules\\strip-ansi"
             }
           ]
         }
@@ -14333,6 +18543,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-pre-gyp"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14351,6 +18567,12 @@
               "url": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp\\node_modules\\chownr"
             }
           ]
         },
@@ -14372,6 +18594,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp\\node_modules\\fs-minipass"
+            }
           ]
         },
         {
@@ -14391,6 +18619,12 @@
               "url": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp\\node_modules\\minipass"
             }
           ]
         },
@@ -14412,6 +18646,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp\\node_modules\\minizlib"
+            }
           ]
         },
         {
@@ -14431,6 +18671,12 @@
               "url": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp\\node_modules\\mkdirp"
             }
           ]
         },
@@ -14452,6 +18698,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp\\node_modules\\nopt"
+            }
           ]
         },
         {
@@ -14471,6 +18723,12 @@
               "url": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp\\node_modules\\rimraf"
             }
           ]
         },
@@ -14492,6 +18750,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp\\node_modules\\safe-buffer"
+            }
           ]
         },
         {
@@ -14511,6 +18775,12 @@
               "url": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp\\node_modules\\semver"
             }
           ]
         },
@@ -14532,6 +18802,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp\\node_modules\\tar"
+            }
           ]
         },
         {
@@ -14551,6 +18827,12 @@
               "url": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp\\node_modules\\yallist"
             }
           ]
         }
@@ -14574,6 +18856,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/noop-logger"
+        }
       ]
     },
     {
@@ -14593,6 +18881,12 @@
           "url": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/nopt"
         }
       ]
     },
@@ -14615,6 +18909,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/normalize-package-data"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14633,6 +18933,12 @@
               "url": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/normalize-package-data\\node_modules\\semver"
             }
           ]
         }
@@ -14656,6 +18962,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/normalize-path"
+        }
       ]
     },
     {
@@ -14675,6 +18987,12 @@
           "url": "https://registry.npmjs.org/normalize-url/-/normalize-url-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/normalize-url"
         }
       ]
     },
@@ -14697,6 +19015,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/notevil"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14715,6 +19039,12 @@
               "url": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/notevil\\node_modules\\esprima"
             }
           ]
         }
@@ -14738,6 +19068,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/npm-bundled"
+        }
       ]
     },
     {
@@ -14757,6 +19093,12 @@
           "url": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/npm-normalize-package-bin"
         }
       ]
     },
@@ -14778,6 +19120,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/npm-packlist"
+        }
       ]
     },
     {
@@ -14797,6 +19145,12 @@
           "url": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/npmlog"
         }
       ]
     },
@@ -14818,6 +19172,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/number-is-nan"
+        }
       ]
     },
     {
@@ -14838,6 +19198,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/oauth-sign"
+        }
       ]
     },
     {
@@ -14857,6 +19223,12 @@
           "url": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-assign"
         }
       ]
     },
@@ -14879,6 +19251,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-copy"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14897,6 +19275,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy\\node_modules\\define-property"
             }
           ]
         },
@@ -14918,6 +19302,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy\\node_modules\\is-accessor-descriptor"
+            }
           ]
         },
         {
@@ -14937,6 +19327,12 @@
               "url": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy\\node_modules\\is-data-descriptor"
             }
           ]
         },
@@ -14959,6 +19355,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy\\node_modules\\is-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -14977,6 +19379,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/object-copy\\node_modules\\is-descriptor\\node_modules\\kind-of"
                 }
               ]
             }
@@ -15000,6 +19408,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy\\node_modules\\kind-of"
+            }
           ]
         }
       ]
@@ -15022,6 +19436,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-inspect"
+        }
       ]
     },
     {
@@ -15041,6 +19461,12 @@
           "url": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-is"
         }
       ]
     },
@@ -15062,6 +19488,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-keys"
+        }
       ]
     },
     {
@@ -15081,6 +19513,12 @@
           "url": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-visit"
         }
       ]
     },
@@ -15102,6 +19540,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object.assign"
+        }
       ]
     },
     {
@@ -15121,6 +19565,12 @@
           "url": "https://registry.npmjs.org/object.defaults/-/object.defaults-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object.defaults"
         }
       ]
     },
@@ -15142,6 +19592,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object.map"
+        }
       ]
     },
     {
@@ -15161,6 +19617,12 @@
           "url": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object.pick"
         }
       ]
     },
@@ -15182,6 +19644,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/on-finished"
+        }
       ]
     },
     {
@@ -15201,6 +19669,12 @@
           "url": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/on-headers"
         }
       ]
     },
@@ -15222,6 +19696,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/once"
+        }
       ]
     },
     {
@@ -15241,6 +19721,12 @@
           "url": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/one-time"
         }
       ]
     },
@@ -15262,6 +19748,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/opentype.js"
+        }
       ]
     },
     {
@@ -15281,6 +19773,12 @@
           "url": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/optionator"
         }
       ]
     },
@@ -15302,6 +19800,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/os-homedir"
+        }
       ]
     },
     {
@@ -15321,6 +19825,12 @@
           "url": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/os-tmpdir"
         }
       ]
     },
@@ -15342,6 +19852,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/osenv"
+        }
       ]
     },
     {
@@ -15361,6 +19877,12 @@
           "url": "https://registry.npmjs.org/otplib/-/otplib-12.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/otplib"
         }
       ]
     },
@@ -15382,6 +19904,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-cancelable"
+        }
       ]
     },
     {
@@ -15401,6 +19929,12 @@
           "url": "https://registry.npmjs.org/p-event/-/p-event-2.3.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-event"
         }
       ]
     },
@@ -15422,6 +19956,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-finally"
+        }
       ]
     },
     {
@@ -15441,6 +19981,12 @@
           "url": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-is-promise"
         }
       ]
     },
@@ -15462,6 +20008,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-limit"
+        }
       ]
     },
     {
@@ -15481,6 +20033,12 @@
           "url": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-locate"
         }
       ]
     },
@@ -15502,6 +20060,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-map"
+        }
       ]
     },
     {
@@ -15521,6 +20085,12 @@
           "url": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-timeout"
         }
       ]
     },
@@ -15542,6 +20112,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-try"
+        }
       ]
     },
     {
@@ -15561,6 +20137,12 @@
           "url": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pako"
         }
       ]
     },
@@ -15582,6 +20164,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/parse-filepath"
+        }
       ]
     },
     {
@@ -15601,6 +20189,12 @@
           "url": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/parse-json"
         }
       ]
     },
@@ -15622,6 +20216,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/parse-passwd"
+        }
       ]
     },
     {
@@ -15641,6 +20241,12 @@
           "url": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/parseurl"
         }
       ]
     },
@@ -15662,6 +20268,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pascalcase"
+        }
       ]
     },
     {
@@ -15681,6 +20293,12 @@
           "url": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-exists"
         }
       ]
     },
@@ -15702,6 +20320,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-is-absolute"
+        }
       ]
     },
     {
@@ -15721,6 +20345,12 @@
           "url": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-parse"
         }
       ]
     },
@@ -15742,6 +20372,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-root-regex"
+        }
       ]
     },
     {
@@ -15761,6 +20397,12 @@
           "url": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-root"
         }
       ]
     },
@@ -15782,6 +20424,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-to-regexp"
+        }
       ]
     },
     {
@@ -15801,6 +20449,12 @@
           "url": "https://registry.npmjs.org/pdfkit/-/pdfkit-0.11.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pdfkit"
         }
       ]
     },
@@ -15822,6 +20476,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/peek-readable"
+        }
       ]
     },
     {
@@ -15841,6 +20501,12 @@
           "url": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pend"
         }
       ]
     },
@@ -15862,6 +20528,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/performance-now"
+        }
       ]
     },
     {
@@ -15881,6 +20553,12 @@
           "url": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.5.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pg-connection-string"
         }
       ]
     },
@@ -15902,6 +20580,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/picomatch"
+        }
       ]
     },
     {
@@ -15921,6 +20605,12 @@
           "url": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pify"
         }
       ]
     },
@@ -15942,6 +20632,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pinkie-promise"
+        }
       ]
     },
     {
@@ -15961,6 +20657,12 @@
           "url": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pinkie"
         }
       ]
     },
@@ -15982,6 +20684,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/png-js"
+        }
       ]
     },
     {
@@ -16001,6 +20709,12 @@
           "url": "https://registry.npmjs.org/portscanner/-/portscanner-2.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/portscanner"
         }
       ]
     },
@@ -16022,6 +20736,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/posix-character-classes"
+        }
       ]
     },
     {
@@ -16041,6 +20761,12 @@
           "url": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.3.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/prebuild-install"
         }
       ]
     },
@@ -16062,6 +20788,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/prelude-ls"
+        }
       ]
     },
     {
@@ -16081,6 +20813,12 @@
           "url": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/prepend-http"
         }
       ]
     },
@@ -16102,6 +20840,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pretty-bytes"
+        }
       ]
     },
     {
@@ -16121,6 +20865,12 @@
           "url": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/process-nextick-args"
         }
       ]
     },
@@ -16142,6 +20892,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/prom-client"
+        }
       ]
     },
     {
@@ -16161,6 +20917,12 @@
           "url": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/promise-inflight"
         }
       ]
     },
@@ -16183,6 +20945,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/promise-retry"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -16201,6 +20969,12 @@
               "url": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/promise-retry\\node_modules\\err-code"
             }
           ]
         },
@@ -16221,6 +20995,12 @@
               "url": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/promise-retry\\node_modules\\retry"
             }
           ]
         }
@@ -16244,6 +21024,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/promise"
+        }
       ]
     },
     {
@@ -16263,6 +21049,12 @@
           "url": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/proper-lockfile"
         }
       ]
     },
@@ -16284,6 +21076,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/proxy-addr"
+        }
       ]
     },
     {
@@ -16303,6 +21101,12 @@
           "url": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/psl"
         }
       ]
     },
@@ -16324,6 +21128,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-attrs"
+        }
       ]
     },
     {
@@ -16343,6 +21153,12 @@
           "url": "https://registry.npmjs.org/pug-code-gen/-/pug-code-gen-3.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-code-gen"
         }
       ]
     },
@@ -16364,6 +21180,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-error"
+        }
       ]
     },
     {
@@ -16383,6 +21205,12 @@
           "url": "https://registry.npmjs.org/pug-filters/-/pug-filters-4.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-filters"
         }
       ]
     },
@@ -16404,6 +21232,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-lexer"
+        }
       ]
     },
     {
@@ -16423,6 +21257,12 @@
           "url": "https://registry.npmjs.org/pug-linker/-/pug-linker-4.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-linker"
         }
       ]
     },
@@ -16444,6 +21284,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-load"
+        }
       ]
     },
     {
@@ -16463,6 +21309,12 @@
           "url": "https://registry.npmjs.org/pug-parser/-/pug-parser-6.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-parser"
         }
       ]
     },
@@ -16484,6 +21336,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-runtime"
+        }
       ]
     },
     {
@@ -16503,6 +21361,12 @@
           "url": "https://registry.npmjs.org/pug-strip-comments/-/pug-strip-comments-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-strip-comments"
         }
       ]
     },
@@ -16524,6 +21388,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-walk"
+        }
       ]
     },
     {
@@ -16543,6 +21413,12 @@
           "url": "https://registry.npmjs.org/pug/-/pug-3.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug"
         }
       ]
     },
@@ -16564,6 +21440,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pump"
+        }
       ]
     },
     {
@@ -16583,6 +21465,12 @@
           "url": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/punycode"
         }
       ]
     },
@@ -16604,6 +21492,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/qs"
+        }
       ]
     },
     {
@@ -16623,6 +21517,12 @@
           "url": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/query-string"
         }
       ]
     },
@@ -16644,6 +21544,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/range_check"
+        }
       ]
     },
     {
@@ -16663,6 +21569,12 @@
           "url": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/range-parser"
         }
       ]
     },
@@ -16684,6 +21596,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/raw-body"
+        }
       ]
     },
     {
@@ -16703,6 +21621,12 @@
           "url": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/rc"
         }
       ]
     },
@@ -16725,6 +21649,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/read-pkg"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -16743,6 +21673,12 @@
               "url": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/read-pkg\\node_modules\\pify"
             }
           ]
         }
@@ -16767,6 +21703,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/readable-stream"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -16785,6 +21727,12 @@
               "url": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/readable-stream\\node_modules\\isarray"
             }
           ]
         }
@@ -16809,6 +21757,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/readable-web-to-node-stream"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -16827,6 +21781,12 @@
               "url": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/readable-web-to-node-stream\\node_modules\\readable-stream"
             }
           ]
         }
@@ -16850,6 +21810,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/readdirp"
+        }
       ]
     },
     {
@@ -16869,6 +21835,12 @@
           "url": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/rechoir"
         }
       ]
     },
@@ -16890,6 +21862,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/regex-not"
+        }
       ]
     },
     {
@@ -16909,6 +21887,12 @@
           "url": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/regexp.prototype.flags"
         }
       ]
     },
@@ -16930,6 +21914,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/remove-trailing-separator"
+        }
       ]
     },
     {
@@ -16950,6 +21940,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/repeat-element"
+        }
       ]
     },
     {
@@ -16969,6 +21965,12 @@
           "url": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/repeat-string"
         }
       ]
     },
@@ -16991,6 +21993,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/replace"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17009,6 +22017,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\ansi-regex"
             }
           ]
         },
@@ -17030,6 +22044,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\ansi-styles"
+            }
           ]
         },
         {
@@ -17049,6 +22069,12 @@
               "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\brace-expansion"
             }
           ]
         },
@@ -17070,6 +22096,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\cliui"
+            }
           ]
         },
         {
@@ -17089,6 +22121,12 @@
               "url": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\color-convert"
             }
           ]
         },
@@ -17110,6 +22148,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\color-name"
+            }
           ]
         },
         {
@@ -17129,6 +22173,12 @@
               "url": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\find-up"
             }
           ]
         },
@@ -17150,6 +22200,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\is-fullwidth-code-point"
+            }
           ]
         },
         {
@@ -17169,6 +22225,12 @@
               "url": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\locate-path"
             }
           ]
         },
@@ -17190,6 +22252,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\minimatch"
+            }
           ]
         },
         {
@@ -17209,6 +22277,12 @@
               "url": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\p-locate"
             }
           ]
         },
@@ -17230,6 +22304,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\path-exists"
+            }
           ]
         },
         {
@@ -17249,6 +22329,12 @@
               "url": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\string-width"
             }
           ]
         },
@@ -17270,6 +22356,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\strip-ansi"
+            }
           ]
         },
         {
@@ -17289,6 +22381,12 @@
               "url": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\wrap-ansi"
             }
           ]
         },
@@ -17310,6 +22408,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\yargs-parser"
+            }
           ]
         },
         {
@@ -17329,6 +22433,12 @@
               "url": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\yargs"
             }
           ]
         }
@@ -17353,6 +22463,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/request"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17371,6 +22487,12 @@
               "url": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/request\\node_modules\\qs"
             }
           ]
         }
@@ -17394,6 +22516,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/require-directory"
+        }
       ]
     },
     {
@@ -17413,6 +22541,12 @@
           "url": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/require-main-filename"
         }
       ]
     },
@@ -17434,6 +22568,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/resolve-dir"
+        }
       ]
     },
     {
@@ -17453,6 +22593,12 @@
           "url": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/resolve-url"
         }
       ]
     },
@@ -17474,6 +22620,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/resolve"
+        }
       ]
     },
     {
@@ -17493,6 +22645,12 @@
           "url": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/responselike"
         }
       ]
     },
@@ -17514,6 +22672,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/restructure"
+        }
       ]
     },
     {
@@ -17533,6 +22697,12 @@
           "url": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ret"
         }
       ]
     },
@@ -17554,6 +22724,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/retry-as-promised"
+        }
       ]
     },
     {
@@ -17574,6 +22750,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/retry"
+        }
       ]
     },
     {
@@ -17593,6 +22775,12 @@
           "url": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/rimraf"
         }
       ]
     },
@@ -17615,6 +22803,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/rxjs"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17633,6 +22827,12 @@
               "url": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/rxjs\\node_modules\\tslib"
             }
           ]
         }
@@ -17656,6 +22856,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safe-buffer"
+        }
       ]
     },
     {
@@ -17675,6 +22881,12 @@
           "url": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safe-regex-test"
         }
       ]
     },
@@ -17696,6 +22908,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safe-regex"
+        }
       ]
     },
     {
@@ -17715,6 +22933,12 @@
           "url": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safe-stable-stringify"
         }
       ]
     },
@@ -17736,6 +22960,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safer-buffer"
+        }
       ]
     },
     {
@@ -17756,6 +22986,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/samsam"
+        }
       ]
     },
     {
@@ -17775,6 +23011,12 @@
           "url": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sanitize-filename"
         }
       ]
     },
@@ -17797,6 +23039,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sanitize-html"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17815,6 +23063,12 @@
               "url": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sanitize-html\\node_modules\\lodash"
             }
           ]
         }
@@ -17838,6 +23092,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sax"
+        }
       ]
     },
     {
@@ -17858,6 +23118,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/seek-bzip"
+        }
       ]
     },
     {
@@ -17877,6 +23143,12 @@
           "url": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/semver"
         }
       ]
     },
@@ -17899,6 +23171,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/send"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17917,6 +23195,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/send\\node_modules\\ms"
             }
           ]
         }
@@ -17940,6 +23224,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sequelize-pool"
+        }
       ]
     },
     {
@@ -17961,6 +23251,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sequelize"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17979,6 +23275,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sequelize\\node_modules\\debug"
             }
           ]
         },
@@ -18000,6 +23302,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sequelize\\node_modules\\ms"
+            }
           ]
         },
         {
@@ -18019,6 +23327,12 @@
               "url": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sequelize\\node_modules\\uuid"
             }
           ]
         }
@@ -18043,6 +23357,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/serve-index"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18061,6 +23381,12 @@
               "url": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index\\node_modules\\depd"
             }
           ]
         },
@@ -18082,6 +23408,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index\\node_modules\\http-errors"
+            }
           ]
         },
         {
@@ -18101,6 +23433,12 @@
               "url": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index\\node_modules\\inherits"
             }
           ]
         },
@@ -18122,6 +23460,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index\\node_modules\\setprototypeof"
+            }
           ]
         },
         {
@@ -18141,6 +23485,12 @@
               "url": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index\\node_modules\\statuses"
             }
           ]
         }
@@ -18164,6 +23514,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/serve-static"
+        }
       ]
     },
     {
@@ -18183,6 +23539,12 @@
           "url": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/set-blocking"
         }
       ]
     },
@@ -18205,6 +23567,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/set-value"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18223,6 +23591,12 @@
               "url": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/set-value\\node_modules\\extend-shallow"
             }
           ]
         },
@@ -18243,6 +23617,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/set-value\\node_modules\\is-extendable"
             }
           ]
         }
@@ -18266,6 +23646,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/setimmediate"
+        }
       ]
     },
     {
@@ -18285,6 +23671,12 @@
           "url": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/setprototypeof"
         }
       ]
     },
@@ -18306,6 +23698,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/side-channel"
+        }
       ]
     },
     {
@@ -18326,6 +23724,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/signal-exit"
+        }
       ]
     },
     {
@@ -18345,6 +23749,12 @@
           "url": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/simple-concat"
         }
       ]
     },
@@ -18367,6 +23777,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/simple-get"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18385,6 +23801,12 @@
               "url": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/simple-get\\node_modules\\decompress-response"
             }
           ]
         },
@@ -18405,6 +23827,12 @@
               "url": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/simple-get\\node_modules\\mimic-response"
             }
           ]
         }
@@ -18429,6 +23857,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/simple-swizzle"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18447,6 +23881,12 @@
               "url": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/simple-swizzle\\node_modules\\is-arrayish"
             }
           ]
         }
@@ -18470,6 +23910,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sinon"
+        }
       ]
     },
     {
@@ -18489,6 +23935,12 @@
           "url": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/smart-buffer"
         }
       ]
     },
@@ -18511,6 +23963,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/snapdragon-node"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18529,6 +23987,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon-node\\node_modules\\define-property"
             }
           ]
         }
@@ -18553,6 +24017,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/snapdragon-util"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18571,6 +24041,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon-util\\node_modules\\kind-of"
             }
           ]
         }
@@ -18595,6 +24071,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/snapdragon"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18613,6 +24095,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon\\node_modules\\define-property"
             }
           ]
         },
@@ -18633,6 +24121,12 @@
               "url": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon\\node_modules\\extend-shallow"
             }
           ]
         },
@@ -18655,6 +24149,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon\\node_modules\\is-accessor-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -18673,6 +24173,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/snapdragon\\node_modules\\is-accessor-descriptor\\node_modules\\kind-of"
                 }
               ]
             }
@@ -18697,6 +24203,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon\\node_modules\\is-data-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -18715,6 +24227,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/snapdragon\\node_modules\\is-data-descriptor\\node_modules\\kind-of"
                 }
               ]
             }
@@ -18738,6 +24256,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon\\node_modules\\is-descriptor"
+            }
           ]
         },
         {
@@ -18757,6 +24281,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon\\node_modules\\is-extendable"
             }
           ]
         },
@@ -18778,6 +24308,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon\\node_modules\\kind-of"
+            }
           ]
         },
         {
@@ -18797,6 +24333,12 @@
               "url": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon\\node_modules\\source-map"
             }
           ]
         }
@@ -18820,6 +24362,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socket.io-adapter"
+        }
       ]
     },
     {
@@ -18841,6 +24389,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socket.io-parser"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18859,6 +24413,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socket.io-parser\\node_modules\\debug"
             }
           ]
         },
@@ -18879,6 +24439,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socket.io-parser\\node_modules\\ms"
             }
           ]
         }
@@ -18903,6 +24469,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socket.io"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18921,6 +24493,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socket.io\\node_modules\\debug"
             }
           ]
         },
@@ -18941,6 +24519,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socket.io\\node_modules\\ms"
             }
           ]
         }
@@ -18965,6 +24549,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socks-proxy-agent"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18983,6 +24573,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socks-proxy-agent\\node_modules\\debug"
             }
           ]
         },
@@ -19003,6 +24599,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socks-proxy-agent\\node_modules\\ms"
             }
           ]
         }
@@ -19027,6 +24629,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socks"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -19045,6 +24653,12 @@
               "url": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socks\\node_modules\\ip"
             }
           ]
         }
@@ -19069,6 +24683,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sort-keys-length"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -19087,6 +24707,12 @@
               "url": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sort-keys-length\\node_modules\\sort-keys"
             }
           ]
         }
@@ -19110,6 +24736,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sort-keys"
+        }
       ]
     },
     {
@@ -19129,6 +24761,12 @@
           "url": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/source-map-resolve"
         }
       ]
     },
@@ -19150,6 +24788,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/source-map-support"
+        }
       ]
     },
     {
@@ -19169,6 +24813,12 @@
           "url": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/source-map-url"
         }
       ]
     },
@@ -19190,6 +24840,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/source-map"
+        }
       ]
     },
     {
@@ -19209,6 +24865,12 @@
           "url": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2-1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spawn-command"
         }
       ]
     },
@@ -19230,6 +24892,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spdx-correct"
+        }
       ]
     },
     {
@@ -19249,6 +24917,12 @@
           "url": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spdx-exceptions"
         }
       ]
     },
@@ -19270,6 +24944,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spdx-expression-parse"
+        }
       ]
     },
     {
@@ -19289,6 +24969,12 @@
           "url": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.12.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spdx-license-ids"
         }
       ]
     },
@@ -19310,6 +24996,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/split-string"
+        }
       ]
     },
     {
@@ -19329,6 +25021,12 @@
           "url": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sprintf-js"
         }
       ]
     },
@@ -19350,6 +25048,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sqlite3"
+        }
       ]
     },
     {
@@ -19369,6 +25073,12 @@
           "url": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sshpk"
         }
       ]
     },
@@ -19390,6 +25100,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ssri"
+        }
       ]
     },
     {
@@ -19409,6 +25125,12 @@
           "url": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/stack-trace"
         }
       ]
     },
@@ -19431,6 +25153,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/static-extend"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -19449,6 +25177,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend\\node_modules\\define-property"
             }
           ]
         },
@@ -19471,6 +25205,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend\\node_modules\\is-accessor-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -19489,6 +25229,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/static-extend\\node_modules\\is-accessor-descriptor\\node_modules\\kind-of"
                 }
               ]
             }
@@ -19513,6 +25259,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend\\node_modules\\is-data-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -19531,6 +25283,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/static-extend\\node_modules\\is-data-descriptor\\node_modules\\kind-of"
                 }
               ]
             }
@@ -19554,6 +25312,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend\\node_modules\\is-descriptor"
+            }
           ]
         },
         {
@@ -19573,6 +25337,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend\\node_modules\\kind-of"
             }
           ]
         }
@@ -19596,6 +25366,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/statuses"
+        }
       ]
     },
     {
@@ -19615,6 +25391,12 @@
           "url": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-2.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/stream-buffers"
         }
       ]
     },
@@ -19636,6 +25418,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/streamsearch"
+        }
       ]
     },
     {
@@ -19655,6 +25443,12 @@
           "url": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strict-uri-encode"
         }
       ]
     },
@@ -19676,6 +25470,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string_decoder"
+        }
       ]
     },
     {
@@ -19695,6 +25495,12 @@
           "url": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string-width"
         }
       ]
     },
@@ -19716,6 +25522,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string.fromcodepoint"
+        }
       ]
     },
     {
@@ -19735,6 +25547,12 @@
           "url": "https://registry.npmjs.org/string.prototype.codepointat/-/string.prototype.codepointat-0.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string.prototype.codepointat"
         }
       ]
     },
@@ -19756,6 +25574,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string.prototype.trimend"
+        }
       ]
     },
     {
@@ -19775,6 +25599,12 @@
           "url": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string.prototype.trimstart"
         }
       ]
     },
@@ -19796,6 +25626,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-ansi"
+        }
       ]
     },
     {
@@ -19815,6 +25651,12 @@
           "url": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-bom"
         }
       ]
     },
@@ -19836,6 +25678,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-dirs"
+        }
       ]
     },
     {
@@ -19855,6 +25703,12 @@
           "url": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-json-comments"
         }
       ]
     },
@@ -19876,6 +25730,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-outer"
+        }
       ]
     },
     {
@@ -19895,6 +25755,12 @@
           "url": "https://registry.npmjs.org/strtok3/-/strtok3-6.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strtok3"
         }
       ]
     },
@@ -19916,6 +25782,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/supports-color"
+        }
       ]
     },
     {
@@ -19935,6 +25807,12 @@
           "url": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/supports-preserve-symlinks-flag"
         }
       ]
     },
@@ -19956,6 +25834,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/svg-captcha"
+        }
       ]
     },
     {
@@ -19976,6 +25860,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/swagger-ui-dist"
+        }
       ]
     },
     {
@@ -19995,6 +25885,12 @@
           "url": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-4.5.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/swagger-ui-express"
         }
       ]
     },
@@ -20017,6 +25913,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tar-fs"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -20035,6 +25937,12 @@
               "url": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/tar-fs\\node_modules\\bl"
             }
           ]
         },
@@ -20056,6 +25964,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/tar-fs\\node_modules\\chownr"
+            }
           ]
         },
         {
@@ -20076,6 +25990,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/tar-fs\\node_modules\\readable-stream"
+            }
           ]
         },
         {
@@ -20095,6 +26015,12 @@
               "url": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/tar-fs\\node_modules\\tar-stream"
             }
           ]
         }
@@ -20118,6 +26044,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tar-stream"
+        }
       ]
     },
     {
@@ -20137,6 +26069,12 @@
           "url": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tar"
         }
       ]
     },
@@ -20158,6 +26096,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tdigest"
+        }
       ]
     },
     {
@@ -20177,6 +26121,12 @@
           "url": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/text-hex"
         }
       ]
     },
@@ -20198,6 +26148,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/thirty-two"
+        }
       ]
     },
     {
@@ -20217,6 +26173,12 @@
           "url": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/through"
         }
       ]
     },
@@ -20238,6 +26200,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/timed-out"
+        }
       ]
     },
     {
@@ -20257,6 +26225,12 @@
           "url": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tiny-inflate"
         }
       ]
     },
@@ -20278,6 +26252,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-buffer"
+        }
       ]
     },
     {
@@ -20297,6 +26277,12 @@
           "url": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-fast-properties"
         }
       ]
     },
@@ -20319,6 +26305,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-object-path"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -20337,6 +26329,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/to-object-path\\node_modules\\kind-of"
             }
           ]
         }
@@ -20360,6 +26358,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-regex-range"
+        }
       ]
     },
     {
@@ -20379,6 +26383,12 @@
           "url": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-regex"
         }
       ]
     },
@@ -20400,6 +26410,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/toidentifier"
+        }
       ]
     },
     {
@@ -20419,6 +26435,12 @@
           "url": "https://registry.npmjs.org/token-stream/-/token-stream-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/token-stream"
         }
       ]
     },
@@ -20440,6 +26462,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/token-types"
+        }
       ]
     },
     {
@@ -20459,6 +26487,12 @@
           "url": "https://registry.npmjs.org/toposort-class/-/toposort-class-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/toposort-class"
         }
       ]
     },
@@ -20480,6 +26514,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tough-cookie"
+        }
       ]
     },
     {
@@ -20499,6 +26539,12 @@
           "url": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tr46"
         }
       ]
     },
@@ -20520,6 +26566,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/traverse"
+        }
       ]
     },
     {
@@ -20539,6 +26591,12 @@
           "url": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tree-kill"
         }
       ]
     },
@@ -20560,6 +26618,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/trim-repeated"
+        }
       ]
     },
     {
@@ -20580,6 +26644,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/triple-beam"
+        }
       ]
     },
     {
@@ -20599,6 +26669,12 @@
           "url": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/truncate-utf8-bytes"
         }
       ]
     },
@@ -20621,6 +26697,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ts-node-dev"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -20639,6 +26721,12 @@
               "url": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/ts-node-dev\\node_modules\\rimraf"
             }
           ]
         }
@@ -20662,6 +26750,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ts-node"
+        }
       ]
     },
     {
@@ -20681,6 +26775,12 @@
           "url": "https://registry.npmjs.org/tsconfig/-/tsconfig-7.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tsconfig"
         }
       ]
     },
@@ -20702,6 +26802,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tslib"
+        }
       ]
     },
     {
@@ -20721,6 +26827,12 @@
           "url": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tunnel-agent"
         }
       ]
     },
@@ -20742,6 +26854,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tweetnacl"
+        }
       ]
     },
     {
@@ -20761,6 +26879,12 @@
           "url": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/type-check"
         }
       ]
     },
@@ -20782,6 +26906,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/type-is"
+        }
       ]
     },
     {
@@ -20801,6 +26931,12 @@
           "url": "https://registry.npmjs.org/typecast/-/typecast-0.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/typecast"
         }
       ]
     },
@@ -20822,6 +26958,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/typedarray"
+        }
       ]
     },
     {
@@ -20841,6 +26983,12 @@
           "url": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/typescript"
         }
       ]
     },
@@ -20862,6 +27010,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/uglify-js"
+        }
       ]
     },
     {
@@ -20881,6 +27035,12 @@
           "url": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unbox-primitive"
         }
       ]
     },
@@ -20902,6 +27062,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unbzip2-stream"
+        }
       ]
     },
     {
@@ -20921,6 +27087,12 @@
           "url": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unc-path-regex"
         }
       ]
     },
@@ -20942,6 +27114,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/underscore.string"
+        }
       ]
     },
     {
@@ -20962,6 +27140,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unicode-properties"
+        }
       ]
     },
     {
@@ -20981,6 +27165,12 @@
           "url": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unicode-trie"
         }
       ]
     },
@@ -21003,6 +27193,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/union-value"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21021,6 +27217,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/union-value\\node_modules\\is-extendable"
             }
           ]
         }
@@ -21044,6 +27246,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unique-filename"
+        }
       ]
     },
     {
@@ -21063,6 +27271,12 @@
           "url": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unique-slug"
         }
       ]
     },
@@ -21084,6 +27298,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unit-compare"
+        }
       ]
     },
     {
@@ -21104,6 +27324,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/universalify"
+        }
       ]
     },
     {
@@ -21123,6 +27349,12 @@
           "url": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unpipe"
         }
       ]
     },
@@ -21145,6 +27377,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unset-value"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21165,6 +27403,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/unset-value\\node_modules\\has-value"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -21183,6 +27427,12 @@
                   "url": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/unset-value\\node_modules\\has-value\\node_modules\\isobject"
                 }
               ]
             }
@@ -21206,6 +27456,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/unset-value\\node_modules\\has-values"
+            }
           ]
         },
         {
@@ -21225,6 +27481,12 @@
               "url": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/unset-value\\node_modules\\isarray"
             }
           ]
         }
@@ -21248,6 +27510,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/untildify"
+        }
       ]
     },
     {
@@ -21269,6 +27537,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unzipper"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21287,6 +27561,12 @@
               "url": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/unzipper\\node_modules\\bluebird"
             }
           ]
         }
@@ -21310,6 +27590,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/uri-js"
+        }
       ]
     },
     {
@@ -21329,6 +27615,12 @@
           "url": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/urix"
         }
       ]
     },
@@ -21350,6 +27642,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/url-parse-lax"
+        }
       ]
     },
     {
@@ -21369,6 +27667,12 @@
           "url": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/url-to-options"
         }
       ]
     },
@@ -21390,6 +27694,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/use"
+        }
       ]
     },
     {
@@ -21409,6 +27719,12 @@
           "url": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/utf8-byte-length"
         }
       ]
     },
@@ -21430,6 +27746,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/util-deprecate"
+        }
       ]
     },
     {
@@ -21449,6 +27771,12 @@
           "url": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/util"
         }
       ]
     },
@@ -21470,6 +27798,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/utils-merge"
+        }
       ]
     },
     {
@@ -21489,6 +27823,12 @@
           "url": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/uuid"
         }
       ]
     },
@@ -21510,6 +27850,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/v8flags"
+        }
       ]
     },
     {
@@ -21529,6 +27875,12 @@
           "url": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/validate-npm-package-license"
         }
       ]
     },
@@ -21550,6 +27902,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/validate"
+        }
       ]
     },
     {
@@ -21570,6 +27928,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/validator"
+        }
       ]
     },
     {
@@ -21589,6 +27953,12 @@
           "url": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/vary"
         }
       ]
     },
@@ -21611,6 +27981,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/verror"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21629,6 +28005,12 @@
               "url": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/verror\\node_modules\\core-util-is"
             }
           ]
         }
@@ -21653,6 +28035,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/vm2"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21671,6 +28059,12 @@
               "url": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/vm2\\node_modules\\acorn"
             }
           ]
         }
@@ -21694,6 +28088,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/void-elements"
+        }
       ]
     },
     {
@@ -21713,6 +28113,12 @@
           "url": "https://registry.npmjs.org/walk/-/walk-2.3.15.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/walk"
         }
       ]
     },
@@ -21734,6 +28140,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/walkdir"
+        }
       ]
     },
     {
@@ -21753,6 +28165,12 @@
           "url": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/webidl-conversions"
         }
       ]
     },
@@ -21774,6 +28192,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/whatwg-url"
+        }
       ]
     },
     {
@@ -21793,6 +28217,12 @@
           "url": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-boxed-primitive"
         }
       ]
     },
@@ -21814,6 +28244,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-collection"
+        }
       ]
     },
     {
@@ -21833,6 +28269,12 @@
           "url": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-module"
         }
       ]
     },
@@ -21854,6 +28296,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-pm-runs"
+        }
       ]
     },
     {
@@ -21873,6 +28321,12 @@
           "url": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-typed-array"
         }
       ]
     },
@@ -21894,6 +28348,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which"
+        }
       ]
     },
     {
@@ -21913,6 +28373,12 @@
           "url": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wide-align"
         }
       ]
     },
@@ -21935,6 +28401,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/winston-transport"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21953,6 +28425,12 @@
               "url": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/winston-transport\\node_modules\\readable-stream"
             }
           ]
         }
@@ -21977,6 +28455,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/winston"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21995,6 +28479,12 @@
               "url": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/winston\\node_modules\\async"
             }
           ]
         },
@@ -22016,6 +28506,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/winston\\node_modules\\is-stream"
+            }
           ]
         },
         {
@@ -22035,6 +28531,12 @@
               "url": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/winston\\node_modules\\readable-stream"
             }
           ]
         }
@@ -22058,6 +28560,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/with"
+        }
       ]
     },
     {
@@ -22077,6 +28585,12 @@
           "url": "https://registry.npmjs.org/wkx/-/wkx-0.5.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wkx"
         }
       ]
     },
@@ -22098,6 +28612,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/word-wrap"
+        }
       ]
     },
     {
@@ -22117,6 +28637,12 @@
           "url": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wordwrap"
         }
       ]
     },
@@ -22139,6 +28665,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wrap-ansi"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -22157,6 +28689,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi\\node_modules\\ansi-regex"
             }
           ]
         },
@@ -22178,6 +28716,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi\\node_modules\\emoji-regex"
+            }
           ]
         },
         {
@@ -22197,6 +28741,12 @@
               "url": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi\\node_modules\\is-fullwidth-code-point"
             }
           ]
         },
@@ -22218,6 +28768,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi\\node_modules\\string-width"
+            }
           ]
         },
         {
@@ -22237,6 +28793,12 @@
               "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi\\node_modules\\strip-ansi"
             }
           ]
         }
@@ -22260,6 +28822,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wrappy"
+        }
       ]
     },
     {
@@ -22279,6 +28847,12 @@
           "url": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ws"
         }
       ]
     },
@@ -22300,6 +28874,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/xtend"
+        }
       ]
     },
     {
@@ -22319,6 +28899,12 @@
           "url": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/y18n"
         }
       ]
     },
@@ -22340,6 +28926,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yallist"
+        }
       ]
     },
     {
@@ -22360,6 +28952,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yaml-schema-validator"
+        }
       ]
     },
     {
@@ -22379,6 +28977,12 @@
           "url": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yargs-parser"
         }
       ]
     },
@@ -22401,6 +29005,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yargs"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -22419,6 +29029,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs\\node_modules\\ansi-regex"
             }
           ]
         },
@@ -22440,6 +29056,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs\\node_modules\\emoji-regex"
+            }
           ]
         },
         {
@@ -22459,6 +29081,12 @@
               "url": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs\\node_modules\\is-fullwidth-code-point"
             }
           ]
         },
@@ -22480,6 +29108,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs\\node_modules\\string-width"
+            }
           ]
         },
         {
@@ -22499,6 +29133,12 @@
               "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs\\node_modules\\strip-ansi"
             }
           ]
         }
@@ -22522,6 +29162,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yauzl"
+        }
       ]
     },
     {
@@ -22541,6 +29187,12 @@
           "url": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yn"
         }
       ]
     },
@@ -22562,6 +29214,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/z85"
+        }
       ]
     },
     {
@@ -22582,6 +29240,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/zip-stream"
+        }
       ]
     },
     {
@@ -22601,6 +29265,12 @@
           "url": "https://registry.npmjs.org/zlibjs/-/zlibjs-0.3.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/zlibjs"
         }
       ]
     }

--- a/tests/_data/sbom_demo-results/juice-shop_npm9_node16_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/juice-shop_npm9_node16_windows-latest.snap.json
@@ -62,7 +62,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -95,7 +95,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@babel\\helper-string-parser"
         }
       ]
@@ -122,7 +122,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@babel\\helper-validator-identifier"
         }
       ]
@@ -149,7 +149,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@babel\\parser"
         }
       ]
@@ -176,7 +176,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@babel\\types"
         }
       ]
@@ -203,7 +203,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@colors\\colors"
         }
       ]
@@ -230,7 +230,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@dabh\\diagnostics"
         }
       ]
@@ -257,7 +257,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@gar\\promisify"
         }
       ]
@@ -284,7 +284,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@mapbox\\node-pre-gyp"
         }
       ],
@@ -310,7 +310,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\ansi-regex"
             }
           ]
@@ -336,7 +336,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\are-we-there-yet"
             }
           ]
@@ -362,7 +362,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\detect-libc"
             }
           ]
@@ -388,7 +388,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\gauge"
             }
           ]
@@ -414,7 +414,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\is-fullwidth-code-point"
             }
           ]
@@ -440,7 +440,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\make-dir"
             }
           ],
@@ -466,7 +466,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\make-dir\\node_modules\\semver"
                 }
               ]
@@ -494,7 +494,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\nopt"
             }
           ]
@@ -520,7 +520,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\npmlog"
             }
           ]
@@ -546,7 +546,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\readable-stream"
             }
           ]
@@ -572,7 +572,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\string-width"
             }
           ]
@@ -598,7 +598,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\strip-ansi"
             }
           ]
@@ -627,7 +627,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\core-loader"
         }
       ]
@@ -654,7 +654,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\core"
         }
       ]
@@ -681,7 +681,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\evaluator"
         }
       ]
@@ -708,7 +708,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-all"
         }
       ]
@@ -735,7 +735,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-ar"
         }
       ]
@@ -762,7 +762,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-bn"
         }
       ]
@@ -789,7 +789,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-ca"
         }
       ]
@@ -816,7 +816,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-cs"
         }
       ]
@@ -843,7 +843,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-da"
         }
       ]
@@ -870,7 +870,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-de"
         }
       ]
@@ -897,7 +897,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-el"
         }
       ]
@@ -924,7 +924,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-en-min"
         }
       ]
@@ -951,7 +951,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-en"
         }
       ]
@@ -978,7 +978,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-es"
         }
       ]
@@ -1005,7 +1005,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-eu"
         }
       ]
@@ -1032,7 +1032,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-fa"
         }
       ]
@@ -1059,7 +1059,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-fi"
         }
       ]
@@ -1086,7 +1086,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-fr"
         }
       ]
@@ -1113,7 +1113,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-ga"
         }
       ]
@@ -1140,7 +1140,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-gl"
         }
       ]
@@ -1167,7 +1167,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-hi"
         }
       ]
@@ -1194,7 +1194,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-hu"
         }
       ]
@@ -1221,7 +1221,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-hy"
         }
       ]
@@ -1248,7 +1248,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-id"
         }
       ]
@@ -1275,7 +1275,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-it"
         }
       ]
@@ -1302,7 +1302,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-ja"
         }
       ]
@@ -1329,7 +1329,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-ko"
         }
       ]
@@ -1356,7 +1356,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-lt"
         }
       ]
@@ -1383,7 +1383,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-ms"
         }
       ]
@@ -1410,7 +1410,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-ne"
         }
       ]
@@ -1437,7 +1437,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-nl"
         }
       ]
@@ -1464,7 +1464,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-no"
         }
       ]
@@ -1491,7 +1491,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-pl"
         }
       ]
@@ -1518,7 +1518,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-pt"
         }
       ]
@@ -1545,7 +1545,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-ro"
         }
       ]
@@ -1572,7 +1572,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-ru"
         }
       ]
@@ -1599,7 +1599,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-sl"
         }
       ]
@@ -1626,7 +1626,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-sr"
         }
       ]
@@ -1653,7 +1653,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-sv"
         }
       ]
@@ -1680,7 +1680,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-ta"
         }
       ]
@@ -1707,7 +1707,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-th"
         }
       ]
@@ -1734,7 +1734,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-tl"
         }
       ]
@@ -1761,7 +1761,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-tr"
         }
       ]
@@ -1788,7 +1788,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-uk"
         }
       ]
@@ -1815,7 +1815,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-zh"
         }
       ]
@@ -1842,7 +1842,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\language-min"
         }
       ]
@@ -1869,7 +1869,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\language"
         }
       ]
@@ -1896,7 +1896,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\ner"
         }
       ]
@@ -1923,7 +1923,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\neural"
         }
       ]
@@ -1950,7 +1950,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\nlg"
         }
       ]
@@ -1977,7 +1977,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\nlp"
         }
       ]
@@ -2004,7 +2004,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\nlu"
         }
       ]
@@ -2031,7 +2031,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\request"
         }
       ]
@@ -2058,7 +2058,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\sentiment"
         }
       ]
@@ -2085,7 +2085,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\similarity"
         }
       ]
@@ -2112,7 +2112,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\slot"
         }
       ]
@@ -2139,7 +2139,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@npmcli\\fs"
         }
       ]
@@ -2166,7 +2166,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@npmcli\\move-file"
         }
       ]
@@ -2193,7 +2193,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib\\core"
         }
       ]
@@ -2220,7 +2220,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib\\plugin-crypto"
         }
       ]
@@ -2247,7 +2247,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib\\plugin-thirty-two"
         }
       ]
@@ -2274,7 +2274,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib\\preset-default"
         }
       ]
@@ -2301,7 +2301,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib\\preset-v11"
         }
       ]
@@ -2328,7 +2328,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@sindresorhus\\is"
         }
       ]
@@ -2355,7 +2355,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@swc\\helpers"
         }
       ]
@@ -2382,7 +2382,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@tokenizer\\token"
         }
       ]
@@ -2409,7 +2409,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@tootallnate\\once"
         }
       ]
@@ -2436,7 +2436,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types\\component-emitter"
         }
       ]
@@ -2463,7 +2463,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types\\cookie"
         }
       ]
@@ -2490,7 +2490,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types\\cors"
         }
       ]
@@ -2517,7 +2517,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types\\debug"
         }
       ]
@@ -2544,7 +2544,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types\\ms"
         }
       ]
@@ -2571,7 +2571,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types\\node"
         }
       ]
@@ -2598,7 +2598,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types\\strip-bom"
         }
       ]
@@ -2625,7 +2625,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types\\strip-json-comments"
         }
       ]
@@ -2652,7 +2652,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types\\validator"
         }
       ]
@@ -2678,7 +2678,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/abbrev"
         }
       ]
@@ -2704,7 +2704,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/accepts"
         }
       ]
@@ -2730,7 +2730,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/acorn-walk"
         }
       ]
@@ -2756,7 +2756,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/acorn"
         }
       ]
@@ -2782,7 +2782,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/agent-base"
         }
       ],
@@ -2808,7 +2808,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agent-base\\node_modules\\debug"
             }
           ]
@@ -2834,7 +2834,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agent-base\\node_modules\\ms"
             }
           ]
@@ -2862,7 +2862,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/agentkeepalive"
         }
       ],
@@ -2888,7 +2888,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agentkeepalive\\node_modules\\debug"
             }
           ]
@@ -2914,7 +2914,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agentkeepalive\\node_modules\\depd"
             }
           ]
@@ -2940,7 +2940,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agentkeepalive\\node_modules\\ms"
             }
           ]
@@ -2968,7 +2968,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/aggregate-error"
         }
       ]
@@ -2994,7 +2994,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ajv"
         }
       ]
@@ -3020,7 +3020,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ansi-regex"
         }
       ]
@@ -3046,7 +3046,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ansi-styles"
         }
       ]
@@ -3072,7 +3072,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/anymatch"
         }
       ],
@@ -3098,7 +3098,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/anymatch\\node_modules\\normalize-path"
             }
           ]
@@ -3126,7 +3126,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/append-field"
         }
       ]
@@ -3152,7 +3152,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/aproba"
         }
       ]
@@ -3178,7 +3178,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/archive-type"
         }
       ],
@@ -3204,7 +3204,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/archive-type\\node_modules\\file-type"
             }
           ]
@@ -3232,7 +3232,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/archiver-utils"
         }
       ]
@@ -3258,7 +3258,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/archiver"
         }
       ]
@@ -3284,7 +3284,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/are-we-there-yet"
         }
       ]
@@ -3310,7 +3310,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/arg"
         }
       ]
@@ -3336,7 +3336,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/argparse"
         }
       ],
@@ -3362,7 +3362,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/argparse\\node_modules\\sprintf-js"
             }
           ]
@@ -3390,7 +3390,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/arr-diff"
         }
       ]
@@ -3416,7 +3416,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/arr-flatten"
         }
       ]
@@ -3442,7 +3442,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/arr-union"
         }
       ]
@@ -3468,7 +3468,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/array-each"
         }
       ]
@@ -3494,7 +3494,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/array-flatten"
         }
       ]
@@ -3520,7 +3520,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/array-slice"
         }
       ]
@@ -3546,7 +3546,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/array-unique"
         }
       ]
@@ -3572,7 +3572,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/asap"
         }
       ]
@@ -3598,7 +3598,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/asn1"
         }
       ]
@@ -3624,7 +3624,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/assert-never"
         }
       ]
@@ -3650,7 +3650,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/assert-plus"
         }
       ]
@@ -3676,7 +3676,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/assign-symbols"
         }
       ]
@@ -3702,7 +3702,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/async"
         }
       ]
@@ -3728,7 +3728,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/asynckit"
         }
       ]
@@ -3754,7 +3754,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/at-least-node"
         }
       ]
@@ -3780,7 +3780,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/atob"
         }
       ]
@@ -3806,7 +3806,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/available-typed-arrays"
         }
       ]
@@ -3832,7 +3832,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/aws-sign2"
         }
       ]
@@ -3858,7 +3858,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/aws4"
         }
       ]
@@ -3884,7 +3884,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/babel-walk"
         }
       ]
@@ -3910,7 +3910,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/balanced-match"
         }
       ]
@@ -3936,7 +3936,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base"
         }
       ],
@@ -3962,7 +3962,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/base\\node_modules\\define-property"
             }
           ]
@@ -3990,7 +3990,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base64-arraybuffer"
         }
       ]
@@ -4016,7 +4016,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base64-js"
         }
       ]
@@ -4042,7 +4042,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base64id"
         }
       ]
@@ -4068,7 +4068,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base64url"
         }
       ]
@@ -4094,7 +4094,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/basic-auth"
         }
       ]
@@ -4120,7 +4120,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/batch"
         }
       ]
@@ -4146,7 +4146,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bcrypt-pbkdf"
         }
       ]
@@ -4172,7 +4172,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/big-integer"
         }
       ]
@@ -4198,7 +4198,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/binary-extensions"
         }
       ]
@@ -4224,7 +4224,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/binary"
         }
       ]
@@ -4250,7 +4250,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bindings"
         }
       ]
@@ -4276,7 +4276,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bintrees"
         }
       ]
@@ -4302,7 +4302,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bl"
         }
       ]
@@ -4328,7 +4328,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bluebird"
         }
       ]
@@ -4354,7 +4354,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/body-parser"
         }
       ]
@@ -4380,7 +4380,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bower-config"
         }
       ],
@@ -4406,7 +4406,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bower-config\\node_modules\\minimist"
             }
           ]
@@ -4434,7 +4434,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/brace-expansion"
         }
       ]
@@ -4460,7 +4460,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/braces"
         }
       ],
@@ -4486,7 +4486,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/braces\\node_modules\\extend-shallow"
             }
           ]
@@ -4512,7 +4512,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/braces\\node_modules\\is-extendable"
             }
           ]
@@ -4540,7 +4540,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/brotli"
         }
       ]
@@ -4566,7 +4566,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-alloc-unsafe"
         }
       ]
@@ -4592,7 +4592,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-alloc"
         }
       ]
@@ -4618,7 +4618,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-crc32"
         }
       ]
@@ -4644,7 +4644,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-fill"
         }
       ]
@@ -4670,7 +4670,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-from"
         }
       ]
@@ -4696,7 +4696,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-indexof-polyfill"
         }
       ]
@@ -4722,7 +4722,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer"
         }
       ]
@@ -4748,7 +4748,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffers"
         }
       ]
@@ -4774,7 +4774,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/busboy"
         }
       ],
@@ -4800,7 +4800,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/busboy\\node_modules\\isarray"
             }
           ]
@@ -4826,7 +4826,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/busboy\\node_modules\\readable-stream"
             }
           ]
@@ -4852,7 +4852,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/busboy\\node_modules\\string_decoder"
             }
           ]
@@ -4880,7 +4880,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/byline"
         }
       ]
@@ -4906,7 +4906,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bytes"
         }
       ]
@@ -4932,7 +4932,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cacache"
         }
       ]
@@ -4958,7 +4958,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cache-base"
         }
       ]
@@ -4984,7 +4984,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cacheable-request"
         }
       ],
@@ -5010,7 +5010,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cacheable-request\\node_modules\\get-stream"
             }
           ]
@@ -5036,7 +5036,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cacheable-request\\node_modules\\lowercase-keys"
             }
           ]
@@ -5064,7 +5064,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/call-bind"
         }
       ]
@@ -5090,7 +5090,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/camelcase"
         }
       ]
@@ -5116,7 +5116,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/caseless"
         }
       ]
@@ -5142,7 +5142,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/chainsaw"
         }
       ]
@@ -5168,7 +5168,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/chalk"
         }
       ]
@@ -5194,7 +5194,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/character-parser"
         }
       ]
@@ -5220,7 +5220,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/check-dependencies"
         }
       ],
@@ -5246,7 +5246,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/check-dependencies\\node_modules\\semver"
             }
           ]
@@ -5274,7 +5274,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/check-types"
         }
       ]
@@ -5300,7 +5300,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/chokidar"
         }
       ],
@@ -5326,7 +5326,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar\\node_modules\\braces"
             }
           ]
@@ -5352,7 +5352,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar\\node_modules\\fill-range"
             }
           ]
@@ -5378,7 +5378,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar\\node_modules\\is-glob"
             }
           ]
@@ -5404,7 +5404,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar\\node_modules\\is-number"
             }
           ]
@@ -5430,7 +5430,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar\\node_modules\\normalize-path"
             }
           ]
@@ -5456,7 +5456,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar\\node_modules\\to-regex-range"
             }
           ]
@@ -5484,7 +5484,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/chownr"
         }
       ]
@@ -5510,7 +5510,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/clarinet"
         }
       ]
@@ -5536,7 +5536,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/class-utils"
         }
       ],
@@ -5562,7 +5562,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils\\node_modules\\define-property"
             }
           ]
@@ -5588,7 +5588,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils\\node_modules\\is-accessor-descriptor"
             }
           ],
@@ -5614,7 +5614,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/class-utils\\node_modules\\is-accessor-descriptor\\node_modules\\kind-of"
                 }
               ]
@@ -5642,7 +5642,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils\\node_modules\\is-data-descriptor"
             }
           ],
@@ -5668,7 +5668,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/class-utils\\node_modules\\is-data-descriptor\\node_modules\\kind-of"
                 }
               ]
@@ -5696,7 +5696,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils\\node_modules\\is-descriptor"
             }
           ]
@@ -5722,7 +5722,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils\\node_modules\\kind-of"
             }
           ]
@@ -5750,7 +5750,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/clean-stack"
         }
       ]
@@ -5776,7 +5776,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cliui"
         }
       ],
@@ -5802,7 +5802,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui\\node_modules\\ansi-regex"
             }
           ]
@@ -5828,7 +5828,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui\\node_modules\\emoji-regex"
             }
           ]
@@ -5854,7 +5854,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui\\node_modules\\is-fullwidth-code-point"
             }
           ]
@@ -5880,7 +5880,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui\\node_modules\\string-width"
             }
           ]
@@ -5906,7 +5906,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui\\node_modules\\strip-ansi"
             }
           ]
@@ -5934,7 +5934,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/clone-response"
         }
       ]
@@ -5960,7 +5960,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/clone"
         }
       ]
@@ -5986,7 +5986,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/code-point-at"
         }
       ]
@@ -6012,7 +6012,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/collection-visit"
         }
       ]
@@ -6038,7 +6038,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color-convert"
         }
       ]
@@ -6064,7 +6064,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color-name"
         }
       ]
@@ -6090,7 +6090,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color-string"
         }
       ]
@@ -6116,7 +6116,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color-support"
         }
       ]
@@ -6142,7 +6142,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color"
         }
       ]
@@ -6168,7 +6168,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/colors"
         }
       ]
@@ -6194,7 +6194,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/colorspace"
         }
       ]
@@ -6220,7 +6220,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/combined-stream"
         }
       ]
@@ -6246,7 +6246,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/commander"
         }
       ]
@@ -6272,7 +6272,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/component-emitter"
         }
       ]
@@ -6298,7 +6298,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/component-type"
         }
       ]
@@ -6324,7 +6324,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/compress-commons"
         }
       ]
@@ -6350,7 +6350,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/compressible"
         }
       ]
@@ -6376,7 +6376,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/compression"
         }
       ],
@@ -6402,7 +6402,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/compression\\node_modules\\bytes"
             }
           ]
@@ -6430,7 +6430,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/concat-map"
         }
       ]
@@ -6456,7 +6456,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/concat-stream"
         }
       ]
@@ -6482,7 +6482,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/concurrently"
         }
       ],
@@ -6508,7 +6508,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/concurrently\\node_modules\\supports-color"
             }
           ]
@@ -6536,7 +6536,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/config"
         }
       ]
@@ -6562,7 +6562,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/console-control-strings"
         }
       ]
@@ -6588,7 +6588,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/constantinople"
         }
       ]
@@ -6614,7 +6614,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/content-disposition"
         }
       ],
@@ -6640,7 +6640,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/content-disposition\\node_modules\\safe-buffer"
             }
           ]
@@ -6668,7 +6668,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/content-type"
         }
       ]
@@ -6694,7 +6694,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cookie-parser"
         }
       ]
@@ -6720,7 +6720,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cookie-signature"
         }
       ]
@@ -6746,7 +6746,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cookie"
         }
       ]
@@ -6772,7 +6772,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/copy-descriptor"
         }
       ]
@@ -6798,7 +6798,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/core-util-is"
         }
       ]
@@ -6824,7 +6824,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cors"
         }
       ]
@@ -6850,7 +6850,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/crc"
         }
       ]
@@ -6876,7 +6876,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/crc32-stream"
         }
       ]
@@ -6902,7 +6902,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/create-require"
         }
       ]
@@ -6928,7 +6928,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/crypto-js"
         }
       ]
@@ -6954,7 +6954,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dashdash"
         }
       ]
@@ -6980,7 +6980,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/date-fns"
         }
       ]
@@ -7006,7 +7006,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dateformat"
         }
       ]
@@ -7032,7 +7032,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/debug"
         }
       ]
@@ -7058,7 +7058,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decamelize"
         }
       ]
@@ -7084,7 +7084,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decode-uri-component"
         }
       ]
@@ -7110,7 +7110,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-response"
         }
       ]
@@ -7136,7 +7136,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-tar"
         }
       ],
@@ -7162,7 +7162,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-tar\\node_modules\\file-type"
             }
           ]
@@ -7190,7 +7190,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-tarbz2"
         }
       ],
@@ -7216,7 +7216,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-tarbz2\\node_modules\\file-type"
             }
           ]
@@ -7244,7 +7244,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-targz"
         }
       ],
@@ -7270,7 +7270,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-targz\\node_modules\\file-type"
             }
           ]
@@ -7298,7 +7298,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-unzip"
         }
       ],
@@ -7324,7 +7324,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-unzip\\node_modules\\file-type"
             }
           ]
@@ -7350,7 +7350,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-unzip\\node_modules\\get-stream"
             }
           ]
@@ -7376,7 +7376,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-unzip\\node_modules\\pify"
             }
           ]
@@ -7404,7 +7404,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress"
         }
       ],
@@ -7430,7 +7430,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress\\node_modules\\make-dir"
             }
           ],
@@ -7456,7 +7456,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/decompress\\node_modules\\make-dir\\node_modules\\pify"
                 }
               ]
@@ -7484,7 +7484,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress\\node_modules\\pify"
             }
           ]
@@ -7512,7 +7512,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/deep-equal"
         }
       ]
@@ -7538,7 +7538,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/deep-extend"
         }
       ]
@@ -7564,7 +7564,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/deep-is"
         }
       ]
@@ -7590,7 +7590,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/define-properties"
         }
       ]
@@ -7616,7 +7616,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/define-property"
         }
       ]
@@ -7642,7 +7642,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/delayed-stream"
         }
       ]
@@ -7668,7 +7668,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/delegates"
         }
       ]
@@ -7694,7 +7694,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/depd"
         }
       ]
@@ -7720,7 +7720,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/destroy"
         }
       ]
@@ -7746,7 +7746,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/detect-file"
         }
       ]
@@ -7772,7 +7772,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/detect-libc"
         }
       ]
@@ -7798,7 +7798,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dfa"
         }
       ]
@@ -7824,7 +7824,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dicer"
         }
       ],
@@ -7850,7 +7850,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/dicer\\node_modules\\isarray"
             }
           ]
@@ -7876,7 +7876,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/dicer\\node_modules\\readable-stream"
             }
           ]
@@ -7902,7 +7902,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/dicer\\node_modules\\string_decoder"
             }
           ]
@@ -7930,7 +7930,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/diff"
         }
       ]
@@ -7956,7 +7956,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/doctypes"
         }
       ]
@@ -7982,7 +7982,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/domelementtype"
         }
       ]
@@ -8008,7 +8008,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/domhandler"
         }
       ]
@@ -8034,7 +8034,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/domutils"
         }
       ]
@@ -8060,7 +8060,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dottie"
         }
       ]
@@ -8086,7 +8086,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/double-ended-queue"
         }
       ]
@@ -8112,7 +8112,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/doublearray"
         }
       ]
@@ -8138,7 +8138,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/download"
         }
       ],
@@ -8164,7 +8164,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/download\\node_modules\\file-type"
             }
           ]
@@ -8192,7 +8192,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/duplexer2"
         }
       ]
@@ -8218,7 +8218,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/duplexer3"
         }
       ]
@@ -8244,7 +8244,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dynamic-dedupe"
         }
       ]
@@ -8270,7 +8270,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ecc-jsbn"
         }
       ]
@@ -8296,7 +8296,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ee-first"
         }
       ]
@@ -8322,7 +8322,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/eivindfjeldstad-dot"
         }
       ]
@@ -8348,7 +8348,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/emoji-regex"
         }
       ]
@@ -8374,7 +8374,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/enabled"
         }
       ]
@@ -8400,7 +8400,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/encodeurl"
         }
       ]
@@ -8426,7 +8426,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/encoding"
         }
       ],
@@ -8452,7 +8452,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/encoding\\node_modules\\iconv-lite"
             }
           ]
@@ -8480,7 +8480,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/end-of-stream"
         }
       ]
@@ -8506,7 +8506,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/engine.io-parser"
         }
       ]
@@ -8532,7 +8532,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/engine.io"
         }
       ],
@@ -8558,7 +8558,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/engine.io\\node_modules\\debug"
             }
           ]
@@ -8584,7 +8584,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/engine.io\\node_modules\\ms"
             }
           ]
@@ -8612,7 +8612,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/env-paths"
         }
       ]
@@ -8638,7 +8638,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/err-code"
         }
       ]
@@ -8664,7 +8664,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/error-ex"
         }
       ]
@@ -8690,7 +8690,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/errorhandler"
         }
       ]
@@ -8716,7 +8716,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/es-abstract"
         }
       ]
@@ -8742,7 +8742,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/es-get-iterator"
         }
       ]
@@ -8768,7 +8768,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/es-to-primitive"
         }
       ]
@@ -8794,7 +8794,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/escape-html"
         }
       ]
@@ -8820,7 +8820,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/escape-string-regexp"
         }
       ]
@@ -8846,7 +8846,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/escodegen"
         }
       ]
@@ -8872,7 +8872,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/esprima"
         }
       ]
@@ -8898,7 +8898,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/estraverse"
         }
       ]
@@ -8924,7 +8924,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/esutils"
         }
       ]
@@ -8950,7 +8950,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/etag"
         }
       ]
@@ -8976,7 +8976,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/eventemitter2"
         }
       ]
@@ -9002,7 +9002,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/eventemitter3"
         }
       ]
@@ -9028,7 +9028,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/exif"
         }
       ]
@@ -9054,7 +9054,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/exit"
         }
       ]
@@ -9080,7 +9080,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/expand-brackets"
         }
       ],
@@ -9106,7 +9106,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets\\node_modules\\define-property"
             }
           ]
@@ -9132,7 +9132,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets\\node_modules\\extend-shallow"
             }
           ]
@@ -9158,7 +9158,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets\\node_modules\\is-accessor-descriptor"
             }
           ],
@@ -9184,7 +9184,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/expand-brackets\\node_modules\\is-accessor-descriptor\\node_modules\\kind-of"
                 }
               ]
@@ -9212,7 +9212,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets\\node_modules\\is-data-descriptor"
             }
           ],
@@ -9238,7 +9238,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/expand-brackets\\node_modules\\is-data-descriptor\\node_modules\\kind-of"
                 }
               ]
@@ -9266,7 +9266,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets\\node_modules\\is-descriptor"
             }
           ]
@@ -9292,7 +9292,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets\\node_modules\\is-extendable"
             }
           ]
@@ -9318,7 +9318,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets\\node_modules\\kind-of"
             }
           ]
@@ -9346,7 +9346,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/expand-template"
         }
       ]
@@ -9372,7 +9372,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/expand-tilde"
         }
       ]
@@ -9398,7 +9398,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-ipfilter"
         }
       ]
@@ -9424,7 +9424,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-jwt"
         }
       ],
@@ -9450,7 +9450,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/express-jwt\\node_modules\\jsonwebtoken"
             }
           ]
@@ -9476,7 +9476,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/express-jwt\\node_modules\\moment"
             }
           ]
@@ -9504,7 +9504,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-rate-limit"
         }
       ]
@@ -9530,7 +9530,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-robots-txt"
         }
       ]
@@ -9556,7 +9556,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-security.txt"
         }
       ]
@@ -9582,7 +9582,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express"
         }
       ],
@@ -9608,7 +9608,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/express\\node_modules\\cookie"
             }
           ]
@@ -9634,7 +9634,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/express\\node_modules\\safe-buffer"
             }
           ]
@@ -9662,7 +9662,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ext-list"
         }
       ]
@@ -9688,7 +9688,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ext-name"
         }
       ]
@@ -9714,7 +9714,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/extend-shallow"
         }
       ]
@@ -9740,7 +9740,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/extend"
         }
       ]
@@ -9766,7 +9766,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/extglob"
         }
       ],
@@ -9792,7 +9792,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/extglob\\node_modules\\define-property"
             }
           ]
@@ -9818,7 +9818,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/extglob\\node_modules\\extend-shallow"
             }
           ]
@@ -9844,7 +9844,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/extglob\\node_modules\\is-extendable"
             }
           ]
@@ -9872,7 +9872,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/extsprintf"
         }
       ]
@@ -9898,7 +9898,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fast-deep-equal"
         }
       ]
@@ -9924,7 +9924,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fast-json-stable-stringify"
         }
       ]
@@ -9950,7 +9950,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fast-levenshtein"
         }
       ]
@@ -9976,7 +9976,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fast.js"
         }
       ]
@@ -10002,7 +10002,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fd-slicer"
         }
       ]
@@ -10028,7 +10028,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/feature-policy"
         }
       ]
@@ -10054,7 +10054,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fecha"
         }
       ]
@@ -10080,7 +10080,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/file-js"
         }
       ],
@@ -10106,7 +10106,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/file-js\\node_modules\\brace-expansion"
             }
           ]
@@ -10132,7 +10132,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/file-js\\node_modules\\minimatch"
             }
           ]
@@ -10160,7 +10160,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/file-stream-rotator"
         }
       ]
@@ -10186,7 +10186,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/file-type"
         }
       ]
@@ -10212,7 +10212,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/file-uri-to-path"
         }
       ]
@@ -10238,7 +10238,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/filehound"
         }
       ]
@@ -10264,7 +10264,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/filename-reserved-regex"
         }
       ]
@@ -10290,7 +10290,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/filenamify"
         }
       ]
@@ -10316,7 +10316,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/filesniffer"
         }
       ]
@@ -10342,7 +10342,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fill-range"
         }
       ],
@@ -10368,7 +10368,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/fill-range\\node_modules\\extend-shallow"
             }
           ]
@@ -10394,7 +10394,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/fill-range\\node_modules\\is-extendable"
             }
           ]
@@ -10422,7 +10422,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/finale-rest"
         }
       ]
@@ -10448,7 +10448,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/finalhandler"
         }
       ]
@@ -10474,7 +10474,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/find-up"
         }
       ]
@@ -10500,7 +10500,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/findup-sync"
         }
       ]
@@ -10526,7 +10526,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fined"
         }
       ]
@@ -10552,7 +10552,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/flagged-respawn"
         }
       ]
@@ -10578,7 +10578,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fn.name"
         }
       ]
@@ -10604,7 +10604,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fontkit"
         }
       ]
@@ -10630,7 +10630,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/for-each"
         }
       ]
@@ -10656,7 +10656,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/for-in"
         }
       ]
@@ -10682,7 +10682,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/for-own"
         }
       ]
@@ -10708,7 +10708,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/foreachasync"
         }
       ]
@@ -10734,7 +10734,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/forever-agent"
         }
       ]
@@ -10760,7 +10760,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/form-data"
         }
       ]
@@ -10786,7 +10786,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/formatio"
         }
       ]
@@ -10812,7 +10812,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/forwarded"
         }
       ]
@@ -10838,7 +10838,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fragment-cache"
         }
       ]
@@ -10864,7 +10864,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fresh"
         }
       ]
@@ -10890,7 +10890,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/from2"
         }
       ]
@@ -10916,7 +10916,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fs-constants"
         }
       ]
@@ -10942,7 +10942,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fs-extra"
         }
       ]
@@ -10968,7 +10968,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fs-minipass"
         }
       ]
@@ -10994,7 +10994,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fs.realpath"
         }
       ]
@@ -11020,7 +11020,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fstream"
         }
       ],
@@ -11046,7 +11046,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/fstream\\node_modules\\mkdirp"
             }
           ]
@@ -11072,7 +11072,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/fstream\\node_modules\\rimraf"
             }
           ]
@@ -11100,7 +11100,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/function-bind"
         }
       ]
@@ -11126,7 +11126,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/function.prototype.name"
         }
       ]
@@ -11152,7 +11152,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/functions-have-names"
         }
       ]
@@ -11178,7 +11178,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fuzzball"
         }
       ]
@@ -11204,7 +11204,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/gauge"
         }
       ]
@@ -11230,7 +11230,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/geojson-utils"
         }
       ]
@@ -11256,7 +11256,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-caller-file"
         }
       ]
@@ -11282,7 +11282,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-intrinsic"
         }
       ]
@@ -11308,7 +11308,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-stream"
         }
       ]
@@ -11334,7 +11334,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-symbol-description"
         }
       ]
@@ -11360,7 +11360,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-value"
         }
       ]
@@ -11386,7 +11386,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/getobject"
         }
       ]
@@ -11412,7 +11412,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/getpass"
         }
       ]
@@ -11438,7 +11438,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/github-from-package"
         }
       ]
@@ -11464,7 +11464,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/glob-parent"
         }
       ],
@@ -11490,7 +11490,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/glob-parent\\node_modules\\is-glob"
             }
           ]
@@ -11518,7 +11518,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/glob"
         }
       ],
@@ -11544,7 +11544,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/glob\\node_modules\\brace-expansion"
             }
           ]
@@ -11570,7 +11570,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/glob\\node_modules\\minimatch"
             }
           ]
@@ -11598,7 +11598,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/global-modules"
         }
       ]
@@ -11624,7 +11624,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/global-prefix"
         }
       ],
@@ -11650,7 +11650,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/global-prefix\\node_modules\\which"
             }
           ]
@@ -11678,7 +11678,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/got"
         }
       ],
@@ -11704,7 +11704,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/got\\node_modules\\get-stream"
             }
           ]
@@ -11730,7 +11730,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/got\\node_modules\\pify"
             }
           ]
@@ -11758,7 +11758,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/graceful-fs"
         }
       ]
@@ -11784,7 +11784,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-cli"
         }
       ],
@@ -11810,7 +11810,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-cli\\node_modules\\nopt"
             }
           ]
@@ -11838,7 +11838,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-contrib-compress"
         }
       ],
@@ -11864,7 +11864,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-contrib-compress\\node_modules\\ansi-styles"
             }
           ]
@@ -11890,7 +11890,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-contrib-compress\\node_modules\\chalk"
             }
           ]
@@ -11916,7 +11916,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-contrib-compress\\node_modules\\supports-color"
             }
           ]
@@ -11944,7 +11944,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-known-options"
         }
       ]
@@ -11970,7 +11970,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-legacy-log-utils"
         }
       ],
@@ -11996,7 +11996,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils\\node_modules\\ansi-styles"
             }
           ]
@@ -12022,7 +12022,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils\\node_modules\\chalk"
             }
           ]
@@ -12048,7 +12048,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils\\node_modules\\color-convert"
             }
           ]
@@ -12074,7 +12074,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils\\node_modules\\color-name"
             }
           ]
@@ -12100,7 +12100,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils\\node_modules\\has-flag"
             }
           ]
@@ -12126,7 +12126,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils\\node_modules\\supports-color"
             }
           ]
@@ -12154,7 +12154,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-legacy-log"
         }
       ],
@@ -12180,7 +12180,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log\\node_modules\\colors"
             }
           ]
@@ -12208,7 +12208,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-legacy-util"
         }
       ],
@@ -12234,7 +12234,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-util\\node_modules\\async"
             }
           ]
@@ -12262,7 +12262,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-replace-json"
         }
       ]
@@ -12288,7 +12288,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt"
         }
       ],
@@ -12314,7 +12314,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt\\node_modules\\brace-expansion"
             }
           ]
@@ -12340,7 +12340,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt\\node_modules\\findup-sync"
             }
           ],
@@ -12366,7 +12366,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/grunt\\node_modules\\findup-sync\\node_modules\\glob"
                 }
               ]
@@ -12394,7 +12394,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt\\node_modules\\glob"
             }
           ]
@@ -12420,7 +12420,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt\\node_modules\\minimatch"
             }
           ]
@@ -12448,7 +12448,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/handlebars"
         }
       ],
@@ -12474,7 +12474,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/handlebars\\node_modules\\wordwrap"
             }
           ]
@@ -12502,7 +12502,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/har-schema"
         }
       ]
@@ -12528,7 +12528,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/har-validator"
         }
       ]
@@ -12554,7 +12554,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-ansi"
         }
       ]
@@ -12580,7 +12580,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-bigints"
         }
       ]
@@ -12606,7 +12606,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-flag"
         }
       ]
@@ -12632,7 +12632,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-property-descriptors"
         }
       ]
@@ -12658,7 +12658,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-symbol-support-x"
         }
       ]
@@ -12684,7 +12684,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-symbols"
         }
       ]
@@ -12710,7 +12710,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-to-string-tag-x"
         }
       ]
@@ -12736,7 +12736,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-tostringtag"
         }
       ]
@@ -12762,7 +12762,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-unicode"
         }
       ]
@@ -12788,7 +12788,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-value"
         }
       ]
@@ -12814,7 +12814,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-values"
         }
       ],
@@ -12840,7 +12840,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/has-values\\node_modules\\kind-of"
             }
           ]
@@ -12868,7 +12868,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has"
         }
       ]
@@ -12894,7 +12894,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hashids"
         }
       ]
@@ -12920,7 +12920,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hbs"
         }
       ]
@@ -12946,7 +12946,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/he"
         }
       ]
@@ -12972,7 +12972,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/heap"
         }
       ]
@@ -12998,7 +12998,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/helmet"
         }
       ]
@@ -13024,7 +13024,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hoister"
         }
       ]
@@ -13050,7 +13050,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/homedir-polyfill"
         }
       ]
@@ -13076,7 +13076,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hooker"
         }
       ]
@@ -13102,7 +13102,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hosted-git-info"
         }
       ]
@@ -13128,7 +13128,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/html-entities"
         }
       ]
@@ -13154,7 +13154,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/htmlparser2"
         }
       ],
@@ -13180,7 +13180,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/htmlparser2\\node_modules\\isarray"
             }
           ]
@@ -13206,7 +13206,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/htmlparser2\\node_modules\\readable-stream"
             }
           ]
@@ -13232,7 +13232,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/htmlparser2\\node_modules\\string_decoder"
             }
           ]
@@ -13260,7 +13260,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/http-cache-semantics"
         }
       ]
@@ -13286,7 +13286,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/http-errors"
         }
       ]
@@ -13312,7 +13312,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/http-proxy-agent"
         }
       ],
@@ -13338,7 +13338,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/http-proxy-agent\\node_modules\\debug"
             }
           ]
@@ -13364,7 +13364,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/http-proxy-agent\\node_modules\\ms"
             }
           ]
@@ -13392,7 +13392,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/http-signature"
         }
       ]
@@ -13418,7 +13418,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/https-proxy-agent"
         }
       ],
@@ -13444,7 +13444,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/https-proxy-agent\\node_modules\\debug"
             }
           ]
@@ -13470,7 +13470,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/https-proxy-agent\\node_modules\\ms"
             }
           ]
@@ -13498,7 +13498,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/humanize-ms"
         }
       ]
@@ -13524,7 +13524,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/i18n"
         }
       ]
@@ -13550,7 +13550,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/iconv-lite"
         }
       ]
@@ -13576,7 +13576,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ieee754"
         }
       ]
@@ -13602,7 +13602,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ignore-walk"
         }
       ],
@@ -13628,7 +13628,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/ignore-walk\\node_modules\\brace-expansion"
             }
           ]
@@ -13654,7 +13654,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/ignore-walk\\node_modules\\minimatch"
             }
           ]
@@ -13682,7 +13682,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/iltorb"
         }
       ]
@@ -13708,7 +13708,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/imurmurhash"
         }
       ]
@@ -13734,7 +13734,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/indent-string"
         }
       ]
@@ -13760,7 +13760,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/infer-owner"
         }
       ]
@@ -13786,7 +13786,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/inflection"
         }
       ]
@@ -13812,7 +13812,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/inflight"
         }
       ]
@@ -13838,7 +13838,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/inherits"
         }
       ]
@@ -13864,7 +13864,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ini"
         }
       ]
@@ -13890,7 +13890,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/internal-slot"
         }
       ]
@@ -13916,7 +13916,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/interpret"
         }
       ]
@@ -13942,7 +13942,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/into-stream"
         }
       ]
@@ -13968,7 +13968,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/invariant"
         }
       ]
@@ -13994,7 +13994,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ip"
         }
       ]
@@ -14020,7 +14020,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ip6"
         }
       ]
@@ -14046,7 +14046,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ipaddr.js"
         }
       ]
@@ -14072,7 +14072,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-absolute"
         }
       ]
@@ -14098,7 +14098,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-accessor-descriptor"
         }
       ]
@@ -14124,7 +14124,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-arguments"
         }
       ]
@@ -14150,7 +14150,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-arrayish"
         }
       ]
@@ -14176,7 +14176,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-bigint"
         }
       ]
@@ -14202,7 +14202,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-binary-path"
         }
       ]
@@ -14228,7 +14228,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-boolean-object"
         }
       ]
@@ -14254,7 +14254,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-buffer"
         }
       ]
@@ -14280,7 +14280,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-callable"
         }
       ]
@@ -14306,7 +14306,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-core-module"
         }
       ]
@@ -14332,7 +14332,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-data-descriptor"
         }
       ]
@@ -14358,7 +14358,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-date-object"
         }
       ]
@@ -14384,7 +14384,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-descriptor"
         }
       ]
@@ -14410,7 +14410,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-docker"
         }
       ]
@@ -14436,7 +14436,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-expression"
         }
       ]
@@ -14462,7 +14462,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-extendable"
         }
       ]
@@ -14488,7 +14488,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-extglob"
         }
       ]
@@ -14514,7 +14514,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-fullwidth-code-point"
         }
       ]
@@ -14540,7 +14540,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-generator-function"
         }
       ]
@@ -14566,7 +14566,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-glob"
         }
       ]
@@ -14592,7 +14592,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-heroku"
         }
       ]
@@ -14618,7 +14618,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-lambda"
         }
       ]
@@ -14644,7 +14644,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-map"
         }
       ]
@@ -14670,7 +14670,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-natural-number"
         }
       ]
@@ -14696,7 +14696,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-negative-zero"
         }
       ]
@@ -14722,7 +14722,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-number-like"
         }
       ]
@@ -14748,7 +14748,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-number-object"
         }
       ]
@@ -14774,7 +14774,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-number"
         }
       ],
@@ -14800,7 +14800,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/is-number\\node_modules\\kind-of"
             }
           ]
@@ -14828,7 +14828,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-object"
         }
       ]
@@ -14854,7 +14854,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-plain-obj"
         }
       ]
@@ -14880,7 +14880,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-plain-object"
         }
       ]
@@ -14906,7 +14906,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-promise"
         }
       ]
@@ -14932,7 +14932,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-regex"
         }
       ]
@@ -14958,7 +14958,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-relative"
         }
       ]
@@ -14984,7 +14984,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-retry-allowed"
         }
       ]
@@ -15010,7 +15010,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-set"
         }
       ]
@@ -15036,7 +15036,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-shared-array-buffer"
         }
       ]
@@ -15062,7 +15062,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-stream"
         }
       ]
@@ -15088,7 +15088,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-string"
         }
       ]
@@ -15114,7 +15114,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-symbol"
         }
       ]
@@ -15140,7 +15140,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-typed-array"
         }
       ]
@@ -15166,7 +15166,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-typedarray"
         }
       ]
@@ -15192,7 +15192,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-unc-path"
         }
       ]
@@ -15218,7 +15218,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-weakmap"
         }
       ]
@@ -15244,7 +15244,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-weakref"
         }
       ]
@@ -15270,7 +15270,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-weakset"
         }
       ]
@@ -15296,7 +15296,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-windows"
         }
       ]
@@ -15322,7 +15322,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isarray"
         }
       ]
@@ -15348,7 +15348,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isexe"
         }
       ]
@@ -15374,7 +15374,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isobject"
         }
       ]
@@ -15400,7 +15400,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isstream"
         }
       ]
@@ -15426,7 +15426,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isurl"
         }
       ]
@@ -15452,7 +15452,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/js-stringify"
         }
       ]
@@ -15478,7 +15478,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/js-tokens"
         }
       ]
@@ -15504,7 +15504,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/js-yaml"
         }
       ]
@@ -15530,7 +15530,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jsbn"
         }
       ]
@@ -15556,7 +15556,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-buffer"
         }
       ]
@@ -15582,7 +15582,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-parse-better-errors"
         }
       ]
@@ -15608,7 +15608,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-schema-traverse"
         }
       ]
@@ -15634,7 +15634,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-schema"
         }
       ]
@@ -15660,7 +15660,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-stringify-safe"
         }
       ]
@@ -15686,7 +15686,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json5"
         }
       ]
@@ -15712,7 +15712,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jsonfile"
         }
       ]
@@ -15738,7 +15738,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jsonwebtoken"
         }
       ]
@@ -15764,7 +15764,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jsprim"
         }
       ]
@@ -15790,7 +15790,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jssha"
         }
       ]
@@ -15816,7 +15816,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jstransformer"
         }
       ]
@@ -15842,7 +15842,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/juicy-chat-bot"
         }
       ]
@@ -15868,7 +15868,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jwa"
         }
       ]
@@ -15894,7 +15894,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jws"
         }
       ]
@@ -15920,7 +15920,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/keyv"
         }
       ]
@@ -15946,7 +15946,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/kind-of"
         }
       ]
@@ -15972,7 +15972,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/kuler"
         }
       ]
@@ -15998,7 +15998,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/kuromoji"
         }
       ]
@@ -16024,7 +16024,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lazystream"
         }
       ]
@@ -16050,7 +16050,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/levn"
         }
       ]
@@ -16076,7 +16076,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/libxmljs2"
         }
       ],
@@ -16102,7 +16102,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/libxmljs2\\node_modules\\nan"
             }
           ]
@@ -16130,7 +16130,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/liftup"
         }
       ],
@@ -16156,7 +16156,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup\\node_modules\\braces"
             }
           ]
@@ -16182,7 +16182,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup\\node_modules\\fill-range"
             }
           ]
@@ -16208,7 +16208,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup\\node_modules\\findup-sync"
             }
           ]
@@ -16234,7 +16234,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup\\node_modules\\is-glob"
             }
           ]
@@ -16260,7 +16260,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup\\node_modules\\is-number"
             }
           ]
@@ -16286,7 +16286,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup\\node_modules\\micromatch"
             }
           ]
@@ -16312,7 +16312,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup\\node_modules\\to-regex-range"
             }
           ]
@@ -16340,7 +16340,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/linebreak"
         }
       ],
@@ -16366,7 +16366,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/linebreak\\node_modules\\base64-js"
             }
           ]
@@ -16394,7 +16394,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/listenercount"
         }
       ]
@@ -16420,7 +16420,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/locate-path"
         }
       ]
@@ -16446,7 +16446,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lodash.camelcase"
         }
       ]
@@ -16472,7 +16472,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lodash.isfinite"
         }
       ]
@@ -16498,7 +16498,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lodash.set"
         }
       ]
@@ -16524,7 +16524,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lodash"
         }
       ]
@@ -16550,7 +16550,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/logform"
         }
       ],
@@ -16576,7 +16576,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/logform\\node_modules\\ms"
             }
           ]
@@ -16604,7 +16604,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lolex"
         }
       ]
@@ -16630,7 +16630,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/loose-envify"
         }
       ]
@@ -16656,7 +16656,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lowercase-keys"
         }
       ]
@@ -16682,7 +16682,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lru-cache"
         }
       ]
@@ -16708,7 +16708,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-dir"
         }
       ],
@@ -16734,7 +16734,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-dir\\node_modules\\semver"
             }
           ]
@@ -16762,7 +16762,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-error"
         }
       ]
@@ -16788,7 +16788,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-fetch-happen"
         }
       ],
@@ -16815,7 +16815,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen\\node_modules\\@tootallnate\\once"
             }
           ]
@@ -16841,7 +16841,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen\\node_modules\\debug"
             }
           ]
@@ -16867,7 +16867,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen\\node_modules\\http-cache-semantics"
             }
           ]
@@ -16893,7 +16893,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen\\node_modules\\http-proxy-agent"
             }
           ]
@@ -16919,7 +16919,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen\\node_modules\\ms"
             }
           ]
@@ -16947,7 +16947,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-iterator"
         }
       ]
@@ -16973,7 +16973,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-plural"
         }
       ]
@@ -16999,7 +16999,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/map-cache"
         }
       ]
@@ -17025,7 +17025,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/map-visit"
         }
       ]
@@ -17051,7 +17051,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/marsdb"
         }
       ]
@@ -17077,7 +17077,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/math-interval-parser"
         }
       ]
@@ -17103,7 +17103,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/media-typer"
         }
       ]
@@ -17129,7 +17129,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/merge-descriptors"
         }
       ]
@@ -17155,7 +17155,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/messageformat-formatters"
         }
       ]
@@ -17181,7 +17181,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/messageformat-parser"
         }
       ]
@@ -17207,7 +17207,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/messageformat"
         }
       ],
@@ -17233,7 +17233,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/messageformat\\node_modules\\make-plural"
             }
           ]
@@ -17261,7 +17261,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/methods"
         }
       ]
@@ -17287,7 +17287,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/micromatch"
         }
       ]
@@ -17313,7 +17313,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mime-db"
         }
       ]
@@ -17339,7 +17339,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mime-types"
         }
       ]
@@ -17365,7 +17365,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mime"
         }
       ]
@@ -17391,7 +17391,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mimic-response"
         }
       ]
@@ -17417,7 +17417,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minimatch"
         }
       ]
@@ -17443,7 +17443,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minimist"
         }
       ]
@@ -17469,7 +17469,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-collect"
         }
       ]
@@ -17495,7 +17495,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-fetch"
         }
       ]
@@ -17521,7 +17521,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-flush"
         }
       ]
@@ -17547,7 +17547,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-pipeline"
         }
       ]
@@ -17573,7 +17573,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-sized"
         }
       ]
@@ -17599,7 +17599,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass"
         }
       ]
@@ -17625,7 +17625,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minizlib"
         }
       ]
@@ -17651,7 +17651,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mixin-deep"
         }
       ]
@@ -17677,7 +17677,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mkdirp-classic"
         }
       ]
@@ -17703,7 +17703,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mkdirp"
         }
       ]
@@ -17729,7 +17729,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/moment-timezone"
         }
       ]
@@ -17755,7 +17755,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/moment"
         }
       ]
@@ -17781,7 +17781,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/morgan"
         }
       ],
@@ -17807,7 +17807,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/morgan\\node_modules\\on-finished"
             }
           ]
@@ -17835,7 +17835,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mout"
         }
       ]
@@ -17861,7 +17861,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ms"
         }
       ]
@@ -17887,7 +17887,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/multer"
         }
       ],
@@ -17913,7 +17913,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/multer\\node_modules\\mkdirp"
             }
           ]
@@ -17941,7 +17941,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mustache"
         }
       ]
@@ -17967,7 +17967,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/nan"
         }
       ]
@@ -17993,7 +17993,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/nanomatch"
         }
       ]
@@ -18019,7 +18019,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/napi-build-utils"
         }
       ]
@@ -18045,7 +18045,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/needle"
         }
       ],
@@ -18071,7 +18071,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/needle\\node_modules\\debug"
             }
           ]
@@ -18097,7 +18097,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/needle\\node_modules\\ms"
             }
           ]
@@ -18125,7 +18125,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/negotiator"
         }
       ]
@@ -18151,7 +18151,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/neo-async"
         }
       ]
@@ -18177,7 +18177,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-abi"
         }
       ],
@@ -18203,7 +18203,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-abi\\node_modules\\semver"
             }
           ]
@@ -18231,7 +18231,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-addon-api"
         }
       ]
@@ -18257,7 +18257,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-fetch"
         }
       ]
@@ -18283,7 +18283,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-gyp"
         }
       ],
@@ -18309,7 +18309,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp\\node_modules\\ansi-regex"
             }
           ]
@@ -18335,7 +18335,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp\\node_modules\\are-we-there-yet"
             }
           ]
@@ -18361,7 +18361,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp\\node_modules\\gauge"
             }
           ]
@@ -18387,7 +18387,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp\\node_modules\\is-fullwidth-code-point"
             }
           ]
@@ -18413,7 +18413,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp\\node_modules\\nopt"
             }
           ]
@@ -18439,7 +18439,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp\\node_modules\\npmlog"
             }
           ]
@@ -18465,7 +18465,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp\\node_modules\\readable-stream"
             }
           ]
@@ -18491,7 +18491,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp\\node_modules\\string-width"
             }
           ]
@@ -18517,7 +18517,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp\\node_modules\\strip-ansi"
             }
           ]
@@ -18545,7 +18545,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-pre-gyp"
         }
       ],
@@ -18571,7 +18571,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp\\node_modules\\chownr"
             }
           ]
@@ -18597,7 +18597,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp\\node_modules\\fs-minipass"
             }
           ]
@@ -18623,7 +18623,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp\\node_modules\\minipass"
             }
           ]
@@ -18649,7 +18649,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp\\node_modules\\minizlib"
             }
           ]
@@ -18675,7 +18675,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp\\node_modules\\mkdirp"
             }
           ]
@@ -18701,7 +18701,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp\\node_modules\\nopt"
             }
           ]
@@ -18727,7 +18727,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp\\node_modules\\rimraf"
             }
           ]
@@ -18753,7 +18753,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp\\node_modules\\safe-buffer"
             }
           ]
@@ -18779,7 +18779,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp\\node_modules\\semver"
             }
           ]
@@ -18805,7 +18805,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp\\node_modules\\tar"
             }
           ]
@@ -18831,7 +18831,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp\\node_modules\\yallist"
             }
           ]
@@ -18859,7 +18859,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/noop-logger"
         }
       ]
@@ -18885,7 +18885,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/nopt"
         }
       ]
@@ -18911,7 +18911,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/normalize-package-data"
         }
       ],
@@ -18937,7 +18937,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/normalize-package-data\\node_modules\\semver"
             }
           ]
@@ -18965,7 +18965,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/normalize-path"
         }
       ]
@@ -18991,7 +18991,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/normalize-url"
         }
       ]
@@ -19017,7 +19017,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/notevil"
         }
       ],
@@ -19043,7 +19043,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/notevil\\node_modules\\esprima"
             }
           ]
@@ -19071,7 +19071,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/npm-bundled"
         }
       ]
@@ -19097,7 +19097,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/npm-normalize-package-bin"
         }
       ]
@@ -19123,7 +19123,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/npm-packlist"
         }
       ]
@@ -19149,7 +19149,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/npmlog"
         }
       ]
@@ -19175,7 +19175,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/number-is-nan"
         }
       ]
@@ -19201,7 +19201,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/oauth-sign"
         }
       ]
@@ -19227,7 +19227,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-assign"
         }
       ]
@@ -19253,7 +19253,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-copy"
         }
       ],
@@ -19279,7 +19279,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy\\node_modules\\define-property"
             }
           ]
@@ -19305,7 +19305,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy\\node_modules\\is-accessor-descriptor"
             }
           ]
@@ -19331,7 +19331,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy\\node_modules\\is-data-descriptor"
             }
           ]
@@ -19357,7 +19357,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy\\node_modules\\is-descriptor"
             }
           ],
@@ -19383,7 +19383,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/object-copy\\node_modules\\is-descriptor\\node_modules\\kind-of"
                 }
               ]
@@ -19411,7 +19411,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy\\node_modules\\kind-of"
             }
           ]
@@ -19439,7 +19439,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-inspect"
         }
       ]
@@ -19465,7 +19465,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-is"
         }
       ]
@@ -19491,7 +19491,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-keys"
         }
       ]
@@ -19517,7 +19517,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-visit"
         }
       ]
@@ -19543,7 +19543,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object.assign"
         }
       ]
@@ -19569,7 +19569,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object.defaults"
         }
       ]
@@ -19595,7 +19595,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object.map"
         }
       ]
@@ -19621,7 +19621,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object.pick"
         }
       ]
@@ -19647,7 +19647,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/on-finished"
         }
       ]
@@ -19673,7 +19673,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/on-headers"
         }
       ]
@@ -19699,7 +19699,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/once"
         }
       ]
@@ -19725,7 +19725,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/one-time"
         }
       ]
@@ -19751,7 +19751,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/opentype.js"
         }
       ]
@@ -19777,7 +19777,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/optionator"
         }
       ]
@@ -19803,7 +19803,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/os-homedir"
         }
       ]
@@ -19829,7 +19829,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/os-tmpdir"
         }
       ]
@@ -19855,7 +19855,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/osenv"
         }
       ]
@@ -19881,7 +19881,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/otplib"
         }
       ]
@@ -19907,7 +19907,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-cancelable"
         }
       ]
@@ -19933,7 +19933,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-event"
         }
       ]
@@ -19959,7 +19959,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-finally"
         }
       ]
@@ -19985,7 +19985,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-is-promise"
         }
       ]
@@ -20011,7 +20011,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-limit"
         }
       ]
@@ -20037,7 +20037,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-locate"
         }
       ]
@@ -20063,7 +20063,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-map"
         }
       ]
@@ -20089,7 +20089,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-timeout"
         }
       ]
@@ -20115,7 +20115,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-try"
         }
       ]
@@ -20141,7 +20141,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pako"
         }
       ]
@@ -20167,7 +20167,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/parse-filepath"
         }
       ]
@@ -20193,7 +20193,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/parse-json"
         }
       ]
@@ -20219,7 +20219,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/parse-passwd"
         }
       ]
@@ -20245,7 +20245,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/parseurl"
         }
       ]
@@ -20271,7 +20271,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pascalcase"
         }
       ]
@@ -20297,7 +20297,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-exists"
         }
       ]
@@ -20323,7 +20323,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-is-absolute"
         }
       ]
@@ -20349,7 +20349,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-parse"
         }
       ]
@@ -20375,7 +20375,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-root-regex"
         }
       ]
@@ -20401,7 +20401,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-root"
         }
       ]
@@ -20427,7 +20427,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-to-regexp"
         }
       ]
@@ -20453,7 +20453,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pdfkit"
         }
       ]
@@ -20479,7 +20479,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/peek-readable"
         }
       ]
@@ -20505,7 +20505,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pend"
         }
       ]
@@ -20531,7 +20531,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/performance-now"
         }
       ]
@@ -20557,7 +20557,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pg-connection-string"
         }
       ]
@@ -20583,7 +20583,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/picomatch"
         }
       ]
@@ -20609,7 +20609,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pify"
         }
       ]
@@ -20635,7 +20635,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pinkie-promise"
         }
       ]
@@ -20661,7 +20661,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pinkie"
         }
       ]
@@ -20687,7 +20687,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/png-js"
         }
       ]
@@ -20713,7 +20713,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/portscanner"
         }
       ]
@@ -20739,7 +20739,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/posix-character-classes"
         }
       ]
@@ -20765,7 +20765,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/prebuild-install"
         }
       ]
@@ -20791,7 +20791,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/prelude-ls"
         }
       ]
@@ -20817,7 +20817,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/prepend-http"
         }
       ]
@@ -20843,7 +20843,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pretty-bytes"
         }
       ]
@@ -20869,7 +20869,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/process-nextick-args"
         }
       ]
@@ -20895,7 +20895,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/prom-client"
         }
       ]
@@ -20921,7 +20921,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/promise-inflight"
         }
       ]
@@ -20947,7 +20947,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/promise-retry"
         }
       ],
@@ -20973,7 +20973,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/promise-retry\\node_modules\\err-code"
             }
           ]
@@ -20999,7 +20999,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/promise-retry\\node_modules\\retry"
             }
           ]
@@ -21027,7 +21027,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/promise"
         }
       ]
@@ -21053,7 +21053,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/proper-lockfile"
         }
       ]
@@ -21079,7 +21079,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/proxy-addr"
         }
       ]
@@ -21105,7 +21105,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/psl"
         }
       ]
@@ -21131,7 +21131,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-attrs"
         }
       ]
@@ -21157,7 +21157,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-code-gen"
         }
       ]
@@ -21183,7 +21183,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-error"
         }
       ]
@@ -21209,7 +21209,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-filters"
         }
       ]
@@ -21235,7 +21235,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-lexer"
         }
       ]
@@ -21261,7 +21261,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-linker"
         }
       ]
@@ -21287,7 +21287,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-load"
         }
       ]
@@ -21313,7 +21313,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-parser"
         }
       ]
@@ -21339,7 +21339,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-runtime"
         }
       ]
@@ -21365,7 +21365,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-strip-comments"
         }
       ]
@@ -21391,7 +21391,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-walk"
         }
       ]
@@ -21417,7 +21417,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug"
         }
       ]
@@ -21443,7 +21443,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pump"
         }
       ]
@@ -21469,7 +21469,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/punycode"
         }
       ]
@@ -21495,7 +21495,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/qs"
         }
       ]
@@ -21521,7 +21521,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/query-string"
         }
       ]
@@ -21547,7 +21547,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/range_check"
         }
       ]
@@ -21573,7 +21573,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/range-parser"
         }
       ]
@@ -21599,7 +21599,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/raw-body"
         }
       ]
@@ -21625,7 +21625,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/rc"
         }
       ]
@@ -21651,7 +21651,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/read-pkg"
         }
       ],
@@ -21677,7 +21677,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/read-pkg\\node_modules\\pify"
             }
           ]
@@ -21705,7 +21705,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/readable-stream"
         }
       ],
@@ -21731,7 +21731,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/readable-stream\\node_modules\\isarray"
             }
           ]
@@ -21759,7 +21759,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/readable-web-to-node-stream"
         }
       ],
@@ -21785,7 +21785,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/readable-web-to-node-stream\\node_modules\\readable-stream"
             }
           ]
@@ -21813,7 +21813,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/readdirp"
         }
       ]
@@ -21839,7 +21839,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/rechoir"
         }
       ]
@@ -21865,7 +21865,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/regex-not"
         }
       ]
@@ -21891,7 +21891,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/regexp.prototype.flags"
         }
       ]
@@ -21917,7 +21917,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/remove-trailing-separator"
         }
       ]
@@ -21943,7 +21943,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/repeat-element"
         }
       ]
@@ -21969,7 +21969,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/repeat-string"
         }
       ]
@@ -21995,7 +21995,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/replace"
         }
       ],
@@ -22021,7 +22021,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\ansi-regex"
             }
           ]
@@ -22047,7 +22047,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\ansi-styles"
             }
           ]
@@ -22073,7 +22073,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\brace-expansion"
             }
           ]
@@ -22099,7 +22099,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\cliui"
             }
           ]
@@ -22125,7 +22125,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\color-convert"
             }
           ]
@@ -22151,7 +22151,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\color-name"
             }
           ]
@@ -22177,7 +22177,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\find-up"
             }
           ]
@@ -22203,7 +22203,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\is-fullwidth-code-point"
             }
           ]
@@ -22229,7 +22229,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\locate-path"
             }
           ]
@@ -22255,7 +22255,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\minimatch"
             }
           ]
@@ -22281,7 +22281,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\p-locate"
             }
           ]
@@ -22307,7 +22307,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\path-exists"
             }
           ]
@@ -22333,7 +22333,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\string-width"
             }
           ]
@@ -22359,7 +22359,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\strip-ansi"
             }
           ]
@@ -22385,7 +22385,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\wrap-ansi"
             }
           ]
@@ -22411,7 +22411,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\yargs-parser"
             }
           ]
@@ -22437,7 +22437,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\yargs"
             }
           ]
@@ -22465,7 +22465,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/request"
         }
       ],
@@ -22491,7 +22491,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/request\\node_modules\\qs"
             }
           ]
@@ -22519,7 +22519,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/require-directory"
         }
       ]
@@ -22545,7 +22545,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/require-main-filename"
         }
       ]
@@ -22571,7 +22571,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/resolve-dir"
         }
       ]
@@ -22597,7 +22597,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/resolve-url"
         }
       ]
@@ -22623,7 +22623,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/resolve"
         }
       ]
@@ -22649,7 +22649,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/responselike"
         }
       ]
@@ -22675,7 +22675,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/restructure"
         }
       ]
@@ -22701,7 +22701,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ret"
         }
       ]
@@ -22727,7 +22727,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/retry-as-promised"
         }
       ]
@@ -22753,7 +22753,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/retry"
         }
       ]
@@ -22779,7 +22779,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/rimraf"
         }
       ]
@@ -22805,7 +22805,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/rxjs"
         }
       ],
@@ -22831,7 +22831,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/rxjs\\node_modules\\tslib"
             }
           ]
@@ -22859,7 +22859,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safe-buffer"
         }
       ]
@@ -22885,7 +22885,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safe-regex-test"
         }
       ]
@@ -22911,7 +22911,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safe-regex"
         }
       ]
@@ -22937,7 +22937,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safe-stable-stringify"
         }
       ]
@@ -22963,7 +22963,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safer-buffer"
         }
       ]
@@ -22989,7 +22989,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/samsam"
         }
       ]
@@ -23015,7 +23015,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sanitize-filename"
         }
       ]
@@ -23041,7 +23041,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sanitize-html"
         }
       ],
@@ -23067,7 +23067,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sanitize-html\\node_modules\\lodash"
             }
           ]
@@ -23095,7 +23095,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sax"
         }
       ]
@@ -23121,7 +23121,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/seek-bzip"
         }
       ]
@@ -23147,7 +23147,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/semver"
         }
       ]
@@ -23173,7 +23173,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/send"
         }
       ],
@@ -23199,7 +23199,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/send\\node_modules\\ms"
             }
           ]
@@ -23227,7 +23227,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sequelize-pool"
         }
       ]
@@ -23253,7 +23253,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sequelize"
         }
       ],
@@ -23279,7 +23279,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sequelize\\node_modules\\debug"
             }
           ]
@@ -23305,7 +23305,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sequelize\\node_modules\\ms"
             }
           ]
@@ -23331,7 +23331,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sequelize\\node_modules\\uuid"
             }
           ]
@@ -23359,7 +23359,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/serve-index"
         }
       ],
@@ -23385,7 +23385,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index\\node_modules\\depd"
             }
           ]
@@ -23411,7 +23411,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index\\node_modules\\http-errors"
             }
           ]
@@ -23437,7 +23437,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index\\node_modules\\inherits"
             }
           ]
@@ -23463,7 +23463,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index\\node_modules\\setprototypeof"
             }
           ]
@@ -23489,7 +23489,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index\\node_modules\\statuses"
             }
           ]
@@ -23517,7 +23517,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/serve-static"
         }
       ]
@@ -23543,7 +23543,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/set-blocking"
         }
       ]
@@ -23569,7 +23569,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/set-value"
         }
       ],
@@ -23595,7 +23595,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/set-value\\node_modules\\extend-shallow"
             }
           ]
@@ -23621,7 +23621,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/set-value\\node_modules\\is-extendable"
             }
           ]
@@ -23649,7 +23649,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/setimmediate"
         }
       ]
@@ -23675,7 +23675,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/setprototypeof"
         }
       ]
@@ -23701,7 +23701,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/side-channel"
         }
       ]
@@ -23727,7 +23727,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/signal-exit"
         }
       ]
@@ -23753,7 +23753,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/simple-concat"
         }
       ]
@@ -23779,7 +23779,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/simple-get"
         }
       ],
@@ -23805,7 +23805,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/simple-get\\node_modules\\decompress-response"
             }
           ]
@@ -23831,7 +23831,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/simple-get\\node_modules\\mimic-response"
             }
           ]
@@ -23859,7 +23859,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/simple-swizzle"
         }
       ],
@@ -23885,7 +23885,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/simple-swizzle\\node_modules\\is-arrayish"
             }
           ]
@@ -23913,7 +23913,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sinon"
         }
       ]
@@ -23939,7 +23939,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/smart-buffer"
         }
       ]
@@ -23965,7 +23965,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/snapdragon-node"
         }
       ],
@@ -23991,7 +23991,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon-node\\node_modules\\define-property"
             }
           ]
@@ -24019,7 +24019,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/snapdragon-util"
         }
       ],
@@ -24045,7 +24045,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon-util\\node_modules\\kind-of"
             }
           ]
@@ -24073,7 +24073,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/snapdragon"
         }
       ],
@@ -24099,7 +24099,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon\\node_modules\\define-property"
             }
           ]
@@ -24125,7 +24125,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon\\node_modules\\extend-shallow"
             }
           ]
@@ -24151,7 +24151,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon\\node_modules\\is-accessor-descriptor"
             }
           ],
@@ -24177,7 +24177,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/snapdragon\\node_modules\\is-accessor-descriptor\\node_modules\\kind-of"
                 }
               ]
@@ -24205,7 +24205,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon\\node_modules\\is-data-descriptor"
             }
           ],
@@ -24231,7 +24231,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/snapdragon\\node_modules\\is-data-descriptor\\node_modules\\kind-of"
                 }
               ]
@@ -24259,7 +24259,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon\\node_modules\\is-descriptor"
             }
           ]
@@ -24285,7 +24285,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon\\node_modules\\is-extendable"
             }
           ]
@@ -24311,7 +24311,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon\\node_modules\\kind-of"
             }
           ]
@@ -24337,7 +24337,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon\\node_modules\\source-map"
             }
           ]
@@ -24365,7 +24365,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socket.io-adapter"
         }
       ]
@@ -24391,7 +24391,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socket.io-parser"
         }
       ],
@@ -24417,7 +24417,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socket.io-parser\\node_modules\\debug"
             }
           ]
@@ -24443,7 +24443,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socket.io-parser\\node_modules\\ms"
             }
           ]
@@ -24471,7 +24471,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socket.io"
         }
       ],
@@ -24497,7 +24497,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socket.io\\node_modules\\debug"
             }
           ]
@@ -24523,7 +24523,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socket.io\\node_modules\\ms"
             }
           ]
@@ -24551,7 +24551,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socks-proxy-agent"
         }
       ],
@@ -24577,7 +24577,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socks-proxy-agent\\node_modules\\debug"
             }
           ]
@@ -24603,7 +24603,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socks-proxy-agent\\node_modules\\ms"
             }
           ]
@@ -24631,7 +24631,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socks"
         }
       ],
@@ -24657,7 +24657,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socks\\node_modules\\ip"
             }
           ]
@@ -24685,7 +24685,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sort-keys-length"
         }
       ],
@@ -24711,7 +24711,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sort-keys-length\\node_modules\\sort-keys"
             }
           ]
@@ -24739,7 +24739,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sort-keys"
         }
       ]
@@ -24765,7 +24765,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/source-map-resolve"
         }
       ]
@@ -24791,7 +24791,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/source-map-support"
         }
       ]
@@ -24817,7 +24817,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/source-map-url"
         }
       ]
@@ -24843,7 +24843,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/source-map"
         }
       ]
@@ -24869,7 +24869,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spawn-command"
         }
       ]
@@ -24895,7 +24895,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spdx-correct"
         }
       ]
@@ -24921,7 +24921,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spdx-exceptions"
         }
       ]
@@ -24947,7 +24947,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spdx-expression-parse"
         }
       ]
@@ -24973,7 +24973,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spdx-license-ids"
         }
       ]
@@ -24999,7 +24999,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/split-string"
         }
       ]
@@ -25025,7 +25025,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sprintf-js"
         }
       ]
@@ -25051,7 +25051,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sqlite3"
         }
       ]
@@ -25077,7 +25077,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sshpk"
         }
       ]
@@ -25103,7 +25103,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ssri"
         }
       ]
@@ -25129,7 +25129,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/stack-trace"
         }
       ]
@@ -25155,7 +25155,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/static-extend"
         }
       ],
@@ -25181,7 +25181,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend\\node_modules\\define-property"
             }
           ]
@@ -25207,7 +25207,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend\\node_modules\\is-accessor-descriptor"
             }
           ],
@@ -25233,7 +25233,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/static-extend\\node_modules\\is-accessor-descriptor\\node_modules\\kind-of"
                 }
               ]
@@ -25261,7 +25261,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend\\node_modules\\is-data-descriptor"
             }
           ],
@@ -25287,7 +25287,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/static-extend\\node_modules\\is-data-descriptor\\node_modules\\kind-of"
                 }
               ]
@@ -25315,7 +25315,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend\\node_modules\\is-descriptor"
             }
           ]
@@ -25341,7 +25341,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend\\node_modules\\kind-of"
             }
           ]
@@ -25369,7 +25369,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/statuses"
         }
       ]
@@ -25395,7 +25395,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/stream-buffers"
         }
       ]
@@ -25421,7 +25421,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/streamsearch"
         }
       ]
@@ -25447,7 +25447,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strict-uri-encode"
         }
       ]
@@ -25473,7 +25473,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string_decoder"
         }
       ]
@@ -25499,7 +25499,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string-width"
         }
       ]
@@ -25525,7 +25525,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string.fromcodepoint"
         }
       ]
@@ -25551,7 +25551,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string.prototype.codepointat"
         }
       ]
@@ -25577,7 +25577,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string.prototype.trimend"
         }
       ]
@@ -25603,7 +25603,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string.prototype.trimstart"
         }
       ]
@@ -25629,7 +25629,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-ansi"
         }
       ]
@@ -25655,7 +25655,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-bom"
         }
       ]
@@ -25681,7 +25681,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-dirs"
         }
       ]
@@ -25707,7 +25707,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-json-comments"
         }
       ]
@@ -25733,7 +25733,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-outer"
         }
       ]
@@ -25759,7 +25759,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strtok3"
         }
       ]
@@ -25785,7 +25785,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/supports-color"
         }
       ]
@@ -25811,7 +25811,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/supports-preserve-symlinks-flag"
         }
       ]
@@ -25837,7 +25837,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/svg-captcha"
         }
       ]
@@ -25863,7 +25863,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/swagger-ui-dist"
         }
       ]
@@ -25889,7 +25889,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/swagger-ui-express"
         }
       ]
@@ -25915,7 +25915,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tar-fs"
         }
       ],
@@ -25941,7 +25941,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/tar-fs\\node_modules\\bl"
             }
           ]
@@ -25967,7 +25967,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/tar-fs\\node_modules\\chownr"
             }
           ]
@@ -25993,7 +25993,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/tar-fs\\node_modules\\readable-stream"
             }
           ]
@@ -26019,7 +26019,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/tar-fs\\node_modules\\tar-stream"
             }
           ]
@@ -26047,7 +26047,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tar-stream"
         }
       ]
@@ -26073,7 +26073,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tar"
         }
       ]
@@ -26099,7 +26099,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tdigest"
         }
       ]
@@ -26125,7 +26125,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/text-hex"
         }
       ]
@@ -26151,7 +26151,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/thirty-two"
         }
       ]
@@ -26177,7 +26177,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/through"
         }
       ]
@@ -26203,7 +26203,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/timed-out"
         }
       ]
@@ -26229,7 +26229,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tiny-inflate"
         }
       ]
@@ -26255,7 +26255,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-buffer"
         }
       ]
@@ -26281,7 +26281,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-fast-properties"
         }
       ]
@@ -26307,7 +26307,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-object-path"
         }
       ],
@@ -26333,7 +26333,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/to-object-path\\node_modules\\kind-of"
             }
           ]
@@ -26361,7 +26361,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-regex-range"
         }
       ]
@@ -26387,7 +26387,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-regex"
         }
       ]
@@ -26413,7 +26413,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/toidentifier"
         }
       ]
@@ -26439,7 +26439,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/token-stream"
         }
       ]
@@ -26465,7 +26465,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/token-types"
         }
       ]
@@ -26491,7 +26491,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/toposort-class"
         }
       ]
@@ -26517,7 +26517,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tough-cookie"
         }
       ]
@@ -26543,7 +26543,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tr46"
         }
       ]
@@ -26569,7 +26569,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/traverse"
         }
       ]
@@ -26595,7 +26595,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tree-kill"
         }
       ]
@@ -26621,7 +26621,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/trim-repeated"
         }
       ]
@@ -26647,7 +26647,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/triple-beam"
         }
       ]
@@ -26673,7 +26673,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/truncate-utf8-bytes"
         }
       ]
@@ -26699,7 +26699,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ts-node-dev"
         }
       ],
@@ -26725,7 +26725,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/ts-node-dev\\node_modules\\rimraf"
             }
           ]
@@ -26753,7 +26753,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ts-node"
         }
       ]
@@ -26779,7 +26779,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tsconfig"
         }
       ]
@@ -26805,7 +26805,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tslib"
         }
       ]
@@ -26831,7 +26831,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tunnel-agent"
         }
       ]
@@ -26857,7 +26857,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tweetnacl"
         }
       ]
@@ -26883,7 +26883,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/type-check"
         }
       ]
@@ -26909,7 +26909,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/type-is"
         }
       ]
@@ -26935,7 +26935,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/typecast"
         }
       ]
@@ -26961,7 +26961,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/typedarray"
         }
       ]
@@ -26987,7 +26987,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/typescript"
         }
       ]
@@ -27013,7 +27013,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/uglify-js"
         }
       ]
@@ -27039,7 +27039,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unbox-primitive"
         }
       ]
@@ -27065,7 +27065,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unbzip2-stream"
         }
       ]
@@ -27091,7 +27091,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unc-path-regex"
         }
       ]
@@ -27117,7 +27117,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/underscore.string"
         }
       ]
@@ -27143,7 +27143,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unicode-properties"
         }
       ]
@@ -27169,7 +27169,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unicode-trie"
         }
       ]
@@ -27195,7 +27195,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/union-value"
         }
       ],
@@ -27221,7 +27221,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/union-value\\node_modules\\is-extendable"
             }
           ]
@@ -27249,7 +27249,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unique-filename"
         }
       ]
@@ -27275,7 +27275,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unique-slug"
         }
       ]
@@ -27301,7 +27301,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unit-compare"
         }
       ]
@@ -27327,7 +27327,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/universalify"
         }
       ]
@@ -27353,7 +27353,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unpipe"
         }
       ]
@@ -27379,7 +27379,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unset-value"
         }
       ],
@@ -27405,7 +27405,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/unset-value\\node_modules\\has-value"
             }
           ],
@@ -27431,7 +27431,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/unset-value\\node_modules\\has-value\\node_modules\\isobject"
                 }
               ]
@@ -27459,7 +27459,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/unset-value\\node_modules\\has-values"
             }
           ]
@@ -27485,7 +27485,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/unset-value\\node_modules\\isarray"
             }
           ]
@@ -27513,7 +27513,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/untildify"
         }
       ]
@@ -27539,7 +27539,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unzipper"
         }
       ],
@@ -27565,7 +27565,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/unzipper\\node_modules\\bluebird"
             }
           ]
@@ -27593,7 +27593,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/uri-js"
         }
       ]
@@ -27619,7 +27619,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/urix"
         }
       ]
@@ -27645,7 +27645,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/url-parse-lax"
         }
       ]
@@ -27671,7 +27671,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/url-to-options"
         }
       ]
@@ -27697,7 +27697,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/use"
         }
       ]
@@ -27723,7 +27723,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/utf8-byte-length"
         }
       ]
@@ -27749,7 +27749,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/util-deprecate"
         }
       ]
@@ -27775,7 +27775,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/util"
         }
       ]
@@ -27801,7 +27801,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/utils-merge"
         }
       ]
@@ -27827,7 +27827,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/uuid"
         }
       ]
@@ -27853,7 +27853,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/v8flags"
         }
       ]
@@ -27879,7 +27879,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/validate-npm-package-license"
         }
       ]
@@ -27905,7 +27905,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/validate"
         }
       ]
@@ -27931,7 +27931,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/validator"
         }
       ]
@@ -27957,7 +27957,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/vary"
         }
       ]
@@ -27983,7 +27983,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/verror"
         }
       ],
@@ -28009,7 +28009,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/verror\\node_modules\\core-util-is"
             }
           ]
@@ -28037,7 +28037,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/vm2"
         }
       ],
@@ -28063,7 +28063,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/vm2\\node_modules\\acorn"
             }
           ]
@@ -28091,7 +28091,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/void-elements"
         }
       ]
@@ -28117,7 +28117,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/walk"
         }
       ]
@@ -28143,7 +28143,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/walkdir"
         }
       ]
@@ -28169,7 +28169,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/webidl-conversions"
         }
       ]
@@ -28195,7 +28195,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/whatwg-url"
         }
       ]
@@ -28221,7 +28221,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-boxed-primitive"
         }
       ]
@@ -28247,7 +28247,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-collection"
         }
       ]
@@ -28273,7 +28273,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-module"
         }
       ]
@@ -28299,7 +28299,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-pm-runs"
         }
       ]
@@ -28325,7 +28325,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-typed-array"
         }
       ]
@@ -28351,7 +28351,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which"
         }
       ]
@@ -28377,7 +28377,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wide-align"
         }
       ]
@@ -28403,7 +28403,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/winston-transport"
         }
       ],
@@ -28429,7 +28429,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/winston-transport\\node_modules\\readable-stream"
             }
           ]
@@ -28457,7 +28457,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/winston"
         }
       ],
@@ -28483,7 +28483,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/winston\\node_modules\\async"
             }
           ]
@@ -28509,7 +28509,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/winston\\node_modules\\is-stream"
             }
           ]
@@ -28535,7 +28535,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/winston\\node_modules\\readable-stream"
             }
           ]
@@ -28563,7 +28563,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/with"
         }
       ]
@@ -28589,7 +28589,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wkx"
         }
       ]
@@ -28615,7 +28615,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/word-wrap"
         }
       ]
@@ -28641,7 +28641,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wordwrap"
         }
       ]
@@ -28667,7 +28667,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wrap-ansi"
         }
       ],
@@ -28693,7 +28693,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi\\node_modules\\ansi-regex"
             }
           ]
@@ -28719,7 +28719,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi\\node_modules\\emoji-regex"
             }
           ]
@@ -28745,7 +28745,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi\\node_modules\\is-fullwidth-code-point"
             }
           ]
@@ -28771,7 +28771,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi\\node_modules\\string-width"
             }
           ]
@@ -28797,7 +28797,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi\\node_modules\\strip-ansi"
             }
           ]
@@ -28825,7 +28825,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wrappy"
         }
       ]
@@ -28851,7 +28851,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ws"
         }
       ]
@@ -28877,7 +28877,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/xtend"
         }
       ]
@@ -28903,7 +28903,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/y18n"
         }
       ]
@@ -28929,7 +28929,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yallist"
         }
       ]
@@ -28955,7 +28955,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yaml-schema-validator"
         }
       ]
@@ -28981,7 +28981,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yargs-parser"
         }
       ]
@@ -29007,7 +29007,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yargs"
         }
       ],
@@ -29033,7 +29033,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs\\node_modules\\ansi-regex"
             }
           ]
@@ -29059,7 +29059,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs\\node_modules\\emoji-regex"
             }
           ]
@@ -29085,7 +29085,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs\\node_modules\\is-fullwidth-code-point"
             }
           ]
@@ -29111,7 +29111,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs\\node_modules\\string-width"
             }
           ]
@@ -29137,7 +29137,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs\\node_modules\\strip-ansi"
             }
           ]
@@ -29165,7 +29165,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yauzl"
         }
       ]
@@ -29191,7 +29191,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yn"
         }
       ]
@@ -29217,7 +29217,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/z85"
         }
       ]
@@ -29243,7 +29243,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/zip-stream"
         }
       ]
@@ -29269,7 +29269,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/zlibjs"
         }
       ]

--- a/tests/_data/sbom_demo-results/juice-shop_npm9_node18_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/juice-shop_npm9_node18_macos-latest.snap.json
@@ -62,7 +62,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -95,7 +95,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@babel/helper-string-parser"
         }
       ]
@@ -122,7 +122,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@babel/helper-validator-identifier"
         }
       ]
@@ -149,7 +149,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@babel/parser"
         }
       ]
@@ -176,7 +176,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@babel/types"
         }
       ]
@@ -203,7 +203,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@colors/colors"
         }
       ]
@@ -230,7 +230,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@dabh/diagnostics"
         }
       ]
@@ -257,7 +257,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@gar/promisify"
         }
       ]
@@ -284,7 +284,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@mapbox/node-pre-gyp"
         }
       ],
@@ -310,7 +310,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/ansi-regex"
             }
           ]
@@ -336,7 +336,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/are-we-there-yet"
             }
           ]
@@ -362,7 +362,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/detect-libc"
             }
           ]
@@ -388,7 +388,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/gauge"
             }
           ]
@@ -414,7 +414,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -440,7 +440,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/make-dir"
             }
           ],
@@ -466,7 +466,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/@mapbox/node-pre-gyp/node_modules/make-dir/node_modules/semver"
                 }
               ]
@@ -494,7 +494,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/nopt"
             }
           ]
@@ -520,7 +520,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/npmlog"
             }
           ]
@@ -546,7 +546,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/readable-stream"
             }
           ]
@@ -572,7 +572,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/string-width"
             }
           ]
@@ -598,7 +598,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/strip-ansi"
             }
           ]
@@ -627,7 +627,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/core-loader"
         }
       ]
@@ -654,7 +654,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/core"
         }
       ]
@@ -681,7 +681,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/evaluator"
         }
       ]
@@ -708,7 +708,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-all"
         }
       ]
@@ -735,7 +735,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ar"
         }
       ]
@@ -762,7 +762,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-bn"
         }
       ]
@@ -789,7 +789,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ca"
         }
       ]
@@ -816,7 +816,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-cs"
         }
       ]
@@ -843,7 +843,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-da"
         }
       ]
@@ -870,7 +870,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-de"
         }
       ]
@@ -897,7 +897,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-el"
         }
       ]
@@ -924,7 +924,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-en-min"
         }
       ]
@@ -951,7 +951,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-en"
         }
       ]
@@ -978,7 +978,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-es"
         }
       ]
@@ -1005,7 +1005,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-eu"
         }
       ]
@@ -1032,7 +1032,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-fa"
         }
       ]
@@ -1059,7 +1059,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-fi"
         }
       ]
@@ -1086,7 +1086,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-fr"
         }
       ]
@@ -1113,7 +1113,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ga"
         }
       ]
@@ -1140,7 +1140,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-gl"
         }
       ]
@@ -1167,7 +1167,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-hi"
         }
       ]
@@ -1194,7 +1194,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-hu"
         }
       ]
@@ -1221,7 +1221,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-hy"
         }
       ]
@@ -1248,7 +1248,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-id"
         }
       ]
@@ -1275,7 +1275,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-it"
         }
       ]
@@ -1302,7 +1302,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ja"
         }
       ]
@@ -1329,7 +1329,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ko"
         }
       ]
@@ -1356,7 +1356,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-lt"
         }
       ]
@@ -1383,7 +1383,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ms"
         }
       ]
@@ -1410,7 +1410,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ne"
         }
       ]
@@ -1437,7 +1437,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-nl"
         }
       ]
@@ -1464,7 +1464,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-no"
         }
       ]
@@ -1491,7 +1491,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-pl"
         }
       ]
@@ -1518,7 +1518,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-pt"
         }
       ]
@@ -1545,7 +1545,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ro"
         }
       ]
@@ -1572,7 +1572,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ru"
         }
       ]
@@ -1599,7 +1599,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-sl"
         }
       ]
@@ -1626,7 +1626,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-sr"
         }
       ]
@@ -1653,7 +1653,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-sv"
         }
       ]
@@ -1680,7 +1680,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ta"
         }
       ]
@@ -1707,7 +1707,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-th"
         }
       ]
@@ -1734,7 +1734,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-tl"
         }
       ]
@@ -1761,7 +1761,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-tr"
         }
       ]
@@ -1788,7 +1788,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-uk"
         }
       ]
@@ -1815,7 +1815,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-zh"
         }
       ]
@@ -1842,7 +1842,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/language-min"
         }
       ]
@@ -1869,7 +1869,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/language"
         }
       ]
@@ -1896,7 +1896,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/ner"
         }
       ]
@@ -1923,7 +1923,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/neural"
         }
       ]
@@ -1950,7 +1950,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/nlg"
         }
       ]
@@ -1977,7 +1977,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/nlp"
         }
       ]
@@ -2004,7 +2004,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/nlu"
         }
       ]
@@ -2031,7 +2031,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/request"
         }
       ]
@@ -2058,7 +2058,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/sentiment"
         }
       ]
@@ -2085,7 +2085,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/similarity"
         }
       ]
@@ -2112,7 +2112,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/slot"
         }
       ]
@@ -2139,7 +2139,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@npmcli/fs"
         }
       ]
@@ -2166,7 +2166,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@npmcli/move-file"
         }
       ]
@@ -2193,7 +2193,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib/core"
         }
       ]
@@ -2220,7 +2220,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib/plugin-crypto"
         }
       ]
@@ -2247,7 +2247,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib/plugin-thirty-two"
         }
       ]
@@ -2274,7 +2274,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib/preset-default"
         }
       ]
@@ -2301,7 +2301,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib/preset-v11"
         }
       ]
@@ -2328,7 +2328,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@sindresorhus/is"
         }
       ]
@@ -2355,7 +2355,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@swc/helpers"
         }
       ]
@@ -2382,7 +2382,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@tokenizer/token"
         }
       ]
@@ -2409,7 +2409,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@tootallnate/once"
         }
       ]
@@ -2436,7 +2436,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/component-emitter"
         }
       ]
@@ -2463,7 +2463,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/cookie"
         }
       ]
@@ -2490,7 +2490,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/cors"
         }
       ]
@@ -2517,7 +2517,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/debug"
         }
       ]
@@ -2544,7 +2544,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/ms"
         }
       ]
@@ -2571,7 +2571,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/node"
         }
       ]
@@ -2598,7 +2598,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/strip-bom"
         }
       ]
@@ -2625,7 +2625,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/strip-json-comments"
         }
       ]
@@ -2652,7 +2652,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/validator"
         }
       ]
@@ -2678,7 +2678,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/abbrev"
         }
       ]
@@ -2704,7 +2704,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/accepts"
         }
       ]
@@ -2730,7 +2730,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/acorn-walk"
         }
       ]
@@ -2756,7 +2756,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/acorn"
         }
       ]
@@ -2782,7 +2782,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/agent-base"
         }
       ],
@@ -2808,7 +2808,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agent-base/node_modules/debug"
             }
           ]
@@ -2834,7 +2834,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agent-base/node_modules/ms"
             }
           ]
@@ -2862,7 +2862,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/agentkeepalive"
         }
       ],
@@ -2888,7 +2888,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agentkeepalive/node_modules/debug"
             }
           ]
@@ -2914,7 +2914,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agentkeepalive/node_modules/depd"
             }
           ]
@@ -2940,7 +2940,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agentkeepalive/node_modules/ms"
             }
           ]
@@ -2968,7 +2968,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/aggregate-error"
         }
       ]
@@ -2994,7 +2994,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ajv"
         }
       ]
@@ -3020,7 +3020,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ansi-regex"
         }
       ]
@@ -3046,7 +3046,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ansi-styles"
         }
       ]
@@ -3072,7 +3072,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/anymatch"
         }
       ],
@@ -3098,7 +3098,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/anymatch/node_modules/normalize-path"
             }
           ]
@@ -3126,7 +3126,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/append-field"
         }
       ]
@@ -3152,7 +3152,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/aproba"
         }
       ]
@@ -3178,7 +3178,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/archive-type"
         }
       ],
@@ -3204,7 +3204,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/archive-type/node_modules/file-type"
             }
           ]
@@ -3232,7 +3232,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/archiver-utils"
         }
       ]
@@ -3258,7 +3258,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/archiver"
         }
       ]
@@ -3284,7 +3284,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/are-we-there-yet"
         }
       ]
@@ -3310,7 +3310,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/arg"
         }
       ]
@@ -3336,7 +3336,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/argparse"
         }
       ],
@@ -3362,7 +3362,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/argparse/node_modules/sprintf-js"
             }
           ]
@@ -3390,7 +3390,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/arr-diff"
         }
       ]
@@ -3416,7 +3416,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/arr-flatten"
         }
       ]
@@ -3442,7 +3442,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/arr-union"
         }
       ]
@@ -3468,7 +3468,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/array-each"
         }
       ]
@@ -3494,7 +3494,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/array-flatten"
         }
       ]
@@ -3520,7 +3520,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/array-slice"
         }
       ]
@@ -3546,7 +3546,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/array-unique"
         }
       ]
@@ -3572,7 +3572,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/asap"
         }
       ]
@@ -3598,7 +3598,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/asn1"
         }
       ]
@@ -3624,7 +3624,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/assert-never"
         }
       ]
@@ -3650,7 +3650,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/assert-plus"
         }
       ]
@@ -3676,7 +3676,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/assign-symbols"
         }
       ]
@@ -3702,7 +3702,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/async"
         }
       ]
@@ -3728,7 +3728,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/asynckit"
         }
       ]
@@ -3754,7 +3754,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/at-least-node"
         }
       ]
@@ -3780,7 +3780,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/atob"
         }
       ]
@@ -3806,7 +3806,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/available-typed-arrays"
         }
       ]
@@ -3832,7 +3832,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/aws-sign2"
         }
       ]
@@ -3858,7 +3858,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/aws4"
         }
       ]
@@ -3884,7 +3884,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/babel-walk"
         }
       ]
@@ -3910,7 +3910,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/balanced-match"
         }
       ]
@@ -3936,7 +3936,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base"
         }
       ],
@@ -3962,7 +3962,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/base/node_modules/define-property"
             }
           ]
@@ -3990,7 +3990,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base64-arraybuffer"
         }
       ]
@@ -4016,7 +4016,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base64-js"
         }
       ]
@@ -4042,7 +4042,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base64id"
         }
       ]
@@ -4068,7 +4068,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base64url"
         }
       ]
@@ -4094,7 +4094,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/basic-auth"
         }
       ]
@@ -4120,7 +4120,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/batch"
         }
       ]
@@ -4146,7 +4146,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bcrypt-pbkdf"
         }
       ]
@@ -4172,7 +4172,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/big-integer"
         }
       ]
@@ -4198,7 +4198,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/binary-extensions"
         }
       ]
@@ -4224,7 +4224,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/binary"
         }
       ]
@@ -4250,7 +4250,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bindings"
         }
       ]
@@ -4276,7 +4276,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bintrees"
         }
       ]
@@ -4302,7 +4302,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bl"
         }
       ]
@@ -4328,7 +4328,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bluebird"
         }
       ]
@@ -4354,7 +4354,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/body-parser"
         }
       ]
@@ -4380,7 +4380,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bower-config"
         }
       ],
@@ -4406,7 +4406,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bower-config/node_modules/minimist"
             }
           ]
@@ -4434,7 +4434,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/brace-expansion"
         }
       ]
@@ -4460,7 +4460,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/braces"
         }
       ],
@@ -4486,7 +4486,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/braces/node_modules/extend-shallow"
             }
           ]
@@ -4512,7 +4512,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/braces/node_modules/is-extendable"
             }
           ]
@@ -4540,7 +4540,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/brotli"
         }
       ]
@@ -4566,7 +4566,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-alloc-unsafe"
         }
       ]
@@ -4592,7 +4592,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-alloc"
         }
       ]
@@ -4618,7 +4618,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-crc32"
         }
       ]
@@ -4644,7 +4644,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-fill"
         }
       ]
@@ -4670,7 +4670,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-from"
         }
       ]
@@ -4696,7 +4696,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-indexof-polyfill"
         }
       ]
@@ -4722,7 +4722,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer"
         }
       ]
@@ -4748,7 +4748,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffers"
         }
       ]
@@ -4774,7 +4774,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/busboy"
         }
       ],
@@ -4800,7 +4800,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/busboy/node_modules/isarray"
             }
           ]
@@ -4826,7 +4826,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/busboy/node_modules/readable-stream"
             }
           ]
@@ -4852,7 +4852,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/busboy/node_modules/string_decoder"
             }
           ]
@@ -4880,7 +4880,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/byline"
         }
       ]
@@ -4906,7 +4906,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bytes"
         }
       ]
@@ -4932,7 +4932,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cacache"
         }
       ]
@@ -4958,7 +4958,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cache-base"
         }
       ]
@@ -4984,7 +4984,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cacheable-request"
         }
       ],
@@ -5010,7 +5010,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cacheable-request/node_modules/get-stream"
             }
           ]
@@ -5036,7 +5036,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cacheable-request/node_modules/lowercase-keys"
             }
           ]
@@ -5064,7 +5064,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/call-bind"
         }
       ]
@@ -5090,7 +5090,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/camelcase"
         }
       ]
@@ -5116,7 +5116,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/caseless"
         }
       ]
@@ -5142,7 +5142,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/chainsaw"
         }
       ]
@@ -5168,7 +5168,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/chalk"
         }
       ]
@@ -5194,7 +5194,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/character-parser"
         }
       ]
@@ -5220,7 +5220,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/check-dependencies"
         }
       ],
@@ -5246,7 +5246,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/check-dependencies/node_modules/semver"
             }
           ]
@@ -5274,7 +5274,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/check-types"
         }
       ]
@@ -5300,7 +5300,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/chokidar"
         }
       ],
@@ -5326,7 +5326,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar/node_modules/braces"
             }
           ]
@@ -5352,7 +5352,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar/node_modules/fill-range"
             }
           ]
@@ -5378,7 +5378,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar/node_modules/is-glob"
             }
           ]
@@ -5404,7 +5404,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar/node_modules/is-number"
             }
           ]
@@ -5430,7 +5430,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar/node_modules/normalize-path"
             }
           ]
@@ -5456,7 +5456,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar/node_modules/to-regex-range"
             }
           ]
@@ -5484,7 +5484,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/chownr"
         }
       ]
@@ -5510,7 +5510,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/clarinet"
         }
       ]
@@ -5536,7 +5536,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/class-utils"
         }
       ],
@@ -5562,7 +5562,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils/node_modules/define-property"
             }
           ]
@@ -5588,7 +5588,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils/node_modules/is-accessor-descriptor"
             }
           ],
@@ -5614,7 +5614,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/class-utils/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
@@ -5642,7 +5642,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils/node_modules/is-data-descriptor"
             }
           ],
@@ -5668,7 +5668,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/class-utils/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
@@ -5696,7 +5696,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils/node_modules/is-descriptor"
             }
           ]
@@ -5722,7 +5722,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils/node_modules/kind-of"
             }
           ]
@@ -5750,7 +5750,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/clean-stack"
         }
       ]
@@ -5776,7 +5776,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cliui"
         }
       ],
@@ -5802,7 +5802,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui/node_modules/ansi-regex"
             }
           ]
@@ -5828,7 +5828,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui/node_modules/emoji-regex"
             }
           ]
@@ -5854,7 +5854,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -5880,7 +5880,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui/node_modules/string-width"
             }
           ]
@@ -5906,7 +5906,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui/node_modules/strip-ansi"
             }
           ]
@@ -5934,7 +5934,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/clone-response"
         }
       ]
@@ -5960,7 +5960,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/clone"
         }
       ]
@@ -5986,7 +5986,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/code-point-at"
         }
       ]
@@ -6012,7 +6012,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/collection-visit"
         }
       ]
@@ -6038,7 +6038,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color-convert"
         }
       ]
@@ -6064,7 +6064,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color-name"
         }
       ]
@@ -6090,7 +6090,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color-string"
         }
       ]
@@ -6116,7 +6116,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color-support"
         }
       ]
@@ -6142,7 +6142,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color"
         }
       ]
@@ -6168,7 +6168,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/colors"
         }
       ]
@@ -6194,7 +6194,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/colorspace"
         }
       ]
@@ -6220,7 +6220,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/combined-stream"
         }
       ]
@@ -6246,7 +6246,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/commander"
         }
       ]
@@ -6272,7 +6272,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/component-emitter"
         }
       ]
@@ -6298,7 +6298,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/component-type"
         }
       ]
@@ -6324,7 +6324,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/compress-commons"
         }
       ]
@@ -6350,7 +6350,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/compressible"
         }
       ]
@@ -6376,7 +6376,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/compression"
         }
       ],
@@ -6402,7 +6402,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/compression/node_modules/bytes"
             }
           ]
@@ -6430,7 +6430,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/concat-map"
         }
       ]
@@ -6456,7 +6456,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/concat-stream"
         }
       ]
@@ -6482,7 +6482,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/concurrently"
         }
       ],
@@ -6508,7 +6508,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/concurrently/node_modules/supports-color"
             }
           ]
@@ -6536,7 +6536,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/config"
         }
       ]
@@ -6562,7 +6562,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/console-control-strings"
         }
       ]
@@ -6588,7 +6588,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/constantinople"
         }
       ]
@@ -6614,7 +6614,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/content-disposition"
         }
       ],
@@ -6640,7 +6640,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/content-disposition/node_modules/safe-buffer"
             }
           ]
@@ -6668,7 +6668,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/content-type"
         }
       ]
@@ -6694,7 +6694,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cookie-parser"
         }
       ]
@@ -6720,7 +6720,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cookie-signature"
         }
       ]
@@ -6746,7 +6746,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cookie"
         }
       ]
@@ -6772,7 +6772,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/copy-descriptor"
         }
       ]
@@ -6798,7 +6798,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/core-util-is"
         }
       ]
@@ -6824,7 +6824,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cors"
         }
       ]
@@ -6850,7 +6850,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/crc"
         }
       ]
@@ -6876,7 +6876,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/crc32-stream"
         }
       ]
@@ -6902,7 +6902,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/create-require"
         }
       ]
@@ -6928,7 +6928,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/crypto-js"
         }
       ]
@@ -6954,7 +6954,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dashdash"
         }
       ]
@@ -6980,7 +6980,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/date-fns"
         }
       ]
@@ -7006,7 +7006,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dateformat"
         }
       ]
@@ -7032,7 +7032,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/debug"
         }
       ]
@@ -7058,7 +7058,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decamelize"
         }
       ]
@@ -7084,7 +7084,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decode-uri-component"
         }
       ]
@@ -7110,7 +7110,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-response"
         }
       ]
@@ -7136,7 +7136,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-tar"
         }
       ],
@@ -7162,7 +7162,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-tar/node_modules/file-type"
             }
           ]
@@ -7190,7 +7190,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-tarbz2"
         }
       ],
@@ -7216,7 +7216,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-tarbz2/node_modules/file-type"
             }
           ]
@@ -7244,7 +7244,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-targz"
         }
       ],
@@ -7270,7 +7270,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-targz/node_modules/file-type"
             }
           ]
@@ -7298,7 +7298,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-unzip"
         }
       ],
@@ -7324,7 +7324,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-unzip/node_modules/file-type"
             }
           ]
@@ -7350,7 +7350,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-unzip/node_modules/get-stream"
             }
           ]
@@ -7376,7 +7376,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-unzip/node_modules/pify"
             }
           ]
@@ -7404,7 +7404,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress"
         }
       ],
@@ -7430,7 +7430,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress/node_modules/make-dir"
             }
           ],
@@ -7456,7 +7456,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/decompress/node_modules/make-dir/node_modules/pify"
                 }
               ]
@@ -7484,7 +7484,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress/node_modules/pify"
             }
           ]
@@ -7512,7 +7512,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/deep-equal"
         }
       ]
@@ -7538,7 +7538,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/deep-extend"
         }
       ]
@@ -7564,7 +7564,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/deep-is"
         }
       ]
@@ -7590,7 +7590,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/define-properties"
         }
       ]
@@ -7616,7 +7616,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/define-property"
         }
       ]
@@ -7642,7 +7642,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/delayed-stream"
         }
       ]
@@ -7668,7 +7668,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/delegates"
         }
       ]
@@ -7694,7 +7694,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/depd"
         }
       ]
@@ -7720,7 +7720,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/destroy"
         }
       ]
@@ -7746,7 +7746,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/detect-file"
         }
       ]
@@ -7772,7 +7772,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/detect-libc"
         }
       ]
@@ -7798,7 +7798,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dfa"
         }
       ]
@@ -7824,7 +7824,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dicer"
         }
       ],
@@ -7850,7 +7850,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/dicer/node_modules/isarray"
             }
           ]
@@ -7876,7 +7876,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/dicer/node_modules/readable-stream"
             }
           ]
@@ -7902,7 +7902,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/dicer/node_modules/string_decoder"
             }
           ]
@@ -7930,7 +7930,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/diff"
         }
       ]
@@ -7956,7 +7956,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/doctypes"
         }
       ]
@@ -7982,7 +7982,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/domelementtype"
         }
       ]
@@ -8008,7 +8008,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/domhandler"
         }
       ]
@@ -8034,7 +8034,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/domutils"
         }
       ]
@@ -8060,7 +8060,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dottie"
         }
       ]
@@ -8086,7 +8086,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/double-ended-queue"
         }
       ]
@@ -8112,7 +8112,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/doublearray"
         }
       ]
@@ -8138,7 +8138,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/download"
         }
       ],
@@ -8164,7 +8164,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/download/node_modules/file-type"
             }
           ]
@@ -8192,7 +8192,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/duplexer2"
         }
       ]
@@ -8218,7 +8218,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/duplexer3"
         }
       ]
@@ -8244,7 +8244,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dynamic-dedupe"
         }
       ]
@@ -8270,7 +8270,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ecc-jsbn"
         }
       ]
@@ -8296,7 +8296,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ee-first"
         }
       ]
@@ -8322,7 +8322,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/eivindfjeldstad-dot"
         }
       ]
@@ -8348,7 +8348,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/emoji-regex"
         }
       ]
@@ -8374,7 +8374,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/enabled"
         }
       ]
@@ -8400,7 +8400,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/encodeurl"
         }
       ]
@@ -8426,7 +8426,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/encoding"
         }
       ],
@@ -8452,7 +8452,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/encoding/node_modules/iconv-lite"
             }
           ]
@@ -8480,7 +8480,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/end-of-stream"
         }
       ]
@@ -8506,7 +8506,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/engine.io-parser"
         }
       ]
@@ -8532,7 +8532,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/engine.io"
         }
       ],
@@ -8558,7 +8558,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/engine.io/node_modules/debug"
             }
           ]
@@ -8584,7 +8584,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/engine.io/node_modules/ms"
             }
           ]
@@ -8612,7 +8612,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/env-paths"
         }
       ]
@@ -8638,7 +8638,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/err-code"
         }
       ]
@@ -8664,7 +8664,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/error-ex"
         }
       ]
@@ -8690,7 +8690,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/errorhandler"
         }
       ]
@@ -8716,7 +8716,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/es-abstract"
         }
       ]
@@ -8742,7 +8742,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/es-get-iterator"
         }
       ]
@@ -8768,7 +8768,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/es-to-primitive"
         }
       ]
@@ -8794,7 +8794,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/escape-html"
         }
       ]
@@ -8820,7 +8820,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/escape-string-regexp"
         }
       ]
@@ -8846,7 +8846,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/escodegen"
         }
       ]
@@ -8872,7 +8872,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/esprima"
         }
       ]
@@ -8898,7 +8898,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/estraverse"
         }
       ]
@@ -8924,7 +8924,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/esutils"
         }
       ]
@@ -8950,7 +8950,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/etag"
         }
       ]
@@ -8976,7 +8976,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/eventemitter2"
         }
       ]
@@ -9002,7 +9002,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/eventemitter3"
         }
       ]
@@ -9028,7 +9028,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/exif"
         }
       ]
@@ -9054,7 +9054,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/exit"
         }
       ]
@@ -9080,7 +9080,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/expand-brackets"
         }
       ],
@@ -9106,7 +9106,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/define-property"
             }
           ]
@@ -9132,7 +9132,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/extend-shallow"
             }
           ]
@@ -9158,7 +9158,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/is-accessor-descriptor"
             }
           ],
@@ -9184,7 +9184,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/expand-brackets/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
@@ -9212,7 +9212,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/is-data-descriptor"
             }
           ],
@@ -9238,7 +9238,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/expand-brackets/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
@@ -9266,7 +9266,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/is-descriptor"
             }
           ]
@@ -9292,7 +9292,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/is-extendable"
             }
           ]
@@ -9318,7 +9318,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/kind-of"
             }
           ]
@@ -9346,7 +9346,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/expand-template"
         }
       ]
@@ -9372,7 +9372,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/expand-tilde"
         }
       ]
@@ -9398,7 +9398,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-ipfilter"
         }
       ]
@@ -9424,7 +9424,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-jwt"
         }
       ],
@@ -9450,7 +9450,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/express-jwt/node_modules/jsonwebtoken"
             }
           ]
@@ -9476,7 +9476,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/express-jwt/node_modules/moment"
             }
           ]
@@ -9504,7 +9504,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-rate-limit"
         }
       ]
@@ -9530,7 +9530,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-robots-txt"
         }
       ]
@@ -9556,7 +9556,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-security.txt"
         }
       ]
@@ -9582,7 +9582,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express"
         }
       ],
@@ -9608,7 +9608,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/express/node_modules/cookie"
             }
           ]
@@ -9634,7 +9634,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/express/node_modules/safe-buffer"
             }
           ]
@@ -9662,7 +9662,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ext-list"
         }
       ]
@@ -9688,7 +9688,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ext-name"
         }
       ]
@@ -9714,7 +9714,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/extend-shallow"
         }
       ]
@@ -9740,7 +9740,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/extend"
         }
       ]
@@ -9766,7 +9766,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/extglob"
         }
       ],
@@ -9792,7 +9792,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/extglob/node_modules/define-property"
             }
           ]
@@ -9818,7 +9818,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/extglob/node_modules/extend-shallow"
             }
           ]
@@ -9844,7 +9844,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/extglob/node_modules/is-extendable"
             }
           ]
@@ -9872,7 +9872,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/extsprintf"
         }
       ]
@@ -9898,7 +9898,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fast-deep-equal"
         }
       ]
@@ -9924,7 +9924,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fast-json-stable-stringify"
         }
       ]
@@ -9950,7 +9950,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fast-levenshtein"
         }
       ]
@@ -9976,7 +9976,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fast.js"
         }
       ]
@@ -10002,7 +10002,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fd-slicer"
         }
       ]
@@ -10028,7 +10028,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/feature-policy"
         }
       ]
@@ -10054,7 +10054,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fecha"
         }
       ]
@@ -10080,7 +10080,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/file-js"
         }
       ],
@@ -10106,7 +10106,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/file-js/node_modules/brace-expansion"
             }
           ]
@@ -10132,7 +10132,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/file-js/node_modules/minimatch"
             }
           ]
@@ -10160,7 +10160,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/file-stream-rotator"
         }
       ]
@@ -10186,7 +10186,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/file-type"
         }
       ]
@@ -10212,7 +10212,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/file-uri-to-path"
         }
       ]
@@ -10238,7 +10238,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/filehound"
         }
       ]
@@ -10264,7 +10264,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/filename-reserved-regex"
         }
       ]
@@ -10290,7 +10290,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/filenamify"
         }
       ]
@@ -10316,7 +10316,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/filesniffer"
         }
       ]
@@ -10342,7 +10342,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fill-range"
         }
       ],
@@ -10368,7 +10368,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/fill-range/node_modules/extend-shallow"
             }
           ]
@@ -10394,7 +10394,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/fill-range/node_modules/is-extendable"
             }
           ]
@@ -10422,7 +10422,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/finale-rest"
         }
       ]
@@ -10448,7 +10448,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/finalhandler"
         }
       ]
@@ -10474,7 +10474,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/find-up"
         }
       ]
@@ -10500,7 +10500,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/findup-sync"
         }
       ]
@@ -10526,7 +10526,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fined"
         }
       ]
@@ -10552,7 +10552,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/flagged-respawn"
         }
       ]
@@ -10578,7 +10578,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fn.name"
         }
       ]
@@ -10604,7 +10604,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fontkit"
         }
       ]
@@ -10630,7 +10630,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/for-each"
         }
       ]
@@ -10656,7 +10656,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/for-in"
         }
       ]
@@ -10682,7 +10682,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/for-own"
         }
       ]
@@ -10708,7 +10708,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/foreachasync"
         }
       ]
@@ -10734,7 +10734,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/forever-agent"
         }
       ]
@@ -10760,7 +10760,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/form-data"
         }
       ]
@@ -10786,7 +10786,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/formatio"
         }
       ]
@@ -10812,7 +10812,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/forwarded"
         }
       ]
@@ -10838,7 +10838,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fragment-cache"
         }
       ]
@@ -10864,7 +10864,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fresh"
         }
       ]
@@ -10890,7 +10890,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/from2"
         }
       ]
@@ -10916,7 +10916,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fs-constants"
         }
       ]
@@ -10942,7 +10942,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fs-extra"
         }
       ]
@@ -10968,7 +10968,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fs-minipass"
         }
       ]
@@ -10994,7 +10994,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fs.realpath"
         }
       ]
@@ -11020,7 +11020,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fsevents"
         }
       ]
@@ -11046,7 +11046,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fstream"
         }
       ],
@@ -11072,7 +11072,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/fstream/node_modules/mkdirp"
             }
           ]
@@ -11098,7 +11098,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/fstream/node_modules/rimraf"
             }
           ]
@@ -11126,7 +11126,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/function-bind"
         }
       ]
@@ -11152,7 +11152,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/function.prototype.name"
         }
       ]
@@ -11178,7 +11178,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/functions-have-names"
         }
       ]
@@ -11204,7 +11204,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fuzzball"
         }
       ]
@@ -11230,7 +11230,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/gauge"
         }
       ]
@@ -11256,7 +11256,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/geojson-utils"
         }
       ]
@@ -11282,7 +11282,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-caller-file"
         }
       ]
@@ -11308,7 +11308,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-intrinsic"
         }
       ]
@@ -11334,7 +11334,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-stream"
         }
       ]
@@ -11360,7 +11360,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-symbol-description"
         }
       ]
@@ -11386,7 +11386,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-value"
         }
       ]
@@ -11412,7 +11412,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/getobject"
         }
       ]
@@ -11438,7 +11438,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/getpass"
         }
       ]
@@ -11464,7 +11464,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/github-from-package"
         }
       ]
@@ -11490,7 +11490,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/glob-parent"
         }
       ],
@@ -11516,7 +11516,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/glob-parent/node_modules/is-glob"
             }
           ]
@@ -11544,7 +11544,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/glob"
         }
       ],
@@ -11570,7 +11570,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/glob/node_modules/brace-expansion"
             }
           ]
@@ -11596,7 +11596,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/glob/node_modules/minimatch"
             }
           ]
@@ -11624,7 +11624,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/global-modules"
         }
       ]
@@ -11650,7 +11650,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/global-prefix"
         }
       ],
@@ -11676,7 +11676,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/global-prefix/node_modules/which"
             }
           ]
@@ -11704,7 +11704,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/got"
         }
       ],
@@ -11730,7 +11730,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/got/node_modules/get-stream"
             }
           ]
@@ -11756,7 +11756,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/got/node_modules/pify"
             }
           ]
@@ -11784,7 +11784,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/graceful-fs"
         }
       ]
@@ -11810,7 +11810,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-cli"
         }
       ],
@@ -11836,7 +11836,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-cli/node_modules/nopt"
             }
           ]
@@ -11864,7 +11864,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-contrib-compress"
         }
       ],
@@ -11890,7 +11890,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-contrib-compress/node_modules/ansi-styles"
             }
           ]
@@ -11916,7 +11916,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-contrib-compress/node_modules/chalk"
             }
           ]
@@ -11942,7 +11942,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-contrib-compress/node_modules/supports-color"
             }
           ]
@@ -11970,7 +11970,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-known-options"
         }
       ]
@@ -11996,7 +11996,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-legacy-log-utils"
         }
       ],
@@ -12022,7 +12022,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils/node_modules/ansi-styles"
             }
           ]
@@ -12048,7 +12048,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils/node_modules/chalk"
             }
           ]
@@ -12074,7 +12074,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils/node_modules/color-convert"
             }
           ]
@@ -12100,7 +12100,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils/node_modules/color-name"
             }
           ]
@@ -12126,7 +12126,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils/node_modules/has-flag"
             }
           ]
@@ -12152,7 +12152,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils/node_modules/supports-color"
             }
           ]
@@ -12180,7 +12180,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-legacy-log"
         }
       ],
@@ -12206,7 +12206,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log/node_modules/colors"
             }
           ]
@@ -12234,7 +12234,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-legacy-util"
         }
       ],
@@ -12260,7 +12260,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-util/node_modules/async"
             }
           ]
@@ -12288,7 +12288,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-replace-json"
         }
       ]
@@ -12314,7 +12314,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt"
         }
       ],
@@ -12340,7 +12340,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt/node_modules/brace-expansion"
             }
           ]
@@ -12366,7 +12366,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt/node_modules/findup-sync"
             }
           ],
@@ -12392,7 +12392,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/grunt/node_modules/findup-sync/node_modules/glob"
                 }
               ]
@@ -12420,7 +12420,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt/node_modules/glob"
             }
           ]
@@ -12446,7 +12446,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt/node_modules/minimatch"
             }
           ]
@@ -12474,7 +12474,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/handlebars"
         }
       ],
@@ -12500,7 +12500,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/handlebars/node_modules/wordwrap"
             }
           ]
@@ -12528,7 +12528,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/har-schema"
         }
       ]
@@ -12554,7 +12554,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/har-validator"
         }
       ]
@@ -12580,7 +12580,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-ansi"
         }
       ]
@@ -12606,7 +12606,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-bigints"
         }
       ]
@@ -12632,7 +12632,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-flag"
         }
       ]
@@ -12658,7 +12658,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-property-descriptors"
         }
       ]
@@ -12684,7 +12684,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-symbol-support-x"
         }
       ]
@@ -12710,7 +12710,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-symbols"
         }
       ]
@@ -12736,7 +12736,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-to-string-tag-x"
         }
       ]
@@ -12762,7 +12762,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-tostringtag"
         }
       ]
@@ -12788,7 +12788,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-unicode"
         }
       ]
@@ -12814,7 +12814,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-value"
         }
       ]
@@ -12840,7 +12840,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-values"
         }
       ],
@@ -12866,7 +12866,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/has-values/node_modules/kind-of"
             }
           ]
@@ -12894,7 +12894,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has"
         }
       ]
@@ -12920,7 +12920,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hashids"
         }
       ]
@@ -12946,7 +12946,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hbs"
         }
       ]
@@ -12972,7 +12972,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/he"
         }
       ]
@@ -12998,7 +12998,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/heap"
         }
       ]
@@ -13024,7 +13024,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/helmet"
         }
       ]
@@ -13050,7 +13050,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hoister"
         }
       ]
@@ -13076,7 +13076,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/homedir-polyfill"
         }
       ]
@@ -13102,7 +13102,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hooker"
         }
       ]
@@ -13128,7 +13128,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hosted-git-info"
         }
       ]
@@ -13154,7 +13154,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/html-entities"
         }
       ]
@@ -13180,7 +13180,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/htmlparser2"
         }
       ],
@@ -13206,7 +13206,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/htmlparser2/node_modules/isarray"
             }
           ]
@@ -13232,7 +13232,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/htmlparser2/node_modules/readable-stream"
             }
           ]
@@ -13258,7 +13258,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/htmlparser2/node_modules/string_decoder"
             }
           ]
@@ -13286,7 +13286,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/http-cache-semantics"
         }
       ]
@@ -13312,7 +13312,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/http-errors"
         }
       ]
@@ -13338,7 +13338,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/http-proxy-agent"
         }
       ],
@@ -13364,7 +13364,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/http-proxy-agent/node_modules/debug"
             }
           ]
@@ -13390,7 +13390,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/http-proxy-agent/node_modules/ms"
             }
           ]
@@ -13418,7 +13418,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/http-signature"
         }
       ]
@@ -13444,7 +13444,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/https-proxy-agent"
         }
       ],
@@ -13470,7 +13470,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/https-proxy-agent/node_modules/debug"
             }
           ]
@@ -13496,7 +13496,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/https-proxy-agent/node_modules/ms"
             }
           ]
@@ -13524,7 +13524,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/humanize-ms"
         }
       ]
@@ -13550,7 +13550,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/i18n"
         }
       ]
@@ -13576,7 +13576,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/iconv-lite"
         }
       ]
@@ -13602,7 +13602,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ieee754"
         }
       ]
@@ -13628,7 +13628,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ignore-walk"
         }
       ],
@@ -13654,7 +13654,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/ignore-walk/node_modules/brace-expansion"
             }
           ]
@@ -13680,7 +13680,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/ignore-walk/node_modules/minimatch"
             }
           ]
@@ -13708,7 +13708,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/iltorb"
         }
       ]
@@ -13734,7 +13734,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/imurmurhash"
         }
       ]
@@ -13760,7 +13760,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/indent-string"
         }
       ]
@@ -13786,7 +13786,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/infer-owner"
         }
       ]
@@ -13812,7 +13812,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/inflection"
         }
       ]
@@ -13838,7 +13838,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/inflight"
         }
       ]
@@ -13864,7 +13864,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/inherits"
         }
       ]
@@ -13890,7 +13890,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ini"
         }
       ]
@@ -13916,7 +13916,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/internal-slot"
         }
       ]
@@ -13942,7 +13942,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/interpret"
         }
       ]
@@ -13968,7 +13968,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/into-stream"
         }
       ]
@@ -13994,7 +13994,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/invariant"
         }
       ]
@@ -14020,7 +14020,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ip"
         }
       ]
@@ -14046,7 +14046,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ip6"
         }
       ]
@@ -14072,7 +14072,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ipaddr.js"
         }
       ]
@@ -14098,7 +14098,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-absolute"
         }
       ]
@@ -14124,7 +14124,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-accessor-descriptor"
         }
       ]
@@ -14150,7 +14150,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-arguments"
         }
       ]
@@ -14176,7 +14176,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-arrayish"
         }
       ]
@@ -14202,7 +14202,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-bigint"
         }
       ]
@@ -14228,7 +14228,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-binary-path"
         }
       ]
@@ -14254,7 +14254,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-boolean-object"
         }
       ]
@@ -14280,7 +14280,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-buffer"
         }
       ]
@@ -14306,7 +14306,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-callable"
         }
       ]
@@ -14332,7 +14332,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-core-module"
         }
       ]
@@ -14358,7 +14358,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-data-descriptor"
         }
       ]
@@ -14384,7 +14384,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-date-object"
         }
       ]
@@ -14410,7 +14410,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-descriptor"
         }
       ]
@@ -14436,7 +14436,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-docker"
         }
       ]
@@ -14462,7 +14462,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-expression"
         }
       ]
@@ -14488,7 +14488,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-extendable"
         }
       ]
@@ -14514,7 +14514,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-extglob"
         }
       ]
@@ -14540,7 +14540,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-fullwidth-code-point"
         }
       ]
@@ -14566,7 +14566,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-generator-function"
         }
       ]
@@ -14592,7 +14592,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-glob"
         }
       ]
@@ -14618,7 +14618,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-heroku"
         }
       ]
@@ -14644,7 +14644,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-lambda"
         }
       ]
@@ -14670,7 +14670,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-map"
         }
       ]
@@ -14696,7 +14696,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-natural-number"
         }
       ]
@@ -14722,7 +14722,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-negative-zero"
         }
       ]
@@ -14748,7 +14748,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-number-like"
         }
       ]
@@ -14774,7 +14774,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-number-object"
         }
       ]
@@ -14800,7 +14800,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-number"
         }
       ],
@@ -14826,7 +14826,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/is-number/node_modules/kind-of"
             }
           ]
@@ -14854,7 +14854,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-object"
         }
       ]
@@ -14880,7 +14880,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-plain-obj"
         }
       ]
@@ -14906,7 +14906,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-plain-object"
         }
       ]
@@ -14932,7 +14932,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-promise"
         }
       ]
@@ -14958,7 +14958,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-regex"
         }
       ]
@@ -14984,7 +14984,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-relative"
         }
       ]
@@ -15010,7 +15010,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-retry-allowed"
         }
       ]
@@ -15036,7 +15036,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-set"
         }
       ]
@@ -15062,7 +15062,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-shared-array-buffer"
         }
       ]
@@ -15088,7 +15088,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-stream"
         }
       ]
@@ -15114,7 +15114,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-string"
         }
       ]
@@ -15140,7 +15140,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-symbol"
         }
       ]
@@ -15166,7 +15166,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-typed-array"
         }
       ]
@@ -15192,7 +15192,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-typedarray"
         }
       ]
@@ -15218,7 +15218,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-unc-path"
         }
       ]
@@ -15244,7 +15244,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-weakmap"
         }
       ]
@@ -15270,7 +15270,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-weakref"
         }
       ]
@@ -15296,7 +15296,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-weakset"
         }
       ]
@@ -15322,7 +15322,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-windows"
         }
       ]
@@ -15348,7 +15348,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isarray"
         }
       ]
@@ -15374,7 +15374,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isexe"
         }
       ]
@@ -15400,7 +15400,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isobject"
         }
       ]
@@ -15426,7 +15426,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isstream"
         }
       ]
@@ -15452,7 +15452,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isurl"
         }
       ]
@@ -15478,7 +15478,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/js-stringify"
         }
       ]
@@ -15504,7 +15504,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/js-tokens"
         }
       ]
@@ -15530,7 +15530,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/js-yaml"
         }
       ]
@@ -15556,7 +15556,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jsbn"
         }
       ]
@@ -15582,7 +15582,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-buffer"
         }
       ]
@@ -15608,7 +15608,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-parse-better-errors"
         }
       ]
@@ -15634,7 +15634,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-schema-traverse"
         }
       ]
@@ -15660,7 +15660,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-schema"
         }
       ]
@@ -15686,7 +15686,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-stringify-safe"
         }
       ]
@@ -15712,7 +15712,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json5"
         }
       ]
@@ -15738,7 +15738,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jsonfile"
         }
       ]
@@ -15764,7 +15764,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jsonwebtoken"
         }
       ]
@@ -15790,7 +15790,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jsprim"
         }
       ]
@@ -15816,7 +15816,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jssha"
         }
       ]
@@ -15842,7 +15842,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jstransformer"
         }
       ]
@@ -15868,7 +15868,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/juicy-chat-bot"
         }
       ]
@@ -15894,7 +15894,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jwa"
         }
       ]
@@ -15920,7 +15920,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jws"
         }
       ]
@@ -15946,7 +15946,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/keyv"
         }
       ]
@@ -15972,7 +15972,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/kind-of"
         }
       ]
@@ -15998,7 +15998,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/kuler"
         }
       ]
@@ -16024,7 +16024,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/kuromoji"
         }
       ]
@@ -16050,7 +16050,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lazystream"
         }
       ]
@@ -16076,7 +16076,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/levn"
         }
       ]
@@ -16102,7 +16102,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/libxmljs2"
         }
       ],
@@ -16128,7 +16128,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/libxmljs2/node_modules/nan"
             }
           ]
@@ -16156,7 +16156,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/liftup"
         }
       ],
@@ -16182,7 +16182,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/braces"
             }
           ]
@@ -16208,7 +16208,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/fill-range"
             }
           ]
@@ -16234,7 +16234,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/findup-sync"
             }
           ]
@@ -16260,7 +16260,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/is-glob"
             }
           ]
@@ -16286,7 +16286,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/is-number"
             }
           ]
@@ -16312,7 +16312,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/micromatch"
             }
           ]
@@ -16338,7 +16338,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/to-regex-range"
             }
           ]
@@ -16366,7 +16366,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/linebreak"
         }
       ],
@@ -16392,7 +16392,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/linebreak/node_modules/base64-js"
             }
           ]
@@ -16420,7 +16420,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/listenercount"
         }
       ]
@@ -16446,7 +16446,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/locate-path"
         }
       ]
@@ -16472,7 +16472,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lodash.camelcase"
         }
       ]
@@ -16498,7 +16498,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lodash.isfinite"
         }
       ]
@@ -16524,7 +16524,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lodash.set"
         }
       ]
@@ -16550,7 +16550,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lodash"
         }
       ]
@@ -16576,7 +16576,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/logform"
         }
       ],
@@ -16602,7 +16602,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/logform/node_modules/ms"
             }
           ]
@@ -16630,7 +16630,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lolex"
         }
       ]
@@ -16656,7 +16656,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/loose-envify"
         }
       ]
@@ -16682,7 +16682,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lowercase-keys"
         }
       ]
@@ -16708,7 +16708,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lru-cache"
         }
       ]
@@ -16734,7 +16734,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-dir"
         }
       ],
@@ -16760,7 +16760,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-dir/node_modules/semver"
             }
           ]
@@ -16788,7 +16788,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-error"
         }
       ]
@@ -16814,7 +16814,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-fetch-happen"
         }
       ],
@@ -16841,7 +16841,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen/node_modules/@tootallnate/once"
             }
           ]
@@ -16867,7 +16867,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen/node_modules/debug"
             }
           ]
@@ -16893,7 +16893,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen/node_modules/http-cache-semantics"
             }
           ]
@@ -16919,7 +16919,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen/node_modules/http-proxy-agent"
             }
           ]
@@ -16945,7 +16945,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen/node_modules/ms"
             }
           ]
@@ -16973,7 +16973,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-iterator"
         }
       ]
@@ -16999,7 +16999,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-plural"
         }
       ]
@@ -17025,7 +17025,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/map-cache"
         }
       ]
@@ -17051,7 +17051,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/map-visit"
         }
       ]
@@ -17077,7 +17077,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/marsdb"
         }
       ]
@@ -17103,7 +17103,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/math-interval-parser"
         }
       ]
@@ -17129,7 +17129,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/media-typer"
         }
       ]
@@ -17155,7 +17155,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/merge-descriptors"
         }
       ]
@@ -17181,7 +17181,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/messageformat-formatters"
         }
       ]
@@ -17207,7 +17207,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/messageformat-parser"
         }
       ]
@@ -17233,7 +17233,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/messageformat"
         }
       ],
@@ -17259,7 +17259,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/messageformat/node_modules/make-plural"
             }
           ]
@@ -17287,7 +17287,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/methods"
         }
       ]
@@ -17313,7 +17313,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/micromatch"
         }
       ]
@@ -17339,7 +17339,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mime-db"
         }
       ]
@@ -17365,7 +17365,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mime-types"
         }
       ]
@@ -17391,7 +17391,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mime"
         }
       ]
@@ -17417,7 +17417,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mimic-response"
         }
       ]
@@ -17443,7 +17443,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minimatch"
         }
       ]
@@ -17469,7 +17469,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minimist"
         }
       ]
@@ -17495,7 +17495,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-collect"
         }
       ]
@@ -17521,7 +17521,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-fetch"
         }
       ]
@@ -17547,7 +17547,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-flush"
         }
       ]
@@ -17573,7 +17573,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-pipeline"
         }
       ]
@@ -17599,7 +17599,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-sized"
         }
       ]
@@ -17625,7 +17625,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass"
         }
       ]
@@ -17651,7 +17651,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minizlib"
         }
       ]
@@ -17677,7 +17677,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mixin-deep"
         }
       ]
@@ -17703,7 +17703,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mkdirp-classic"
         }
       ]
@@ -17729,7 +17729,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mkdirp"
         }
       ]
@@ -17755,7 +17755,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/moment-timezone"
         }
       ]
@@ -17781,7 +17781,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/moment"
         }
       ]
@@ -17807,7 +17807,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/morgan"
         }
       ],
@@ -17833,7 +17833,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/morgan/node_modules/on-finished"
             }
           ]
@@ -17861,7 +17861,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mout"
         }
       ]
@@ -17887,7 +17887,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ms"
         }
       ]
@@ -17913,7 +17913,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/multer"
         }
       ],
@@ -17939,7 +17939,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/multer/node_modules/mkdirp"
             }
           ]
@@ -17967,7 +17967,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mustache"
         }
       ]
@@ -17993,7 +17993,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/nan"
         }
       ]
@@ -18019,7 +18019,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/nanomatch"
         }
       ]
@@ -18045,7 +18045,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/napi-build-utils"
         }
       ]
@@ -18071,7 +18071,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/needle"
         }
       ],
@@ -18097,7 +18097,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/needle/node_modules/debug"
             }
           ]
@@ -18123,7 +18123,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/needle/node_modules/ms"
             }
           ]
@@ -18151,7 +18151,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/negotiator"
         }
       ]
@@ -18177,7 +18177,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/neo-async"
         }
       ]
@@ -18203,7 +18203,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-abi"
         }
       ],
@@ -18229,7 +18229,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-abi/node_modules/semver"
             }
           ]
@@ -18257,7 +18257,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-addon-api"
         }
       ]
@@ -18283,7 +18283,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-fetch"
         }
       ]
@@ -18309,7 +18309,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-gyp"
         }
       ],
@@ -18335,7 +18335,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/ansi-regex"
             }
           ]
@@ -18361,7 +18361,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/are-we-there-yet"
             }
           ]
@@ -18387,7 +18387,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/gauge"
             }
           ]
@@ -18413,7 +18413,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -18439,7 +18439,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/nopt"
             }
           ]
@@ -18465,7 +18465,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/npmlog"
             }
           ]
@@ -18491,7 +18491,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/readable-stream"
             }
           ]
@@ -18517,7 +18517,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/string-width"
             }
           ]
@@ -18543,7 +18543,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/strip-ansi"
             }
           ]
@@ -18571,7 +18571,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-pre-gyp"
         }
       ],
@@ -18597,7 +18597,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/chownr"
             }
           ]
@@ -18623,7 +18623,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/fs-minipass"
             }
           ]
@@ -18649,7 +18649,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/minipass"
             }
           ]
@@ -18675,7 +18675,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/minizlib"
             }
           ]
@@ -18701,7 +18701,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/mkdirp"
             }
           ]
@@ -18727,7 +18727,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/nopt"
             }
           ]
@@ -18753,7 +18753,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/rimraf"
             }
           ]
@@ -18779,7 +18779,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/safe-buffer"
             }
           ]
@@ -18805,7 +18805,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/semver"
             }
           ]
@@ -18831,7 +18831,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/tar"
             }
           ]
@@ -18857,7 +18857,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/yallist"
             }
           ]
@@ -18885,7 +18885,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/noop-logger"
         }
       ]
@@ -18911,7 +18911,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/nopt"
         }
       ]
@@ -18937,7 +18937,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/normalize-package-data"
         }
       ],
@@ -18963,7 +18963,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/normalize-package-data/node_modules/semver"
             }
           ]
@@ -18991,7 +18991,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/normalize-path"
         }
       ]
@@ -19017,7 +19017,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/normalize-url"
         }
       ]
@@ -19043,7 +19043,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/notevil"
         }
       ],
@@ -19069,7 +19069,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/notevil/node_modules/esprima"
             }
           ]
@@ -19097,7 +19097,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/npm-bundled"
         }
       ]
@@ -19123,7 +19123,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/npm-normalize-package-bin"
         }
       ]
@@ -19149,7 +19149,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/npm-packlist"
         }
       ]
@@ -19175,7 +19175,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/npmlog"
         }
       ]
@@ -19201,7 +19201,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/number-is-nan"
         }
       ]
@@ -19227,7 +19227,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/oauth-sign"
         }
       ]
@@ -19253,7 +19253,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-assign"
         }
       ]
@@ -19279,7 +19279,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-copy"
         }
       ],
@@ -19305,7 +19305,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy/node_modules/define-property"
             }
           ]
@@ -19331,7 +19331,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy/node_modules/is-accessor-descriptor"
             }
           ]
@@ -19357,7 +19357,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy/node_modules/is-data-descriptor"
             }
           ]
@@ -19383,7 +19383,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy/node_modules/is-descriptor"
             }
           ],
@@ -19409,7 +19409,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/object-copy/node_modules/is-descriptor/node_modules/kind-of"
                 }
               ]
@@ -19437,7 +19437,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy/node_modules/kind-of"
             }
           ]
@@ -19465,7 +19465,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-inspect"
         }
       ]
@@ -19491,7 +19491,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-is"
         }
       ]
@@ -19517,7 +19517,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-keys"
         }
       ]
@@ -19543,7 +19543,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-visit"
         }
       ]
@@ -19569,7 +19569,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object.assign"
         }
       ]
@@ -19595,7 +19595,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object.defaults"
         }
       ]
@@ -19621,7 +19621,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object.map"
         }
       ]
@@ -19647,7 +19647,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object.pick"
         }
       ]
@@ -19673,7 +19673,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/on-finished"
         }
       ]
@@ -19699,7 +19699,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/on-headers"
         }
       ]
@@ -19725,7 +19725,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/once"
         }
       ]
@@ -19751,7 +19751,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/one-time"
         }
       ]
@@ -19777,7 +19777,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/opentype.js"
         }
       ]
@@ -19803,7 +19803,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/optionator"
         }
       ]
@@ -19829,7 +19829,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/os-homedir"
         }
       ]
@@ -19855,7 +19855,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/os-tmpdir"
         }
       ]
@@ -19881,7 +19881,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/osenv"
         }
       ]
@@ -19907,7 +19907,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/otplib"
         }
       ]
@@ -19933,7 +19933,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-cancelable"
         }
       ]
@@ -19959,7 +19959,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-event"
         }
       ]
@@ -19985,7 +19985,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-finally"
         }
       ]
@@ -20011,7 +20011,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-is-promise"
         }
       ]
@@ -20037,7 +20037,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-limit"
         }
       ]
@@ -20063,7 +20063,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-locate"
         }
       ]
@@ -20089,7 +20089,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-map"
         }
       ]
@@ -20115,7 +20115,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-timeout"
         }
       ]
@@ -20141,7 +20141,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-try"
         }
       ]
@@ -20167,7 +20167,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pako"
         }
       ]
@@ -20193,7 +20193,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/parse-filepath"
         }
       ]
@@ -20219,7 +20219,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/parse-json"
         }
       ]
@@ -20245,7 +20245,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/parse-passwd"
         }
       ]
@@ -20271,7 +20271,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/parseurl"
         }
       ]
@@ -20297,7 +20297,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pascalcase"
         }
       ]
@@ -20323,7 +20323,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-exists"
         }
       ]
@@ -20349,7 +20349,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-is-absolute"
         }
       ]
@@ -20375,7 +20375,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-parse"
         }
       ]
@@ -20401,7 +20401,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-root-regex"
         }
       ]
@@ -20427,7 +20427,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-root"
         }
       ]
@@ -20453,7 +20453,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-to-regexp"
         }
       ]
@@ -20479,7 +20479,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pdfkit"
         }
       ]
@@ -20505,7 +20505,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/peek-readable"
         }
       ]
@@ -20531,7 +20531,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pend"
         }
       ]
@@ -20557,7 +20557,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/performance-now"
         }
       ]
@@ -20583,7 +20583,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pg-connection-string"
         }
       ]
@@ -20609,7 +20609,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/picomatch"
         }
       ]
@@ -20635,7 +20635,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pify"
         }
       ]
@@ -20661,7 +20661,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pinkie-promise"
         }
       ]
@@ -20687,7 +20687,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pinkie"
         }
       ]
@@ -20713,7 +20713,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/png-js"
         }
       ]
@@ -20739,7 +20739,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/portscanner"
         }
       ]
@@ -20765,7 +20765,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/posix-character-classes"
         }
       ]
@@ -20791,7 +20791,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/prebuild-install"
         }
       ]
@@ -20817,7 +20817,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/prelude-ls"
         }
       ]
@@ -20843,7 +20843,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/prepend-http"
         }
       ]
@@ -20869,7 +20869,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pretty-bytes"
         }
       ]
@@ -20895,7 +20895,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/process-nextick-args"
         }
       ]
@@ -20921,7 +20921,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/prom-client"
         }
       ]
@@ -20947,7 +20947,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/promise-inflight"
         }
       ]
@@ -20973,7 +20973,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/promise-retry"
         }
       ],
@@ -20999,7 +20999,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/promise-retry/node_modules/err-code"
             }
           ]
@@ -21025,7 +21025,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/promise-retry/node_modules/retry"
             }
           ]
@@ -21053,7 +21053,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/promise"
         }
       ]
@@ -21079,7 +21079,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/proper-lockfile"
         }
       ]
@@ -21105,7 +21105,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/proxy-addr"
         }
       ]
@@ -21131,7 +21131,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/psl"
         }
       ]
@@ -21157,7 +21157,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-attrs"
         }
       ]
@@ -21183,7 +21183,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-code-gen"
         }
       ]
@@ -21209,7 +21209,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-error"
         }
       ]
@@ -21235,7 +21235,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-filters"
         }
       ]
@@ -21261,7 +21261,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-lexer"
         }
       ]
@@ -21287,7 +21287,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-linker"
         }
       ]
@@ -21313,7 +21313,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-load"
         }
       ]
@@ -21339,7 +21339,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-parser"
         }
       ]
@@ -21365,7 +21365,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-runtime"
         }
       ]
@@ -21391,7 +21391,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-strip-comments"
         }
       ]
@@ -21417,7 +21417,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-walk"
         }
       ]
@@ -21443,7 +21443,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug"
         }
       ]
@@ -21469,7 +21469,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pump"
         }
       ]
@@ -21495,7 +21495,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/punycode"
         }
       ]
@@ -21521,7 +21521,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/qs"
         }
       ]
@@ -21547,7 +21547,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/query-string"
         }
       ]
@@ -21573,7 +21573,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/range_check"
         }
       ]
@@ -21599,7 +21599,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/range-parser"
         }
       ]
@@ -21625,7 +21625,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/raw-body"
         }
       ]
@@ -21651,7 +21651,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/rc"
         }
       ]
@@ -21677,7 +21677,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/read-pkg"
         }
       ],
@@ -21703,7 +21703,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/read-pkg/node_modules/pify"
             }
           ]
@@ -21731,7 +21731,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/readable-stream"
         }
       ],
@@ -21757,7 +21757,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/readable-stream/node_modules/isarray"
             }
           ]
@@ -21785,7 +21785,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/readable-web-to-node-stream"
         }
       ],
@@ -21811,7 +21811,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/readable-web-to-node-stream/node_modules/readable-stream"
             }
           ]
@@ -21839,7 +21839,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/readdirp"
         }
       ]
@@ -21865,7 +21865,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/rechoir"
         }
       ]
@@ -21891,7 +21891,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/regex-not"
         }
       ]
@@ -21917,7 +21917,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/regexp.prototype.flags"
         }
       ]
@@ -21943,7 +21943,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/remove-trailing-separator"
         }
       ]
@@ -21969,7 +21969,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/repeat-element"
         }
       ]
@@ -21995,7 +21995,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/repeat-string"
         }
       ]
@@ -22021,7 +22021,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/replace"
         }
       ],
@@ -22047,7 +22047,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/ansi-regex"
             }
           ]
@@ -22073,7 +22073,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/ansi-styles"
             }
           ]
@@ -22099,7 +22099,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/brace-expansion"
             }
           ]
@@ -22125,7 +22125,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/cliui"
             }
           ]
@@ -22151,7 +22151,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/color-convert"
             }
           ]
@@ -22177,7 +22177,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/color-name"
             }
           ]
@@ -22203,7 +22203,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/find-up"
             }
           ]
@@ -22229,7 +22229,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -22255,7 +22255,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/locate-path"
             }
           ]
@@ -22281,7 +22281,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/minimatch"
             }
           ]
@@ -22307,7 +22307,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/p-locate"
             }
           ]
@@ -22333,7 +22333,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/path-exists"
             }
           ]
@@ -22359,7 +22359,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/string-width"
             }
           ]
@@ -22385,7 +22385,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/strip-ansi"
             }
           ]
@@ -22411,7 +22411,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/wrap-ansi"
             }
           ]
@@ -22437,7 +22437,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/yargs-parser"
             }
           ]
@@ -22463,7 +22463,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/yargs"
             }
           ]
@@ -22491,7 +22491,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/request"
         }
       ],
@@ -22517,7 +22517,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/request/node_modules/qs"
             }
           ]
@@ -22545,7 +22545,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/require-directory"
         }
       ]
@@ -22571,7 +22571,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/require-main-filename"
         }
       ]
@@ -22597,7 +22597,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/resolve-dir"
         }
       ]
@@ -22623,7 +22623,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/resolve-url"
         }
       ]
@@ -22649,7 +22649,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/resolve"
         }
       ]
@@ -22675,7 +22675,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/responselike"
         }
       ]
@@ -22701,7 +22701,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/restructure"
         }
       ]
@@ -22727,7 +22727,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ret"
         }
       ]
@@ -22753,7 +22753,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/retry-as-promised"
         }
       ]
@@ -22779,7 +22779,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/retry"
         }
       ]
@@ -22805,7 +22805,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/rimraf"
         }
       ]
@@ -22831,7 +22831,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/rxjs"
         }
       ],
@@ -22857,7 +22857,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/rxjs/node_modules/tslib"
             }
           ]
@@ -22885,7 +22885,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safe-buffer"
         }
       ]
@@ -22911,7 +22911,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safe-regex-test"
         }
       ]
@@ -22937,7 +22937,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safe-regex"
         }
       ]
@@ -22963,7 +22963,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safe-stable-stringify"
         }
       ]
@@ -22989,7 +22989,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safer-buffer"
         }
       ]
@@ -23015,7 +23015,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/samsam"
         }
       ]
@@ -23041,7 +23041,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sanitize-filename"
         }
       ]
@@ -23067,7 +23067,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sanitize-html"
         }
       ],
@@ -23093,7 +23093,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sanitize-html/node_modules/lodash"
             }
           ]
@@ -23121,7 +23121,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sax"
         }
       ]
@@ -23147,7 +23147,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/seek-bzip"
         }
       ]
@@ -23173,7 +23173,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/semver"
         }
       ]
@@ -23199,7 +23199,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/send"
         }
       ],
@@ -23225,7 +23225,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/send/node_modules/ms"
             }
           ]
@@ -23253,7 +23253,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sequelize-pool"
         }
       ]
@@ -23279,7 +23279,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sequelize"
         }
       ],
@@ -23305,7 +23305,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sequelize/node_modules/debug"
             }
           ]
@@ -23331,7 +23331,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sequelize/node_modules/ms"
             }
           ]
@@ -23357,7 +23357,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sequelize/node_modules/uuid"
             }
           ]
@@ -23385,7 +23385,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/serve-index"
         }
       ],
@@ -23411,7 +23411,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index/node_modules/depd"
             }
           ]
@@ -23437,7 +23437,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index/node_modules/http-errors"
             }
           ]
@@ -23463,7 +23463,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index/node_modules/inherits"
             }
           ]
@@ -23489,7 +23489,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index/node_modules/setprototypeof"
             }
           ]
@@ -23515,7 +23515,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index/node_modules/statuses"
             }
           ]
@@ -23543,7 +23543,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/serve-static"
         }
       ]
@@ -23569,7 +23569,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/set-blocking"
         }
       ]
@@ -23595,7 +23595,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/set-value"
         }
       ],
@@ -23621,7 +23621,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/set-value/node_modules/extend-shallow"
             }
           ]
@@ -23647,7 +23647,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/set-value/node_modules/is-extendable"
             }
           ]
@@ -23675,7 +23675,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/setimmediate"
         }
       ]
@@ -23701,7 +23701,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/setprototypeof"
         }
       ]
@@ -23727,7 +23727,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/side-channel"
         }
       ]
@@ -23753,7 +23753,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/signal-exit"
         }
       ]
@@ -23779,7 +23779,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/simple-concat"
         }
       ]
@@ -23805,7 +23805,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/simple-get"
         }
       ],
@@ -23831,7 +23831,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/simple-get/node_modules/decompress-response"
             }
           ]
@@ -23857,7 +23857,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/simple-get/node_modules/mimic-response"
             }
           ]
@@ -23885,7 +23885,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/simple-swizzle"
         }
       ],
@@ -23911,7 +23911,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/simple-swizzle/node_modules/is-arrayish"
             }
           ]
@@ -23939,7 +23939,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sinon"
         }
       ]
@@ -23965,7 +23965,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/smart-buffer"
         }
       ]
@@ -23991,7 +23991,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/snapdragon-node"
         }
       ],
@@ -24017,7 +24017,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon-node/node_modules/define-property"
             }
           ]
@@ -24045,7 +24045,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/snapdragon-util"
         }
       ],
@@ -24071,7 +24071,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon-util/node_modules/kind-of"
             }
           ]
@@ -24099,7 +24099,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/snapdragon"
         }
       ],
@@ -24125,7 +24125,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/define-property"
             }
           ]
@@ -24151,7 +24151,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/extend-shallow"
             }
           ]
@@ -24177,7 +24177,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/is-accessor-descriptor"
             }
           ],
@@ -24203,7 +24203,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/snapdragon/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
@@ -24231,7 +24231,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/is-data-descriptor"
             }
           ],
@@ -24257,7 +24257,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/snapdragon/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
@@ -24285,7 +24285,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/is-descriptor"
             }
           ]
@@ -24311,7 +24311,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/is-extendable"
             }
           ]
@@ -24337,7 +24337,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/kind-of"
             }
           ]
@@ -24363,7 +24363,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/source-map"
             }
           ]
@@ -24391,7 +24391,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socket.io-adapter"
         }
       ]
@@ -24417,7 +24417,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socket.io-parser"
         }
       ],
@@ -24443,7 +24443,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socket.io-parser/node_modules/debug"
             }
           ]
@@ -24469,7 +24469,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socket.io-parser/node_modules/ms"
             }
           ]
@@ -24497,7 +24497,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socket.io"
         }
       ],
@@ -24523,7 +24523,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socket.io/node_modules/debug"
             }
           ]
@@ -24549,7 +24549,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socket.io/node_modules/ms"
             }
           ]
@@ -24577,7 +24577,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socks-proxy-agent"
         }
       ],
@@ -24603,7 +24603,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socks-proxy-agent/node_modules/debug"
             }
           ]
@@ -24629,7 +24629,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socks-proxy-agent/node_modules/ms"
             }
           ]
@@ -24657,7 +24657,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socks"
         }
       ],
@@ -24683,7 +24683,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socks/node_modules/ip"
             }
           ]
@@ -24711,7 +24711,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sort-keys-length"
         }
       ],
@@ -24737,7 +24737,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sort-keys-length/node_modules/sort-keys"
             }
           ]
@@ -24765,7 +24765,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sort-keys"
         }
       ]
@@ -24791,7 +24791,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/source-map-resolve"
         }
       ]
@@ -24817,7 +24817,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/source-map-support"
         }
       ]
@@ -24843,7 +24843,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/source-map-url"
         }
       ]
@@ -24869,7 +24869,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/source-map"
         }
       ]
@@ -24895,7 +24895,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spawn-command"
         }
       ]
@@ -24921,7 +24921,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spdx-correct"
         }
       ]
@@ -24947,7 +24947,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spdx-exceptions"
         }
       ]
@@ -24973,7 +24973,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spdx-expression-parse"
         }
       ]
@@ -24999,7 +24999,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spdx-license-ids"
         }
       ]
@@ -25025,7 +25025,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/split-string"
         }
       ]
@@ -25051,7 +25051,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sprintf-js"
         }
       ]
@@ -25077,7 +25077,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sqlite3"
         }
       ]
@@ -25103,7 +25103,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sshpk"
         }
       ]
@@ -25129,7 +25129,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ssri"
         }
       ]
@@ -25155,7 +25155,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/stack-trace"
         }
       ]
@@ -25181,7 +25181,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/static-extend"
         }
       ],
@@ -25207,7 +25207,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend/node_modules/define-property"
             }
           ]
@@ -25233,7 +25233,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend/node_modules/is-accessor-descriptor"
             }
           ],
@@ -25259,7 +25259,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/static-extend/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
@@ -25287,7 +25287,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend/node_modules/is-data-descriptor"
             }
           ],
@@ -25313,7 +25313,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/static-extend/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
@@ -25341,7 +25341,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend/node_modules/is-descriptor"
             }
           ]
@@ -25367,7 +25367,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend/node_modules/kind-of"
             }
           ]
@@ -25395,7 +25395,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/statuses"
         }
       ]
@@ -25421,7 +25421,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/stream-buffers"
         }
       ]
@@ -25447,7 +25447,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/streamsearch"
         }
       ]
@@ -25473,7 +25473,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strict-uri-encode"
         }
       ]
@@ -25499,7 +25499,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string_decoder"
         }
       ]
@@ -25525,7 +25525,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string-width"
         }
       ]
@@ -25551,7 +25551,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string.fromcodepoint"
         }
       ]
@@ -25577,7 +25577,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string.prototype.codepointat"
         }
       ]
@@ -25603,7 +25603,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string.prototype.trimend"
         }
       ]
@@ -25629,7 +25629,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string.prototype.trimstart"
         }
       ]
@@ -25655,7 +25655,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-ansi"
         }
       ]
@@ -25681,7 +25681,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-bom"
         }
       ]
@@ -25707,7 +25707,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-dirs"
         }
       ]
@@ -25733,7 +25733,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-json-comments"
         }
       ]
@@ -25759,7 +25759,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-outer"
         }
       ]
@@ -25785,7 +25785,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strtok3"
         }
       ]
@@ -25811,7 +25811,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/supports-color"
         }
       ]
@@ -25837,7 +25837,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/supports-preserve-symlinks-flag"
         }
       ]
@@ -25863,7 +25863,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/svg-captcha"
         }
       ]
@@ -25889,7 +25889,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/swagger-ui-dist"
         }
       ]
@@ -25915,7 +25915,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/swagger-ui-express"
         }
       ]
@@ -25941,7 +25941,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tar-fs"
         }
       ],
@@ -25967,7 +25967,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/tar-fs/node_modules/bl"
             }
           ]
@@ -25993,7 +25993,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/tar-fs/node_modules/chownr"
             }
           ]
@@ -26019,7 +26019,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/tar-fs/node_modules/readable-stream"
             }
           ]
@@ -26045,7 +26045,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/tar-fs/node_modules/tar-stream"
             }
           ]
@@ -26073,7 +26073,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tar-stream"
         }
       ]
@@ -26099,7 +26099,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tar"
         }
       ]
@@ -26125,7 +26125,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tdigest"
         }
       ]
@@ -26151,7 +26151,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/text-hex"
         }
       ]
@@ -26177,7 +26177,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/thirty-two"
         }
       ]
@@ -26203,7 +26203,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/through"
         }
       ]
@@ -26229,7 +26229,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/timed-out"
         }
       ]
@@ -26255,7 +26255,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tiny-inflate"
         }
       ]
@@ -26281,7 +26281,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-buffer"
         }
       ]
@@ -26307,7 +26307,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-fast-properties"
         }
       ]
@@ -26333,7 +26333,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-object-path"
         }
       ],
@@ -26359,7 +26359,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/to-object-path/node_modules/kind-of"
             }
           ]
@@ -26387,7 +26387,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-regex-range"
         }
       ]
@@ -26413,7 +26413,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-regex"
         }
       ]
@@ -26439,7 +26439,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/toidentifier"
         }
       ]
@@ -26465,7 +26465,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/token-stream"
         }
       ]
@@ -26491,7 +26491,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/token-types"
         }
       ]
@@ -26517,7 +26517,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/toposort-class"
         }
       ]
@@ -26543,7 +26543,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tough-cookie"
         }
       ]
@@ -26569,7 +26569,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tr46"
         }
       ]
@@ -26595,7 +26595,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/traverse"
         }
       ]
@@ -26621,7 +26621,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tree-kill"
         }
       ]
@@ -26647,7 +26647,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/trim-repeated"
         }
       ]
@@ -26673,7 +26673,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/triple-beam"
         }
       ]
@@ -26699,7 +26699,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/truncate-utf8-bytes"
         }
       ]
@@ -26725,7 +26725,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ts-node-dev"
         }
       ],
@@ -26751,7 +26751,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/ts-node-dev/node_modules/rimraf"
             }
           ]
@@ -26779,7 +26779,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ts-node"
         }
       ]
@@ -26805,7 +26805,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tsconfig"
         }
       ]
@@ -26831,7 +26831,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tslib"
         }
       ]
@@ -26857,7 +26857,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tunnel-agent"
         }
       ]
@@ -26883,7 +26883,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tweetnacl"
         }
       ]
@@ -26909,7 +26909,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/type-check"
         }
       ]
@@ -26935,7 +26935,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/type-is"
         }
       ]
@@ -26961,7 +26961,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/typecast"
         }
       ]
@@ -26987,7 +26987,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/typedarray"
         }
       ]
@@ -27013,7 +27013,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/typescript"
         }
       ]
@@ -27039,7 +27039,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/uglify-js"
         }
       ]
@@ -27065,7 +27065,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unbox-primitive"
         }
       ]
@@ -27091,7 +27091,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unbzip2-stream"
         }
       ]
@@ -27117,7 +27117,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unc-path-regex"
         }
       ]
@@ -27143,7 +27143,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/underscore.string"
         }
       ]
@@ -27169,7 +27169,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unicode-properties"
         }
       ]
@@ -27195,7 +27195,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unicode-trie"
         }
       ]
@@ -27221,7 +27221,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/union-value"
         }
       ],
@@ -27247,7 +27247,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/union-value/node_modules/is-extendable"
             }
           ]
@@ -27275,7 +27275,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unique-filename"
         }
       ]
@@ -27301,7 +27301,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unique-slug"
         }
       ]
@@ -27327,7 +27327,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unit-compare"
         }
       ]
@@ -27353,7 +27353,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/universalify"
         }
       ]
@@ -27379,7 +27379,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unpipe"
         }
       ]
@@ -27405,7 +27405,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unset-value"
         }
       ],
@@ -27431,7 +27431,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/unset-value/node_modules/has-value"
             }
           ],
@@ -27457,7 +27457,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/unset-value/node_modules/has-value/node_modules/isobject"
                 }
               ]
@@ -27485,7 +27485,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/unset-value/node_modules/has-values"
             }
           ]
@@ -27511,7 +27511,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/unset-value/node_modules/isarray"
             }
           ]
@@ -27539,7 +27539,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/untildify"
         }
       ]
@@ -27565,7 +27565,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unzipper"
         }
       ],
@@ -27591,7 +27591,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/unzipper/node_modules/bluebird"
             }
           ]
@@ -27619,7 +27619,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/uri-js"
         }
       ]
@@ -27645,7 +27645,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/urix"
         }
       ]
@@ -27671,7 +27671,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/url-parse-lax"
         }
       ]
@@ -27697,7 +27697,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/url-to-options"
         }
       ]
@@ -27723,7 +27723,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/use"
         }
       ]
@@ -27749,7 +27749,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/utf8-byte-length"
         }
       ]
@@ -27775,7 +27775,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/util-deprecate"
         }
       ]
@@ -27801,7 +27801,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/util"
         }
       ]
@@ -27827,7 +27827,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/utils-merge"
         }
       ]
@@ -27853,7 +27853,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/uuid"
         }
       ]
@@ -27879,7 +27879,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/v8flags"
         }
       ]
@@ -27905,7 +27905,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/validate-npm-package-license"
         }
       ]
@@ -27931,7 +27931,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/validate"
         }
       ]
@@ -27957,7 +27957,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/validator"
         }
       ]
@@ -27983,7 +27983,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/vary"
         }
       ]
@@ -28009,7 +28009,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/verror"
         }
       ],
@@ -28035,7 +28035,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/verror/node_modules/core-util-is"
             }
           ]
@@ -28063,7 +28063,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/vm2"
         }
       ],
@@ -28089,7 +28089,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/vm2/node_modules/acorn"
             }
           ]
@@ -28117,7 +28117,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/void-elements"
         }
       ]
@@ -28143,7 +28143,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/walk"
         }
       ]
@@ -28169,7 +28169,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/walkdir"
         }
       ]
@@ -28195,7 +28195,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/webidl-conversions"
         }
       ]
@@ -28221,7 +28221,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/whatwg-url"
         }
       ]
@@ -28247,7 +28247,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-boxed-primitive"
         }
       ]
@@ -28273,7 +28273,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-collection"
         }
       ]
@@ -28299,7 +28299,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-module"
         }
       ]
@@ -28325,7 +28325,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-pm-runs"
         }
       ]
@@ -28351,7 +28351,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-typed-array"
         }
       ]
@@ -28377,7 +28377,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which"
         }
       ]
@@ -28403,7 +28403,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wide-align"
         }
       ]
@@ -28429,7 +28429,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/winston-transport"
         }
       ],
@@ -28455,7 +28455,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/winston-transport/node_modules/readable-stream"
             }
           ]
@@ -28483,7 +28483,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/winston"
         }
       ],
@@ -28509,7 +28509,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/winston/node_modules/async"
             }
           ]
@@ -28535,7 +28535,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/winston/node_modules/is-stream"
             }
           ]
@@ -28561,7 +28561,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/winston/node_modules/readable-stream"
             }
           ]
@@ -28589,7 +28589,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/with"
         }
       ]
@@ -28615,7 +28615,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wkx"
         }
       ]
@@ -28641,7 +28641,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/word-wrap"
         }
       ]
@@ -28667,7 +28667,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wordwrap"
         }
       ]
@@ -28693,7 +28693,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wrap-ansi"
         }
       ],
@@ -28719,7 +28719,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi/node_modules/ansi-regex"
             }
           ]
@@ -28745,7 +28745,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi/node_modules/emoji-regex"
             }
           ]
@@ -28771,7 +28771,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -28797,7 +28797,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi/node_modules/string-width"
             }
           ]
@@ -28823,7 +28823,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi/node_modules/strip-ansi"
             }
           ]
@@ -28851,7 +28851,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wrappy"
         }
       ]
@@ -28877,7 +28877,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ws"
         }
       ]
@@ -28903,7 +28903,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/xtend"
         }
       ]
@@ -28929,7 +28929,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/y18n"
         }
       ]
@@ -28955,7 +28955,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yallist"
         }
       ]
@@ -28981,7 +28981,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yaml-schema-validator"
         }
       ]
@@ -29007,7 +29007,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yargs-parser"
         }
       ]
@@ -29033,7 +29033,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yargs"
         }
       ],
@@ -29059,7 +29059,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs/node_modules/ansi-regex"
             }
           ]
@@ -29085,7 +29085,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs/node_modules/emoji-regex"
             }
           ]
@@ -29111,7 +29111,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -29137,7 +29137,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs/node_modules/string-width"
             }
           ]
@@ -29163,7 +29163,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs/node_modules/strip-ansi"
             }
           ]
@@ -29191,7 +29191,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yauzl"
         }
       ]
@@ -29217,7 +29217,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yn"
         }
       ]
@@ -29243,7 +29243,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/z85"
         }
       ]
@@ -29269,7 +29269,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/zip-stream"
         }
       ]
@@ -29295,7 +29295,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/zlibjs"
         }
       ]

--- a/tests/_data/sbom_demo-results/juice-shop_npm9_node18_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/juice-shop_npm9_node18_macos-latest.snap.json
@@ -62,6 +62,10 @@
       ],
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -88,6 +92,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@babel/helper-string-parser"
+        }
       ]
     },
     {
@@ -108,6 +118,12 @@
           "url": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@babel/helper-validator-identifier"
         }
       ]
     },
@@ -130,6 +146,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@babel/parser"
+        }
       ]
     },
     {
@@ -150,6 +172,12 @@
           "url": "https://registry.npmjs.org/@babel/types/-/types-7.20.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@babel/types"
         }
       ]
     },
@@ -172,6 +200,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@colors/colors"
+        }
       ]
     },
     {
@@ -193,6 +227,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@dabh/diagnostics"
+        }
       ]
     },
     {
@@ -213,6 +253,12 @@
           "url": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@gar/promisify"
         }
       ]
     },
@@ -236,6 +282,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@mapbox/node-pre-gyp"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -254,6 +306,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/ansi-regex"
             }
           ]
         },
@@ -275,6 +333,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/are-we-there-yet"
+            }
           ]
         },
         {
@@ -294,6 +358,12 @@
               "url": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/detect-libc"
             }
           ]
         },
@@ -315,6 +385,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/gauge"
+            }
           ]
         },
         {
@@ -334,6 +410,12 @@
               "url": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/is-fullwidth-code-point"
             }
           ]
         },
@@ -356,6 +438,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/make-dir"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -374,6 +462,12 @@
                   "url": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/@mapbox/node-pre-gyp/node_modules/make-dir/node_modules/semver"
                 }
               ]
             }
@@ -397,6 +491,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/nopt"
+            }
           ]
         },
         {
@@ -416,6 +516,12 @@
               "url": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/npmlog"
             }
           ]
         },
@@ -437,6 +543,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/readable-stream"
+            }
           ]
         },
         {
@@ -457,6 +569,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/string-width"
+            }
           ]
         },
         {
@@ -476,6 +594,12 @@
               "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/strip-ansi"
             }
           ]
         }
@@ -500,6 +624,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/core-loader"
+        }
       ]
     },
     {
@@ -520,6 +650,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/core/-/core-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/core"
         }
       ]
     },
@@ -542,6 +678,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/evaluator"
+        }
       ]
     },
     {
@@ -562,6 +704,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-all/-/lang-all-4.24.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-all"
         }
       ]
     },
@@ -584,6 +732,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ar"
+        }
       ]
     },
     {
@@ -604,6 +758,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-bn/-/lang-bn-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-bn"
         }
       ]
     },
@@ -626,6 +786,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ca"
+        }
       ]
     },
     {
@@ -646,6 +812,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-cs/-/lang-cs-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-cs"
         }
       ]
     },
@@ -668,6 +840,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-da"
+        }
       ]
     },
     {
@@ -688,6 +866,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-de/-/lang-de-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-de"
         }
       ]
     },
@@ -710,6 +894,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-el"
+        }
       ]
     },
     {
@@ -730,6 +920,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-en-min/-/lang-en-min-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-en-min"
         }
       ]
     },
@@ -752,6 +948,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-en"
+        }
       ]
     },
     {
@@ -772,6 +974,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-es/-/lang-es-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-es"
         }
       ]
     },
@@ -794,6 +1002,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-eu"
+        }
       ]
     },
     {
@@ -814,6 +1028,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-fa/-/lang-fa-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-fa"
         }
       ]
     },
@@ -836,6 +1056,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-fi"
+        }
       ]
     },
     {
@@ -856,6 +1082,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-fr/-/lang-fr-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-fr"
         }
       ]
     },
@@ -878,6 +1110,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ga"
+        }
       ]
     },
     {
@@ -898,6 +1136,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-gl/-/lang-gl-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-gl"
         }
       ]
     },
@@ -920,6 +1164,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-hi"
+        }
       ]
     },
     {
@@ -940,6 +1190,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-hu/-/lang-hu-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-hu"
         }
       ]
     },
@@ -962,6 +1218,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-hy"
+        }
       ]
     },
     {
@@ -982,6 +1244,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-id/-/lang-id-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-id"
         }
       ]
     },
@@ -1004,6 +1272,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-it"
+        }
       ]
     },
     {
@@ -1024,6 +1298,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-ja/-/lang-ja-4.24.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ja"
         }
       ]
     },
@@ -1046,6 +1326,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ko"
+        }
       ]
     },
     {
@@ -1066,6 +1352,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-lt/-/lang-lt-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-lt"
         }
       ]
     },
@@ -1088,6 +1380,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ms"
+        }
       ]
     },
     {
@@ -1108,6 +1406,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-ne/-/lang-ne-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ne"
         }
       ]
     },
@@ -1130,6 +1434,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-nl"
+        }
       ]
     },
     {
@@ -1150,6 +1460,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-no/-/lang-no-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-no"
         }
       ]
     },
@@ -1172,6 +1488,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-pl"
+        }
       ]
     },
     {
@@ -1192,6 +1514,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-pt/-/lang-pt-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-pt"
         }
       ]
     },
@@ -1214,6 +1542,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ro"
+        }
       ]
     },
     {
@@ -1234,6 +1568,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-ru/-/lang-ru-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ru"
         }
       ]
     },
@@ -1256,6 +1596,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-sl"
+        }
       ]
     },
     {
@@ -1276,6 +1622,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-sr/-/lang-sr-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-sr"
         }
       ]
     },
@@ -1298,6 +1650,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-sv"
+        }
       ]
     },
     {
@@ -1318,6 +1676,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-ta/-/lang-ta-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ta"
         }
       ]
     },
@@ -1340,6 +1704,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-th"
+        }
       ]
     },
     {
@@ -1360,6 +1730,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-tl/-/lang-tl-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-tl"
         }
       ]
     },
@@ -1382,6 +1758,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-tr"
+        }
       ]
     },
     {
@@ -1402,6 +1784,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-uk/-/lang-uk-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-uk"
         }
       ]
     },
@@ -1424,6 +1812,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-zh"
+        }
       ]
     },
     {
@@ -1444,6 +1838,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/language-min/-/language-min-4.22.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/language-min"
         }
       ]
     },
@@ -1466,6 +1866,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/language"
+        }
       ]
     },
     {
@@ -1486,6 +1892,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/ner/-/ner-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/ner"
         }
       ]
     },
@@ -1508,6 +1920,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/neural"
+        }
       ]
     },
     {
@@ -1528,6 +1946,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/nlg/-/nlg-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/nlg"
         }
       ]
     },
@@ -1550,6 +1974,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/nlp"
+        }
       ]
     },
     {
@@ -1570,6 +2000,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/nlu/-/nlu-4.23.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/nlu"
         }
       ]
     },
@@ -1592,6 +2028,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/request"
+        }
       ]
     },
     {
@@ -1612,6 +2054,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/sentiment/-/sentiment-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/sentiment"
         }
       ]
     },
@@ -1634,6 +2082,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/similarity"
+        }
       ]
     },
     {
@@ -1654,6 +2108,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/slot/-/slot-4.22.17.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/slot"
         }
       ]
     },
@@ -1676,6 +2136,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@npmcli/fs"
+        }
       ]
     },
     {
@@ -1696,6 +2162,12 @@
           "url": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@npmcli/move-file"
         }
       ]
     },
@@ -1718,6 +2190,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib/core"
+        }
       ]
     },
     {
@@ -1738,6 +2216,12 @@
           "url": "https://registry.npmjs.org/@otplib/plugin-crypto/-/plugin-crypto-12.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib/plugin-crypto"
         }
       ]
     },
@@ -1760,6 +2244,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib/plugin-thirty-two"
+        }
       ]
     },
     {
@@ -1780,6 +2270,12 @@
           "url": "https://registry.npmjs.org/@otplib/preset-default/-/preset-default-12.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib/preset-default"
         }
       ]
     },
@@ -1802,6 +2298,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib/preset-v11"
+        }
       ]
     },
     {
@@ -1822,6 +2324,12 @@
           "url": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@sindresorhus/is"
         }
       ]
     },
@@ -1844,6 +2352,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@swc/helpers"
+        }
       ]
     },
     {
@@ -1864,6 +2378,12 @@
           "url": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@tokenizer/token"
         }
       ]
     },
@@ -1886,6 +2406,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@tootallnate/once"
+        }
       ]
     },
     {
@@ -1906,6 +2432,12 @@
           "url": "https://registry.npmjs.org/@types/component-emitter/-/component-emitter-1.2.11.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/component-emitter"
         }
       ]
     },
@@ -1928,6 +2460,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/cookie"
+        }
       ]
     },
     {
@@ -1948,6 +2486,12 @@
           "url": "https://registry.npmjs.org/@types/cors/-/cors-2.8.12.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/cors"
         }
       ]
     },
@@ -1970,6 +2514,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/debug"
+        }
       ]
     },
     {
@@ -1990,6 +2540,12 @@
           "url": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/ms"
         }
       ]
     },
@@ -2012,6 +2568,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/node"
+        }
       ]
     },
     {
@@ -2032,6 +2594,12 @@
           "url": "https://registry.npmjs.org/@types/strip-bom/-/strip-bom-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/strip-bom"
         }
       ]
     },
@@ -2054,6 +2622,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/strip-json-comments"
+        }
       ]
     },
     {
@@ -2075,6 +2649,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/validator"
+        }
       ]
     },
     {
@@ -2094,6 +2674,12 @@
           "url": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/abbrev"
         }
       ]
     },
@@ -2115,6 +2701,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/accepts"
+        }
       ]
     },
     {
@@ -2135,6 +2727,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/acorn-walk"
+        }
       ]
     },
     {
@@ -2154,6 +2752,12 @@
           "url": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/acorn"
         }
       ]
     },
@@ -2176,6 +2780,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/agent-base"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -2194,6 +2804,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agent-base/node_modules/debug"
             }
           ]
         },
@@ -2214,6 +2830,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agent-base/node_modules/ms"
             }
           ]
         }
@@ -2238,6 +2860,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/agentkeepalive"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -2256,6 +2884,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agentkeepalive/node_modules/debug"
             }
           ]
         },
@@ -2277,6 +2911,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agentkeepalive/node_modules/depd"
+            }
           ]
         },
         {
@@ -2296,6 +2936,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agentkeepalive/node_modules/ms"
             }
           ]
         }
@@ -2319,6 +2965,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/aggregate-error"
+        }
       ]
     },
     {
@@ -2338,6 +2990,12 @@
           "url": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ajv"
         }
       ]
     },
@@ -2359,6 +3017,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ansi-regex"
+        }
       ]
     },
     {
@@ -2378,6 +3042,12 @@
           "url": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ansi-styles"
         }
       ]
     },
@@ -2400,6 +3070,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/anymatch"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -2418,6 +3094,12 @@
               "url": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/anymatch/node_modules/normalize-path"
             }
           ]
         }
@@ -2441,6 +3123,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/append-field"
+        }
       ]
     },
     {
@@ -2460,6 +3148,12 @@
           "url": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/aproba"
         }
       ]
     },
@@ -2482,6 +3176,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/archive-type"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -2500,6 +3200,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-4.4.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/archive-type/node_modules/file-type"
             }
           ]
         }
@@ -2523,6 +3229,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/archiver-utils"
+        }
       ]
     },
     {
@@ -2542,6 +3254,12 @@
           "url": "https://registry.npmjs.org/archiver/-/archiver-1.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/archiver"
         }
       ]
     },
@@ -2563,6 +3281,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/are-we-there-yet"
+        }
       ]
     },
     {
@@ -2582,6 +3306,12 @@
           "url": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/arg"
         }
       ]
     },
@@ -2604,6 +3334,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/argparse"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -2622,6 +3358,12 @@
               "url": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/argparse/node_modules/sprintf-js"
             }
           ]
         }
@@ -2645,6 +3387,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/arr-diff"
+        }
       ]
     },
     {
@@ -2664,6 +3412,12 @@
           "url": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/arr-flatten"
         }
       ]
     },
@@ -2685,6 +3439,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/arr-union"
+        }
       ]
     },
     {
@@ -2704,6 +3464,12 @@
           "url": "https://registry.npmjs.org/array-each/-/array-each-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/array-each"
         }
       ]
     },
@@ -2725,6 +3491,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/array-flatten"
+        }
       ]
     },
     {
@@ -2744,6 +3516,12 @@
           "url": "https://registry.npmjs.org/array-slice/-/array-slice-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/array-slice"
         }
       ]
     },
@@ -2765,6 +3543,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/array-unique"
+        }
       ]
     },
     {
@@ -2784,6 +3568,12 @@
           "url": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/asap"
         }
       ]
     },
@@ -2805,6 +3595,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/asn1"
+        }
       ]
     },
     {
@@ -2824,6 +3620,12 @@
           "url": "https://registry.npmjs.org/assert-never/-/assert-never-1.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/assert-never"
         }
       ]
     },
@@ -2845,6 +3647,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/assert-plus"
+        }
       ]
     },
     {
@@ -2864,6 +3672,12 @@
           "url": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/assign-symbols"
         }
       ]
     },
@@ -2885,6 +3699,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/async"
+        }
       ]
     },
     {
@@ -2904,6 +3724,12 @@
           "url": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/asynckit"
         }
       ]
     },
@@ -2925,6 +3751,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/at-least-node"
+        }
       ]
     },
     {
@@ -2944,6 +3776,12 @@
           "url": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/atob"
         }
       ]
     },
@@ -2965,6 +3803,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/available-typed-arrays"
+        }
       ]
     },
     {
@@ -2984,6 +3828,12 @@
           "url": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/aws-sign2"
         }
       ]
     },
@@ -3005,6 +3855,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/aws4"
+        }
       ]
     },
     {
@@ -3025,6 +3881,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/babel-walk"
+        }
       ]
     },
     {
@@ -3044,6 +3906,12 @@
           "url": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/balanced-match"
         }
       ]
     },
@@ -3066,6 +3934,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -3084,6 +3958,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/base/node_modules/define-property"
             }
           ]
         }
@@ -3107,6 +3987,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base64-arraybuffer"
+        }
       ]
     },
     {
@@ -3126,6 +4012,12 @@
           "url": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base64-js"
         }
       ]
     },
@@ -3147,6 +4039,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base64id"
+        }
       ]
     },
     {
@@ -3166,6 +4064,12 @@
           "url": "https://registry.npmjs.org/base64url/-/base64url-0.0.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base64url"
         }
       ]
     },
@@ -3187,6 +4091,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/basic-auth"
+        }
       ]
     },
     {
@@ -3206,6 +4116,12 @@
           "url": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/batch"
         }
       ]
     },
@@ -3227,6 +4143,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bcrypt-pbkdf"
+        }
       ]
     },
     {
@@ -3246,6 +4168,12 @@
           "url": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/big-integer"
         }
       ]
     },
@@ -3267,6 +4195,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/binary-extensions"
+        }
       ]
     },
     {
@@ -3286,6 +4220,12 @@
           "url": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/binary"
         }
       ]
     },
@@ -3307,6 +4247,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bindings"
+        }
       ]
     },
     {
@@ -3326,6 +4272,12 @@
           "url": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bintrees"
         }
       ]
     },
@@ -3347,6 +4299,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bl"
+        }
       ]
     },
     {
@@ -3367,6 +4325,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bluebird"
+        }
       ]
     },
     {
@@ -3386,6 +4350,12 @@
           "url": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/body-parser"
         }
       ]
     },
@@ -3408,6 +4378,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bower-config"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -3426,6 +4402,12 @@
               "url": "https://registry.npmjs.org/minimist/-/minimist-0.2.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bower-config/node_modules/minimist"
             }
           ]
         }
@@ -3449,6 +4431,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/brace-expansion"
+        }
       ]
     },
     {
@@ -3470,6 +4458,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/braces"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -3488,6 +4482,12 @@
               "url": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/braces/node_modules/extend-shallow"
             }
           ]
         },
@@ -3508,6 +4508,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/braces/node_modules/is-extendable"
             }
           ]
         }
@@ -3531,6 +4537,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/brotli"
+        }
       ]
     },
     {
@@ -3550,6 +4562,12 @@
           "url": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-alloc-unsafe"
         }
       ]
     },
@@ -3571,6 +4589,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-alloc"
+        }
       ]
     },
     {
@@ -3590,6 +4614,12 @@
           "url": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-crc32"
         }
       ]
     },
@@ -3611,6 +4641,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-fill"
+        }
       ]
     },
     {
@@ -3630,6 +4666,12 @@
           "url": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-from"
         }
       ]
     },
@@ -3651,6 +4693,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-indexof-polyfill"
+        }
       ]
     },
     {
@@ -3671,6 +4719,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer"
+        }
       ]
     },
     {
@@ -3690,6 +4744,12 @@
           "url": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffers"
         }
       ]
     },
@@ -3712,6 +4772,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/busboy"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -3730,6 +4796,12 @@
               "url": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/busboy/node_modules/isarray"
             }
           ]
         },
@@ -3751,6 +4823,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/busboy/node_modules/readable-stream"
+            }
           ]
         },
         {
@@ -3770,6 +4848,12 @@
               "url": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/busboy/node_modules/string_decoder"
             }
           ]
         }
@@ -3793,6 +4877,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/byline"
+        }
       ]
     },
     {
@@ -3812,6 +4902,12 @@
           "url": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bytes"
         }
       ]
     },
@@ -3833,6 +4929,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cacache"
+        }
       ]
     },
     {
@@ -3852,6 +4954,12 @@
           "url": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cache-base"
         }
       ]
     },
@@ -3874,6 +4982,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cacheable-request"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -3892,6 +5006,12 @@
               "url": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cacheable-request/node_modules/get-stream"
             }
           ]
         },
@@ -3912,6 +5032,12 @@
               "url": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cacheable-request/node_modules/lowercase-keys"
             }
           ]
         }
@@ -3935,6 +5061,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/call-bind"
+        }
       ]
     },
     {
@@ -3954,6 +5086,12 @@
           "url": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/camelcase"
         }
       ]
     },
@@ -3975,6 +5113,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/caseless"
+        }
       ]
     },
     {
@@ -3994,6 +5138,12 @@
           "url": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/chainsaw"
         }
       ]
     },
@@ -4015,6 +5165,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/chalk"
+        }
       ]
     },
     {
@@ -4034,6 +5190,12 @@
           "url": "https://registry.npmjs.org/character-parser/-/character-parser-2.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/character-parser"
         }
       ]
     },
@@ -4056,6 +5218,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/check-dependencies"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4074,6 +5242,12 @@
               "url": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/check-dependencies/node_modules/semver"
             }
           ]
         }
@@ -4097,6 +5271,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/check-types"
+        }
       ]
     },
     {
@@ -4118,6 +5298,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/chokidar"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4136,6 +5322,12 @@
               "url": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar/node_modules/braces"
             }
           ]
         },
@@ -4157,6 +5349,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar/node_modules/fill-range"
+            }
           ]
         },
         {
@@ -4176,6 +5374,12 @@
               "url": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar/node_modules/is-glob"
             }
           ]
         },
@@ -4197,6 +5401,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar/node_modules/is-number"
+            }
           ]
         },
         {
@@ -4217,6 +5427,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar/node_modules/normalize-path"
+            }
           ]
         },
         {
@@ -4236,6 +5452,12 @@
               "url": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar/node_modules/to-regex-range"
             }
           ]
         }
@@ -4259,6 +5481,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/chownr"
+        }
       ]
     },
     {
@@ -4278,6 +5506,12 @@
           "url": "https://registry.npmjs.org/clarinet/-/clarinet-0.12.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/clarinet"
         }
       ]
     },
@@ -4300,6 +5534,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/class-utils"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4318,6 +5558,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils/node_modules/define-property"
             }
           ]
         },
@@ -4340,6 +5586,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils/node_modules/is-accessor-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -4358,6 +5610,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/class-utils/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -4382,6 +5640,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils/node_modules/is-data-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -4400,6 +5664,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/class-utils/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -4423,6 +5693,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils/node_modules/is-descriptor"
+            }
           ]
         },
         {
@@ -4442,6 +5718,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils/node_modules/kind-of"
             }
           ]
         }
@@ -4465,6 +5747,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/clean-stack"
+        }
       ]
     },
     {
@@ -4486,6 +5774,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cliui"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4504,6 +5798,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui/node_modules/ansi-regex"
             }
           ]
         },
@@ -4525,6 +5825,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui/node_modules/emoji-regex"
+            }
           ]
         },
         {
@@ -4544,6 +5850,12 @@
               "url": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui/node_modules/is-fullwidth-code-point"
             }
           ]
         },
@@ -4565,6 +5877,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui/node_modules/string-width"
+            }
           ]
         },
         {
@@ -4584,6 +5902,12 @@
               "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui/node_modules/strip-ansi"
             }
           ]
         }
@@ -4607,6 +5931,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/clone-response"
+        }
       ]
     },
     {
@@ -4626,6 +5956,12 @@
           "url": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/clone"
         }
       ]
     },
@@ -4647,6 +5983,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/code-point-at"
+        }
       ]
     },
     {
@@ -4666,6 +6008,12 @@
           "url": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/collection-visit"
         }
       ]
     },
@@ -4687,6 +6035,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color-convert"
+        }
       ]
     },
     {
@@ -4706,6 +6060,12 @@
           "url": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color-name"
         }
       ]
     },
@@ -4727,6 +6087,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color-string"
+        }
       ]
     },
     {
@@ -4746,6 +6112,12 @@
           "url": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color-support"
         }
       ]
     },
@@ -4767,6 +6139,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color"
+        }
       ]
     },
     {
@@ -4786,6 +6164,12 @@
           "url": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/colors"
         }
       ]
     },
@@ -4807,6 +6191,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/colorspace"
+        }
       ]
     },
     {
@@ -4826,6 +6216,12 @@
           "url": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/combined-stream"
         }
       ]
     },
@@ -4847,6 +6243,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/commander"
+        }
       ]
     },
     {
@@ -4866,6 +6268,12 @@
           "url": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/component-emitter"
         }
       ]
     },
@@ -4887,6 +6295,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/component-type"
+        }
       ]
     },
     {
@@ -4907,6 +6321,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/compress-commons"
+        }
       ]
     },
     {
@@ -4926,6 +6346,12 @@
           "url": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/compressible"
         }
       ]
     },
@@ -4948,6 +6374,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/compression"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4966,6 +6398,12 @@
               "url": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/compression/node_modules/bytes"
             }
           ]
         }
@@ -4989,6 +6427,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/concat-map"
+        }
       ]
     },
     {
@@ -5008,6 +6452,12 @@
           "url": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/concat-stream"
         }
       ]
     },
@@ -5030,6 +6480,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/concurrently"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5048,6 +6504,12 @@
               "url": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/concurrently/node_modules/supports-color"
             }
           ]
         }
@@ -5071,6 +6533,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/config"
+        }
       ]
     },
     {
@@ -5091,6 +6559,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/console-control-strings"
+        }
       ]
     },
     {
@@ -5110,6 +6584,12 @@
           "url": "https://registry.npmjs.org/constantinople/-/constantinople-4.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/constantinople"
         }
       ]
     },
@@ -5132,6 +6612,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/content-disposition"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5150,6 +6636,12 @@
               "url": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/content-disposition/node_modules/safe-buffer"
             }
           ]
         }
@@ -5173,6 +6665,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/content-type"
+        }
       ]
     },
     {
@@ -5192,6 +6690,12 @@
           "url": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cookie-parser"
         }
       ]
     },
@@ -5213,6 +6717,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cookie-signature"
+        }
       ]
     },
     {
@@ -5232,6 +6742,12 @@
           "url": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cookie"
         }
       ]
     },
@@ -5253,6 +6769,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/copy-descriptor"
+        }
       ]
     },
     {
@@ -5272,6 +6794,12 @@
           "url": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/core-util-is"
         }
       ]
     },
@@ -5293,6 +6821,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cors"
+        }
       ]
     },
     {
@@ -5312,6 +6846,12 @@
           "url": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/crc"
         }
       ]
     },
@@ -5333,6 +6873,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/crc32-stream"
+        }
       ]
     },
     {
@@ -5352,6 +6898,12 @@
           "url": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/create-require"
         }
       ]
     },
@@ -5373,6 +6925,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/crypto-js"
+        }
       ]
     },
     {
@@ -5392,6 +6950,12 @@
           "url": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dashdash"
         }
       ]
     },
@@ -5413,6 +6977,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/date-fns"
+        }
       ]
     },
     {
@@ -5432,6 +7002,12 @@
           "url": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dateformat"
         }
       ]
     },
@@ -5453,6 +7029,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/debug"
+        }
       ]
     },
     {
@@ -5472,6 +7054,12 @@
           "url": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decamelize"
         }
       ]
     },
@@ -5493,6 +7081,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decode-uri-component"
+        }
       ]
     },
     {
@@ -5512,6 +7106,12 @@
           "url": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-response"
         }
       ]
     },
@@ -5534,6 +7134,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-tar"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5552,6 +7158,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-tar/node_modules/file-type"
             }
           ]
         }
@@ -5576,6 +7188,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-tarbz2"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5594,6 +7212,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-6.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-tarbz2/node_modules/file-type"
             }
           ]
         }
@@ -5618,6 +7242,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-targz"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5636,6 +7266,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-targz/node_modules/file-type"
             }
           ]
         }
@@ -5660,6 +7296,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-unzip"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5678,6 +7320,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-unzip/node_modules/file-type"
             }
           ]
         },
@@ -5699,6 +7347,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-unzip/node_modules/get-stream"
+            }
           ]
         },
         {
@@ -5718,6 +7372,12 @@
               "url": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-unzip/node_modules/pify"
             }
           ]
         }
@@ -5742,6 +7402,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5762,6 +7428,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress/node_modules/make-dir"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -5780,6 +7452,12 @@
                   "url": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/decompress/node_modules/make-dir/node_modules/pify"
                 }
               ]
             }
@@ -5803,6 +7481,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress/node_modules/pify"
+            }
           ]
         }
       ]
@@ -5825,6 +7509,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/deep-equal"
+        }
       ]
     },
     {
@@ -5844,6 +7534,12 @@
           "url": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/deep-extend"
         }
       ]
     },
@@ -5865,6 +7561,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/deep-is"
+        }
       ]
     },
     {
@@ -5884,6 +7586,12 @@
           "url": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/define-properties"
         }
       ]
     },
@@ -5905,6 +7613,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/define-property"
+        }
       ]
     },
     {
@@ -5924,6 +7638,12 @@
           "url": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/delayed-stream"
         }
       ]
     },
@@ -5945,6 +7665,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/delegates"
+        }
       ]
     },
     {
@@ -5964,6 +7690,12 @@
           "url": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/depd"
         }
       ]
     },
@@ -5985,6 +7717,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/destroy"
+        }
       ]
     },
     {
@@ -6004,6 +7742,12 @@
           "url": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/detect-file"
         }
       ]
     },
@@ -6025,6 +7769,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/detect-libc"
+        }
       ]
     },
     {
@@ -6044,6 +7794,12 @@
           "url": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dfa"
         }
       ]
     },
@@ -6066,6 +7822,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dicer"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -6084,6 +7846,12 @@
               "url": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/dicer/node_modules/isarray"
             }
           ]
         },
@@ -6105,6 +7873,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/dicer/node_modules/readable-stream"
+            }
           ]
         },
         {
@@ -6124,6 +7898,12 @@
               "url": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/dicer/node_modules/string_decoder"
             }
           ]
         }
@@ -6147,6 +7927,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/diff"
+        }
       ]
     },
     {
@@ -6166,6 +7952,12 @@
           "url": "https://registry.npmjs.org/doctypes/-/doctypes-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/doctypes"
         }
       ]
     },
@@ -6187,6 +7979,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/domelementtype"
+        }
       ]
     },
     {
@@ -6206,6 +8004,12 @@
           "url": "https://registry.npmjs.org/domhandler/-/domhandler-2.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/domhandler"
         }
       ]
     },
@@ -6227,6 +8031,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/domutils"
+        }
       ]
     },
     {
@@ -6246,6 +8056,12 @@
           "url": "https://registry.npmjs.org/dottie/-/dottie-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dottie"
         }
       ]
     },
@@ -6267,6 +8083,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/double-ended-queue"
+        }
       ]
     },
     {
@@ -6286,6 +8108,12 @@
           "url": "https://registry.npmjs.org/doublearray/-/doublearray-0.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/doublearray"
         }
       ]
     },
@@ -6308,6 +8136,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/download"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -6326,6 +8160,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-11.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/download/node_modules/file-type"
             }
           ]
         }
@@ -6349,6 +8189,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/duplexer2"
+        }
       ]
     },
     {
@@ -6368,6 +8214,12 @@
           "url": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/duplexer3"
         }
       ]
     },
@@ -6389,6 +8241,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dynamic-dedupe"
+        }
       ]
     },
     {
@@ -6408,6 +8266,12 @@
           "url": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ecc-jsbn"
         }
       ]
     },
@@ -6429,6 +8293,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ee-first"
+        }
       ]
     },
     {
@@ -6448,6 +8318,12 @@
           "url": "https://registry.npmjs.org/eivindfjeldstad-dot/-/eivindfjeldstad-dot-0.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/eivindfjeldstad-dot"
         }
       ]
     },
@@ -6469,6 +8345,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/emoji-regex"
+        }
       ]
     },
     {
@@ -6489,6 +8371,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/enabled"
+        }
       ]
     },
     {
@@ -6508,6 +8396,12 @@
           "url": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/encodeurl"
         }
       ]
     },
@@ -6530,6 +8424,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/encoding"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -6548,6 +8448,12 @@
               "url": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/encoding/node_modules/iconv-lite"
             }
           ]
         }
@@ -6571,6 +8477,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/end-of-stream"
+        }
       ]
     },
     {
@@ -6590,6 +8502,12 @@
           "url": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-4.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/engine.io-parser"
         }
       ]
     },
@@ -6612,6 +8530,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/engine.io"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -6630,6 +8554,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/engine.io/node_modules/debug"
             }
           ]
         },
@@ -6650,6 +8580,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/engine.io/node_modules/ms"
             }
           ]
         }
@@ -6673,6 +8609,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/env-paths"
+        }
       ]
     },
     {
@@ -6692,6 +8634,12 @@
           "url": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/err-code"
         }
       ]
     },
@@ -6713,6 +8661,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/error-ex"
+        }
       ]
     },
     {
@@ -6732,6 +8686,12 @@
           "url": "https://registry.npmjs.org/errorhandler/-/errorhandler-1.5.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/errorhandler"
         }
       ]
     },
@@ -6753,6 +8713,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/es-abstract"
+        }
       ]
     },
     {
@@ -6772,6 +8738,12 @@
           "url": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/es-get-iterator"
         }
       ]
     },
@@ -6793,6 +8765,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/es-to-primitive"
+        }
       ]
     },
     {
@@ -6812,6 +8790,12 @@
           "url": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/escape-html"
         }
       ]
     },
@@ -6833,6 +8817,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/escape-string-regexp"
+        }
       ]
     },
     {
@@ -6852,6 +8842,12 @@
           "url": "https://registry.npmjs.org/escodegen/-/escodegen-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/escodegen"
         }
       ]
     },
@@ -6873,6 +8869,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/esprima"
+        }
       ]
     },
     {
@@ -6892,6 +8894,12 @@
           "url": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/estraverse"
         }
       ]
     },
@@ -6913,6 +8921,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/esutils"
+        }
       ]
     },
     {
@@ -6932,6 +8946,12 @@
           "url": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/etag"
         }
       ]
     },
@@ -6953,6 +8973,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/eventemitter2"
+        }
       ]
     },
     {
@@ -6972,6 +8998,12 @@
           "url": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/eventemitter3"
         }
       ]
     },
@@ -6993,6 +9025,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/exif"
+        }
       ]
     },
     {
@@ -7012,6 +9050,12 @@
           "url": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/exit"
         }
       ]
     },
@@ -7034,6 +9078,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/expand-brackets"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7052,6 +9102,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/define-property"
             }
           ]
         },
@@ -7072,6 +9128,12 @@
               "url": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/extend-shallow"
             }
           ]
         },
@@ -7094,6 +9156,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/is-accessor-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -7112,6 +9180,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/expand-brackets/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -7136,6 +9210,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/is-data-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -7154,6 +9234,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/expand-brackets/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -7177,6 +9263,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/is-descriptor"
+            }
           ]
         },
         {
@@ -7197,6 +9289,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/is-extendable"
+            }
           ]
         },
         {
@@ -7216,6 +9314,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/kind-of"
             }
           ]
         }
@@ -7239,6 +9343,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/expand-template"
+        }
       ]
     },
     {
@@ -7259,6 +9369,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/expand-tilde"
+        }
       ]
     },
     {
@@ -7278,6 +9394,12 @@
           "url": "https://registry.npmjs.org/express-ipfilter/-/express-ipfilter-1.3.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-ipfilter"
         }
       ]
     },
@@ -7300,6 +9422,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-jwt"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7318,6 +9446,12 @@
               "url": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-0.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/express-jwt/node_modules/jsonwebtoken"
             }
           ]
         },
@@ -7338,6 +9472,12 @@
               "url": "https://registry.npmjs.org/moment/-/moment-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/express-jwt/node_modules/moment"
             }
           ]
         }
@@ -7361,6 +9501,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-rate-limit"
+        }
       ]
     },
     {
@@ -7381,6 +9527,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-robots-txt"
+        }
       ]
     },
     {
@@ -7400,6 +9552,12 @@
           "url": "https://registry.npmjs.org/express-security.txt/-/express-security.txt-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-security.txt"
         }
       ]
     },
@@ -7422,6 +9580,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7440,6 +9604,12 @@
               "url": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/express/node_modules/cookie"
             }
           ]
         },
@@ -7460,6 +9630,12 @@
               "url": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/express/node_modules/safe-buffer"
             }
           ]
         }
@@ -7483,6 +9659,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ext-list"
+        }
       ]
     },
     {
@@ -7502,6 +9684,12 @@
           "url": "https://registry.npmjs.org/ext-name/-/ext-name-5.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ext-name"
         }
       ]
     },
@@ -7523,6 +9711,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/extend-shallow"
+        }
       ]
     },
     {
@@ -7542,6 +9736,12 @@
           "url": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/extend"
         }
       ]
     },
@@ -7564,6 +9764,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/extglob"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7582,6 +9788,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/extglob/node_modules/define-property"
             }
           ]
         },
@@ -7603,6 +9815,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/extglob/node_modules/extend-shallow"
+            }
           ]
         },
         {
@@ -7622,6 +9840,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/extglob/node_modules/is-extendable"
             }
           ]
         }
@@ -7645,6 +9869,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/extsprintf"
+        }
       ]
     },
     {
@@ -7664,6 +9894,12 @@
           "url": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fast-deep-equal"
         }
       ]
     },
@@ -7685,6 +9921,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fast-json-stable-stringify"
+        }
       ]
     },
     {
@@ -7704,6 +9946,12 @@
           "url": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fast-levenshtein"
         }
       ]
     },
@@ -7725,6 +9973,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fast.js"
+        }
       ]
     },
     {
@@ -7744,6 +9998,12 @@
           "url": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fd-slicer"
         }
       ]
     },
@@ -7765,6 +10025,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/feature-policy"
+        }
       ]
     },
     {
@@ -7784,6 +10050,12 @@
           "url": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fecha"
         }
       ]
     },
@@ -7806,6 +10078,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/file-js"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7824,6 +10102,12 @@
               "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/file-js/node_modules/brace-expansion"
             }
           ]
         },
@@ -7844,6 +10128,12 @@
               "url": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/file-js/node_modules/minimatch"
             }
           ]
         }
@@ -7867,6 +10157,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/file-stream-rotator"
+        }
       ]
     },
     {
@@ -7886,6 +10182,12 @@
           "url": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/file-type"
         }
       ]
     },
@@ -7907,6 +10209,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/file-uri-to-path"
+        }
       ]
     },
     {
@@ -7926,6 +10234,12 @@
           "url": "https://registry.npmjs.org/filehound/-/filehound-1.17.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/filehound"
         }
       ]
     },
@@ -7947,6 +10261,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/filename-reserved-regex"
+        }
       ]
     },
     {
@@ -7967,6 +10287,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/filenamify"
+        }
       ]
     },
     {
@@ -7986,6 +10312,12 @@
           "url": "https://registry.npmjs.org/filesniffer/-/filesniffer-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/filesniffer"
         }
       ]
     },
@@ -8008,6 +10340,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fill-range"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -8026,6 +10364,12 @@
               "url": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/fill-range/node_modules/extend-shallow"
             }
           ]
         },
@@ -8046,6 +10390,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/fill-range/node_modules/is-extendable"
             }
           ]
         }
@@ -8069,6 +10419,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/finale-rest"
+        }
       ]
     },
     {
@@ -8088,6 +10444,12 @@
           "url": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/finalhandler"
         }
       ]
     },
@@ -8109,6 +10471,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/find-up"
+        }
       ]
     },
     {
@@ -8128,6 +10496,12 @@
           "url": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/findup-sync"
         }
       ]
     },
@@ -8149,6 +10523,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fined"
+        }
       ]
     },
     {
@@ -8168,6 +10548,12 @@
           "url": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/flagged-respawn"
         }
       ]
     },
@@ -8189,6 +10575,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fn.name"
+        }
       ]
     },
     {
@@ -8208,6 +10600,12 @@
           "url": "https://registry.npmjs.org/fontkit/-/fontkit-1.9.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fontkit"
         }
       ]
     },
@@ -8229,6 +10627,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/for-each"
+        }
       ]
     },
     {
@@ -8248,6 +10652,12 @@
           "url": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/for-in"
         }
       ]
     },
@@ -8269,6 +10679,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/for-own"
+        }
       ]
     },
     {
@@ -8288,6 +10704,12 @@
           "url": "https://registry.npmjs.org/foreachasync/-/foreachasync-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/foreachasync"
         }
       ]
     },
@@ -8309,6 +10731,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/forever-agent"
+        }
       ]
     },
     {
@@ -8328,6 +10756,12 @@
           "url": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/form-data"
         }
       ]
     },
@@ -8349,6 +10783,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/formatio"
+        }
       ]
     },
     {
@@ -8368,6 +10808,12 @@
           "url": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/forwarded"
         }
       ]
     },
@@ -8389,6 +10835,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fragment-cache"
+        }
       ]
     },
     {
@@ -8408,6 +10860,12 @@
           "url": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fresh"
         }
       ]
     },
@@ -8429,6 +10887,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/from2"
+        }
       ]
     },
     {
@@ -8448,6 +10912,12 @@
           "url": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fs-constants"
         }
       ]
     },
@@ -8469,6 +10939,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fs-extra"
+        }
       ]
     },
     {
@@ -8488,6 +10964,12 @@
           "url": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fs-minipass"
         }
       ]
     },
@@ -8509,6 +10991,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fs.realpath"
+        }
       ]
     },
     {
@@ -8528,6 +11016,12 @@
           "url": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fsevents"
         }
       ]
     },
@@ -8550,6 +11044,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fstream"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -8568,6 +11068,12 @@
               "url": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/fstream/node_modules/mkdirp"
             }
           ]
         },
@@ -8588,6 +11094,12 @@
               "url": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/fstream/node_modules/rimraf"
             }
           ]
         }
@@ -8611,6 +11123,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/function-bind"
+        }
       ]
     },
     {
@@ -8630,6 +11148,12 @@
           "url": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/function.prototype.name"
         }
       ]
     },
@@ -8651,6 +11175,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/functions-have-names"
+        }
       ]
     },
     {
@@ -8670,6 +11200,12 @@
           "url": "https://registry.npmjs.org/fuzzball/-/fuzzball-1.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fuzzball"
         }
       ]
     },
@@ -8691,6 +11227,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/gauge"
+        }
       ]
     },
     {
@@ -8710,6 +11252,12 @@
           "url": "https://registry.npmjs.org/geojson-utils/-/geojson-utils-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/geojson-utils"
         }
       ]
     },
@@ -8731,6 +11279,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-caller-file"
+        }
       ]
     },
     {
@@ -8750,6 +11304,12 @@
           "url": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-intrinsic"
         }
       ]
     },
@@ -8771,6 +11331,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-stream"
+        }
       ]
     },
     {
@@ -8790,6 +11356,12 @@
           "url": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-symbol-description"
         }
       ]
     },
@@ -8811,6 +11383,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-value"
+        }
       ]
     },
     {
@@ -8830,6 +11408,12 @@
           "url": "https://registry.npmjs.org/getobject/-/getobject-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/getobject"
         }
       ]
     },
@@ -8851,6 +11435,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/getpass"
+        }
       ]
     },
     {
@@ -8870,6 +11460,12 @@
           "url": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/github-from-package"
         }
       ]
     },
@@ -8892,6 +11488,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/glob-parent"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -8910,6 +11512,12 @@
               "url": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/glob-parent/node_modules/is-glob"
             }
           ]
         }
@@ -8934,6 +11542,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/glob"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -8952,6 +11566,12 @@
               "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/glob/node_modules/brace-expansion"
             }
           ]
         },
@@ -8972,6 +11592,12 @@
               "url": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/glob/node_modules/minimatch"
             }
           ]
         }
@@ -8995,6 +11621,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/global-modules"
+        }
       ]
     },
     {
@@ -9016,6 +11648,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/global-prefix"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9034,6 +11672,12 @@
               "url": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/global-prefix/node_modules/which"
             }
           ]
         }
@@ -9058,6 +11702,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/got"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9076,6 +11726,12 @@
               "url": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/got/node_modules/get-stream"
             }
           ]
         },
@@ -9096,6 +11752,12 @@
               "url": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/got/node_modules/pify"
             }
           ]
         }
@@ -9119,6 +11781,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/graceful-fs"
+        }
       ]
     },
     {
@@ -9140,6 +11808,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-cli"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9158,6 +11832,12 @@
               "url": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-cli/node_modules/nopt"
             }
           ]
         }
@@ -9182,6 +11862,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-contrib-compress"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9200,6 +11886,12 @@
               "url": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-contrib-compress/node_modules/ansi-styles"
             }
           ]
         },
@@ -9221,6 +11913,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-contrib-compress/node_modules/chalk"
+            }
           ]
         },
         {
@@ -9240,6 +11938,12 @@
               "url": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-contrib-compress/node_modules/supports-color"
             }
           ]
         }
@@ -9263,6 +11967,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-known-options"
+        }
       ]
     },
     {
@@ -9284,6 +11994,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-legacy-log-utils"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9302,6 +12018,12 @@
               "url": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils/node_modules/ansi-styles"
             }
           ]
         },
@@ -9323,6 +12045,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils/node_modules/chalk"
+            }
           ]
         },
         {
@@ -9342,6 +12070,12 @@
               "url": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils/node_modules/color-convert"
             }
           ]
         },
@@ -9363,6 +12097,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils/node_modules/color-name"
+            }
           ]
         },
         {
@@ -9383,6 +12123,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils/node_modules/has-flag"
+            }
           ]
         },
         {
@@ -9402,6 +12148,12 @@
               "url": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils/node_modules/supports-color"
             }
           ]
         }
@@ -9426,6 +12178,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-legacy-log"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9444,6 +12202,12 @@
               "url": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log/node_modules/colors"
             }
           ]
         }
@@ -9468,6 +12232,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-legacy-util"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9486,6 +12256,12 @@
               "url": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-util/node_modules/async"
             }
           ]
         }
@@ -9509,6 +12285,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-replace-json"
+        }
       ]
     },
     {
@@ -9530,6 +12312,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9548,6 +12336,12 @@
               "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt/node_modules/brace-expansion"
             }
           ]
         },
@@ -9570,6 +12364,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt/node_modules/findup-sync"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -9588,6 +12388,12 @@
                   "url": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/grunt/node_modules/findup-sync/node_modules/glob"
                 }
               ]
             }
@@ -9611,6 +12417,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt/node_modules/glob"
+            }
           ]
         },
         {
@@ -9630,6 +12442,12 @@
               "url": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.8.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt/node_modules/minimatch"
             }
           ]
         }
@@ -9654,6 +12472,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/handlebars"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9672,6 +12496,12 @@
               "url": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/handlebars/node_modules/wordwrap"
             }
           ]
         }
@@ -9695,6 +12525,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/har-schema"
+        }
       ]
     },
     {
@@ -9714,6 +12550,12 @@
           "url": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/har-validator"
         }
       ]
     },
@@ -9735,6 +12577,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-ansi"
+        }
       ]
     },
     {
@@ -9754,6 +12602,12 @@
           "url": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-bigints"
         }
       ]
     },
@@ -9775,6 +12629,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-flag"
+        }
       ]
     },
     {
@@ -9794,6 +12654,12 @@
           "url": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-property-descriptors"
         }
       ]
     },
@@ -9815,6 +12681,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-symbol-support-x"
+        }
       ]
     },
     {
@@ -9834,6 +12706,12 @@
           "url": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-symbols"
         }
       ]
     },
@@ -9855,6 +12733,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-to-string-tag-x"
+        }
       ]
     },
     {
@@ -9874,6 +12758,12 @@
           "url": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-tostringtag"
         }
       ]
     },
@@ -9895,6 +12785,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-unicode"
+        }
       ]
     },
     {
@@ -9914,6 +12810,12 @@
           "url": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-value"
         }
       ]
     },
@@ -9936,6 +12838,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-values"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9954,6 +12862,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/has-values/node_modules/kind-of"
             }
           ]
         }
@@ -9977,6 +12891,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has"
+        }
       ]
     },
     {
@@ -9996,6 +12916,12 @@
           "url": "https://registry.npmjs.org/hashids/-/hashids-2.2.10.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hashids"
         }
       ]
     },
@@ -10017,6 +12943,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hbs"
+        }
       ]
     },
     {
@@ -10036,6 +12968,12 @@
           "url": "https://registry.npmjs.org/he/-/he-0.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/he"
         }
       ]
     },
@@ -10057,6 +12995,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/heap"
+        }
       ]
     },
     {
@@ -10076,6 +13020,12 @@
           "url": "https://registry.npmjs.org/helmet/-/helmet-4.6.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/helmet"
         }
       ]
     },
@@ -10097,6 +13047,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hoister"
+        }
       ]
     },
     {
@@ -10116,6 +13072,12 @@
           "url": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/homedir-polyfill"
         }
       ]
     },
@@ -10137,6 +13099,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hooker"
+        }
       ]
     },
     {
@@ -10157,6 +13125,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hosted-git-info"
+        }
       ]
     },
     {
@@ -10176,6 +13150,12 @@
           "url": "https://registry.npmjs.org/html-entities/-/html-entities-1.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/html-entities"
         }
       ]
     },
@@ -10198,6 +13178,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/htmlparser2"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -10216,6 +13202,12 @@
               "url": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/htmlparser2/node_modules/isarray"
             }
           ]
         },
@@ -10237,6 +13229,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/htmlparser2/node_modules/readable-stream"
+            }
           ]
         },
         {
@@ -10256,6 +13254,12 @@
               "url": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/htmlparser2/node_modules/string_decoder"
             }
           ]
         }
@@ -10279,6 +13283,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/http-cache-semantics"
+        }
       ]
     },
     {
@@ -10298,6 +13308,12 @@
           "url": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/http-errors"
         }
       ]
     },
@@ -10320,6 +13336,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/http-proxy-agent"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -10338,6 +13360,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/http-proxy-agent/node_modules/debug"
             }
           ]
         },
@@ -10358,6 +13386,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/http-proxy-agent/node_modules/ms"
             }
           ]
         }
@@ -10381,6 +13415,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/http-signature"
+        }
       ]
     },
     {
@@ -10402,6 +13442,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/https-proxy-agent"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -10420,6 +13466,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/https-proxy-agent/node_modules/debug"
             }
           ]
         },
@@ -10440,6 +13492,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/https-proxy-agent/node_modules/ms"
             }
           ]
         }
@@ -10463,6 +13521,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/humanize-ms"
+        }
       ]
     },
     {
@@ -10482,6 +13546,12 @@
           "url": "https://registry.npmjs.org/i18n/-/i18n-0.11.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/i18n"
         }
       ]
     },
@@ -10503,6 +13573,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/iconv-lite"
+        }
       ]
     },
     {
@@ -10522,6 +13598,12 @@
           "url": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ieee754"
         }
       ]
     },
@@ -10544,6 +13626,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ignore-walk"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -10562,6 +13650,12 @@
               "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/ignore-walk/node_modules/brace-expansion"
             }
           ]
         },
@@ -10582,6 +13676,12 @@
               "url": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/ignore-walk/node_modules/minimatch"
             }
           ]
         }
@@ -10605,6 +13705,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/iltorb"
+        }
       ]
     },
     {
@@ -10624,6 +13730,12 @@
           "url": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/imurmurhash"
         }
       ]
     },
@@ -10645,6 +13757,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/indent-string"
+        }
       ]
     },
     {
@@ -10664,6 +13782,12 @@
           "url": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/infer-owner"
         }
       ]
     },
@@ -10685,6 +13809,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/inflection"
+        }
       ]
     },
     {
@@ -10704,6 +13834,12 @@
           "url": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/inflight"
         }
       ]
     },
@@ -10725,6 +13861,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/inherits"
+        }
       ]
     },
     {
@@ -10744,6 +13886,12 @@
           "url": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ini"
         }
       ]
     },
@@ -10765,6 +13913,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/internal-slot"
+        }
       ]
     },
     {
@@ -10784,6 +13938,12 @@
           "url": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/interpret"
         }
       ]
     },
@@ -10805,6 +13965,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/into-stream"
+        }
       ]
     },
     {
@@ -10824,6 +13990,12 @@
           "url": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/invariant"
         }
       ]
     },
@@ -10845,6 +14017,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ip"
+        }
       ]
     },
     {
@@ -10864,6 +14042,12 @@
           "url": "https://registry.npmjs.org/ip6/-/ip6-0.2.10.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ip6"
         }
       ]
     },
@@ -10885,6 +14069,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ipaddr.js"
+        }
       ]
     },
     {
@@ -10904,6 +14094,12 @@
           "url": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-absolute"
         }
       ]
     },
@@ -10925,6 +14121,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-accessor-descriptor"
+        }
       ]
     },
     {
@@ -10944,6 +14146,12 @@
           "url": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-arguments"
         }
       ]
     },
@@ -10965,6 +14173,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-arrayish"
+        }
       ]
     },
     {
@@ -10984,6 +14198,12 @@
           "url": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-bigint"
         }
       ]
     },
@@ -11005,6 +14225,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-binary-path"
+        }
       ]
     },
     {
@@ -11024,6 +14250,12 @@
           "url": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-boolean-object"
         }
       ]
     },
@@ -11045,6 +14277,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-buffer"
+        }
       ]
     },
     {
@@ -11064,6 +14302,12 @@
           "url": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-callable"
         }
       ]
     },
@@ -11085,6 +14329,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-core-module"
+        }
       ]
     },
     {
@@ -11104,6 +14354,12 @@
           "url": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-data-descriptor"
         }
       ]
     },
@@ -11125,6 +14381,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-date-object"
+        }
       ]
     },
     {
@@ -11144,6 +14406,12 @@
           "url": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-descriptor"
         }
       ]
     },
@@ -11165,6 +14433,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-docker"
+        }
       ]
     },
     {
@@ -11184,6 +14458,12 @@
           "url": "https://registry.npmjs.org/is-expression/-/is-expression-4.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-expression"
         }
       ]
     },
@@ -11205,6 +14485,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-extendable"
+        }
       ]
     },
     {
@@ -11224,6 +14510,12 @@
           "url": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-extglob"
         }
       ]
     },
@@ -11245,6 +14537,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-fullwidth-code-point"
+        }
       ]
     },
     {
@@ -11264,6 +14562,12 @@
           "url": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-generator-function"
         }
       ]
     },
@@ -11285,6 +14589,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-glob"
+        }
       ]
     },
     {
@@ -11304,6 +14614,12 @@
           "url": "https://registry.npmjs.org/is-heroku/-/is-heroku-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-heroku"
         }
       ]
     },
@@ -11325,6 +14641,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-lambda"
+        }
       ]
     },
     {
@@ -11344,6 +14666,12 @@
           "url": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-map"
         }
       ]
     },
@@ -11365,6 +14693,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-natural-number"
+        }
       ]
     },
     {
@@ -11384,6 +14718,12 @@
           "url": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-negative-zero"
         }
       ]
     },
@@ -11405,6 +14745,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-number-like"
+        }
       ]
     },
     {
@@ -11424,6 +14770,12 @@
           "url": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-number-object"
         }
       ]
     },
@@ -11446,6 +14798,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-number"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -11464,6 +14822,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/is-number/node_modules/kind-of"
             }
           ]
         }
@@ -11487,6 +14851,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-object"
+        }
       ]
     },
     {
@@ -11506,6 +14876,12 @@
           "url": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-plain-obj"
         }
       ]
     },
@@ -11527,6 +14903,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-plain-object"
+        }
       ]
     },
     {
@@ -11546,6 +14928,12 @@
           "url": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-promise"
         }
       ]
     },
@@ -11567,6 +14955,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-regex"
+        }
       ]
     },
     {
@@ -11586,6 +14980,12 @@
           "url": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-relative"
         }
       ]
     },
@@ -11607,6 +15007,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-retry-allowed"
+        }
       ]
     },
     {
@@ -11626,6 +15032,12 @@
           "url": "https://registry.npmjs.org/is-set/-/is-set-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-set"
         }
       ]
     },
@@ -11647,6 +15059,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-shared-array-buffer"
+        }
       ]
     },
     {
@@ -11666,6 +15084,12 @@
           "url": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-stream"
         }
       ]
     },
@@ -11687,6 +15111,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-string"
+        }
       ]
     },
     {
@@ -11706,6 +15136,12 @@
           "url": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-symbol"
         }
       ]
     },
@@ -11727,6 +15163,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-typed-array"
+        }
       ]
     },
     {
@@ -11746,6 +15188,12 @@
           "url": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-typedarray"
         }
       ]
     },
@@ -11767,6 +15215,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-unc-path"
+        }
       ]
     },
     {
@@ -11786,6 +15240,12 @@
           "url": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-weakmap"
         }
       ]
     },
@@ -11807,6 +15267,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-weakref"
+        }
       ]
     },
     {
@@ -11826,6 +15292,12 @@
           "url": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-weakset"
         }
       ]
     },
@@ -11847,6 +15319,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-windows"
+        }
       ]
     },
     {
@@ -11866,6 +15344,12 @@
           "url": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isarray"
         }
       ]
     },
@@ -11887,6 +15371,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isexe"
+        }
       ]
     },
     {
@@ -11906,6 +15396,12 @@
           "url": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isobject"
         }
       ]
     },
@@ -11927,6 +15423,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isstream"
+        }
       ]
     },
     {
@@ -11946,6 +15448,12 @@
           "url": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isurl"
         }
       ]
     },
@@ -11967,6 +15475,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/js-stringify"
+        }
       ]
     },
     {
@@ -11986,6 +15500,12 @@
           "url": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/js-tokens"
         }
       ]
     },
@@ -12007,6 +15527,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/js-yaml"
+        }
       ]
     },
     {
@@ -12026,6 +15552,12 @@
           "url": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jsbn"
         }
       ]
     },
@@ -12047,6 +15579,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-buffer"
+        }
       ]
     },
     {
@@ -12066,6 +15604,12 @@
           "url": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-parse-better-errors"
         }
       ]
     },
@@ -12087,6 +15631,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-schema-traverse"
+        }
       ]
     },
     {
@@ -12106,6 +15656,12 @@
           "url": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-schema"
         }
       ]
     },
@@ -12127,6 +15683,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-stringify-safe"
+        }
       ]
     },
     {
@@ -12146,6 +15708,12 @@
           "url": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json5"
         }
       ]
     },
@@ -12167,6 +15735,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jsonfile"
+        }
       ]
     },
     {
@@ -12186,6 +15760,12 @@
           "url": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-0.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jsonwebtoken"
         }
       ]
     },
@@ -12207,6 +15787,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jsprim"
+        }
       ]
     },
     {
@@ -12226,6 +15812,12 @@
           "url": "https://registry.npmjs.org/jssha/-/jssha-3.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jssha"
         }
       ]
     },
@@ -12247,6 +15839,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jstransformer"
+        }
       ]
     },
     {
@@ -12266,6 +15864,12 @@
           "url": "https://registry.npmjs.org/juicy-chat-bot/-/juicy-chat-bot-0.6.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/juicy-chat-bot"
         }
       ]
     },
@@ -12287,6 +15891,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jwa"
+        }
       ]
     },
     {
@@ -12306,6 +15916,12 @@
           "url": "https://registry.npmjs.org/jws/-/jws-0.2.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jws"
         }
       ]
     },
@@ -12327,6 +15943,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/keyv"
+        }
       ]
     },
     {
@@ -12346,6 +15968,12 @@
           "url": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/kind-of"
         }
       ]
     },
@@ -12367,6 +15995,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/kuler"
+        }
       ]
     },
     {
@@ -12386,6 +16020,12 @@
           "url": "https://registry.npmjs.org/kuromoji/-/kuromoji-0.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/kuromoji"
         }
       ]
     },
@@ -12407,6 +16047,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lazystream"
+        }
       ]
     },
     {
@@ -12426,6 +16072,12 @@
           "url": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/levn"
         }
       ]
     },
@@ -12448,6 +16100,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/libxmljs2"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12466,6 +16124,12 @@
               "url": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/libxmljs2/node_modules/nan"
             }
           ]
         }
@@ -12490,6 +16154,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/liftup"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12508,6 +16178,12 @@
               "url": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/braces"
             }
           ]
         },
@@ -12529,6 +16205,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/fill-range"
+            }
           ]
         },
         {
@@ -12548,6 +16230,12 @@
               "url": "https://registry.npmjs.org/findup-sync/-/findup-sync-4.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/findup-sync"
             }
           ]
         },
@@ -12569,6 +16257,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/is-glob"
+            }
           ]
         },
         {
@@ -12588,6 +16282,12 @@
               "url": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/is-number"
             }
           ]
         },
@@ -12609,6 +16309,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/micromatch"
+            }
           ]
         },
         {
@@ -12628,6 +16334,12 @@
               "url": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/to-regex-range"
             }
           ]
         }
@@ -12652,6 +16364,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/linebreak"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12670,6 +16388,12 @@
               "url": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/linebreak/node_modules/base64-js"
             }
           ]
         }
@@ -12693,6 +16417,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/listenercount"
+        }
       ]
     },
     {
@@ -12712,6 +16442,12 @@
           "url": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/locate-path"
         }
       ]
     },
@@ -12733,6 +16469,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lodash.camelcase"
+        }
       ]
     },
     {
@@ -12752,6 +16494,12 @@
           "url": "https://registry.npmjs.org/lodash.isfinite/-/lodash.isfinite-3.3.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lodash.isfinite"
         }
       ]
     },
@@ -12773,6 +16521,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lodash.set"
+        }
       ]
     },
     {
@@ -12792,6 +16546,12 @@
           "url": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lodash"
         }
       ]
     },
@@ -12814,6 +16574,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/logform"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12832,6 +16598,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/logform/node_modules/ms"
             }
           ]
         }
@@ -12855,6 +16627,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lolex"
+        }
       ]
     },
     {
@@ -12874,6 +16652,12 @@
           "url": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/loose-envify"
         }
       ]
     },
@@ -12895,6 +16679,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lowercase-keys"
+        }
       ]
     },
     {
@@ -12914,6 +16704,12 @@
           "url": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lru-cache"
         }
       ]
     },
@@ -12936,6 +16732,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-dir"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12954,6 +16756,12 @@
               "url": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-dir/node_modules/semver"
             }
           ]
         }
@@ -12977,6 +16785,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-error"
+        }
       ]
     },
     {
@@ -12996,6 +16810,12 @@
           "url": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-9.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-fetch-happen"
         }
       ],
       "components": [
@@ -13018,6 +16838,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen/node_modules/@tootallnate/once"
+            }
           ]
         },
         {
@@ -13037,6 +16863,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen/node_modules/debug"
             }
           ]
         },
@@ -13058,6 +16890,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen/node_modules/http-cache-semantics"
+            }
           ]
         },
         {
@@ -13078,6 +16916,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen/node_modules/http-proxy-agent"
+            }
           ]
         },
         {
@@ -13097,6 +16941,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen/node_modules/ms"
             }
           ]
         }
@@ -13120,6 +16970,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-iterator"
+        }
       ]
     },
     {
@@ -13139,6 +16995,12 @@
           "url": "https://registry.npmjs.org/make-plural/-/make-plural-6.2.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-plural"
         }
       ]
     },
@@ -13160,6 +17022,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/map-cache"
+        }
       ]
     },
     {
@@ -13179,6 +17047,12 @@
           "url": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/map-visit"
         }
       ]
     },
@@ -13200,6 +17074,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/marsdb"
+        }
       ]
     },
     {
@@ -13219,6 +17099,12 @@
           "url": "https://registry.npmjs.org/math-interval-parser/-/math-interval-parser-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/math-interval-parser"
         }
       ]
     },
@@ -13240,6 +17126,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/media-typer"
+        }
       ]
     },
     {
@@ -13259,6 +17151,12 @@
           "url": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/merge-descriptors"
         }
       ]
     },
@@ -13280,6 +17178,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/messageformat-formatters"
+        }
       ]
     },
     {
@@ -13299,6 +17203,12 @@
           "url": "https://registry.npmjs.org/messageformat-parser/-/messageformat-parser-4.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/messageformat-parser"
         }
       ]
     },
@@ -13321,6 +17231,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/messageformat"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -13339,6 +17255,12 @@
               "url": "https://registry.npmjs.org/make-plural/-/make-plural-4.3.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/messageformat/node_modules/make-plural"
             }
           ]
         }
@@ -13362,6 +17284,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/methods"
+        }
       ]
     },
     {
@@ -13381,6 +17309,12 @@
           "url": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/micromatch"
         }
       ]
     },
@@ -13402,6 +17336,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mime-db"
+        }
       ]
     },
     {
@@ -13421,6 +17361,12 @@
           "url": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mime-types"
         }
       ]
     },
@@ -13442,6 +17388,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mime"
+        }
       ]
     },
     {
@@ -13461,6 +17413,12 @@
           "url": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mimic-response"
         }
       ]
     },
@@ -13482,6 +17440,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minimatch"
+        }
       ]
     },
     {
@@ -13501,6 +17465,12 @@
           "url": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minimist"
         }
       ]
     },
@@ -13522,6 +17492,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-collect"
+        }
       ]
     },
     {
@@ -13541,6 +17517,12 @@
           "url": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-1.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-fetch"
         }
       ]
     },
@@ -13562,6 +17544,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-flush"
+        }
       ]
     },
     {
@@ -13581,6 +17569,12 @@
           "url": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-pipeline"
         }
       ]
     },
@@ -13602,6 +17596,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-sized"
+        }
       ]
     },
     {
@@ -13621,6 +17621,12 @@
           "url": "https://registry.npmjs.org/minipass/-/minipass-3.3.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass"
         }
       ]
     },
@@ -13642,6 +17648,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minizlib"
+        }
       ]
     },
     {
@@ -13661,6 +17673,12 @@
           "url": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mixin-deep"
         }
       ]
     },
@@ -13682,6 +17700,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mkdirp-classic"
+        }
       ]
     },
     {
@@ -13701,6 +17725,12 @@
           "url": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mkdirp"
         }
       ]
     },
@@ -13722,6 +17752,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/moment-timezone"
+        }
       ]
     },
     {
@@ -13741,6 +17777,12 @@
           "url": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/moment"
         }
       ]
     },
@@ -13763,6 +17805,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/morgan"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -13781,6 +17829,12 @@
               "url": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/morgan/node_modules/on-finished"
             }
           ]
         }
@@ -13804,6 +17858,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mout"
+        }
       ]
     },
     {
@@ -13823,6 +17883,12 @@
           "url": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ms"
         }
       ]
     },
@@ -13845,6 +17911,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/multer"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -13863,6 +17935,12 @@
               "url": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/multer/node_modules/mkdirp"
             }
           ]
         }
@@ -13886,6 +17964,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mustache"
+        }
       ]
     },
     {
@@ -13905,6 +17989,12 @@
           "url": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/nan"
         }
       ]
     },
@@ -13926,6 +18016,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/nanomatch"
+        }
       ]
     },
     {
@@ -13945,6 +18041,12 @@
           "url": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/napi-build-utils"
         }
       ]
     },
@@ -13967,6 +18069,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/needle"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -13985,6 +18093,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/needle/node_modules/debug"
             }
           ]
         },
@@ -14005,6 +18119,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/needle/node_modules/ms"
             }
           ]
         }
@@ -14028,6 +18148,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/negotiator"
+        }
       ]
     },
     {
@@ -14047,6 +18173,12 @@
           "url": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/neo-async"
         }
       ]
     },
@@ -14069,6 +18201,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-abi"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14087,6 +18225,12 @@
               "url": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-abi/node_modules/semver"
             }
           ]
         }
@@ -14110,6 +18254,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-addon-api"
+        }
       ]
     },
     {
@@ -14129,6 +18279,12 @@
           "url": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-fetch"
         }
       ]
     },
@@ -14151,6 +18307,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-gyp"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14169,6 +18331,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/ansi-regex"
             }
           ]
         },
@@ -14190,6 +18358,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/are-we-there-yet"
+            }
           ]
         },
         {
@@ -14209,6 +18383,12 @@
               "url": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/gauge"
             }
           ]
         },
@@ -14230,6 +18410,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/is-fullwidth-code-point"
+            }
           ]
         },
         {
@@ -14249,6 +18435,12 @@
               "url": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/nopt"
             }
           ]
         },
@@ -14270,6 +18462,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/npmlog"
+            }
           ]
         },
         {
@@ -14289,6 +18487,12 @@
               "url": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/readable-stream"
             }
           ]
         },
@@ -14310,6 +18514,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/string-width"
+            }
           ]
         },
         {
@@ -14329,6 +18539,12 @@
               "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/strip-ansi"
             }
           ]
         }
@@ -14353,6 +18569,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-pre-gyp"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14371,6 +18593,12 @@
               "url": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/chownr"
             }
           ]
         },
@@ -14392,6 +18620,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/fs-minipass"
+            }
           ]
         },
         {
@@ -14411,6 +18645,12 @@
               "url": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/minipass"
             }
           ]
         },
@@ -14432,6 +18672,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/minizlib"
+            }
           ]
         },
         {
@@ -14451,6 +18697,12 @@
               "url": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/mkdirp"
             }
           ]
         },
@@ -14472,6 +18724,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/nopt"
+            }
           ]
         },
         {
@@ -14491,6 +18749,12 @@
               "url": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/rimraf"
             }
           ]
         },
@@ -14512,6 +18776,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/safe-buffer"
+            }
           ]
         },
         {
@@ -14531,6 +18801,12 @@
               "url": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/semver"
             }
           ]
         },
@@ -14552,6 +18828,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/tar"
+            }
           ]
         },
         {
@@ -14571,6 +18853,12 @@
               "url": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/yallist"
             }
           ]
         }
@@ -14594,6 +18882,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/noop-logger"
+        }
       ]
     },
     {
@@ -14613,6 +18907,12 @@
           "url": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/nopt"
         }
       ]
     },
@@ -14635,6 +18935,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/normalize-package-data"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14653,6 +18959,12 @@
               "url": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/normalize-package-data/node_modules/semver"
             }
           ]
         }
@@ -14676,6 +18988,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/normalize-path"
+        }
       ]
     },
     {
@@ -14695,6 +19013,12 @@
           "url": "https://registry.npmjs.org/normalize-url/-/normalize-url-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/normalize-url"
         }
       ]
     },
@@ -14717,6 +19041,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/notevil"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14735,6 +19065,12 @@
               "url": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/notevil/node_modules/esprima"
             }
           ]
         }
@@ -14758,6 +19094,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/npm-bundled"
+        }
       ]
     },
     {
@@ -14777,6 +19119,12 @@
           "url": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/npm-normalize-package-bin"
         }
       ]
     },
@@ -14798,6 +19146,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/npm-packlist"
+        }
       ]
     },
     {
@@ -14817,6 +19171,12 @@
           "url": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/npmlog"
         }
       ]
     },
@@ -14838,6 +19198,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/number-is-nan"
+        }
       ]
     },
     {
@@ -14858,6 +19224,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/oauth-sign"
+        }
       ]
     },
     {
@@ -14877,6 +19249,12 @@
           "url": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-assign"
         }
       ]
     },
@@ -14899,6 +19277,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-copy"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14917,6 +19301,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy/node_modules/define-property"
             }
           ]
         },
@@ -14938,6 +19328,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy/node_modules/is-accessor-descriptor"
+            }
           ]
         },
         {
@@ -14957,6 +19353,12 @@
               "url": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy/node_modules/is-data-descriptor"
             }
           ]
         },
@@ -14979,6 +19381,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy/node_modules/is-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -14997,6 +19405,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/object-copy/node_modules/is-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -15020,6 +19434,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy/node_modules/kind-of"
+            }
           ]
         }
       ]
@@ -15042,6 +19462,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-inspect"
+        }
       ]
     },
     {
@@ -15061,6 +19487,12 @@
           "url": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-is"
         }
       ]
     },
@@ -15082,6 +19514,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-keys"
+        }
       ]
     },
     {
@@ -15101,6 +19539,12 @@
           "url": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-visit"
         }
       ]
     },
@@ -15122,6 +19566,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object.assign"
+        }
       ]
     },
     {
@@ -15141,6 +19591,12 @@
           "url": "https://registry.npmjs.org/object.defaults/-/object.defaults-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object.defaults"
         }
       ]
     },
@@ -15162,6 +19618,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object.map"
+        }
       ]
     },
     {
@@ -15181,6 +19643,12 @@
           "url": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object.pick"
         }
       ]
     },
@@ -15202,6 +19670,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/on-finished"
+        }
       ]
     },
     {
@@ -15221,6 +19695,12 @@
           "url": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/on-headers"
         }
       ]
     },
@@ -15242,6 +19722,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/once"
+        }
       ]
     },
     {
@@ -15261,6 +19747,12 @@
           "url": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/one-time"
         }
       ]
     },
@@ -15282,6 +19774,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/opentype.js"
+        }
       ]
     },
     {
@@ -15301,6 +19799,12 @@
           "url": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/optionator"
         }
       ]
     },
@@ -15322,6 +19826,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/os-homedir"
+        }
       ]
     },
     {
@@ -15341,6 +19851,12 @@
           "url": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/os-tmpdir"
         }
       ]
     },
@@ -15362,6 +19878,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/osenv"
+        }
       ]
     },
     {
@@ -15381,6 +19903,12 @@
           "url": "https://registry.npmjs.org/otplib/-/otplib-12.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/otplib"
         }
       ]
     },
@@ -15402,6 +19930,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-cancelable"
+        }
       ]
     },
     {
@@ -15421,6 +19955,12 @@
           "url": "https://registry.npmjs.org/p-event/-/p-event-2.3.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-event"
         }
       ]
     },
@@ -15442,6 +19982,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-finally"
+        }
       ]
     },
     {
@@ -15461,6 +20007,12 @@
           "url": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-is-promise"
         }
       ]
     },
@@ -15482,6 +20034,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-limit"
+        }
       ]
     },
     {
@@ -15501,6 +20059,12 @@
           "url": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-locate"
         }
       ]
     },
@@ -15522,6 +20086,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-map"
+        }
       ]
     },
     {
@@ -15541,6 +20111,12 @@
           "url": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-timeout"
         }
       ]
     },
@@ -15562,6 +20138,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-try"
+        }
       ]
     },
     {
@@ -15581,6 +20163,12 @@
           "url": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pako"
         }
       ]
     },
@@ -15602,6 +20190,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/parse-filepath"
+        }
       ]
     },
     {
@@ -15621,6 +20215,12 @@
           "url": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/parse-json"
         }
       ]
     },
@@ -15642,6 +20242,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/parse-passwd"
+        }
       ]
     },
     {
@@ -15661,6 +20267,12 @@
           "url": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/parseurl"
         }
       ]
     },
@@ -15682,6 +20294,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pascalcase"
+        }
       ]
     },
     {
@@ -15701,6 +20319,12 @@
           "url": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-exists"
         }
       ]
     },
@@ -15722,6 +20346,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-is-absolute"
+        }
       ]
     },
     {
@@ -15741,6 +20371,12 @@
           "url": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-parse"
         }
       ]
     },
@@ -15762,6 +20398,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-root-regex"
+        }
       ]
     },
     {
@@ -15781,6 +20423,12 @@
           "url": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-root"
         }
       ]
     },
@@ -15802,6 +20450,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-to-regexp"
+        }
       ]
     },
     {
@@ -15821,6 +20475,12 @@
           "url": "https://registry.npmjs.org/pdfkit/-/pdfkit-0.11.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pdfkit"
         }
       ]
     },
@@ -15842,6 +20502,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/peek-readable"
+        }
       ]
     },
     {
@@ -15861,6 +20527,12 @@
           "url": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pend"
         }
       ]
     },
@@ -15882,6 +20554,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/performance-now"
+        }
       ]
     },
     {
@@ -15901,6 +20579,12 @@
           "url": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.5.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pg-connection-string"
         }
       ]
     },
@@ -15922,6 +20606,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/picomatch"
+        }
       ]
     },
     {
@@ -15941,6 +20631,12 @@
           "url": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pify"
         }
       ]
     },
@@ -15962,6 +20658,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pinkie-promise"
+        }
       ]
     },
     {
@@ -15981,6 +20683,12 @@
           "url": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pinkie"
         }
       ]
     },
@@ -16002,6 +20710,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/png-js"
+        }
       ]
     },
     {
@@ -16021,6 +20735,12 @@
           "url": "https://registry.npmjs.org/portscanner/-/portscanner-2.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/portscanner"
         }
       ]
     },
@@ -16042,6 +20762,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/posix-character-classes"
+        }
       ]
     },
     {
@@ -16061,6 +20787,12 @@
           "url": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.3.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/prebuild-install"
         }
       ]
     },
@@ -16082,6 +20814,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/prelude-ls"
+        }
       ]
     },
     {
@@ -16101,6 +20839,12 @@
           "url": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/prepend-http"
         }
       ]
     },
@@ -16122,6 +20866,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pretty-bytes"
+        }
       ]
     },
     {
@@ -16141,6 +20891,12 @@
           "url": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/process-nextick-args"
         }
       ]
     },
@@ -16162,6 +20918,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/prom-client"
+        }
       ]
     },
     {
@@ -16181,6 +20943,12 @@
           "url": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/promise-inflight"
         }
       ]
     },
@@ -16203,6 +20971,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/promise-retry"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -16221,6 +20995,12 @@
               "url": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/promise-retry/node_modules/err-code"
             }
           ]
         },
@@ -16241,6 +21021,12 @@
               "url": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/promise-retry/node_modules/retry"
             }
           ]
         }
@@ -16264,6 +21050,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/promise"
+        }
       ]
     },
     {
@@ -16283,6 +21075,12 @@
           "url": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/proper-lockfile"
         }
       ]
     },
@@ -16304,6 +21102,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/proxy-addr"
+        }
       ]
     },
     {
@@ -16323,6 +21127,12 @@
           "url": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/psl"
         }
       ]
     },
@@ -16344,6 +21154,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-attrs"
+        }
       ]
     },
     {
@@ -16363,6 +21179,12 @@
           "url": "https://registry.npmjs.org/pug-code-gen/-/pug-code-gen-3.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-code-gen"
         }
       ]
     },
@@ -16384,6 +21206,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-error"
+        }
       ]
     },
     {
@@ -16403,6 +21231,12 @@
           "url": "https://registry.npmjs.org/pug-filters/-/pug-filters-4.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-filters"
         }
       ]
     },
@@ -16424,6 +21258,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-lexer"
+        }
       ]
     },
     {
@@ -16443,6 +21283,12 @@
           "url": "https://registry.npmjs.org/pug-linker/-/pug-linker-4.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-linker"
         }
       ]
     },
@@ -16464,6 +21310,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-load"
+        }
       ]
     },
     {
@@ -16483,6 +21335,12 @@
           "url": "https://registry.npmjs.org/pug-parser/-/pug-parser-6.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-parser"
         }
       ]
     },
@@ -16504,6 +21362,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-runtime"
+        }
       ]
     },
     {
@@ -16523,6 +21387,12 @@
           "url": "https://registry.npmjs.org/pug-strip-comments/-/pug-strip-comments-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-strip-comments"
         }
       ]
     },
@@ -16544,6 +21414,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-walk"
+        }
       ]
     },
     {
@@ -16563,6 +21439,12 @@
           "url": "https://registry.npmjs.org/pug/-/pug-3.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug"
         }
       ]
     },
@@ -16584,6 +21466,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pump"
+        }
       ]
     },
     {
@@ -16603,6 +21491,12 @@
           "url": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/punycode"
         }
       ]
     },
@@ -16624,6 +21518,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/qs"
+        }
       ]
     },
     {
@@ -16643,6 +21543,12 @@
           "url": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/query-string"
         }
       ]
     },
@@ -16664,6 +21570,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/range_check"
+        }
       ]
     },
     {
@@ -16683,6 +21595,12 @@
           "url": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/range-parser"
         }
       ]
     },
@@ -16704,6 +21622,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/raw-body"
+        }
       ]
     },
     {
@@ -16723,6 +21647,12 @@
           "url": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/rc"
         }
       ]
     },
@@ -16745,6 +21675,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/read-pkg"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -16763,6 +21699,12 @@
               "url": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/read-pkg/node_modules/pify"
             }
           ]
         }
@@ -16787,6 +21729,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/readable-stream"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -16805,6 +21753,12 @@
               "url": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/readable-stream/node_modules/isarray"
             }
           ]
         }
@@ -16829,6 +21783,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/readable-web-to-node-stream"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -16847,6 +21807,12 @@
               "url": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/readable-web-to-node-stream/node_modules/readable-stream"
             }
           ]
         }
@@ -16870,6 +21836,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/readdirp"
+        }
       ]
     },
     {
@@ -16889,6 +21861,12 @@
           "url": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/rechoir"
         }
       ]
     },
@@ -16910,6 +21888,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/regex-not"
+        }
       ]
     },
     {
@@ -16929,6 +21913,12 @@
           "url": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/regexp.prototype.flags"
         }
       ]
     },
@@ -16950,6 +21940,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/remove-trailing-separator"
+        }
       ]
     },
     {
@@ -16970,6 +21966,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/repeat-element"
+        }
       ]
     },
     {
@@ -16989,6 +21991,12 @@
           "url": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/repeat-string"
         }
       ]
     },
@@ -17011,6 +22019,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/replace"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17029,6 +22043,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/ansi-regex"
             }
           ]
         },
@@ -17050,6 +22070,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/ansi-styles"
+            }
           ]
         },
         {
@@ -17069,6 +22095,12 @@
               "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/brace-expansion"
             }
           ]
         },
@@ -17090,6 +22122,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/cliui"
+            }
           ]
         },
         {
@@ -17109,6 +22147,12 @@
               "url": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/color-convert"
             }
           ]
         },
@@ -17130,6 +22174,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/color-name"
+            }
           ]
         },
         {
@@ -17149,6 +22199,12 @@
               "url": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/find-up"
             }
           ]
         },
@@ -17170,6 +22226,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/is-fullwidth-code-point"
+            }
           ]
         },
         {
@@ -17189,6 +22251,12 @@
               "url": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/locate-path"
             }
           ]
         },
@@ -17210,6 +22278,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/minimatch"
+            }
           ]
         },
         {
@@ -17229,6 +22303,12 @@
               "url": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/p-locate"
             }
           ]
         },
@@ -17250,6 +22330,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/path-exists"
+            }
           ]
         },
         {
@@ -17269,6 +22355,12 @@
               "url": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/string-width"
             }
           ]
         },
@@ -17290,6 +22382,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/strip-ansi"
+            }
           ]
         },
         {
@@ -17309,6 +22407,12 @@
               "url": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/wrap-ansi"
             }
           ]
         },
@@ -17330,6 +22434,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/yargs-parser"
+            }
           ]
         },
         {
@@ -17349,6 +22459,12 @@
               "url": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/yargs"
             }
           ]
         }
@@ -17373,6 +22489,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/request"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17391,6 +22513,12 @@
               "url": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/request/node_modules/qs"
             }
           ]
         }
@@ -17414,6 +22542,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/require-directory"
+        }
       ]
     },
     {
@@ -17433,6 +22567,12 @@
           "url": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/require-main-filename"
         }
       ]
     },
@@ -17454,6 +22594,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/resolve-dir"
+        }
       ]
     },
     {
@@ -17473,6 +22619,12 @@
           "url": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/resolve-url"
         }
       ]
     },
@@ -17494,6 +22646,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/resolve"
+        }
       ]
     },
     {
@@ -17513,6 +22671,12 @@
           "url": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/responselike"
         }
       ]
     },
@@ -17534,6 +22698,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/restructure"
+        }
       ]
     },
     {
@@ -17553,6 +22723,12 @@
           "url": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ret"
         }
       ]
     },
@@ -17574,6 +22750,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/retry-as-promised"
+        }
       ]
     },
     {
@@ -17594,6 +22776,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/retry"
+        }
       ]
     },
     {
@@ -17613,6 +22801,12 @@
           "url": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/rimraf"
         }
       ]
     },
@@ -17635,6 +22829,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/rxjs"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17653,6 +22853,12 @@
               "url": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/rxjs/node_modules/tslib"
             }
           ]
         }
@@ -17676,6 +22882,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safe-buffer"
+        }
       ]
     },
     {
@@ -17695,6 +22907,12 @@
           "url": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safe-regex-test"
         }
       ]
     },
@@ -17716,6 +22934,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safe-regex"
+        }
       ]
     },
     {
@@ -17735,6 +22959,12 @@
           "url": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safe-stable-stringify"
         }
       ]
     },
@@ -17756,6 +22986,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safer-buffer"
+        }
       ]
     },
     {
@@ -17776,6 +23012,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/samsam"
+        }
       ]
     },
     {
@@ -17795,6 +23037,12 @@
           "url": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sanitize-filename"
         }
       ]
     },
@@ -17817,6 +23065,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sanitize-html"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17835,6 +23089,12 @@
               "url": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sanitize-html/node_modules/lodash"
             }
           ]
         }
@@ -17858,6 +23118,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sax"
+        }
       ]
     },
     {
@@ -17878,6 +23144,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/seek-bzip"
+        }
       ]
     },
     {
@@ -17897,6 +23169,12 @@
           "url": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/semver"
         }
       ]
     },
@@ -17919,6 +23197,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/send"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17937,6 +23221,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/send/node_modules/ms"
             }
           ]
         }
@@ -17960,6 +23250,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sequelize-pool"
+        }
       ]
     },
     {
@@ -17981,6 +23277,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sequelize"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17999,6 +23301,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sequelize/node_modules/debug"
             }
           ]
         },
@@ -18020,6 +23328,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sequelize/node_modules/ms"
+            }
           ]
         },
         {
@@ -18039,6 +23353,12 @@
               "url": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sequelize/node_modules/uuid"
             }
           ]
         }
@@ -18063,6 +23383,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/serve-index"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18081,6 +23407,12 @@
               "url": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index/node_modules/depd"
             }
           ]
         },
@@ -18102,6 +23434,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index/node_modules/http-errors"
+            }
           ]
         },
         {
@@ -18121,6 +23459,12 @@
               "url": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index/node_modules/inherits"
             }
           ]
         },
@@ -18142,6 +23486,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index/node_modules/setprototypeof"
+            }
           ]
         },
         {
@@ -18161,6 +23511,12 @@
               "url": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index/node_modules/statuses"
             }
           ]
         }
@@ -18184,6 +23540,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/serve-static"
+        }
       ]
     },
     {
@@ -18203,6 +23565,12 @@
           "url": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/set-blocking"
         }
       ]
     },
@@ -18225,6 +23593,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/set-value"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18243,6 +23617,12 @@
               "url": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/set-value/node_modules/extend-shallow"
             }
           ]
         },
@@ -18263,6 +23643,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/set-value/node_modules/is-extendable"
             }
           ]
         }
@@ -18286,6 +23672,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/setimmediate"
+        }
       ]
     },
     {
@@ -18305,6 +23697,12 @@
           "url": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/setprototypeof"
         }
       ]
     },
@@ -18326,6 +23724,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/side-channel"
+        }
       ]
     },
     {
@@ -18346,6 +23750,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/signal-exit"
+        }
       ]
     },
     {
@@ -18365,6 +23775,12 @@
           "url": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/simple-concat"
         }
       ]
     },
@@ -18387,6 +23803,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/simple-get"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18405,6 +23827,12 @@
               "url": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/simple-get/node_modules/decompress-response"
             }
           ]
         },
@@ -18425,6 +23853,12 @@
               "url": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/simple-get/node_modules/mimic-response"
             }
           ]
         }
@@ -18449,6 +23883,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/simple-swizzle"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18467,6 +23907,12 @@
               "url": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/simple-swizzle/node_modules/is-arrayish"
             }
           ]
         }
@@ -18490,6 +23936,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sinon"
+        }
       ]
     },
     {
@@ -18509,6 +23961,12 @@
           "url": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/smart-buffer"
         }
       ]
     },
@@ -18531,6 +23989,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/snapdragon-node"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18549,6 +24013,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon-node/node_modules/define-property"
             }
           ]
         }
@@ -18573,6 +24043,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/snapdragon-util"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18591,6 +24067,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon-util/node_modules/kind-of"
             }
           ]
         }
@@ -18615,6 +24097,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/snapdragon"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18633,6 +24121,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/define-property"
             }
           ]
         },
@@ -18653,6 +24147,12 @@
               "url": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/extend-shallow"
             }
           ]
         },
@@ -18675,6 +24175,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/is-accessor-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -18693,6 +24199,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/snapdragon/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -18717,6 +24229,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/is-data-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -18735,6 +24253,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/snapdragon/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -18758,6 +24282,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/is-descriptor"
+            }
           ]
         },
         {
@@ -18777,6 +24307,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/is-extendable"
             }
           ]
         },
@@ -18798,6 +24334,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/kind-of"
+            }
           ]
         },
         {
@@ -18817,6 +24359,12 @@
               "url": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/source-map"
             }
           ]
         }
@@ -18840,6 +24388,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socket.io-adapter"
+        }
       ]
     },
     {
@@ -18861,6 +24415,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socket.io-parser"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18879,6 +24439,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socket.io-parser/node_modules/debug"
             }
           ]
         },
@@ -18899,6 +24465,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socket.io-parser/node_modules/ms"
             }
           ]
         }
@@ -18923,6 +24495,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socket.io"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18941,6 +24519,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socket.io/node_modules/debug"
             }
           ]
         },
@@ -18961,6 +24545,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socket.io/node_modules/ms"
             }
           ]
         }
@@ -18985,6 +24575,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socks-proxy-agent"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -19003,6 +24599,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socks-proxy-agent/node_modules/debug"
             }
           ]
         },
@@ -19023,6 +24625,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socks-proxy-agent/node_modules/ms"
             }
           ]
         }
@@ -19047,6 +24655,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socks"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -19065,6 +24679,12 @@
               "url": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socks/node_modules/ip"
             }
           ]
         }
@@ -19089,6 +24709,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sort-keys-length"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -19107,6 +24733,12 @@
               "url": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sort-keys-length/node_modules/sort-keys"
             }
           ]
         }
@@ -19130,6 +24762,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sort-keys"
+        }
       ]
     },
     {
@@ -19149,6 +24787,12 @@
           "url": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/source-map-resolve"
         }
       ]
     },
@@ -19170,6 +24814,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/source-map-support"
+        }
       ]
     },
     {
@@ -19189,6 +24839,12 @@
           "url": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/source-map-url"
         }
       ]
     },
@@ -19210,6 +24866,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/source-map"
+        }
       ]
     },
     {
@@ -19229,6 +24891,12 @@
           "url": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2-1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spawn-command"
         }
       ]
     },
@@ -19250,6 +24918,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spdx-correct"
+        }
       ]
     },
     {
@@ -19269,6 +24943,12 @@
           "url": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spdx-exceptions"
         }
       ]
     },
@@ -19290,6 +24970,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spdx-expression-parse"
+        }
       ]
     },
     {
@@ -19309,6 +24995,12 @@
           "url": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.12.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spdx-license-ids"
         }
       ]
     },
@@ -19330,6 +25022,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/split-string"
+        }
       ]
     },
     {
@@ -19349,6 +25047,12 @@
           "url": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sprintf-js"
         }
       ]
     },
@@ -19370,6 +25074,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sqlite3"
+        }
       ]
     },
     {
@@ -19389,6 +25099,12 @@
           "url": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sshpk"
         }
       ]
     },
@@ -19410,6 +25126,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ssri"
+        }
       ]
     },
     {
@@ -19429,6 +25151,12 @@
           "url": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/stack-trace"
         }
       ]
     },
@@ -19451,6 +25179,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/static-extend"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -19469,6 +25203,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend/node_modules/define-property"
             }
           ]
         },
@@ -19491,6 +25231,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend/node_modules/is-accessor-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -19509,6 +25255,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/static-extend/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -19533,6 +25285,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend/node_modules/is-data-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -19551,6 +25309,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/static-extend/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -19574,6 +25338,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend/node_modules/is-descriptor"
+            }
           ]
         },
         {
@@ -19593,6 +25363,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend/node_modules/kind-of"
             }
           ]
         }
@@ -19616,6 +25392,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/statuses"
+        }
       ]
     },
     {
@@ -19635,6 +25417,12 @@
           "url": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-2.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/stream-buffers"
         }
       ]
     },
@@ -19656,6 +25444,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/streamsearch"
+        }
       ]
     },
     {
@@ -19675,6 +25469,12 @@
           "url": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strict-uri-encode"
         }
       ]
     },
@@ -19696,6 +25496,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string_decoder"
+        }
       ]
     },
     {
@@ -19715,6 +25521,12 @@
           "url": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string-width"
         }
       ]
     },
@@ -19736,6 +25548,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string.fromcodepoint"
+        }
       ]
     },
     {
@@ -19755,6 +25573,12 @@
           "url": "https://registry.npmjs.org/string.prototype.codepointat/-/string.prototype.codepointat-0.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string.prototype.codepointat"
         }
       ]
     },
@@ -19776,6 +25600,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string.prototype.trimend"
+        }
       ]
     },
     {
@@ -19795,6 +25625,12 @@
           "url": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string.prototype.trimstart"
         }
       ]
     },
@@ -19816,6 +25652,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-ansi"
+        }
       ]
     },
     {
@@ -19835,6 +25677,12 @@
           "url": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-bom"
         }
       ]
     },
@@ -19856,6 +25704,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-dirs"
+        }
       ]
     },
     {
@@ -19875,6 +25729,12 @@
           "url": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-json-comments"
         }
       ]
     },
@@ -19896,6 +25756,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-outer"
+        }
       ]
     },
     {
@@ -19915,6 +25781,12 @@
           "url": "https://registry.npmjs.org/strtok3/-/strtok3-6.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strtok3"
         }
       ]
     },
@@ -19936,6 +25808,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/supports-color"
+        }
       ]
     },
     {
@@ -19955,6 +25833,12 @@
           "url": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/supports-preserve-symlinks-flag"
         }
       ]
     },
@@ -19976,6 +25860,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/svg-captcha"
+        }
       ]
     },
     {
@@ -19996,6 +25886,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/swagger-ui-dist"
+        }
       ]
     },
     {
@@ -20015,6 +25911,12 @@
           "url": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-4.5.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/swagger-ui-express"
         }
       ]
     },
@@ -20037,6 +25939,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tar-fs"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -20055,6 +25963,12 @@
               "url": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/tar-fs/node_modules/bl"
             }
           ]
         },
@@ -20076,6 +25990,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/tar-fs/node_modules/chownr"
+            }
           ]
         },
         {
@@ -20096,6 +26016,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/tar-fs/node_modules/readable-stream"
+            }
           ]
         },
         {
@@ -20115,6 +26041,12 @@
               "url": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/tar-fs/node_modules/tar-stream"
             }
           ]
         }
@@ -20138,6 +26070,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tar-stream"
+        }
       ]
     },
     {
@@ -20157,6 +26095,12 @@
           "url": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tar"
         }
       ]
     },
@@ -20178,6 +26122,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tdigest"
+        }
       ]
     },
     {
@@ -20197,6 +26147,12 @@
           "url": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/text-hex"
         }
       ]
     },
@@ -20218,6 +26174,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/thirty-two"
+        }
       ]
     },
     {
@@ -20237,6 +26199,12 @@
           "url": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/through"
         }
       ]
     },
@@ -20258,6 +26226,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/timed-out"
+        }
       ]
     },
     {
@@ -20277,6 +26251,12 @@
           "url": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tiny-inflate"
         }
       ]
     },
@@ -20298,6 +26278,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-buffer"
+        }
       ]
     },
     {
@@ -20317,6 +26303,12 @@
           "url": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-fast-properties"
         }
       ]
     },
@@ -20339,6 +26331,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-object-path"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -20357,6 +26355,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/to-object-path/node_modules/kind-of"
             }
           ]
         }
@@ -20380,6 +26384,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-regex-range"
+        }
       ]
     },
     {
@@ -20399,6 +26409,12 @@
           "url": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-regex"
         }
       ]
     },
@@ -20420,6 +26436,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/toidentifier"
+        }
       ]
     },
     {
@@ -20439,6 +26461,12 @@
           "url": "https://registry.npmjs.org/token-stream/-/token-stream-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/token-stream"
         }
       ]
     },
@@ -20460,6 +26488,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/token-types"
+        }
       ]
     },
     {
@@ -20479,6 +26513,12 @@
           "url": "https://registry.npmjs.org/toposort-class/-/toposort-class-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/toposort-class"
         }
       ]
     },
@@ -20500,6 +26540,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tough-cookie"
+        }
       ]
     },
     {
@@ -20519,6 +26565,12 @@
           "url": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tr46"
         }
       ]
     },
@@ -20540,6 +26592,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/traverse"
+        }
       ]
     },
     {
@@ -20559,6 +26617,12 @@
           "url": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tree-kill"
         }
       ]
     },
@@ -20580,6 +26644,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/trim-repeated"
+        }
       ]
     },
     {
@@ -20600,6 +26670,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/triple-beam"
+        }
       ]
     },
     {
@@ -20619,6 +26695,12 @@
           "url": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/truncate-utf8-bytes"
         }
       ]
     },
@@ -20641,6 +26723,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ts-node-dev"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -20659,6 +26747,12 @@
               "url": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/ts-node-dev/node_modules/rimraf"
             }
           ]
         }
@@ -20682,6 +26776,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ts-node"
+        }
       ]
     },
     {
@@ -20701,6 +26801,12 @@
           "url": "https://registry.npmjs.org/tsconfig/-/tsconfig-7.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tsconfig"
         }
       ]
     },
@@ -20722,6 +26828,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tslib"
+        }
       ]
     },
     {
@@ -20741,6 +26853,12 @@
           "url": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tunnel-agent"
         }
       ]
     },
@@ -20762,6 +26880,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tweetnacl"
+        }
       ]
     },
     {
@@ -20781,6 +26905,12 @@
           "url": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/type-check"
         }
       ]
     },
@@ -20802,6 +26932,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/type-is"
+        }
       ]
     },
     {
@@ -20821,6 +26957,12 @@
           "url": "https://registry.npmjs.org/typecast/-/typecast-0.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/typecast"
         }
       ]
     },
@@ -20842,6 +26984,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/typedarray"
+        }
       ]
     },
     {
@@ -20861,6 +27009,12 @@
           "url": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/typescript"
         }
       ]
     },
@@ -20882,6 +27036,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/uglify-js"
+        }
       ]
     },
     {
@@ -20901,6 +27061,12 @@
           "url": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unbox-primitive"
         }
       ]
     },
@@ -20922,6 +27088,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unbzip2-stream"
+        }
       ]
     },
     {
@@ -20941,6 +27113,12 @@
           "url": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unc-path-regex"
         }
       ]
     },
@@ -20962,6 +27140,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/underscore.string"
+        }
       ]
     },
     {
@@ -20982,6 +27166,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unicode-properties"
+        }
       ]
     },
     {
@@ -21001,6 +27191,12 @@
           "url": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unicode-trie"
         }
       ]
     },
@@ -21023,6 +27219,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/union-value"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21041,6 +27243,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/union-value/node_modules/is-extendable"
             }
           ]
         }
@@ -21064,6 +27272,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unique-filename"
+        }
       ]
     },
     {
@@ -21083,6 +27297,12 @@
           "url": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unique-slug"
         }
       ]
     },
@@ -21104,6 +27324,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unit-compare"
+        }
       ]
     },
     {
@@ -21124,6 +27350,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/universalify"
+        }
       ]
     },
     {
@@ -21143,6 +27375,12 @@
           "url": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unpipe"
         }
       ]
     },
@@ -21165,6 +27403,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unset-value"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21185,6 +27429,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/unset-value/node_modules/has-value"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -21203,6 +27453,12 @@
                   "url": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/unset-value/node_modules/has-value/node_modules/isobject"
                 }
               ]
             }
@@ -21226,6 +27482,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/unset-value/node_modules/has-values"
+            }
           ]
         },
         {
@@ -21245,6 +27507,12 @@
               "url": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/unset-value/node_modules/isarray"
             }
           ]
         }
@@ -21268,6 +27536,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/untildify"
+        }
       ]
     },
     {
@@ -21289,6 +27563,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unzipper"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21307,6 +27587,12 @@
               "url": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/unzipper/node_modules/bluebird"
             }
           ]
         }
@@ -21330,6 +27616,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/uri-js"
+        }
       ]
     },
     {
@@ -21349,6 +27641,12 @@
           "url": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/urix"
         }
       ]
     },
@@ -21370,6 +27668,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/url-parse-lax"
+        }
       ]
     },
     {
@@ -21389,6 +27693,12 @@
           "url": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/url-to-options"
         }
       ]
     },
@@ -21410,6 +27720,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/use"
+        }
       ]
     },
     {
@@ -21429,6 +27745,12 @@
           "url": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/utf8-byte-length"
         }
       ]
     },
@@ -21450,6 +27772,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/util-deprecate"
+        }
       ]
     },
     {
@@ -21469,6 +27797,12 @@
           "url": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/util"
         }
       ]
     },
@@ -21490,6 +27824,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/utils-merge"
+        }
       ]
     },
     {
@@ -21509,6 +27849,12 @@
           "url": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/uuid"
         }
       ]
     },
@@ -21530,6 +27876,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/v8flags"
+        }
       ]
     },
     {
@@ -21549,6 +27901,12 @@
           "url": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/validate-npm-package-license"
         }
       ]
     },
@@ -21570,6 +27928,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/validate"
+        }
       ]
     },
     {
@@ -21590,6 +27954,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/validator"
+        }
       ]
     },
     {
@@ -21609,6 +27979,12 @@
           "url": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/vary"
         }
       ]
     },
@@ -21631,6 +28007,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/verror"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21649,6 +28031,12 @@
               "url": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/verror/node_modules/core-util-is"
             }
           ]
         }
@@ -21673,6 +28061,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/vm2"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21691,6 +28085,12 @@
               "url": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/vm2/node_modules/acorn"
             }
           ]
         }
@@ -21714,6 +28114,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/void-elements"
+        }
       ]
     },
     {
@@ -21733,6 +28139,12 @@
           "url": "https://registry.npmjs.org/walk/-/walk-2.3.15.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/walk"
         }
       ]
     },
@@ -21754,6 +28166,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/walkdir"
+        }
       ]
     },
     {
@@ -21773,6 +28191,12 @@
           "url": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/webidl-conversions"
         }
       ]
     },
@@ -21794,6 +28218,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/whatwg-url"
+        }
       ]
     },
     {
@@ -21813,6 +28243,12 @@
           "url": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-boxed-primitive"
         }
       ]
     },
@@ -21834,6 +28270,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-collection"
+        }
       ]
     },
     {
@@ -21853,6 +28295,12 @@
           "url": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-module"
         }
       ]
     },
@@ -21874,6 +28322,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-pm-runs"
+        }
       ]
     },
     {
@@ -21893,6 +28347,12 @@
           "url": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-typed-array"
         }
       ]
     },
@@ -21914,6 +28374,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which"
+        }
       ]
     },
     {
@@ -21933,6 +28399,12 @@
           "url": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wide-align"
         }
       ]
     },
@@ -21955,6 +28427,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/winston-transport"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21973,6 +28451,12 @@
               "url": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/winston-transport/node_modules/readable-stream"
             }
           ]
         }
@@ -21997,6 +28481,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/winston"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -22015,6 +28505,12 @@
               "url": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/winston/node_modules/async"
             }
           ]
         },
@@ -22036,6 +28532,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/winston/node_modules/is-stream"
+            }
           ]
         },
         {
@@ -22055,6 +28557,12 @@
               "url": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/winston/node_modules/readable-stream"
             }
           ]
         }
@@ -22078,6 +28586,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/with"
+        }
       ]
     },
     {
@@ -22097,6 +28611,12 @@
           "url": "https://registry.npmjs.org/wkx/-/wkx-0.5.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wkx"
         }
       ]
     },
@@ -22118,6 +28638,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/word-wrap"
+        }
       ]
     },
     {
@@ -22137,6 +28663,12 @@
           "url": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wordwrap"
         }
       ]
     },
@@ -22159,6 +28691,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wrap-ansi"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -22177,6 +28715,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi/node_modules/ansi-regex"
             }
           ]
         },
@@ -22198,6 +28742,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi/node_modules/emoji-regex"
+            }
           ]
         },
         {
@@ -22217,6 +28767,12 @@
               "url": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi/node_modules/is-fullwidth-code-point"
             }
           ]
         },
@@ -22238,6 +28794,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi/node_modules/string-width"
+            }
           ]
         },
         {
@@ -22257,6 +28819,12 @@
               "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi/node_modules/strip-ansi"
             }
           ]
         }
@@ -22280,6 +28848,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wrappy"
+        }
       ]
     },
     {
@@ -22299,6 +28873,12 @@
           "url": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ws"
         }
       ]
     },
@@ -22320,6 +28900,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/xtend"
+        }
       ]
     },
     {
@@ -22339,6 +28925,12 @@
           "url": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/y18n"
         }
       ]
     },
@@ -22360,6 +28952,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yallist"
+        }
       ]
     },
     {
@@ -22380,6 +28978,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yaml-schema-validator"
+        }
       ]
     },
     {
@@ -22399,6 +29003,12 @@
           "url": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yargs-parser"
         }
       ]
     },
@@ -22421,6 +29031,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yargs"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -22439,6 +29055,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs/node_modules/ansi-regex"
             }
           ]
         },
@@ -22460,6 +29082,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs/node_modules/emoji-regex"
+            }
           ]
         },
         {
@@ -22479,6 +29107,12 @@
               "url": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs/node_modules/is-fullwidth-code-point"
             }
           ]
         },
@@ -22500,6 +29134,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs/node_modules/string-width"
+            }
           ]
         },
         {
@@ -22519,6 +29159,12 @@
               "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs/node_modules/strip-ansi"
             }
           ]
         }
@@ -22542,6 +29188,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yauzl"
+        }
       ]
     },
     {
@@ -22561,6 +29213,12 @@
           "url": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yn"
         }
       ]
     },
@@ -22582,6 +29240,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/z85"
+        }
       ]
     },
     {
@@ -22602,6 +29266,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/zip-stream"
+        }
       ]
     },
     {
@@ -22621,6 +29291,12 @@
           "url": "https://registry.npmjs.org/zlibjs/-/zlibjs-0.3.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/zlibjs"
         }
       ]
     }

--- a/tests/_data/sbom_demo-results/juice-shop_npm9_node18_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/juice-shop_npm9_node18_ubuntu-latest.snap.json
@@ -62,6 +62,10 @@
       ],
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -88,6 +92,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@babel/helper-string-parser"
+        }
       ]
     },
     {
@@ -108,6 +118,12 @@
           "url": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@babel/helper-validator-identifier"
         }
       ]
     },
@@ -130,6 +146,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@babel/parser"
+        }
       ]
     },
     {
@@ -150,6 +172,12 @@
           "url": "https://registry.npmjs.org/@babel/types/-/types-7.20.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@babel/types"
         }
       ]
     },
@@ -172,6 +200,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@colors/colors"
+        }
       ]
     },
     {
@@ -193,6 +227,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@dabh/diagnostics"
+        }
       ]
     },
     {
@@ -213,6 +253,12 @@
           "url": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@gar/promisify"
         }
       ]
     },
@@ -236,6 +282,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@mapbox/node-pre-gyp"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -254,6 +306,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/ansi-regex"
             }
           ]
         },
@@ -275,6 +333,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/are-we-there-yet"
+            }
           ]
         },
         {
@@ -294,6 +358,12 @@
               "url": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/detect-libc"
             }
           ]
         },
@@ -315,6 +385,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/gauge"
+            }
           ]
         },
         {
@@ -334,6 +410,12 @@
               "url": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/is-fullwidth-code-point"
             }
           ]
         },
@@ -356,6 +438,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/make-dir"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -374,6 +462,12 @@
                   "url": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/@mapbox/node-pre-gyp/node_modules/make-dir/node_modules/semver"
                 }
               ]
             }
@@ -397,6 +491,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/nopt"
+            }
           ]
         },
         {
@@ -416,6 +516,12 @@
               "url": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/npmlog"
             }
           ]
         },
@@ -437,6 +543,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/readable-stream"
+            }
           ]
         },
         {
@@ -457,6 +569,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/string-width"
+            }
           ]
         },
         {
@@ -476,6 +594,12 @@
               "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox/node-pre-gyp/node_modules/strip-ansi"
             }
           ]
         }
@@ -500,6 +624,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/core-loader"
+        }
       ]
     },
     {
@@ -520,6 +650,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/core/-/core-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/core"
         }
       ]
     },
@@ -542,6 +678,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/evaluator"
+        }
       ]
     },
     {
@@ -562,6 +704,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-all/-/lang-all-4.24.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-all"
         }
       ]
     },
@@ -584,6 +732,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ar"
+        }
       ]
     },
     {
@@ -604,6 +758,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-bn/-/lang-bn-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-bn"
         }
       ]
     },
@@ -626,6 +786,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ca"
+        }
       ]
     },
     {
@@ -646,6 +812,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-cs/-/lang-cs-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-cs"
         }
       ]
     },
@@ -668,6 +840,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-da"
+        }
       ]
     },
     {
@@ -688,6 +866,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-de/-/lang-de-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-de"
         }
       ]
     },
@@ -710,6 +894,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-el"
+        }
       ]
     },
     {
@@ -730,6 +920,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-en-min/-/lang-en-min-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-en-min"
         }
       ]
     },
@@ -752,6 +948,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-en"
+        }
       ]
     },
     {
@@ -772,6 +974,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-es/-/lang-es-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-es"
         }
       ]
     },
@@ -794,6 +1002,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-eu"
+        }
       ]
     },
     {
@@ -814,6 +1028,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-fa/-/lang-fa-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-fa"
         }
       ]
     },
@@ -836,6 +1056,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-fi"
+        }
       ]
     },
     {
@@ -856,6 +1082,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-fr/-/lang-fr-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-fr"
         }
       ]
     },
@@ -878,6 +1110,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ga"
+        }
       ]
     },
     {
@@ -898,6 +1136,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-gl/-/lang-gl-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-gl"
         }
       ]
     },
@@ -920,6 +1164,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-hi"
+        }
       ]
     },
     {
@@ -940,6 +1190,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-hu/-/lang-hu-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-hu"
         }
       ]
     },
@@ -962,6 +1218,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-hy"
+        }
       ]
     },
     {
@@ -982,6 +1244,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-id/-/lang-id-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-id"
         }
       ]
     },
@@ -1004,6 +1272,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-it"
+        }
       ]
     },
     {
@@ -1024,6 +1298,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-ja/-/lang-ja-4.24.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ja"
         }
       ]
     },
@@ -1046,6 +1326,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ko"
+        }
       ]
     },
     {
@@ -1066,6 +1352,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-lt/-/lang-lt-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-lt"
         }
       ]
     },
@@ -1088,6 +1380,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ms"
+        }
       ]
     },
     {
@@ -1108,6 +1406,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-ne/-/lang-ne-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ne"
         }
       ]
     },
@@ -1130,6 +1434,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-nl"
+        }
       ]
     },
     {
@@ -1150,6 +1460,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-no/-/lang-no-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-no"
         }
       ]
     },
@@ -1172,6 +1488,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-pl"
+        }
       ]
     },
     {
@@ -1192,6 +1514,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-pt/-/lang-pt-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-pt"
         }
       ]
     },
@@ -1214,6 +1542,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ro"
+        }
       ]
     },
     {
@@ -1234,6 +1568,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-ru/-/lang-ru-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ru"
         }
       ]
     },
@@ -1256,6 +1596,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-sl"
+        }
       ]
     },
     {
@@ -1276,6 +1622,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-sr/-/lang-sr-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-sr"
         }
       ]
     },
@@ -1298,6 +1650,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-sv"
+        }
       ]
     },
     {
@@ -1318,6 +1676,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-ta/-/lang-ta-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-ta"
         }
       ]
     },
@@ -1340,6 +1704,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-th"
+        }
       ]
     },
     {
@@ -1360,6 +1730,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-tl/-/lang-tl-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-tl"
         }
       ]
     },
@@ -1382,6 +1758,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-tr"
+        }
       ]
     },
     {
@@ -1402,6 +1784,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-uk/-/lang-uk-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-uk"
         }
       ]
     },
@@ -1424,6 +1812,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/lang-zh"
+        }
       ]
     },
     {
@@ -1444,6 +1838,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/language-min/-/language-min-4.22.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/language-min"
         }
       ]
     },
@@ -1466,6 +1866,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/language"
+        }
       ]
     },
     {
@@ -1486,6 +1892,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/ner/-/ner-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/ner"
         }
       ]
     },
@@ -1508,6 +1920,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/neural"
+        }
       ]
     },
     {
@@ -1528,6 +1946,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/nlg/-/nlg-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/nlg"
         }
       ]
     },
@@ -1550,6 +1974,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/nlp"
+        }
       ]
     },
     {
@@ -1570,6 +2000,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/nlu/-/nlu-4.23.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/nlu"
         }
       ]
     },
@@ -1592,6 +2028,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/request"
+        }
       ]
     },
     {
@@ -1612,6 +2054,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/sentiment/-/sentiment-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/sentiment"
         }
       ]
     },
@@ -1634,6 +2082,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/similarity"
+        }
       ]
     },
     {
@@ -1654,6 +2108,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/slot/-/slot-4.22.17.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs/slot"
         }
       ]
     },
@@ -1676,6 +2136,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@npmcli/fs"
+        }
       ]
     },
     {
@@ -1696,6 +2162,12 @@
           "url": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@npmcli/move-file"
         }
       ]
     },
@@ -1718,6 +2190,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib/core"
+        }
       ]
     },
     {
@@ -1738,6 +2216,12 @@
           "url": "https://registry.npmjs.org/@otplib/plugin-crypto/-/plugin-crypto-12.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib/plugin-crypto"
         }
       ]
     },
@@ -1760,6 +2244,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib/plugin-thirty-two"
+        }
       ]
     },
     {
@@ -1780,6 +2270,12 @@
           "url": "https://registry.npmjs.org/@otplib/preset-default/-/preset-default-12.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib/preset-default"
         }
       ]
     },
@@ -1802,6 +2298,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib/preset-v11"
+        }
       ]
     },
     {
@@ -1822,6 +2324,12 @@
           "url": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@sindresorhus/is"
         }
       ]
     },
@@ -1844,6 +2352,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@swc/helpers"
+        }
       ]
     },
     {
@@ -1864,6 +2378,12 @@
           "url": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@tokenizer/token"
         }
       ]
     },
@@ -1886,6 +2406,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@tootallnate/once"
+        }
       ]
     },
     {
@@ -1906,6 +2432,12 @@
           "url": "https://registry.npmjs.org/@types/component-emitter/-/component-emitter-1.2.11.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/component-emitter"
         }
       ]
     },
@@ -1928,6 +2460,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/cookie"
+        }
       ]
     },
     {
@@ -1948,6 +2486,12 @@
           "url": "https://registry.npmjs.org/@types/cors/-/cors-2.8.12.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/cors"
         }
       ]
     },
@@ -1970,6 +2514,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/debug"
+        }
       ]
     },
     {
@@ -1990,6 +2540,12 @@
           "url": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/ms"
         }
       ]
     },
@@ -2012,6 +2568,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/node"
+        }
       ]
     },
     {
@@ -2032,6 +2594,12 @@
           "url": "https://registry.npmjs.org/@types/strip-bom/-/strip-bom-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/strip-bom"
         }
       ]
     },
@@ -2054,6 +2622,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/strip-json-comments"
+        }
       ]
     },
     {
@@ -2075,6 +2649,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types/validator"
+        }
       ]
     },
     {
@@ -2094,6 +2674,12 @@
           "url": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/abbrev"
         }
       ]
     },
@@ -2115,6 +2701,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/accepts"
+        }
       ]
     },
     {
@@ -2135,6 +2727,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/acorn-walk"
+        }
       ]
     },
     {
@@ -2154,6 +2752,12 @@
           "url": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/acorn"
         }
       ]
     },
@@ -2176,6 +2780,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/agent-base"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -2194,6 +2804,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agent-base/node_modules/debug"
             }
           ]
         },
@@ -2214,6 +2830,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agent-base/node_modules/ms"
             }
           ]
         }
@@ -2238,6 +2860,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/agentkeepalive"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -2256,6 +2884,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agentkeepalive/node_modules/debug"
             }
           ]
         },
@@ -2277,6 +2911,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agentkeepalive/node_modules/depd"
+            }
           ]
         },
         {
@@ -2296,6 +2936,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agentkeepalive/node_modules/ms"
             }
           ]
         }
@@ -2319,6 +2965,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/aggregate-error"
+        }
       ]
     },
     {
@@ -2338,6 +2990,12 @@
           "url": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ajv"
         }
       ]
     },
@@ -2359,6 +3017,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ansi-regex"
+        }
       ]
     },
     {
@@ -2378,6 +3042,12 @@
           "url": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ansi-styles"
         }
       ]
     },
@@ -2400,6 +3070,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/anymatch"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -2418,6 +3094,12 @@
               "url": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/anymatch/node_modules/normalize-path"
             }
           ]
         }
@@ -2441,6 +3123,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/append-field"
+        }
       ]
     },
     {
@@ -2460,6 +3148,12 @@
           "url": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/aproba"
         }
       ]
     },
@@ -2482,6 +3176,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/archive-type"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -2500,6 +3200,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-4.4.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/archive-type/node_modules/file-type"
             }
           ]
         }
@@ -2523,6 +3229,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/archiver-utils"
+        }
       ]
     },
     {
@@ -2542,6 +3254,12 @@
           "url": "https://registry.npmjs.org/archiver/-/archiver-1.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/archiver"
         }
       ]
     },
@@ -2563,6 +3281,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/are-we-there-yet"
+        }
       ]
     },
     {
@@ -2582,6 +3306,12 @@
           "url": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/arg"
         }
       ]
     },
@@ -2604,6 +3334,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/argparse"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -2622,6 +3358,12 @@
               "url": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/argparse/node_modules/sprintf-js"
             }
           ]
         }
@@ -2645,6 +3387,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/arr-diff"
+        }
       ]
     },
     {
@@ -2664,6 +3412,12 @@
           "url": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/arr-flatten"
         }
       ]
     },
@@ -2685,6 +3439,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/arr-union"
+        }
       ]
     },
     {
@@ -2704,6 +3464,12 @@
           "url": "https://registry.npmjs.org/array-each/-/array-each-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/array-each"
         }
       ]
     },
@@ -2725,6 +3491,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/array-flatten"
+        }
       ]
     },
     {
@@ -2744,6 +3516,12 @@
           "url": "https://registry.npmjs.org/array-slice/-/array-slice-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/array-slice"
         }
       ]
     },
@@ -2765,6 +3543,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/array-unique"
+        }
       ]
     },
     {
@@ -2784,6 +3568,12 @@
           "url": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/asap"
         }
       ]
     },
@@ -2805,6 +3595,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/asn1"
+        }
       ]
     },
     {
@@ -2824,6 +3620,12 @@
           "url": "https://registry.npmjs.org/assert-never/-/assert-never-1.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/assert-never"
         }
       ]
     },
@@ -2845,6 +3647,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/assert-plus"
+        }
       ]
     },
     {
@@ -2864,6 +3672,12 @@
           "url": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/assign-symbols"
         }
       ]
     },
@@ -2885,6 +3699,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/async"
+        }
       ]
     },
     {
@@ -2904,6 +3724,12 @@
           "url": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/asynckit"
         }
       ]
     },
@@ -2925,6 +3751,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/at-least-node"
+        }
       ]
     },
     {
@@ -2944,6 +3776,12 @@
           "url": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/atob"
         }
       ]
     },
@@ -2965,6 +3803,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/available-typed-arrays"
+        }
       ]
     },
     {
@@ -2984,6 +3828,12 @@
           "url": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/aws-sign2"
         }
       ]
     },
@@ -3005,6 +3855,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/aws4"
+        }
       ]
     },
     {
@@ -3025,6 +3881,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/babel-walk"
+        }
       ]
     },
     {
@@ -3044,6 +3906,12 @@
           "url": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/balanced-match"
         }
       ]
     },
@@ -3066,6 +3934,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -3084,6 +3958,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/base/node_modules/define-property"
             }
           ]
         }
@@ -3107,6 +3987,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base64-arraybuffer"
+        }
       ]
     },
     {
@@ -3126,6 +4012,12 @@
           "url": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base64-js"
         }
       ]
     },
@@ -3147,6 +4039,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base64id"
+        }
       ]
     },
     {
@@ -3166,6 +4064,12 @@
           "url": "https://registry.npmjs.org/base64url/-/base64url-0.0.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base64url"
         }
       ]
     },
@@ -3187,6 +4091,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/basic-auth"
+        }
       ]
     },
     {
@@ -3206,6 +4116,12 @@
           "url": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/batch"
         }
       ]
     },
@@ -3227,6 +4143,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bcrypt-pbkdf"
+        }
       ]
     },
     {
@@ -3246,6 +4168,12 @@
           "url": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/big-integer"
         }
       ]
     },
@@ -3267,6 +4195,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/binary-extensions"
+        }
       ]
     },
     {
@@ -3286,6 +4220,12 @@
           "url": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/binary"
         }
       ]
     },
@@ -3307,6 +4247,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bindings"
+        }
       ]
     },
     {
@@ -3326,6 +4272,12 @@
           "url": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bintrees"
         }
       ]
     },
@@ -3347,6 +4299,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bl"
+        }
       ]
     },
     {
@@ -3367,6 +4325,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bluebird"
+        }
       ]
     },
     {
@@ -3386,6 +4350,12 @@
           "url": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/body-parser"
         }
       ]
     },
@@ -3408,6 +4378,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bower-config"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -3426,6 +4402,12 @@
               "url": "https://registry.npmjs.org/minimist/-/minimist-0.2.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bower-config/node_modules/minimist"
             }
           ]
         }
@@ -3449,6 +4431,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/brace-expansion"
+        }
       ]
     },
     {
@@ -3470,6 +4458,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/braces"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -3488,6 +4482,12 @@
               "url": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/braces/node_modules/extend-shallow"
             }
           ]
         },
@@ -3508,6 +4508,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/braces/node_modules/is-extendable"
             }
           ]
         }
@@ -3531,6 +4537,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/brotli"
+        }
       ]
     },
     {
@@ -3550,6 +4562,12 @@
           "url": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-alloc-unsafe"
         }
       ]
     },
@@ -3571,6 +4589,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-alloc"
+        }
       ]
     },
     {
@@ -3590,6 +4614,12 @@
           "url": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-crc32"
         }
       ]
     },
@@ -3611,6 +4641,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-fill"
+        }
       ]
     },
     {
@@ -3630,6 +4666,12 @@
           "url": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-from"
         }
       ]
     },
@@ -3651,6 +4693,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-indexof-polyfill"
+        }
       ]
     },
     {
@@ -3671,6 +4719,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer"
+        }
       ]
     },
     {
@@ -3690,6 +4744,12 @@
           "url": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffers"
         }
       ]
     },
@@ -3712,6 +4772,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/busboy"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -3730,6 +4796,12 @@
               "url": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/busboy/node_modules/isarray"
             }
           ]
         },
@@ -3751,6 +4823,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/busboy/node_modules/readable-stream"
+            }
           ]
         },
         {
@@ -3770,6 +4848,12 @@
               "url": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/busboy/node_modules/string_decoder"
             }
           ]
         }
@@ -3793,6 +4877,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/byline"
+        }
       ]
     },
     {
@@ -3812,6 +4902,12 @@
           "url": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bytes"
         }
       ]
     },
@@ -3833,6 +4929,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cacache"
+        }
       ]
     },
     {
@@ -3852,6 +4954,12 @@
           "url": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cache-base"
         }
       ]
     },
@@ -3874,6 +4982,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cacheable-request"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -3892,6 +5006,12 @@
               "url": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cacheable-request/node_modules/get-stream"
             }
           ]
         },
@@ -3912,6 +5032,12 @@
               "url": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cacheable-request/node_modules/lowercase-keys"
             }
           ]
         }
@@ -3935,6 +5061,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/call-bind"
+        }
       ]
     },
     {
@@ -3954,6 +5086,12 @@
           "url": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/camelcase"
         }
       ]
     },
@@ -3975,6 +5113,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/caseless"
+        }
       ]
     },
     {
@@ -3994,6 +5138,12 @@
           "url": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/chainsaw"
         }
       ]
     },
@@ -4015,6 +5165,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/chalk"
+        }
       ]
     },
     {
@@ -4034,6 +5190,12 @@
           "url": "https://registry.npmjs.org/character-parser/-/character-parser-2.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/character-parser"
         }
       ]
     },
@@ -4056,6 +5218,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/check-dependencies"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4074,6 +5242,12 @@
               "url": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/check-dependencies/node_modules/semver"
             }
           ]
         }
@@ -4097,6 +5271,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/check-types"
+        }
       ]
     },
     {
@@ -4118,6 +5298,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/chokidar"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4136,6 +5322,12 @@
               "url": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar/node_modules/braces"
             }
           ]
         },
@@ -4157,6 +5349,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar/node_modules/fill-range"
+            }
           ]
         },
         {
@@ -4176,6 +5374,12 @@
               "url": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar/node_modules/is-glob"
             }
           ]
         },
@@ -4197,6 +5401,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar/node_modules/is-number"
+            }
           ]
         },
         {
@@ -4217,6 +5427,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar/node_modules/normalize-path"
+            }
           ]
         },
         {
@@ -4236,6 +5452,12 @@
               "url": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar/node_modules/to-regex-range"
             }
           ]
         }
@@ -4259,6 +5481,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/chownr"
+        }
       ]
     },
     {
@@ -4278,6 +5506,12 @@
           "url": "https://registry.npmjs.org/clarinet/-/clarinet-0.12.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/clarinet"
         }
       ]
     },
@@ -4300,6 +5534,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/class-utils"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4318,6 +5558,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils/node_modules/define-property"
             }
           ]
         },
@@ -4340,6 +5586,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils/node_modules/is-accessor-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -4358,6 +5610,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/class-utils/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -4382,6 +5640,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils/node_modules/is-data-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -4400,6 +5664,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/class-utils/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -4423,6 +5693,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils/node_modules/is-descriptor"
+            }
           ]
         },
         {
@@ -4442,6 +5718,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils/node_modules/kind-of"
             }
           ]
         }
@@ -4465,6 +5747,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/clean-stack"
+        }
       ]
     },
     {
@@ -4486,6 +5774,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cliui"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4504,6 +5798,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui/node_modules/ansi-regex"
             }
           ]
         },
@@ -4525,6 +5825,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui/node_modules/emoji-regex"
+            }
           ]
         },
         {
@@ -4544,6 +5850,12 @@
               "url": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui/node_modules/is-fullwidth-code-point"
             }
           ]
         },
@@ -4565,6 +5877,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui/node_modules/string-width"
+            }
           ]
         },
         {
@@ -4584,6 +5902,12 @@
               "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui/node_modules/strip-ansi"
             }
           ]
         }
@@ -4607,6 +5931,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/clone-response"
+        }
       ]
     },
     {
@@ -4626,6 +5956,12 @@
           "url": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/clone"
         }
       ]
     },
@@ -4647,6 +5983,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/code-point-at"
+        }
       ]
     },
     {
@@ -4666,6 +6008,12 @@
           "url": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/collection-visit"
         }
       ]
     },
@@ -4687,6 +6035,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color-convert"
+        }
       ]
     },
     {
@@ -4706,6 +6060,12 @@
           "url": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color-name"
         }
       ]
     },
@@ -4727,6 +6087,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color-string"
+        }
       ]
     },
     {
@@ -4746,6 +6112,12 @@
           "url": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color-support"
         }
       ]
     },
@@ -4767,6 +6139,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color"
+        }
       ]
     },
     {
@@ -4786,6 +6164,12 @@
           "url": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/colors"
         }
       ]
     },
@@ -4807,6 +6191,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/colorspace"
+        }
       ]
     },
     {
@@ -4826,6 +6216,12 @@
           "url": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/combined-stream"
         }
       ]
     },
@@ -4847,6 +6243,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/commander"
+        }
       ]
     },
     {
@@ -4866,6 +6268,12 @@
           "url": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/component-emitter"
         }
       ]
     },
@@ -4887,6 +6295,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/component-type"
+        }
       ]
     },
     {
@@ -4907,6 +6321,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/compress-commons"
+        }
       ]
     },
     {
@@ -4926,6 +6346,12 @@
           "url": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/compressible"
         }
       ]
     },
@@ -4948,6 +6374,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/compression"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4966,6 +6398,12 @@
               "url": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/compression/node_modules/bytes"
             }
           ]
         }
@@ -4989,6 +6427,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/concat-map"
+        }
       ]
     },
     {
@@ -5008,6 +6452,12 @@
           "url": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/concat-stream"
         }
       ]
     },
@@ -5030,6 +6480,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/concurrently"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5048,6 +6504,12 @@
               "url": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/concurrently/node_modules/supports-color"
             }
           ]
         }
@@ -5071,6 +6533,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/config"
+        }
       ]
     },
     {
@@ -5091,6 +6559,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/console-control-strings"
+        }
       ]
     },
     {
@@ -5110,6 +6584,12 @@
           "url": "https://registry.npmjs.org/constantinople/-/constantinople-4.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/constantinople"
         }
       ]
     },
@@ -5132,6 +6612,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/content-disposition"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5150,6 +6636,12 @@
               "url": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/content-disposition/node_modules/safe-buffer"
             }
           ]
         }
@@ -5173,6 +6665,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/content-type"
+        }
       ]
     },
     {
@@ -5192,6 +6690,12 @@
           "url": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cookie-parser"
         }
       ]
     },
@@ -5213,6 +6717,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cookie-signature"
+        }
       ]
     },
     {
@@ -5232,6 +6742,12 @@
           "url": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cookie"
         }
       ]
     },
@@ -5253,6 +6769,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/copy-descriptor"
+        }
       ]
     },
     {
@@ -5272,6 +6794,12 @@
           "url": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/core-util-is"
         }
       ]
     },
@@ -5293,6 +6821,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cors"
+        }
       ]
     },
     {
@@ -5312,6 +6846,12 @@
           "url": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/crc"
         }
       ]
     },
@@ -5333,6 +6873,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/crc32-stream"
+        }
       ]
     },
     {
@@ -5352,6 +6898,12 @@
           "url": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/create-require"
         }
       ]
     },
@@ -5373,6 +6925,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/crypto-js"
+        }
       ]
     },
     {
@@ -5392,6 +6950,12 @@
           "url": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dashdash"
         }
       ]
     },
@@ -5413,6 +6977,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/date-fns"
+        }
       ]
     },
     {
@@ -5432,6 +7002,12 @@
           "url": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dateformat"
         }
       ]
     },
@@ -5453,6 +7029,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/debug"
+        }
       ]
     },
     {
@@ -5472,6 +7054,12 @@
           "url": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decamelize"
         }
       ]
     },
@@ -5493,6 +7081,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decode-uri-component"
+        }
       ]
     },
     {
@@ -5512,6 +7106,12 @@
           "url": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-response"
         }
       ]
     },
@@ -5534,6 +7134,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-tar"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5552,6 +7158,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-tar/node_modules/file-type"
             }
           ]
         }
@@ -5576,6 +7188,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-tarbz2"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5594,6 +7212,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-6.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-tarbz2/node_modules/file-type"
             }
           ]
         }
@@ -5618,6 +7242,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-targz"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5636,6 +7266,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-targz/node_modules/file-type"
             }
           ]
         }
@@ -5660,6 +7296,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-unzip"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5678,6 +7320,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-unzip/node_modules/file-type"
             }
           ]
         },
@@ -5699,6 +7347,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-unzip/node_modules/get-stream"
+            }
           ]
         },
         {
@@ -5718,6 +7372,12 @@
               "url": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-unzip/node_modules/pify"
             }
           ]
         }
@@ -5742,6 +7402,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5762,6 +7428,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress/node_modules/make-dir"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -5780,6 +7452,12 @@
                   "url": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/decompress/node_modules/make-dir/node_modules/pify"
                 }
               ]
             }
@@ -5803,6 +7481,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress/node_modules/pify"
+            }
           ]
         }
       ]
@@ -5825,6 +7509,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/deep-equal"
+        }
       ]
     },
     {
@@ -5844,6 +7534,12 @@
           "url": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/deep-extend"
         }
       ]
     },
@@ -5865,6 +7561,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/deep-is"
+        }
       ]
     },
     {
@@ -5884,6 +7586,12 @@
           "url": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/define-properties"
         }
       ]
     },
@@ -5905,6 +7613,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/define-property"
+        }
       ]
     },
     {
@@ -5924,6 +7638,12 @@
           "url": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/delayed-stream"
         }
       ]
     },
@@ -5945,6 +7665,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/delegates"
+        }
       ]
     },
     {
@@ -5964,6 +7690,12 @@
           "url": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/depd"
         }
       ]
     },
@@ -5985,6 +7717,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/destroy"
+        }
       ]
     },
     {
@@ -6004,6 +7742,12 @@
           "url": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/detect-file"
         }
       ]
     },
@@ -6025,6 +7769,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/detect-libc"
+        }
       ]
     },
     {
@@ -6044,6 +7794,12 @@
           "url": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dfa"
         }
       ]
     },
@@ -6066,6 +7822,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dicer"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -6084,6 +7846,12 @@
               "url": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/dicer/node_modules/isarray"
             }
           ]
         },
@@ -6105,6 +7873,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/dicer/node_modules/readable-stream"
+            }
           ]
         },
         {
@@ -6124,6 +7898,12 @@
               "url": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/dicer/node_modules/string_decoder"
             }
           ]
         }
@@ -6147,6 +7927,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/diff"
+        }
       ]
     },
     {
@@ -6166,6 +7952,12 @@
           "url": "https://registry.npmjs.org/doctypes/-/doctypes-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/doctypes"
         }
       ]
     },
@@ -6187,6 +7979,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/domelementtype"
+        }
       ]
     },
     {
@@ -6206,6 +8004,12 @@
           "url": "https://registry.npmjs.org/domhandler/-/domhandler-2.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/domhandler"
         }
       ]
     },
@@ -6227,6 +8031,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/domutils"
+        }
       ]
     },
     {
@@ -6246,6 +8056,12 @@
           "url": "https://registry.npmjs.org/dottie/-/dottie-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dottie"
         }
       ]
     },
@@ -6267,6 +8083,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/double-ended-queue"
+        }
       ]
     },
     {
@@ -6286,6 +8108,12 @@
           "url": "https://registry.npmjs.org/doublearray/-/doublearray-0.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/doublearray"
         }
       ]
     },
@@ -6308,6 +8136,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/download"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -6326,6 +8160,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-11.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/download/node_modules/file-type"
             }
           ]
         }
@@ -6349,6 +8189,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/duplexer2"
+        }
       ]
     },
     {
@@ -6368,6 +8214,12 @@
           "url": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/duplexer3"
         }
       ]
     },
@@ -6389,6 +8241,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dynamic-dedupe"
+        }
       ]
     },
     {
@@ -6408,6 +8266,12 @@
           "url": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ecc-jsbn"
         }
       ]
     },
@@ -6429,6 +8293,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ee-first"
+        }
       ]
     },
     {
@@ -6448,6 +8318,12 @@
           "url": "https://registry.npmjs.org/eivindfjeldstad-dot/-/eivindfjeldstad-dot-0.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/eivindfjeldstad-dot"
         }
       ]
     },
@@ -6469,6 +8345,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/emoji-regex"
+        }
       ]
     },
     {
@@ -6489,6 +8371,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/enabled"
+        }
       ]
     },
     {
@@ -6508,6 +8396,12 @@
           "url": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/encodeurl"
         }
       ]
     },
@@ -6530,6 +8424,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/encoding"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -6548,6 +8448,12 @@
               "url": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/encoding/node_modules/iconv-lite"
             }
           ]
         }
@@ -6571,6 +8477,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/end-of-stream"
+        }
       ]
     },
     {
@@ -6590,6 +8502,12 @@
           "url": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-4.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/engine.io-parser"
         }
       ]
     },
@@ -6612,6 +8530,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/engine.io"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -6630,6 +8554,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/engine.io/node_modules/debug"
             }
           ]
         },
@@ -6650,6 +8580,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/engine.io/node_modules/ms"
             }
           ]
         }
@@ -6673,6 +8609,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/env-paths"
+        }
       ]
     },
     {
@@ -6692,6 +8634,12 @@
           "url": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/err-code"
         }
       ]
     },
@@ -6713,6 +8661,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/error-ex"
+        }
       ]
     },
     {
@@ -6732,6 +8686,12 @@
           "url": "https://registry.npmjs.org/errorhandler/-/errorhandler-1.5.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/errorhandler"
         }
       ]
     },
@@ -6753,6 +8713,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/es-abstract"
+        }
       ]
     },
     {
@@ -6772,6 +8738,12 @@
           "url": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/es-get-iterator"
         }
       ]
     },
@@ -6793,6 +8765,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/es-to-primitive"
+        }
       ]
     },
     {
@@ -6812,6 +8790,12 @@
           "url": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/escape-html"
         }
       ]
     },
@@ -6833,6 +8817,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/escape-string-regexp"
+        }
       ]
     },
     {
@@ -6852,6 +8842,12 @@
           "url": "https://registry.npmjs.org/escodegen/-/escodegen-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/escodegen"
         }
       ]
     },
@@ -6873,6 +8869,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/esprima"
+        }
       ]
     },
     {
@@ -6892,6 +8894,12 @@
           "url": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/estraverse"
         }
       ]
     },
@@ -6913,6 +8921,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/esutils"
+        }
       ]
     },
     {
@@ -6932,6 +8946,12 @@
           "url": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/etag"
         }
       ]
     },
@@ -6953,6 +8973,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/eventemitter2"
+        }
       ]
     },
     {
@@ -6972,6 +8998,12 @@
           "url": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/eventemitter3"
         }
       ]
     },
@@ -6993,6 +9025,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/exif"
+        }
       ]
     },
     {
@@ -7012,6 +9050,12 @@
           "url": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/exit"
         }
       ]
     },
@@ -7034,6 +9078,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/expand-brackets"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7052,6 +9102,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/define-property"
             }
           ]
         },
@@ -7072,6 +9128,12 @@
               "url": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/extend-shallow"
             }
           ]
         },
@@ -7094,6 +9156,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/is-accessor-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -7112,6 +9180,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/expand-brackets/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -7136,6 +9210,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/is-data-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -7154,6 +9234,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/expand-brackets/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -7177,6 +9263,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/is-descriptor"
+            }
           ]
         },
         {
@@ -7197,6 +9289,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/is-extendable"
+            }
           ]
         },
         {
@@ -7216,6 +9314,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets/node_modules/kind-of"
             }
           ]
         }
@@ -7239,6 +9343,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/expand-template"
+        }
       ]
     },
     {
@@ -7259,6 +9369,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/expand-tilde"
+        }
       ]
     },
     {
@@ -7278,6 +9394,12 @@
           "url": "https://registry.npmjs.org/express-ipfilter/-/express-ipfilter-1.3.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-ipfilter"
         }
       ]
     },
@@ -7300,6 +9422,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-jwt"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7318,6 +9446,12 @@
               "url": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-0.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/express-jwt/node_modules/jsonwebtoken"
             }
           ]
         },
@@ -7338,6 +9472,12 @@
               "url": "https://registry.npmjs.org/moment/-/moment-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/express-jwt/node_modules/moment"
             }
           ]
         }
@@ -7361,6 +9501,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-rate-limit"
+        }
       ]
     },
     {
@@ -7381,6 +9527,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-robots-txt"
+        }
       ]
     },
     {
@@ -7400,6 +9552,12 @@
           "url": "https://registry.npmjs.org/express-security.txt/-/express-security.txt-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-security.txt"
         }
       ]
     },
@@ -7422,6 +9580,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7440,6 +9604,12 @@
               "url": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/express/node_modules/cookie"
             }
           ]
         },
@@ -7460,6 +9630,12 @@
               "url": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/express/node_modules/safe-buffer"
             }
           ]
         }
@@ -7483,6 +9659,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ext-list"
+        }
       ]
     },
     {
@@ -7502,6 +9684,12 @@
           "url": "https://registry.npmjs.org/ext-name/-/ext-name-5.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ext-name"
         }
       ]
     },
@@ -7523,6 +9711,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/extend-shallow"
+        }
       ]
     },
     {
@@ -7542,6 +9736,12 @@
           "url": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/extend"
         }
       ]
     },
@@ -7564,6 +9764,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/extglob"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7582,6 +9788,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/extglob/node_modules/define-property"
             }
           ]
         },
@@ -7603,6 +9815,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/extglob/node_modules/extend-shallow"
+            }
           ]
         },
         {
@@ -7622,6 +9840,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/extglob/node_modules/is-extendable"
             }
           ]
         }
@@ -7645,6 +9869,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/extsprintf"
+        }
       ]
     },
     {
@@ -7664,6 +9894,12 @@
           "url": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fast-deep-equal"
         }
       ]
     },
@@ -7685,6 +9921,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fast-json-stable-stringify"
+        }
       ]
     },
     {
@@ -7704,6 +9946,12 @@
           "url": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fast-levenshtein"
         }
       ]
     },
@@ -7725,6 +9973,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fast.js"
+        }
       ]
     },
     {
@@ -7744,6 +9998,12 @@
           "url": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fd-slicer"
         }
       ]
     },
@@ -7765,6 +10025,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/feature-policy"
+        }
       ]
     },
     {
@@ -7784,6 +10050,12 @@
           "url": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fecha"
         }
       ]
     },
@@ -7806,6 +10078,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/file-js"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7824,6 +10102,12 @@
               "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/file-js/node_modules/brace-expansion"
             }
           ]
         },
@@ -7844,6 +10128,12 @@
               "url": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/file-js/node_modules/minimatch"
             }
           ]
         }
@@ -7867,6 +10157,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/file-stream-rotator"
+        }
       ]
     },
     {
@@ -7886,6 +10182,12 @@
           "url": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/file-type"
         }
       ]
     },
@@ -7907,6 +10209,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/file-uri-to-path"
+        }
       ]
     },
     {
@@ -7926,6 +10234,12 @@
           "url": "https://registry.npmjs.org/filehound/-/filehound-1.17.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/filehound"
         }
       ]
     },
@@ -7947,6 +10261,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/filename-reserved-regex"
+        }
       ]
     },
     {
@@ -7967,6 +10287,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/filenamify"
+        }
       ]
     },
     {
@@ -7986,6 +10312,12 @@
           "url": "https://registry.npmjs.org/filesniffer/-/filesniffer-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/filesniffer"
         }
       ]
     },
@@ -8008,6 +10340,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fill-range"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -8026,6 +10364,12 @@
               "url": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/fill-range/node_modules/extend-shallow"
             }
           ]
         },
@@ -8046,6 +10390,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/fill-range/node_modules/is-extendable"
             }
           ]
         }
@@ -8069,6 +10419,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/finale-rest"
+        }
       ]
     },
     {
@@ -8088,6 +10444,12 @@
           "url": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/finalhandler"
         }
       ]
     },
@@ -8109,6 +10471,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/find-up"
+        }
       ]
     },
     {
@@ -8128,6 +10496,12 @@
           "url": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/findup-sync"
         }
       ]
     },
@@ -8149,6 +10523,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fined"
+        }
       ]
     },
     {
@@ -8168,6 +10548,12 @@
           "url": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/flagged-respawn"
         }
       ]
     },
@@ -8189,6 +10575,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fn.name"
+        }
       ]
     },
     {
@@ -8208,6 +10600,12 @@
           "url": "https://registry.npmjs.org/fontkit/-/fontkit-1.9.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fontkit"
         }
       ]
     },
@@ -8229,6 +10627,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/for-each"
+        }
       ]
     },
     {
@@ -8248,6 +10652,12 @@
           "url": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/for-in"
         }
       ]
     },
@@ -8269,6 +10679,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/for-own"
+        }
       ]
     },
     {
@@ -8288,6 +10704,12 @@
           "url": "https://registry.npmjs.org/foreachasync/-/foreachasync-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/foreachasync"
         }
       ]
     },
@@ -8309,6 +10731,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/forever-agent"
+        }
       ]
     },
     {
@@ -8328,6 +10756,12 @@
           "url": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/form-data"
         }
       ]
     },
@@ -8349,6 +10783,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/formatio"
+        }
       ]
     },
     {
@@ -8368,6 +10808,12 @@
           "url": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/forwarded"
         }
       ]
     },
@@ -8389,6 +10835,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fragment-cache"
+        }
       ]
     },
     {
@@ -8408,6 +10860,12 @@
           "url": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fresh"
         }
       ]
     },
@@ -8429,6 +10887,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/from2"
+        }
       ]
     },
     {
@@ -8448,6 +10912,12 @@
           "url": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fs-constants"
         }
       ]
     },
@@ -8469,6 +10939,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fs-extra"
+        }
       ]
     },
     {
@@ -8489,6 +10965,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fs-minipass"
+        }
       ]
     },
     {
@@ -8508,6 +10990,12 @@
           "url": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fs.realpath"
         }
       ]
     },
@@ -8530,6 +11018,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fstream"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -8548,6 +11042,12 @@
               "url": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/fstream/node_modules/mkdirp"
             }
           ]
         },
@@ -8568,6 +11068,12 @@
               "url": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/fstream/node_modules/rimraf"
             }
           ]
         }
@@ -8591,6 +11097,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/function-bind"
+        }
       ]
     },
     {
@@ -8610,6 +11122,12 @@
           "url": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/function.prototype.name"
         }
       ]
     },
@@ -8631,6 +11149,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/functions-have-names"
+        }
       ]
     },
     {
@@ -8650,6 +11174,12 @@
           "url": "https://registry.npmjs.org/fuzzball/-/fuzzball-1.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fuzzball"
         }
       ]
     },
@@ -8671,6 +11201,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/gauge"
+        }
       ]
     },
     {
@@ -8690,6 +11226,12 @@
           "url": "https://registry.npmjs.org/geojson-utils/-/geojson-utils-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/geojson-utils"
         }
       ]
     },
@@ -8711,6 +11253,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-caller-file"
+        }
       ]
     },
     {
@@ -8730,6 +11278,12 @@
           "url": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-intrinsic"
         }
       ]
     },
@@ -8751,6 +11305,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-stream"
+        }
       ]
     },
     {
@@ -8770,6 +11330,12 @@
           "url": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-symbol-description"
         }
       ]
     },
@@ -8791,6 +11357,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-value"
+        }
       ]
     },
     {
@@ -8810,6 +11382,12 @@
           "url": "https://registry.npmjs.org/getobject/-/getobject-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/getobject"
         }
       ]
     },
@@ -8831,6 +11409,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/getpass"
+        }
       ]
     },
     {
@@ -8850,6 +11434,12 @@
           "url": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/github-from-package"
         }
       ]
     },
@@ -8872,6 +11462,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/glob-parent"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -8890,6 +11486,12 @@
               "url": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/glob-parent/node_modules/is-glob"
             }
           ]
         }
@@ -8914,6 +11516,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/glob"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -8932,6 +11540,12 @@
               "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/glob/node_modules/brace-expansion"
             }
           ]
         },
@@ -8952,6 +11566,12 @@
               "url": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/glob/node_modules/minimatch"
             }
           ]
         }
@@ -8975,6 +11595,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/global-modules"
+        }
       ]
     },
     {
@@ -8996,6 +11622,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/global-prefix"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9014,6 +11646,12 @@
               "url": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/global-prefix/node_modules/which"
             }
           ]
         }
@@ -9038,6 +11676,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/got"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9056,6 +11700,12 @@
               "url": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/got/node_modules/get-stream"
             }
           ]
         },
@@ -9076,6 +11726,12 @@
               "url": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/got/node_modules/pify"
             }
           ]
         }
@@ -9099,6 +11755,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/graceful-fs"
+        }
       ]
     },
     {
@@ -9120,6 +11782,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-cli"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9138,6 +11806,12 @@
               "url": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-cli/node_modules/nopt"
             }
           ]
         }
@@ -9162,6 +11836,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-contrib-compress"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9180,6 +11860,12 @@
               "url": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-contrib-compress/node_modules/ansi-styles"
             }
           ]
         },
@@ -9201,6 +11887,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-contrib-compress/node_modules/chalk"
+            }
           ]
         },
         {
@@ -9220,6 +11912,12 @@
               "url": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-contrib-compress/node_modules/supports-color"
             }
           ]
         }
@@ -9243,6 +11941,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-known-options"
+        }
       ]
     },
     {
@@ -9264,6 +11968,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-legacy-log-utils"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9282,6 +11992,12 @@
               "url": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils/node_modules/ansi-styles"
             }
           ]
         },
@@ -9303,6 +12019,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils/node_modules/chalk"
+            }
           ]
         },
         {
@@ -9322,6 +12044,12 @@
               "url": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils/node_modules/color-convert"
             }
           ]
         },
@@ -9343,6 +12071,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils/node_modules/color-name"
+            }
           ]
         },
         {
@@ -9363,6 +12097,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils/node_modules/has-flag"
+            }
           ]
         },
         {
@@ -9382,6 +12122,12 @@
               "url": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils/node_modules/supports-color"
             }
           ]
         }
@@ -9406,6 +12152,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-legacy-log"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9424,6 +12176,12 @@
               "url": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log/node_modules/colors"
             }
           ]
         }
@@ -9448,6 +12206,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-legacy-util"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9466,6 +12230,12 @@
               "url": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-util/node_modules/async"
             }
           ]
         }
@@ -9489,6 +12259,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-replace-json"
+        }
       ]
     },
     {
@@ -9510,6 +12286,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9528,6 +12310,12 @@
               "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt/node_modules/brace-expansion"
             }
           ]
         },
@@ -9550,6 +12338,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt/node_modules/findup-sync"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -9568,6 +12362,12 @@
                   "url": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/grunt/node_modules/findup-sync/node_modules/glob"
                 }
               ]
             }
@@ -9591,6 +12391,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt/node_modules/glob"
+            }
           ]
         },
         {
@@ -9610,6 +12416,12 @@
               "url": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.8.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt/node_modules/minimatch"
             }
           ]
         }
@@ -9634,6 +12446,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/handlebars"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9652,6 +12470,12 @@
               "url": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/handlebars/node_modules/wordwrap"
             }
           ]
         }
@@ -9675,6 +12499,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/har-schema"
+        }
       ]
     },
     {
@@ -9694,6 +12524,12 @@
           "url": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/har-validator"
         }
       ]
     },
@@ -9715,6 +12551,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-ansi"
+        }
       ]
     },
     {
@@ -9734,6 +12576,12 @@
           "url": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-bigints"
         }
       ]
     },
@@ -9755,6 +12603,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-flag"
+        }
       ]
     },
     {
@@ -9774,6 +12628,12 @@
           "url": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-property-descriptors"
         }
       ]
     },
@@ -9795,6 +12655,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-symbol-support-x"
+        }
       ]
     },
     {
@@ -9814,6 +12680,12 @@
           "url": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-symbols"
         }
       ]
     },
@@ -9835,6 +12707,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-to-string-tag-x"
+        }
       ]
     },
     {
@@ -9854,6 +12732,12 @@
           "url": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-tostringtag"
         }
       ]
     },
@@ -9875,6 +12759,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-unicode"
+        }
       ]
     },
     {
@@ -9894,6 +12784,12 @@
           "url": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-value"
         }
       ]
     },
@@ -9916,6 +12812,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-values"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9934,6 +12836,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/has-values/node_modules/kind-of"
             }
           ]
         }
@@ -9957,6 +12865,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has"
+        }
       ]
     },
     {
@@ -9976,6 +12890,12 @@
           "url": "https://registry.npmjs.org/hashids/-/hashids-2.2.10.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hashids"
         }
       ]
     },
@@ -9997,6 +12917,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hbs"
+        }
       ]
     },
     {
@@ -10016,6 +12942,12 @@
           "url": "https://registry.npmjs.org/he/-/he-0.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/he"
         }
       ]
     },
@@ -10037,6 +12969,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/heap"
+        }
       ]
     },
     {
@@ -10056,6 +12994,12 @@
           "url": "https://registry.npmjs.org/helmet/-/helmet-4.6.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/helmet"
         }
       ]
     },
@@ -10077,6 +13021,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hoister"
+        }
       ]
     },
     {
@@ -10096,6 +13046,12 @@
           "url": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/homedir-polyfill"
         }
       ]
     },
@@ -10117,6 +13073,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hooker"
+        }
       ]
     },
     {
@@ -10137,6 +13099,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hosted-git-info"
+        }
       ]
     },
     {
@@ -10156,6 +13124,12 @@
           "url": "https://registry.npmjs.org/html-entities/-/html-entities-1.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/html-entities"
         }
       ]
     },
@@ -10178,6 +13152,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/htmlparser2"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -10196,6 +13176,12 @@
               "url": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/htmlparser2/node_modules/isarray"
             }
           ]
         },
@@ -10217,6 +13203,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/htmlparser2/node_modules/readable-stream"
+            }
           ]
         },
         {
@@ -10236,6 +13228,12 @@
               "url": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/htmlparser2/node_modules/string_decoder"
             }
           ]
         }
@@ -10259,6 +13257,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/http-cache-semantics"
+        }
       ]
     },
     {
@@ -10278,6 +13282,12 @@
           "url": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/http-errors"
         }
       ]
     },
@@ -10300,6 +13310,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/http-proxy-agent"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -10318,6 +13334,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/http-proxy-agent/node_modules/debug"
             }
           ]
         },
@@ -10338,6 +13360,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/http-proxy-agent/node_modules/ms"
             }
           ]
         }
@@ -10361,6 +13389,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/http-signature"
+        }
       ]
     },
     {
@@ -10382,6 +13416,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/https-proxy-agent"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -10400,6 +13440,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/https-proxy-agent/node_modules/debug"
             }
           ]
         },
@@ -10420,6 +13466,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/https-proxy-agent/node_modules/ms"
             }
           ]
         }
@@ -10443,6 +13495,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/humanize-ms"
+        }
       ]
     },
     {
@@ -10462,6 +13520,12 @@
           "url": "https://registry.npmjs.org/i18n/-/i18n-0.11.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/i18n"
         }
       ]
     },
@@ -10483,6 +13547,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/iconv-lite"
+        }
       ]
     },
     {
@@ -10502,6 +13572,12 @@
           "url": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ieee754"
         }
       ]
     },
@@ -10524,6 +13600,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ignore-walk"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -10542,6 +13624,12 @@
               "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/ignore-walk/node_modules/brace-expansion"
             }
           ]
         },
@@ -10562,6 +13650,12 @@
               "url": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/ignore-walk/node_modules/minimatch"
             }
           ]
         }
@@ -10585,6 +13679,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/iltorb"
+        }
       ]
     },
     {
@@ -10604,6 +13704,12 @@
           "url": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/imurmurhash"
         }
       ]
     },
@@ -10625,6 +13731,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/indent-string"
+        }
       ]
     },
     {
@@ -10644,6 +13756,12 @@
           "url": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/infer-owner"
         }
       ]
     },
@@ -10665,6 +13783,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/inflection"
+        }
       ]
     },
     {
@@ -10684,6 +13808,12 @@
           "url": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/inflight"
         }
       ]
     },
@@ -10705,6 +13835,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/inherits"
+        }
       ]
     },
     {
@@ -10724,6 +13860,12 @@
           "url": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ini"
         }
       ]
     },
@@ -10745,6 +13887,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/internal-slot"
+        }
       ]
     },
     {
@@ -10764,6 +13912,12 @@
           "url": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/interpret"
         }
       ]
     },
@@ -10785,6 +13939,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/into-stream"
+        }
       ]
     },
     {
@@ -10804,6 +13964,12 @@
           "url": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/invariant"
         }
       ]
     },
@@ -10825,6 +13991,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ip"
+        }
       ]
     },
     {
@@ -10844,6 +14016,12 @@
           "url": "https://registry.npmjs.org/ip6/-/ip6-0.2.10.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ip6"
         }
       ]
     },
@@ -10865,6 +14043,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ipaddr.js"
+        }
       ]
     },
     {
@@ -10884,6 +14068,12 @@
           "url": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-absolute"
         }
       ]
     },
@@ -10905,6 +14095,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-accessor-descriptor"
+        }
       ]
     },
     {
@@ -10924,6 +14120,12 @@
           "url": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-arguments"
         }
       ]
     },
@@ -10945,6 +14147,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-arrayish"
+        }
       ]
     },
     {
@@ -10964,6 +14172,12 @@
           "url": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-bigint"
         }
       ]
     },
@@ -10985,6 +14199,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-binary-path"
+        }
       ]
     },
     {
@@ -11004,6 +14224,12 @@
           "url": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-boolean-object"
         }
       ]
     },
@@ -11025,6 +14251,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-buffer"
+        }
       ]
     },
     {
@@ -11044,6 +14276,12 @@
           "url": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-callable"
         }
       ]
     },
@@ -11065,6 +14303,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-core-module"
+        }
       ]
     },
     {
@@ -11084,6 +14328,12 @@
           "url": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-data-descriptor"
         }
       ]
     },
@@ -11105,6 +14355,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-date-object"
+        }
       ]
     },
     {
@@ -11124,6 +14380,12 @@
           "url": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-descriptor"
         }
       ]
     },
@@ -11145,6 +14407,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-docker"
+        }
       ]
     },
     {
@@ -11164,6 +14432,12 @@
           "url": "https://registry.npmjs.org/is-expression/-/is-expression-4.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-expression"
         }
       ]
     },
@@ -11185,6 +14459,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-extendable"
+        }
       ]
     },
     {
@@ -11204,6 +14484,12 @@
           "url": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-extglob"
         }
       ]
     },
@@ -11225,6 +14511,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-fullwidth-code-point"
+        }
       ]
     },
     {
@@ -11244,6 +14536,12 @@
           "url": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-generator-function"
         }
       ]
     },
@@ -11265,6 +14563,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-glob"
+        }
       ]
     },
     {
@@ -11284,6 +14588,12 @@
           "url": "https://registry.npmjs.org/is-heroku/-/is-heroku-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-heroku"
         }
       ]
     },
@@ -11305,6 +14615,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-lambda"
+        }
       ]
     },
     {
@@ -11324,6 +14640,12 @@
           "url": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-map"
         }
       ]
     },
@@ -11345,6 +14667,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-natural-number"
+        }
       ]
     },
     {
@@ -11364,6 +14692,12 @@
           "url": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-negative-zero"
         }
       ]
     },
@@ -11385,6 +14719,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-number-like"
+        }
       ]
     },
     {
@@ -11404,6 +14744,12 @@
           "url": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-number-object"
         }
       ]
     },
@@ -11426,6 +14772,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-number"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -11444,6 +14796,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/is-number/node_modules/kind-of"
             }
           ]
         }
@@ -11467,6 +14825,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-object"
+        }
       ]
     },
     {
@@ -11486,6 +14850,12 @@
           "url": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-plain-obj"
         }
       ]
     },
@@ -11507,6 +14877,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-plain-object"
+        }
       ]
     },
     {
@@ -11526,6 +14902,12 @@
           "url": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-promise"
         }
       ]
     },
@@ -11547,6 +14929,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-regex"
+        }
       ]
     },
     {
@@ -11566,6 +14954,12 @@
           "url": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-relative"
         }
       ]
     },
@@ -11587,6 +14981,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-retry-allowed"
+        }
       ]
     },
     {
@@ -11606,6 +15006,12 @@
           "url": "https://registry.npmjs.org/is-set/-/is-set-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-set"
         }
       ]
     },
@@ -11627,6 +15033,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-shared-array-buffer"
+        }
       ]
     },
     {
@@ -11646,6 +15058,12 @@
           "url": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-stream"
         }
       ]
     },
@@ -11667,6 +15085,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-string"
+        }
       ]
     },
     {
@@ -11686,6 +15110,12 @@
           "url": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-symbol"
         }
       ]
     },
@@ -11707,6 +15137,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-typed-array"
+        }
       ]
     },
     {
@@ -11726,6 +15162,12 @@
           "url": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-typedarray"
         }
       ]
     },
@@ -11747,6 +15189,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-unc-path"
+        }
       ]
     },
     {
@@ -11766,6 +15214,12 @@
           "url": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-weakmap"
         }
       ]
     },
@@ -11787,6 +15241,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-weakref"
+        }
       ]
     },
     {
@@ -11806,6 +15266,12 @@
           "url": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-weakset"
         }
       ]
     },
@@ -11827,6 +15293,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-windows"
+        }
       ]
     },
     {
@@ -11846,6 +15318,12 @@
           "url": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isarray"
         }
       ]
     },
@@ -11867,6 +15345,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isexe"
+        }
       ]
     },
     {
@@ -11886,6 +15370,12 @@
           "url": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isobject"
         }
       ]
     },
@@ -11907,6 +15397,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isstream"
+        }
       ]
     },
     {
@@ -11926,6 +15422,12 @@
           "url": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isurl"
         }
       ]
     },
@@ -11947,6 +15449,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/js-stringify"
+        }
       ]
     },
     {
@@ -11966,6 +15474,12 @@
           "url": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/js-tokens"
         }
       ]
     },
@@ -11987,6 +15501,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/js-yaml"
+        }
       ]
     },
     {
@@ -12006,6 +15526,12 @@
           "url": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jsbn"
         }
       ]
     },
@@ -12027,6 +15553,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-buffer"
+        }
       ]
     },
     {
@@ -12046,6 +15578,12 @@
           "url": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-parse-better-errors"
         }
       ]
     },
@@ -12067,6 +15605,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-schema-traverse"
+        }
       ]
     },
     {
@@ -12086,6 +15630,12 @@
           "url": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-schema"
         }
       ]
     },
@@ -12107,6 +15657,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-stringify-safe"
+        }
       ]
     },
     {
@@ -12126,6 +15682,12 @@
           "url": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json5"
         }
       ]
     },
@@ -12147,6 +15709,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jsonfile"
+        }
       ]
     },
     {
@@ -12166,6 +15734,12 @@
           "url": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-0.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jsonwebtoken"
         }
       ]
     },
@@ -12187,6 +15761,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jsprim"
+        }
       ]
     },
     {
@@ -12206,6 +15786,12 @@
           "url": "https://registry.npmjs.org/jssha/-/jssha-3.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jssha"
         }
       ]
     },
@@ -12227,6 +15813,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jstransformer"
+        }
       ]
     },
     {
@@ -12246,6 +15838,12 @@
           "url": "https://registry.npmjs.org/juicy-chat-bot/-/juicy-chat-bot-0.6.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/juicy-chat-bot"
         }
       ]
     },
@@ -12267,6 +15865,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jwa"
+        }
       ]
     },
     {
@@ -12286,6 +15890,12 @@
           "url": "https://registry.npmjs.org/jws/-/jws-0.2.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jws"
         }
       ]
     },
@@ -12307,6 +15917,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/keyv"
+        }
       ]
     },
     {
@@ -12326,6 +15942,12 @@
           "url": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/kind-of"
         }
       ]
     },
@@ -12347,6 +15969,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/kuler"
+        }
       ]
     },
     {
@@ -12366,6 +15994,12 @@
           "url": "https://registry.npmjs.org/kuromoji/-/kuromoji-0.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/kuromoji"
         }
       ]
     },
@@ -12387,6 +16021,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lazystream"
+        }
       ]
     },
     {
@@ -12406,6 +16046,12 @@
           "url": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/levn"
         }
       ]
     },
@@ -12428,6 +16074,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/libxmljs2"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12446,6 +16098,12 @@
               "url": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/libxmljs2/node_modules/nan"
             }
           ]
         }
@@ -12470,6 +16128,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/liftup"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12488,6 +16152,12 @@
               "url": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/braces"
             }
           ]
         },
@@ -12509,6 +16179,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/fill-range"
+            }
           ]
         },
         {
@@ -12528,6 +16204,12 @@
               "url": "https://registry.npmjs.org/findup-sync/-/findup-sync-4.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/findup-sync"
             }
           ]
         },
@@ -12549,6 +16231,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/is-glob"
+            }
           ]
         },
         {
@@ -12568,6 +16256,12 @@
               "url": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/is-number"
             }
           ]
         },
@@ -12589,6 +16283,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/micromatch"
+            }
           ]
         },
         {
@@ -12608,6 +16308,12 @@
               "url": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup/node_modules/to-regex-range"
             }
           ]
         }
@@ -12632,6 +16338,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/linebreak"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12650,6 +16362,12 @@
               "url": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/linebreak/node_modules/base64-js"
             }
           ]
         }
@@ -12673,6 +16391,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/listenercount"
+        }
       ]
     },
     {
@@ -12692,6 +16416,12 @@
           "url": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/locate-path"
         }
       ]
     },
@@ -12713,6 +16443,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lodash.camelcase"
+        }
       ]
     },
     {
@@ -12732,6 +16468,12 @@
           "url": "https://registry.npmjs.org/lodash.isfinite/-/lodash.isfinite-3.3.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lodash.isfinite"
         }
       ]
     },
@@ -12753,6 +16495,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lodash.set"
+        }
       ]
     },
     {
@@ -12772,6 +16520,12 @@
           "url": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lodash"
         }
       ]
     },
@@ -12794,6 +16548,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/logform"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12812,6 +16572,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/logform/node_modules/ms"
             }
           ]
         }
@@ -12835,6 +16601,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lolex"
+        }
       ]
     },
     {
@@ -12854,6 +16626,12 @@
           "url": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/loose-envify"
         }
       ]
     },
@@ -12875,6 +16653,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lowercase-keys"
+        }
       ]
     },
     {
@@ -12894,6 +16678,12 @@
           "url": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lru-cache"
         }
       ]
     },
@@ -12916,6 +16706,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-dir"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12934,6 +16730,12 @@
               "url": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-dir/node_modules/semver"
             }
           ]
         }
@@ -12957,6 +16759,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-error"
+        }
       ]
     },
     {
@@ -12976,6 +16784,12 @@
           "url": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-9.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-fetch-happen"
         }
       ],
       "components": [
@@ -12998,6 +16812,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen/node_modules/@tootallnate/once"
+            }
           ]
         },
         {
@@ -13017,6 +16837,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen/node_modules/debug"
             }
           ]
         },
@@ -13038,6 +16864,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen/node_modules/http-cache-semantics"
+            }
           ]
         },
         {
@@ -13058,6 +16890,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen/node_modules/http-proxy-agent"
+            }
           ]
         },
         {
@@ -13077,6 +16915,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen/node_modules/ms"
             }
           ]
         }
@@ -13100,6 +16944,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-iterator"
+        }
       ]
     },
     {
@@ -13119,6 +16969,12 @@
           "url": "https://registry.npmjs.org/make-plural/-/make-plural-6.2.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-plural"
         }
       ]
     },
@@ -13140,6 +16996,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/map-cache"
+        }
       ]
     },
     {
@@ -13159,6 +17021,12 @@
           "url": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/map-visit"
         }
       ]
     },
@@ -13180,6 +17048,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/marsdb"
+        }
       ]
     },
     {
@@ -13199,6 +17073,12 @@
           "url": "https://registry.npmjs.org/math-interval-parser/-/math-interval-parser-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/math-interval-parser"
         }
       ]
     },
@@ -13220,6 +17100,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/media-typer"
+        }
       ]
     },
     {
@@ -13239,6 +17125,12 @@
           "url": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/merge-descriptors"
         }
       ]
     },
@@ -13260,6 +17152,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/messageformat-formatters"
+        }
       ]
     },
     {
@@ -13279,6 +17177,12 @@
           "url": "https://registry.npmjs.org/messageformat-parser/-/messageformat-parser-4.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/messageformat-parser"
         }
       ]
     },
@@ -13301,6 +17205,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/messageformat"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -13319,6 +17229,12 @@
               "url": "https://registry.npmjs.org/make-plural/-/make-plural-4.3.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/messageformat/node_modules/make-plural"
             }
           ]
         }
@@ -13342,6 +17258,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/methods"
+        }
       ]
     },
     {
@@ -13361,6 +17283,12 @@
           "url": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/micromatch"
         }
       ]
     },
@@ -13382,6 +17310,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mime-db"
+        }
       ]
     },
     {
@@ -13401,6 +17335,12 @@
           "url": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mime-types"
         }
       ]
     },
@@ -13422,6 +17362,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mime"
+        }
       ]
     },
     {
@@ -13441,6 +17387,12 @@
           "url": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mimic-response"
         }
       ]
     },
@@ -13462,6 +17414,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minimatch"
+        }
       ]
     },
     {
@@ -13481,6 +17439,12 @@
           "url": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minimist"
         }
       ]
     },
@@ -13502,6 +17466,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-collect"
+        }
       ]
     },
     {
@@ -13521,6 +17491,12 @@
           "url": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-1.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-fetch"
         }
       ]
     },
@@ -13542,6 +17518,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-flush"
+        }
       ]
     },
     {
@@ -13561,6 +17543,12 @@
           "url": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-pipeline"
         }
       ]
     },
@@ -13582,6 +17570,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-sized"
+        }
       ]
     },
     {
@@ -13601,6 +17595,12 @@
           "url": "https://registry.npmjs.org/minipass/-/minipass-3.3.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass"
         }
       ]
     },
@@ -13622,6 +17622,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minizlib"
+        }
       ]
     },
     {
@@ -13641,6 +17647,12 @@
           "url": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mixin-deep"
         }
       ]
     },
@@ -13662,6 +17674,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mkdirp-classic"
+        }
       ]
     },
     {
@@ -13681,6 +17699,12 @@
           "url": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mkdirp"
         }
       ]
     },
@@ -13702,6 +17726,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/moment-timezone"
+        }
       ]
     },
     {
@@ -13721,6 +17751,12 @@
           "url": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/moment"
         }
       ]
     },
@@ -13743,6 +17779,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/morgan"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -13761,6 +17803,12 @@
               "url": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/morgan/node_modules/on-finished"
             }
           ]
         }
@@ -13784,6 +17832,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mout"
+        }
       ]
     },
     {
@@ -13803,6 +17857,12 @@
           "url": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ms"
         }
       ]
     },
@@ -13825,6 +17885,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/multer"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -13843,6 +17909,12 @@
               "url": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/multer/node_modules/mkdirp"
             }
           ]
         }
@@ -13866,6 +17938,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mustache"
+        }
       ]
     },
     {
@@ -13885,6 +17963,12 @@
           "url": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/nan"
         }
       ]
     },
@@ -13906,6 +17990,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/nanomatch"
+        }
       ]
     },
     {
@@ -13925,6 +18015,12 @@
           "url": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/napi-build-utils"
         }
       ]
     },
@@ -13947,6 +18043,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/needle"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -13965,6 +18067,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/needle/node_modules/debug"
             }
           ]
         },
@@ -13985,6 +18093,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/needle/node_modules/ms"
             }
           ]
         }
@@ -14008,6 +18122,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/negotiator"
+        }
       ]
     },
     {
@@ -14027,6 +18147,12 @@
           "url": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/neo-async"
         }
       ]
     },
@@ -14049,6 +18175,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-abi"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14067,6 +18199,12 @@
               "url": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-abi/node_modules/semver"
             }
           ]
         }
@@ -14090,6 +18228,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-addon-api"
+        }
       ]
     },
     {
@@ -14109,6 +18253,12 @@
           "url": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-fetch"
         }
       ]
     },
@@ -14131,6 +18281,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-gyp"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14149,6 +18305,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/ansi-regex"
             }
           ]
         },
@@ -14170,6 +18332,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/are-we-there-yet"
+            }
           ]
         },
         {
@@ -14189,6 +18357,12 @@
               "url": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/gauge"
             }
           ]
         },
@@ -14210,6 +18384,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/is-fullwidth-code-point"
+            }
           ]
         },
         {
@@ -14229,6 +18409,12 @@
               "url": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/nopt"
             }
           ]
         },
@@ -14250,6 +18436,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/npmlog"
+            }
           ]
         },
         {
@@ -14269,6 +18461,12 @@
               "url": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/readable-stream"
             }
           ]
         },
@@ -14290,6 +18488,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/string-width"
+            }
           ]
         },
         {
@@ -14309,6 +18513,12 @@
               "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp/node_modules/strip-ansi"
             }
           ]
         }
@@ -14333,6 +18543,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-pre-gyp"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14351,6 +18567,12 @@
               "url": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/chownr"
             }
           ]
         },
@@ -14372,6 +18594,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/fs-minipass"
+            }
           ]
         },
         {
@@ -14391,6 +18619,12 @@
               "url": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/minipass"
             }
           ]
         },
@@ -14412,6 +18646,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/minizlib"
+            }
           ]
         },
         {
@@ -14431,6 +18671,12 @@
               "url": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/mkdirp"
             }
           ]
         },
@@ -14452,6 +18698,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/nopt"
+            }
           ]
         },
         {
@@ -14471,6 +18723,12 @@
               "url": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/rimraf"
             }
           ]
         },
@@ -14492,6 +18750,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/safe-buffer"
+            }
           ]
         },
         {
@@ -14511,6 +18775,12 @@
               "url": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/semver"
             }
           ]
         },
@@ -14532,6 +18802,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/tar"
+            }
           ]
         },
         {
@@ -14551,6 +18827,12 @@
               "url": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp/node_modules/yallist"
             }
           ]
         }
@@ -14574,6 +18856,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/noop-logger"
+        }
       ]
     },
     {
@@ -14593,6 +18881,12 @@
           "url": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/nopt"
         }
       ]
     },
@@ -14615,6 +18909,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/normalize-package-data"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14633,6 +18933,12 @@
               "url": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/normalize-package-data/node_modules/semver"
             }
           ]
         }
@@ -14656,6 +18962,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/normalize-path"
+        }
       ]
     },
     {
@@ -14675,6 +18987,12 @@
           "url": "https://registry.npmjs.org/normalize-url/-/normalize-url-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/normalize-url"
         }
       ]
     },
@@ -14697,6 +19015,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/notevil"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14715,6 +19039,12 @@
               "url": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/notevil/node_modules/esprima"
             }
           ]
         }
@@ -14738,6 +19068,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/npm-bundled"
+        }
       ]
     },
     {
@@ -14757,6 +19093,12 @@
           "url": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/npm-normalize-package-bin"
         }
       ]
     },
@@ -14778,6 +19120,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/npm-packlist"
+        }
       ]
     },
     {
@@ -14797,6 +19145,12 @@
           "url": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/npmlog"
         }
       ]
     },
@@ -14818,6 +19172,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/number-is-nan"
+        }
       ]
     },
     {
@@ -14838,6 +19198,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/oauth-sign"
+        }
       ]
     },
     {
@@ -14857,6 +19223,12 @@
           "url": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-assign"
         }
       ]
     },
@@ -14879,6 +19251,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-copy"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14897,6 +19275,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy/node_modules/define-property"
             }
           ]
         },
@@ -14918,6 +19302,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy/node_modules/is-accessor-descriptor"
+            }
           ]
         },
         {
@@ -14937,6 +19327,12 @@
               "url": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy/node_modules/is-data-descriptor"
             }
           ]
         },
@@ -14959,6 +19355,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy/node_modules/is-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -14977,6 +19379,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/object-copy/node_modules/is-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -15000,6 +19408,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy/node_modules/kind-of"
+            }
           ]
         }
       ]
@@ -15022,6 +19436,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-inspect"
+        }
       ]
     },
     {
@@ -15041,6 +19461,12 @@
           "url": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-is"
         }
       ]
     },
@@ -15062,6 +19488,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-keys"
+        }
       ]
     },
     {
@@ -15081,6 +19513,12 @@
           "url": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-visit"
         }
       ]
     },
@@ -15102,6 +19540,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object.assign"
+        }
       ]
     },
     {
@@ -15121,6 +19565,12 @@
           "url": "https://registry.npmjs.org/object.defaults/-/object.defaults-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object.defaults"
         }
       ]
     },
@@ -15142,6 +19592,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object.map"
+        }
       ]
     },
     {
@@ -15161,6 +19617,12 @@
           "url": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object.pick"
         }
       ]
     },
@@ -15182,6 +19644,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/on-finished"
+        }
       ]
     },
     {
@@ -15201,6 +19669,12 @@
           "url": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/on-headers"
         }
       ]
     },
@@ -15222,6 +19696,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/once"
+        }
       ]
     },
     {
@@ -15241,6 +19721,12 @@
           "url": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/one-time"
         }
       ]
     },
@@ -15262,6 +19748,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/opentype.js"
+        }
       ]
     },
     {
@@ -15281,6 +19773,12 @@
           "url": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/optionator"
         }
       ]
     },
@@ -15302,6 +19800,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/os-homedir"
+        }
       ]
     },
     {
@@ -15321,6 +19825,12 @@
           "url": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/os-tmpdir"
         }
       ]
     },
@@ -15342,6 +19852,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/osenv"
+        }
       ]
     },
     {
@@ -15361,6 +19877,12 @@
           "url": "https://registry.npmjs.org/otplib/-/otplib-12.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/otplib"
         }
       ]
     },
@@ -15382,6 +19904,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-cancelable"
+        }
       ]
     },
     {
@@ -15401,6 +19929,12 @@
           "url": "https://registry.npmjs.org/p-event/-/p-event-2.3.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-event"
         }
       ]
     },
@@ -15422,6 +19956,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-finally"
+        }
       ]
     },
     {
@@ -15441,6 +19981,12 @@
           "url": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-is-promise"
         }
       ]
     },
@@ -15462,6 +20008,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-limit"
+        }
       ]
     },
     {
@@ -15481,6 +20033,12 @@
           "url": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-locate"
         }
       ]
     },
@@ -15502,6 +20060,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-map"
+        }
       ]
     },
     {
@@ -15521,6 +20085,12 @@
           "url": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-timeout"
         }
       ]
     },
@@ -15542,6 +20112,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-try"
+        }
       ]
     },
     {
@@ -15561,6 +20137,12 @@
           "url": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pako"
         }
       ]
     },
@@ -15582,6 +20164,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/parse-filepath"
+        }
       ]
     },
     {
@@ -15601,6 +20189,12 @@
           "url": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/parse-json"
         }
       ]
     },
@@ -15622,6 +20216,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/parse-passwd"
+        }
       ]
     },
     {
@@ -15641,6 +20241,12 @@
           "url": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/parseurl"
         }
       ]
     },
@@ -15662,6 +20268,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pascalcase"
+        }
       ]
     },
     {
@@ -15681,6 +20293,12 @@
           "url": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-exists"
         }
       ]
     },
@@ -15702,6 +20320,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-is-absolute"
+        }
       ]
     },
     {
@@ -15721,6 +20345,12 @@
           "url": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-parse"
         }
       ]
     },
@@ -15742,6 +20372,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-root-regex"
+        }
       ]
     },
     {
@@ -15761,6 +20397,12 @@
           "url": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-root"
         }
       ]
     },
@@ -15782,6 +20424,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-to-regexp"
+        }
       ]
     },
     {
@@ -15801,6 +20449,12 @@
           "url": "https://registry.npmjs.org/pdfkit/-/pdfkit-0.11.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pdfkit"
         }
       ]
     },
@@ -15822,6 +20476,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/peek-readable"
+        }
       ]
     },
     {
@@ -15841,6 +20501,12 @@
           "url": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pend"
         }
       ]
     },
@@ -15862,6 +20528,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/performance-now"
+        }
       ]
     },
     {
@@ -15881,6 +20553,12 @@
           "url": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.5.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pg-connection-string"
         }
       ]
     },
@@ -15902,6 +20580,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/picomatch"
+        }
       ]
     },
     {
@@ -15921,6 +20605,12 @@
           "url": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pify"
         }
       ]
     },
@@ -15942,6 +20632,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pinkie-promise"
+        }
       ]
     },
     {
@@ -15961,6 +20657,12 @@
           "url": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pinkie"
         }
       ]
     },
@@ -15982,6 +20684,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/png-js"
+        }
       ]
     },
     {
@@ -16001,6 +20709,12 @@
           "url": "https://registry.npmjs.org/portscanner/-/portscanner-2.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/portscanner"
         }
       ]
     },
@@ -16022,6 +20736,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/posix-character-classes"
+        }
       ]
     },
     {
@@ -16041,6 +20761,12 @@
           "url": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.3.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/prebuild-install"
         }
       ]
     },
@@ -16062,6 +20788,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/prelude-ls"
+        }
       ]
     },
     {
@@ -16081,6 +20813,12 @@
           "url": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/prepend-http"
         }
       ]
     },
@@ -16102,6 +20840,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pretty-bytes"
+        }
       ]
     },
     {
@@ -16121,6 +20865,12 @@
           "url": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/process-nextick-args"
         }
       ]
     },
@@ -16142,6 +20892,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/prom-client"
+        }
       ]
     },
     {
@@ -16161,6 +20917,12 @@
           "url": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/promise-inflight"
         }
       ]
     },
@@ -16183,6 +20945,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/promise-retry"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -16201,6 +20969,12 @@
               "url": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/promise-retry/node_modules/err-code"
             }
           ]
         },
@@ -16221,6 +20995,12 @@
               "url": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/promise-retry/node_modules/retry"
             }
           ]
         }
@@ -16244,6 +21024,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/promise"
+        }
       ]
     },
     {
@@ -16263,6 +21049,12 @@
           "url": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/proper-lockfile"
         }
       ]
     },
@@ -16284,6 +21076,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/proxy-addr"
+        }
       ]
     },
     {
@@ -16303,6 +21101,12 @@
           "url": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/psl"
         }
       ]
     },
@@ -16324,6 +21128,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-attrs"
+        }
       ]
     },
     {
@@ -16343,6 +21153,12 @@
           "url": "https://registry.npmjs.org/pug-code-gen/-/pug-code-gen-3.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-code-gen"
         }
       ]
     },
@@ -16364,6 +21180,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-error"
+        }
       ]
     },
     {
@@ -16383,6 +21205,12 @@
           "url": "https://registry.npmjs.org/pug-filters/-/pug-filters-4.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-filters"
         }
       ]
     },
@@ -16404,6 +21232,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-lexer"
+        }
       ]
     },
     {
@@ -16423,6 +21257,12 @@
           "url": "https://registry.npmjs.org/pug-linker/-/pug-linker-4.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-linker"
         }
       ]
     },
@@ -16444,6 +21284,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-load"
+        }
       ]
     },
     {
@@ -16463,6 +21309,12 @@
           "url": "https://registry.npmjs.org/pug-parser/-/pug-parser-6.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-parser"
         }
       ]
     },
@@ -16484,6 +21336,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-runtime"
+        }
       ]
     },
     {
@@ -16503,6 +21361,12 @@
           "url": "https://registry.npmjs.org/pug-strip-comments/-/pug-strip-comments-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-strip-comments"
         }
       ]
     },
@@ -16524,6 +21388,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-walk"
+        }
       ]
     },
     {
@@ -16543,6 +21413,12 @@
           "url": "https://registry.npmjs.org/pug/-/pug-3.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug"
         }
       ]
     },
@@ -16564,6 +21440,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pump"
+        }
       ]
     },
     {
@@ -16583,6 +21465,12 @@
           "url": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/punycode"
         }
       ]
     },
@@ -16604,6 +21492,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/qs"
+        }
       ]
     },
     {
@@ -16623,6 +21517,12 @@
           "url": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/query-string"
         }
       ]
     },
@@ -16644,6 +21544,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/range_check"
+        }
       ]
     },
     {
@@ -16663,6 +21569,12 @@
           "url": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/range-parser"
         }
       ]
     },
@@ -16684,6 +21596,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/raw-body"
+        }
       ]
     },
     {
@@ -16703,6 +21621,12 @@
           "url": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/rc"
         }
       ]
     },
@@ -16725,6 +21649,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/read-pkg"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -16743,6 +21673,12 @@
               "url": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/read-pkg/node_modules/pify"
             }
           ]
         }
@@ -16767,6 +21703,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/readable-stream"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -16785,6 +21727,12 @@
               "url": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/readable-stream/node_modules/isarray"
             }
           ]
         }
@@ -16809,6 +21757,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/readable-web-to-node-stream"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -16827,6 +21781,12 @@
               "url": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/readable-web-to-node-stream/node_modules/readable-stream"
             }
           ]
         }
@@ -16850,6 +21810,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/readdirp"
+        }
       ]
     },
     {
@@ -16869,6 +21835,12 @@
           "url": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/rechoir"
         }
       ]
     },
@@ -16890,6 +21862,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/regex-not"
+        }
       ]
     },
     {
@@ -16909,6 +21887,12 @@
           "url": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/regexp.prototype.flags"
         }
       ]
     },
@@ -16930,6 +21914,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/remove-trailing-separator"
+        }
       ]
     },
     {
@@ -16950,6 +21940,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/repeat-element"
+        }
       ]
     },
     {
@@ -16969,6 +21965,12 @@
           "url": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/repeat-string"
         }
       ]
     },
@@ -16991,6 +21993,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/replace"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17009,6 +22017,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/ansi-regex"
             }
           ]
         },
@@ -17030,6 +22044,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/ansi-styles"
+            }
           ]
         },
         {
@@ -17049,6 +22069,12 @@
               "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/brace-expansion"
             }
           ]
         },
@@ -17070,6 +22096,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/cliui"
+            }
           ]
         },
         {
@@ -17089,6 +22121,12 @@
               "url": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/color-convert"
             }
           ]
         },
@@ -17110,6 +22148,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/color-name"
+            }
           ]
         },
         {
@@ -17129,6 +22173,12 @@
               "url": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/find-up"
             }
           ]
         },
@@ -17150,6 +22200,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/is-fullwidth-code-point"
+            }
           ]
         },
         {
@@ -17169,6 +22225,12 @@
               "url": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/locate-path"
             }
           ]
         },
@@ -17190,6 +22252,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/minimatch"
+            }
           ]
         },
         {
@@ -17209,6 +22277,12 @@
               "url": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/p-locate"
             }
           ]
         },
@@ -17230,6 +22304,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/path-exists"
+            }
           ]
         },
         {
@@ -17249,6 +22329,12 @@
               "url": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/string-width"
             }
           ]
         },
@@ -17270,6 +22356,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/strip-ansi"
+            }
           ]
         },
         {
@@ -17289,6 +22381,12 @@
               "url": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/wrap-ansi"
             }
           ]
         },
@@ -17310,6 +22408,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/yargs-parser"
+            }
           ]
         },
         {
@@ -17329,6 +22433,12 @@
               "url": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace/node_modules/yargs"
             }
           ]
         }
@@ -17353,6 +22463,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/request"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17371,6 +22487,12 @@
               "url": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/request/node_modules/qs"
             }
           ]
         }
@@ -17394,6 +22516,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/require-directory"
+        }
       ]
     },
     {
@@ -17413,6 +22541,12 @@
           "url": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/require-main-filename"
         }
       ]
     },
@@ -17434,6 +22568,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/resolve-dir"
+        }
       ]
     },
     {
@@ -17453,6 +22593,12 @@
           "url": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/resolve-url"
         }
       ]
     },
@@ -17474,6 +22620,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/resolve"
+        }
       ]
     },
     {
@@ -17493,6 +22645,12 @@
           "url": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/responselike"
         }
       ]
     },
@@ -17514,6 +22672,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/restructure"
+        }
       ]
     },
     {
@@ -17533,6 +22697,12 @@
           "url": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ret"
         }
       ]
     },
@@ -17554,6 +22724,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/retry-as-promised"
+        }
       ]
     },
     {
@@ -17574,6 +22750,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/retry"
+        }
       ]
     },
     {
@@ -17593,6 +22775,12 @@
           "url": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/rimraf"
         }
       ]
     },
@@ -17615,6 +22803,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/rxjs"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17633,6 +22827,12 @@
               "url": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/rxjs/node_modules/tslib"
             }
           ]
         }
@@ -17656,6 +22856,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safe-buffer"
+        }
       ]
     },
     {
@@ -17675,6 +22881,12 @@
           "url": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safe-regex-test"
         }
       ]
     },
@@ -17696,6 +22908,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safe-regex"
+        }
       ]
     },
     {
@@ -17715,6 +22933,12 @@
           "url": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safe-stable-stringify"
         }
       ]
     },
@@ -17736,6 +22960,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safer-buffer"
+        }
       ]
     },
     {
@@ -17756,6 +22986,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/samsam"
+        }
       ]
     },
     {
@@ -17775,6 +23011,12 @@
           "url": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sanitize-filename"
         }
       ]
     },
@@ -17797,6 +23039,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sanitize-html"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17815,6 +23063,12 @@
               "url": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sanitize-html/node_modules/lodash"
             }
           ]
         }
@@ -17838,6 +23092,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sax"
+        }
       ]
     },
     {
@@ -17858,6 +23118,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/seek-bzip"
+        }
       ]
     },
     {
@@ -17877,6 +23143,12 @@
           "url": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/semver"
         }
       ]
     },
@@ -17899,6 +23171,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/send"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17917,6 +23195,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/send/node_modules/ms"
             }
           ]
         }
@@ -17940,6 +23224,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sequelize-pool"
+        }
       ]
     },
     {
@@ -17961,6 +23251,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sequelize"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17979,6 +23275,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sequelize/node_modules/debug"
             }
           ]
         },
@@ -18000,6 +23302,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sequelize/node_modules/ms"
+            }
           ]
         },
         {
@@ -18019,6 +23327,12 @@
               "url": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sequelize/node_modules/uuid"
             }
           ]
         }
@@ -18043,6 +23357,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/serve-index"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18061,6 +23381,12 @@
               "url": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index/node_modules/depd"
             }
           ]
         },
@@ -18082,6 +23408,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index/node_modules/http-errors"
+            }
           ]
         },
         {
@@ -18101,6 +23433,12 @@
               "url": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index/node_modules/inherits"
             }
           ]
         },
@@ -18122,6 +23460,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index/node_modules/setprototypeof"
+            }
           ]
         },
         {
@@ -18141,6 +23485,12 @@
               "url": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index/node_modules/statuses"
             }
           ]
         }
@@ -18164,6 +23514,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/serve-static"
+        }
       ]
     },
     {
@@ -18183,6 +23539,12 @@
           "url": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/set-blocking"
         }
       ]
     },
@@ -18205,6 +23567,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/set-value"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18223,6 +23591,12 @@
               "url": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/set-value/node_modules/extend-shallow"
             }
           ]
         },
@@ -18243,6 +23617,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/set-value/node_modules/is-extendable"
             }
           ]
         }
@@ -18266,6 +23646,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/setimmediate"
+        }
       ]
     },
     {
@@ -18285,6 +23671,12 @@
           "url": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/setprototypeof"
         }
       ]
     },
@@ -18306,6 +23698,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/side-channel"
+        }
       ]
     },
     {
@@ -18326,6 +23724,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/signal-exit"
+        }
       ]
     },
     {
@@ -18345,6 +23749,12 @@
           "url": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/simple-concat"
         }
       ]
     },
@@ -18367,6 +23777,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/simple-get"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18385,6 +23801,12 @@
               "url": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/simple-get/node_modules/decompress-response"
             }
           ]
         },
@@ -18405,6 +23827,12 @@
               "url": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/simple-get/node_modules/mimic-response"
             }
           ]
         }
@@ -18429,6 +23857,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/simple-swizzle"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18447,6 +23881,12 @@
               "url": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/simple-swizzle/node_modules/is-arrayish"
             }
           ]
         }
@@ -18470,6 +23910,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sinon"
+        }
       ]
     },
     {
@@ -18489,6 +23935,12 @@
           "url": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/smart-buffer"
         }
       ]
     },
@@ -18511,6 +23963,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/snapdragon-node"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18529,6 +23987,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon-node/node_modules/define-property"
             }
           ]
         }
@@ -18553,6 +24017,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/snapdragon-util"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18571,6 +24041,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon-util/node_modules/kind-of"
             }
           ]
         }
@@ -18595,6 +24071,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/snapdragon"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18613,6 +24095,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/define-property"
             }
           ]
         },
@@ -18633,6 +24121,12 @@
               "url": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/extend-shallow"
             }
           ]
         },
@@ -18655,6 +24149,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/is-accessor-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -18673,6 +24173,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/snapdragon/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -18697,6 +24203,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/is-data-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -18715,6 +24227,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/snapdragon/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -18738,6 +24256,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/is-descriptor"
+            }
           ]
         },
         {
@@ -18757,6 +24281,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/is-extendable"
             }
           ]
         },
@@ -18778,6 +24308,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/kind-of"
+            }
           ]
         },
         {
@@ -18797,6 +24333,12 @@
               "url": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon/node_modules/source-map"
             }
           ]
         }
@@ -18820,6 +24362,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socket.io-adapter"
+        }
       ]
     },
     {
@@ -18841,6 +24389,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socket.io-parser"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18859,6 +24413,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socket.io-parser/node_modules/debug"
             }
           ]
         },
@@ -18879,6 +24439,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socket.io-parser/node_modules/ms"
             }
           ]
         }
@@ -18903,6 +24469,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socket.io"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18921,6 +24493,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socket.io/node_modules/debug"
             }
           ]
         },
@@ -18941,6 +24519,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socket.io/node_modules/ms"
             }
           ]
         }
@@ -18965,6 +24549,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socks-proxy-agent"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18983,6 +24573,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socks-proxy-agent/node_modules/debug"
             }
           ]
         },
@@ -19003,6 +24599,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socks-proxy-agent/node_modules/ms"
             }
           ]
         }
@@ -19027,6 +24629,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socks"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -19045,6 +24653,12 @@
               "url": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socks/node_modules/ip"
             }
           ]
         }
@@ -19069,6 +24683,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sort-keys-length"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -19087,6 +24707,12 @@
               "url": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sort-keys-length/node_modules/sort-keys"
             }
           ]
         }
@@ -19110,6 +24736,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sort-keys"
+        }
       ]
     },
     {
@@ -19129,6 +24761,12 @@
           "url": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/source-map-resolve"
         }
       ]
     },
@@ -19150,6 +24788,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/source-map-support"
+        }
       ]
     },
     {
@@ -19169,6 +24813,12 @@
           "url": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/source-map-url"
         }
       ]
     },
@@ -19190,6 +24840,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/source-map"
+        }
       ]
     },
     {
@@ -19209,6 +24865,12 @@
           "url": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2-1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spawn-command"
         }
       ]
     },
@@ -19230,6 +24892,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spdx-correct"
+        }
       ]
     },
     {
@@ -19249,6 +24917,12 @@
           "url": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spdx-exceptions"
         }
       ]
     },
@@ -19270,6 +24944,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spdx-expression-parse"
+        }
       ]
     },
     {
@@ -19289,6 +24969,12 @@
           "url": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.12.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spdx-license-ids"
         }
       ]
     },
@@ -19310,6 +24996,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/split-string"
+        }
       ]
     },
     {
@@ -19329,6 +25021,12 @@
           "url": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sprintf-js"
         }
       ]
     },
@@ -19350,6 +25048,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sqlite3"
+        }
       ]
     },
     {
@@ -19369,6 +25073,12 @@
           "url": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sshpk"
         }
       ]
     },
@@ -19390,6 +25100,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ssri"
+        }
       ]
     },
     {
@@ -19409,6 +25125,12 @@
           "url": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/stack-trace"
         }
       ]
     },
@@ -19431,6 +25153,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/static-extend"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -19449,6 +25177,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend/node_modules/define-property"
             }
           ]
         },
@@ -19471,6 +25205,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend/node_modules/is-accessor-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -19489,6 +25229,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/static-extend/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -19513,6 +25259,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend/node_modules/is-data-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -19531,6 +25283,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/static-extend/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
             }
@@ -19554,6 +25312,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend/node_modules/is-descriptor"
+            }
           ]
         },
         {
@@ -19573,6 +25337,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend/node_modules/kind-of"
             }
           ]
         }
@@ -19596,6 +25366,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/statuses"
+        }
       ]
     },
     {
@@ -19615,6 +25391,12 @@
           "url": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-2.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/stream-buffers"
         }
       ]
     },
@@ -19636,6 +25418,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/streamsearch"
+        }
       ]
     },
     {
@@ -19655,6 +25443,12 @@
           "url": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strict-uri-encode"
         }
       ]
     },
@@ -19676,6 +25470,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string_decoder"
+        }
       ]
     },
     {
@@ -19695,6 +25495,12 @@
           "url": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string-width"
         }
       ]
     },
@@ -19716,6 +25522,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string.fromcodepoint"
+        }
       ]
     },
     {
@@ -19735,6 +25547,12 @@
           "url": "https://registry.npmjs.org/string.prototype.codepointat/-/string.prototype.codepointat-0.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string.prototype.codepointat"
         }
       ]
     },
@@ -19756,6 +25574,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string.prototype.trimend"
+        }
       ]
     },
     {
@@ -19775,6 +25599,12 @@
           "url": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string.prototype.trimstart"
         }
       ]
     },
@@ -19796,6 +25626,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-ansi"
+        }
       ]
     },
     {
@@ -19815,6 +25651,12 @@
           "url": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-bom"
         }
       ]
     },
@@ -19836,6 +25678,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-dirs"
+        }
       ]
     },
     {
@@ -19855,6 +25703,12 @@
           "url": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-json-comments"
         }
       ]
     },
@@ -19876,6 +25730,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-outer"
+        }
       ]
     },
     {
@@ -19895,6 +25755,12 @@
           "url": "https://registry.npmjs.org/strtok3/-/strtok3-6.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strtok3"
         }
       ]
     },
@@ -19916,6 +25782,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/supports-color"
+        }
       ]
     },
     {
@@ -19935,6 +25807,12 @@
           "url": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/supports-preserve-symlinks-flag"
         }
       ]
     },
@@ -19956,6 +25834,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/svg-captcha"
+        }
       ]
     },
     {
@@ -19976,6 +25860,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/swagger-ui-dist"
+        }
       ]
     },
     {
@@ -19995,6 +25885,12 @@
           "url": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-4.5.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/swagger-ui-express"
         }
       ]
     },
@@ -20017,6 +25913,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tar-fs"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -20035,6 +25937,12 @@
               "url": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/tar-fs/node_modules/bl"
             }
           ]
         },
@@ -20056,6 +25964,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/tar-fs/node_modules/chownr"
+            }
           ]
         },
         {
@@ -20076,6 +25990,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/tar-fs/node_modules/readable-stream"
+            }
           ]
         },
         {
@@ -20095,6 +26015,12 @@
               "url": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/tar-fs/node_modules/tar-stream"
             }
           ]
         }
@@ -20118,6 +26044,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tar-stream"
+        }
       ]
     },
     {
@@ -20137,6 +26069,12 @@
           "url": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tar"
         }
       ]
     },
@@ -20158,6 +26096,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tdigest"
+        }
       ]
     },
     {
@@ -20177,6 +26121,12 @@
           "url": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/text-hex"
         }
       ]
     },
@@ -20198,6 +26148,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/thirty-two"
+        }
       ]
     },
     {
@@ -20217,6 +26173,12 @@
           "url": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/through"
         }
       ]
     },
@@ -20238,6 +26200,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/timed-out"
+        }
       ]
     },
     {
@@ -20257,6 +26225,12 @@
           "url": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tiny-inflate"
         }
       ]
     },
@@ -20278,6 +26252,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-buffer"
+        }
       ]
     },
     {
@@ -20297,6 +26277,12 @@
           "url": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-fast-properties"
         }
       ]
     },
@@ -20319,6 +26305,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-object-path"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -20337,6 +26329,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/to-object-path/node_modules/kind-of"
             }
           ]
         }
@@ -20360,6 +26358,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-regex-range"
+        }
       ]
     },
     {
@@ -20379,6 +26383,12 @@
           "url": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-regex"
         }
       ]
     },
@@ -20400,6 +26410,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/toidentifier"
+        }
       ]
     },
     {
@@ -20419,6 +26435,12 @@
           "url": "https://registry.npmjs.org/token-stream/-/token-stream-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/token-stream"
         }
       ]
     },
@@ -20440,6 +26462,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/token-types"
+        }
       ]
     },
     {
@@ -20459,6 +26487,12 @@
           "url": "https://registry.npmjs.org/toposort-class/-/toposort-class-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/toposort-class"
         }
       ]
     },
@@ -20480,6 +26514,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tough-cookie"
+        }
       ]
     },
     {
@@ -20499,6 +26539,12 @@
           "url": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tr46"
         }
       ]
     },
@@ -20520,6 +26566,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/traverse"
+        }
       ]
     },
     {
@@ -20539,6 +26591,12 @@
           "url": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tree-kill"
         }
       ]
     },
@@ -20560,6 +26618,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/trim-repeated"
+        }
       ]
     },
     {
@@ -20580,6 +26644,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/triple-beam"
+        }
       ]
     },
     {
@@ -20599,6 +26669,12 @@
           "url": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/truncate-utf8-bytes"
         }
       ]
     },
@@ -20621,6 +26697,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ts-node-dev"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -20639,6 +26721,12 @@
               "url": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/ts-node-dev/node_modules/rimraf"
             }
           ]
         }
@@ -20662,6 +26750,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ts-node"
+        }
       ]
     },
     {
@@ -20681,6 +26775,12 @@
           "url": "https://registry.npmjs.org/tsconfig/-/tsconfig-7.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tsconfig"
         }
       ]
     },
@@ -20702,6 +26802,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tslib"
+        }
       ]
     },
     {
@@ -20721,6 +26827,12 @@
           "url": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tunnel-agent"
         }
       ]
     },
@@ -20742,6 +26854,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tweetnacl"
+        }
       ]
     },
     {
@@ -20761,6 +26879,12 @@
           "url": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/type-check"
         }
       ]
     },
@@ -20782,6 +26906,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/type-is"
+        }
       ]
     },
     {
@@ -20801,6 +26931,12 @@
           "url": "https://registry.npmjs.org/typecast/-/typecast-0.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/typecast"
         }
       ]
     },
@@ -20822,6 +26958,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/typedarray"
+        }
       ]
     },
     {
@@ -20841,6 +26983,12 @@
           "url": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/typescript"
         }
       ]
     },
@@ -20862,6 +27010,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/uglify-js"
+        }
       ]
     },
     {
@@ -20881,6 +27035,12 @@
           "url": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unbox-primitive"
         }
       ]
     },
@@ -20902,6 +27062,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unbzip2-stream"
+        }
       ]
     },
     {
@@ -20921,6 +27087,12 @@
           "url": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unc-path-regex"
         }
       ]
     },
@@ -20942,6 +27114,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/underscore.string"
+        }
       ]
     },
     {
@@ -20962,6 +27140,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unicode-properties"
+        }
       ]
     },
     {
@@ -20981,6 +27165,12 @@
           "url": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unicode-trie"
         }
       ]
     },
@@ -21003,6 +27193,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/union-value"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21021,6 +27217,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/union-value/node_modules/is-extendable"
             }
           ]
         }
@@ -21044,6 +27246,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unique-filename"
+        }
       ]
     },
     {
@@ -21063,6 +27271,12 @@
           "url": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unique-slug"
         }
       ]
     },
@@ -21084,6 +27298,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unit-compare"
+        }
       ]
     },
     {
@@ -21104,6 +27324,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/universalify"
+        }
       ]
     },
     {
@@ -21123,6 +27349,12 @@
           "url": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unpipe"
         }
       ]
     },
@@ -21145,6 +27377,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unset-value"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21165,6 +27403,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/unset-value/node_modules/has-value"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -21183,6 +27427,12 @@
                   "url": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/unset-value/node_modules/has-value/node_modules/isobject"
                 }
               ]
             }
@@ -21206,6 +27456,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/unset-value/node_modules/has-values"
+            }
           ]
         },
         {
@@ -21225,6 +27481,12 @@
               "url": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/unset-value/node_modules/isarray"
             }
           ]
         }
@@ -21248,6 +27510,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/untildify"
+        }
       ]
     },
     {
@@ -21269,6 +27537,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unzipper"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21287,6 +27561,12 @@
               "url": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/unzipper/node_modules/bluebird"
             }
           ]
         }
@@ -21310,6 +27590,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/uri-js"
+        }
       ]
     },
     {
@@ -21329,6 +27615,12 @@
           "url": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/urix"
         }
       ]
     },
@@ -21350,6 +27642,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/url-parse-lax"
+        }
       ]
     },
     {
@@ -21369,6 +27667,12 @@
           "url": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/url-to-options"
         }
       ]
     },
@@ -21390,6 +27694,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/use"
+        }
       ]
     },
     {
@@ -21409,6 +27719,12 @@
           "url": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/utf8-byte-length"
         }
       ]
     },
@@ -21430,6 +27746,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/util-deprecate"
+        }
       ]
     },
     {
@@ -21449,6 +27771,12 @@
           "url": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/util"
         }
       ]
     },
@@ -21470,6 +27798,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/utils-merge"
+        }
       ]
     },
     {
@@ -21489,6 +27823,12 @@
           "url": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/uuid"
         }
       ]
     },
@@ -21510,6 +27850,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/v8flags"
+        }
       ]
     },
     {
@@ -21529,6 +27875,12 @@
           "url": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/validate-npm-package-license"
         }
       ]
     },
@@ -21550,6 +27902,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/validate"
+        }
       ]
     },
     {
@@ -21570,6 +27928,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/validator"
+        }
       ]
     },
     {
@@ -21589,6 +27953,12 @@
           "url": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/vary"
         }
       ]
     },
@@ -21611,6 +27981,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/verror"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21629,6 +28005,12 @@
               "url": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/verror/node_modules/core-util-is"
             }
           ]
         }
@@ -21653,6 +28035,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/vm2"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21671,6 +28059,12 @@
               "url": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/vm2/node_modules/acorn"
             }
           ]
         }
@@ -21694,6 +28088,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/void-elements"
+        }
       ]
     },
     {
@@ -21713,6 +28113,12 @@
           "url": "https://registry.npmjs.org/walk/-/walk-2.3.15.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/walk"
         }
       ]
     },
@@ -21734,6 +28140,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/walkdir"
+        }
       ]
     },
     {
@@ -21753,6 +28165,12 @@
           "url": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/webidl-conversions"
         }
       ]
     },
@@ -21774,6 +28192,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/whatwg-url"
+        }
       ]
     },
     {
@@ -21793,6 +28217,12 @@
           "url": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-boxed-primitive"
         }
       ]
     },
@@ -21814,6 +28244,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-collection"
+        }
       ]
     },
     {
@@ -21833,6 +28269,12 @@
           "url": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-module"
         }
       ]
     },
@@ -21854,6 +28296,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-pm-runs"
+        }
       ]
     },
     {
@@ -21873,6 +28321,12 @@
           "url": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-typed-array"
         }
       ]
     },
@@ -21894,6 +28348,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which"
+        }
       ]
     },
     {
@@ -21913,6 +28373,12 @@
           "url": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wide-align"
         }
       ]
     },
@@ -21935,6 +28401,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/winston-transport"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21953,6 +28425,12 @@
               "url": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/winston-transport/node_modules/readable-stream"
             }
           ]
         }
@@ -21977,6 +28455,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/winston"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21995,6 +28479,12 @@
               "url": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/winston/node_modules/async"
             }
           ]
         },
@@ -22016,6 +28506,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/winston/node_modules/is-stream"
+            }
           ]
         },
         {
@@ -22035,6 +28531,12 @@
               "url": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/winston/node_modules/readable-stream"
             }
           ]
         }
@@ -22058,6 +28560,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/with"
+        }
       ]
     },
     {
@@ -22077,6 +28585,12 @@
           "url": "https://registry.npmjs.org/wkx/-/wkx-0.5.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wkx"
         }
       ]
     },
@@ -22098,6 +28612,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/word-wrap"
+        }
       ]
     },
     {
@@ -22117,6 +28637,12 @@
           "url": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wordwrap"
         }
       ]
     },
@@ -22139,6 +28665,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wrap-ansi"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -22157,6 +28689,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi/node_modules/ansi-regex"
             }
           ]
         },
@@ -22178,6 +28716,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi/node_modules/emoji-regex"
+            }
           ]
         },
         {
@@ -22197,6 +28741,12 @@
               "url": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi/node_modules/is-fullwidth-code-point"
             }
           ]
         },
@@ -22218,6 +28768,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi/node_modules/string-width"
+            }
           ]
         },
         {
@@ -22237,6 +28793,12 @@
               "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi/node_modules/strip-ansi"
             }
           ]
         }
@@ -22260,6 +28822,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wrappy"
+        }
       ]
     },
     {
@@ -22279,6 +28847,12 @@
           "url": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ws"
         }
       ]
     },
@@ -22300,6 +28874,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/xtend"
+        }
       ]
     },
     {
@@ -22319,6 +28899,12 @@
           "url": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/y18n"
         }
       ]
     },
@@ -22340,6 +28926,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yallist"
+        }
       ]
     },
     {
@@ -22360,6 +28952,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yaml-schema-validator"
+        }
       ]
     },
     {
@@ -22379,6 +28977,12 @@
           "url": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yargs-parser"
         }
       ]
     },
@@ -22401,6 +29005,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yargs"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -22419,6 +29029,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs/node_modules/ansi-regex"
             }
           ]
         },
@@ -22440,6 +29056,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs/node_modules/emoji-regex"
+            }
           ]
         },
         {
@@ -22459,6 +29081,12 @@
               "url": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs/node_modules/is-fullwidth-code-point"
             }
           ]
         },
@@ -22480,6 +29108,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs/node_modules/string-width"
+            }
           ]
         },
         {
@@ -22499,6 +29133,12 @@
               "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs/node_modules/strip-ansi"
             }
           ]
         }
@@ -22522,6 +29162,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yauzl"
+        }
       ]
     },
     {
@@ -22541,6 +29187,12 @@
           "url": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yn"
         }
       ]
     },
@@ -22562,6 +29214,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/z85"
+        }
       ]
     },
     {
@@ -22582,6 +29240,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/zip-stream"
+        }
       ]
     },
     {
@@ -22601,6 +29265,12 @@
           "url": "https://registry.npmjs.org/zlibjs/-/zlibjs-0.3.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/zlibjs"
         }
       ]
     }

--- a/tests/_data/sbom_demo-results/juice-shop_npm9_node18_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/juice-shop_npm9_node18_ubuntu-latest.snap.json
@@ -62,7 +62,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -95,7 +95,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@babel/helper-string-parser"
         }
       ]
@@ -122,7 +122,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@babel/helper-validator-identifier"
         }
       ]
@@ -149,7 +149,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@babel/parser"
         }
       ]
@@ -176,7 +176,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@babel/types"
         }
       ]
@@ -203,7 +203,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@colors/colors"
         }
       ]
@@ -230,7 +230,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@dabh/diagnostics"
         }
       ]
@@ -257,7 +257,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@gar/promisify"
         }
       ]
@@ -284,7 +284,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@mapbox/node-pre-gyp"
         }
       ],
@@ -310,7 +310,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/ansi-regex"
             }
           ]
@@ -336,7 +336,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/are-we-there-yet"
             }
           ]
@@ -362,7 +362,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/detect-libc"
             }
           ]
@@ -388,7 +388,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/gauge"
             }
           ]
@@ -414,7 +414,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -440,7 +440,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/make-dir"
             }
           ],
@@ -466,7 +466,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/@mapbox/node-pre-gyp/node_modules/make-dir/node_modules/semver"
                 }
               ]
@@ -494,7 +494,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/nopt"
             }
           ]
@@ -520,7 +520,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/npmlog"
             }
           ]
@@ -546,7 +546,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/readable-stream"
             }
           ]
@@ -572,7 +572,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/string-width"
             }
           ]
@@ -598,7 +598,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox/node-pre-gyp/node_modules/strip-ansi"
             }
           ]
@@ -627,7 +627,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/core-loader"
         }
       ]
@@ -654,7 +654,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/core"
         }
       ]
@@ -681,7 +681,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/evaluator"
         }
       ]
@@ -708,7 +708,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-all"
         }
       ]
@@ -735,7 +735,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ar"
         }
       ]
@@ -762,7 +762,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-bn"
         }
       ]
@@ -789,7 +789,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ca"
         }
       ]
@@ -816,7 +816,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-cs"
         }
       ]
@@ -843,7 +843,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-da"
         }
       ]
@@ -870,7 +870,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-de"
         }
       ]
@@ -897,7 +897,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-el"
         }
       ]
@@ -924,7 +924,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-en-min"
         }
       ]
@@ -951,7 +951,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-en"
         }
       ]
@@ -978,7 +978,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-es"
         }
       ]
@@ -1005,7 +1005,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-eu"
         }
       ]
@@ -1032,7 +1032,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-fa"
         }
       ]
@@ -1059,7 +1059,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-fi"
         }
       ]
@@ -1086,7 +1086,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-fr"
         }
       ]
@@ -1113,7 +1113,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ga"
         }
       ]
@@ -1140,7 +1140,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-gl"
         }
       ]
@@ -1167,7 +1167,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-hi"
         }
       ]
@@ -1194,7 +1194,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-hu"
         }
       ]
@@ -1221,7 +1221,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-hy"
         }
       ]
@@ -1248,7 +1248,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-id"
         }
       ]
@@ -1275,7 +1275,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-it"
         }
       ]
@@ -1302,7 +1302,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ja"
         }
       ]
@@ -1329,7 +1329,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ko"
         }
       ]
@@ -1356,7 +1356,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-lt"
         }
       ]
@@ -1383,7 +1383,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ms"
         }
       ]
@@ -1410,7 +1410,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ne"
         }
       ]
@@ -1437,7 +1437,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-nl"
         }
       ]
@@ -1464,7 +1464,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-no"
         }
       ]
@@ -1491,7 +1491,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-pl"
         }
       ]
@@ -1518,7 +1518,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-pt"
         }
       ]
@@ -1545,7 +1545,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ro"
         }
       ]
@@ -1572,7 +1572,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ru"
         }
       ]
@@ -1599,7 +1599,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-sl"
         }
       ]
@@ -1626,7 +1626,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-sr"
         }
       ]
@@ -1653,7 +1653,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-sv"
         }
       ]
@@ -1680,7 +1680,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-ta"
         }
       ]
@@ -1707,7 +1707,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-th"
         }
       ]
@@ -1734,7 +1734,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-tl"
         }
       ]
@@ -1761,7 +1761,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-tr"
         }
       ]
@@ -1788,7 +1788,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-uk"
         }
       ]
@@ -1815,7 +1815,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/lang-zh"
         }
       ]
@@ -1842,7 +1842,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/language-min"
         }
       ]
@@ -1869,7 +1869,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/language"
         }
       ]
@@ -1896,7 +1896,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/ner"
         }
       ]
@@ -1923,7 +1923,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/neural"
         }
       ]
@@ -1950,7 +1950,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/nlg"
         }
       ]
@@ -1977,7 +1977,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/nlp"
         }
       ]
@@ -2004,7 +2004,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/nlu"
         }
       ]
@@ -2031,7 +2031,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/request"
         }
       ]
@@ -2058,7 +2058,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/sentiment"
         }
       ]
@@ -2085,7 +2085,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/similarity"
         }
       ]
@@ -2112,7 +2112,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs/slot"
         }
       ]
@@ -2139,7 +2139,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@npmcli/fs"
         }
       ]
@@ -2166,7 +2166,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@npmcli/move-file"
         }
       ]
@@ -2193,7 +2193,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib/core"
         }
       ]
@@ -2220,7 +2220,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib/plugin-crypto"
         }
       ]
@@ -2247,7 +2247,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib/plugin-thirty-two"
         }
       ]
@@ -2274,7 +2274,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib/preset-default"
         }
       ]
@@ -2301,7 +2301,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib/preset-v11"
         }
       ]
@@ -2328,7 +2328,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@sindresorhus/is"
         }
       ]
@@ -2355,7 +2355,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@swc/helpers"
         }
       ]
@@ -2382,7 +2382,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@tokenizer/token"
         }
       ]
@@ -2409,7 +2409,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@tootallnate/once"
         }
       ]
@@ -2436,7 +2436,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/component-emitter"
         }
       ]
@@ -2463,7 +2463,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/cookie"
         }
       ]
@@ -2490,7 +2490,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/cors"
         }
       ]
@@ -2517,7 +2517,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/debug"
         }
       ]
@@ -2544,7 +2544,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/ms"
         }
       ]
@@ -2571,7 +2571,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/node"
         }
       ]
@@ -2598,7 +2598,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/strip-bom"
         }
       ]
@@ -2625,7 +2625,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/strip-json-comments"
         }
       ]
@@ -2652,7 +2652,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types/validator"
         }
       ]
@@ -2678,7 +2678,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/abbrev"
         }
       ]
@@ -2704,7 +2704,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/accepts"
         }
       ]
@@ -2730,7 +2730,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/acorn-walk"
         }
       ]
@@ -2756,7 +2756,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/acorn"
         }
       ]
@@ -2782,7 +2782,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/agent-base"
         }
       ],
@@ -2808,7 +2808,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agent-base/node_modules/debug"
             }
           ]
@@ -2834,7 +2834,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agent-base/node_modules/ms"
             }
           ]
@@ -2862,7 +2862,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/agentkeepalive"
         }
       ],
@@ -2888,7 +2888,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agentkeepalive/node_modules/debug"
             }
           ]
@@ -2914,7 +2914,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agentkeepalive/node_modules/depd"
             }
           ]
@@ -2940,7 +2940,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agentkeepalive/node_modules/ms"
             }
           ]
@@ -2968,7 +2968,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/aggregate-error"
         }
       ]
@@ -2994,7 +2994,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ajv"
         }
       ]
@@ -3020,7 +3020,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ansi-regex"
         }
       ]
@@ -3046,7 +3046,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ansi-styles"
         }
       ]
@@ -3072,7 +3072,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/anymatch"
         }
       ],
@@ -3098,7 +3098,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/anymatch/node_modules/normalize-path"
             }
           ]
@@ -3126,7 +3126,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/append-field"
         }
       ]
@@ -3152,7 +3152,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/aproba"
         }
       ]
@@ -3178,7 +3178,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/archive-type"
         }
       ],
@@ -3204,7 +3204,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/archive-type/node_modules/file-type"
             }
           ]
@@ -3232,7 +3232,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/archiver-utils"
         }
       ]
@@ -3258,7 +3258,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/archiver"
         }
       ]
@@ -3284,7 +3284,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/are-we-there-yet"
         }
       ]
@@ -3310,7 +3310,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/arg"
         }
       ]
@@ -3336,7 +3336,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/argparse"
         }
       ],
@@ -3362,7 +3362,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/argparse/node_modules/sprintf-js"
             }
           ]
@@ -3390,7 +3390,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/arr-diff"
         }
       ]
@@ -3416,7 +3416,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/arr-flatten"
         }
       ]
@@ -3442,7 +3442,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/arr-union"
         }
       ]
@@ -3468,7 +3468,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/array-each"
         }
       ]
@@ -3494,7 +3494,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/array-flatten"
         }
       ]
@@ -3520,7 +3520,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/array-slice"
         }
       ]
@@ -3546,7 +3546,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/array-unique"
         }
       ]
@@ -3572,7 +3572,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/asap"
         }
       ]
@@ -3598,7 +3598,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/asn1"
         }
       ]
@@ -3624,7 +3624,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/assert-never"
         }
       ]
@@ -3650,7 +3650,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/assert-plus"
         }
       ]
@@ -3676,7 +3676,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/assign-symbols"
         }
       ]
@@ -3702,7 +3702,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/async"
         }
       ]
@@ -3728,7 +3728,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/asynckit"
         }
       ]
@@ -3754,7 +3754,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/at-least-node"
         }
       ]
@@ -3780,7 +3780,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/atob"
         }
       ]
@@ -3806,7 +3806,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/available-typed-arrays"
         }
       ]
@@ -3832,7 +3832,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/aws-sign2"
         }
       ]
@@ -3858,7 +3858,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/aws4"
         }
       ]
@@ -3884,7 +3884,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/babel-walk"
         }
       ]
@@ -3910,7 +3910,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/balanced-match"
         }
       ]
@@ -3936,7 +3936,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base"
         }
       ],
@@ -3962,7 +3962,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/base/node_modules/define-property"
             }
           ]
@@ -3990,7 +3990,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base64-arraybuffer"
         }
       ]
@@ -4016,7 +4016,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base64-js"
         }
       ]
@@ -4042,7 +4042,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base64id"
         }
       ]
@@ -4068,7 +4068,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base64url"
         }
       ]
@@ -4094,7 +4094,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/basic-auth"
         }
       ]
@@ -4120,7 +4120,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/batch"
         }
       ]
@@ -4146,7 +4146,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bcrypt-pbkdf"
         }
       ]
@@ -4172,7 +4172,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/big-integer"
         }
       ]
@@ -4198,7 +4198,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/binary-extensions"
         }
       ]
@@ -4224,7 +4224,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/binary"
         }
       ]
@@ -4250,7 +4250,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bindings"
         }
       ]
@@ -4276,7 +4276,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bintrees"
         }
       ]
@@ -4302,7 +4302,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bl"
         }
       ]
@@ -4328,7 +4328,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bluebird"
         }
       ]
@@ -4354,7 +4354,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/body-parser"
         }
       ]
@@ -4380,7 +4380,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bower-config"
         }
       ],
@@ -4406,7 +4406,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bower-config/node_modules/minimist"
             }
           ]
@@ -4434,7 +4434,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/brace-expansion"
         }
       ]
@@ -4460,7 +4460,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/braces"
         }
       ],
@@ -4486,7 +4486,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/braces/node_modules/extend-shallow"
             }
           ]
@@ -4512,7 +4512,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/braces/node_modules/is-extendable"
             }
           ]
@@ -4540,7 +4540,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/brotli"
         }
       ]
@@ -4566,7 +4566,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-alloc-unsafe"
         }
       ]
@@ -4592,7 +4592,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-alloc"
         }
       ]
@@ -4618,7 +4618,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-crc32"
         }
       ]
@@ -4644,7 +4644,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-fill"
         }
       ]
@@ -4670,7 +4670,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-from"
         }
       ]
@@ -4696,7 +4696,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-indexof-polyfill"
         }
       ]
@@ -4722,7 +4722,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer"
         }
       ]
@@ -4748,7 +4748,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffers"
         }
       ]
@@ -4774,7 +4774,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/busboy"
         }
       ],
@@ -4800,7 +4800,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/busboy/node_modules/isarray"
             }
           ]
@@ -4826,7 +4826,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/busboy/node_modules/readable-stream"
             }
           ]
@@ -4852,7 +4852,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/busboy/node_modules/string_decoder"
             }
           ]
@@ -4880,7 +4880,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/byline"
         }
       ]
@@ -4906,7 +4906,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bytes"
         }
       ]
@@ -4932,7 +4932,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cacache"
         }
       ]
@@ -4958,7 +4958,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cache-base"
         }
       ]
@@ -4984,7 +4984,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cacheable-request"
         }
       ],
@@ -5010,7 +5010,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cacheable-request/node_modules/get-stream"
             }
           ]
@@ -5036,7 +5036,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cacheable-request/node_modules/lowercase-keys"
             }
           ]
@@ -5064,7 +5064,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/call-bind"
         }
       ]
@@ -5090,7 +5090,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/camelcase"
         }
       ]
@@ -5116,7 +5116,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/caseless"
         }
       ]
@@ -5142,7 +5142,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/chainsaw"
         }
       ]
@@ -5168,7 +5168,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/chalk"
         }
       ]
@@ -5194,7 +5194,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/character-parser"
         }
       ]
@@ -5220,7 +5220,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/check-dependencies"
         }
       ],
@@ -5246,7 +5246,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/check-dependencies/node_modules/semver"
             }
           ]
@@ -5274,7 +5274,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/check-types"
         }
       ]
@@ -5300,7 +5300,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/chokidar"
         }
       ],
@@ -5326,7 +5326,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar/node_modules/braces"
             }
           ]
@@ -5352,7 +5352,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar/node_modules/fill-range"
             }
           ]
@@ -5378,7 +5378,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar/node_modules/is-glob"
             }
           ]
@@ -5404,7 +5404,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar/node_modules/is-number"
             }
           ]
@@ -5430,7 +5430,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar/node_modules/normalize-path"
             }
           ]
@@ -5456,7 +5456,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar/node_modules/to-regex-range"
             }
           ]
@@ -5484,7 +5484,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/chownr"
         }
       ]
@@ -5510,7 +5510,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/clarinet"
         }
       ]
@@ -5536,7 +5536,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/class-utils"
         }
       ],
@@ -5562,7 +5562,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils/node_modules/define-property"
             }
           ]
@@ -5588,7 +5588,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils/node_modules/is-accessor-descriptor"
             }
           ],
@@ -5614,7 +5614,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/class-utils/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
@@ -5642,7 +5642,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils/node_modules/is-data-descriptor"
             }
           ],
@@ -5668,7 +5668,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/class-utils/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
@@ -5696,7 +5696,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils/node_modules/is-descriptor"
             }
           ]
@@ -5722,7 +5722,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils/node_modules/kind-of"
             }
           ]
@@ -5750,7 +5750,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/clean-stack"
         }
       ]
@@ -5776,7 +5776,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cliui"
         }
       ],
@@ -5802,7 +5802,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui/node_modules/ansi-regex"
             }
           ]
@@ -5828,7 +5828,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui/node_modules/emoji-regex"
             }
           ]
@@ -5854,7 +5854,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -5880,7 +5880,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui/node_modules/string-width"
             }
           ]
@@ -5906,7 +5906,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui/node_modules/strip-ansi"
             }
           ]
@@ -5934,7 +5934,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/clone-response"
         }
       ]
@@ -5960,7 +5960,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/clone"
         }
       ]
@@ -5986,7 +5986,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/code-point-at"
         }
       ]
@@ -6012,7 +6012,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/collection-visit"
         }
       ]
@@ -6038,7 +6038,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color-convert"
         }
       ]
@@ -6064,7 +6064,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color-name"
         }
       ]
@@ -6090,7 +6090,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color-string"
         }
       ]
@@ -6116,7 +6116,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color-support"
         }
       ]
@@ -6142,7 +6142,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color"
         }
       ]
@@ -6168,7 +6168,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/colors"
         }
       ]
@@ -6194,7 +6194,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/colorspace"
         }
       ]
@@ -6220,7 +6220,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/combined-stream"
         }
       ]
@@ -6246,7 +6246,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/commander"
         }
       ]
@@ -6272,7 +6272,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/component-emitter"
         }
       ]
@@ -6298,7 +6298,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/component-type"
         }
       ]
@@ -6324,7 +6324,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/compress-commons"
         }
       ]
@@ -6350,7 +6350,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/compressible"
         }
       ]
@@ -6376,7 +6376,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/compression"
         }
       ],
@@ -6402,7 +6402,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/compression/node_modules/bytes"
             }
           ]
@@ -6430,7 +6430,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/concat-map"
         }
       ]
@@ -6456,7 +6456,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/concat-stream"
         }
       ]
@@ -6482,7 +6482,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/concurrently"
         }
       ],
@@ -6508,7 +6508,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/concurrently/node_modules/supports-color"
             }
           ]
@@ -6536,7 +6536,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/config"
         }
       ]
@@ -6562,7 +6562,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/console-control-strings"
         }
       ]
@@ -6588,7 +6588,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/constantinople"
         }
       ]
@@ -6614,7 +6614,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/content-disposition"
         }
       ],
@@ -6640,7 +6640,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/content-disposition/node_modules/safe-buffer"
             }
           ]
@@ -6668,7 +6668,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/content-type"
         }
       ]
@@ -6694,7 +6694,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cookie-parser"
         }
       ]
@@ -6720,7 +6720,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cookie-signature"
         }
       ]
@@ -6746,7 +6746,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cookie"
         }
       ]
@@ -6772,7 +6772,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/copy-descriptor"
         }
       ]
@@ -6798,7 +6798,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/core-util-is"
         }
       ]
@@ -6824,7 +6824,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cors"
         }
       ]
@@ -6850,7 +6850,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/crc"
         }
       ]
@@ -6876,7 +6876,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/crc32-stream"
         }
       ]
@@ -6902,7 +6902,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/create-require"
         }
       ]
@@ -6928,7 +6928,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/crypto-js"
         }
       ]
@@ -6954,7 +6954,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dashdash"
         }
       ]
@@ -6980,7 +6980,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/date-fns"
         }
       ]
@@ -7006,7 +7006,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dateformat"
         }
       ]
@@ -7032,7 +7032,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/debug"
         }
       ]
@@ -7058,7 +7058,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decamelize"
         }
       ]
@@ -7084,7 +7084,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decode-uri-component"
         }
       ]
@@ -7110,7 +7110,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-response"
         }
       ]
@@ -7136,7 +7136,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-tar"
         }
       ],
@@ -7162,7 +7162,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-tar/node_modules/file-type"
             }
           ]
@@ -7190,7 +7190,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-tarbz2"
         }
       ],
@@ -7216,7 +7216,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-tarbz2/node_modules/file-type"
             }
           ]
@@ -7244,7 +7244,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-targz"
         }
       ],
@@ -7270,7 +7270,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-targz/node_modules/file-type"
             }
           ]
@@ -7298,7 +7298,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-unzip"
         }
       ],
@@ -7324,7 +7324,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-unzip/node_modules/file-type"
             }
           ]
@@ -7350,7 +7350,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-unzip/node_modules/get-stream"
             }
           ]
@@ -7376,7 +7376,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-unzip/node_modules/pify"
             }
           ]
@@ -7404,7 +7404,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress"
         }
       ],
@@ -7430,7 +7430,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress/node_modules/make-dir"
             }
           ],
@@ -7456,7 +7456,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/decompress/node_modules/make-dir/node_modules/pify"
                 }
               ]
@@ -7484,7 +7484,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress/node_modules/pify"
             }
           ]
@@ -7512,7 +7512,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/deep-equal"
         }
       ]
@@ -7538,7 +7538,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/deep-extend"
         }
       ]
@@ -7564,7 +7564,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/deep-is"
         }
       ]
@@ -7590,7 +7590,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/define-properties"
         }
       ]
@@ -7616,7 +7616,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/define-property"
         }
       ]
@@ -7642,7 +7642,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/delayed-stream"
         }
       ]
@@ -7668,7 +7668,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/delegates"
         }
       ]
@@ -7694,7 +7694,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/depd"
         }
       ]
@@ -7720,7 +7720,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/destroy"
         }
       ]
@@ -7746,7 +7746,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/detect-file"
         }
       ]
@@ -7772,7 +7772,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/detect-libc"
         }
       ]
@@ -7798,7 +7798,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dfa"
         }
       ]
@@ -7824,7 +7824,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dicer"
         }
       ],
@@ -7850,7 +7850,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/dicer/node_modules/isarray"
             }
           ]
@@ -7876,7 +7876,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/dicer/node_modules/readable-stream"
             }
           ]
@@ -7902,7 +7902,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/dicer/node_modules/string_decoder"
             }
           ]
@@ -7930,7 +7930,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/diff"
         }
       ]
@@ -7956,7 +7956,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/doctypes"
         }
       ]
@@ -7982,7 +7982,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/domelementtype"
         }
       ]
@@ -8008,7 +8008,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/domhandler"
         }
       ]
@@ -8034,7 +8034,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/domutils"
         }
       ]
@@ -8060,7 +8060,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dottie"
         }
       ]
@@ -8086,7 +8086,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/double-ended-queue"
         }
       ]
@@ -8112,7 +8112,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/doublearray"
         }
       ]
@@ -8138,7 +8138,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/download"
         }
       ],
@@ -8164,7 +8164,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/download/node_modules/file-type"
             }
           ]
@@ -8192,7 +8192,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/duplexer2"
         }
       ]
@@ -8218,7 +8218,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/duplexer3"
         }
       ]
@@ -8244,7 +8244,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dynamic-dedupe"
         }
       ]
@@ -8270,7 +8270,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ecc-jsbn"
         }
       ]
@@ -8296,7 +8296,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ee-first"
         }
       ]
@@ -8322,7 +8322,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/eivindfjeldstad-dot"
         }
       ]
@@ -8348,7 +8348,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/emoji-regex"
         }
       ]
@@ -8374,7 +8374,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/enabled"
         }
       ]
@@ -8400,7 +8400,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/encodeurl"
         }
       ]
@@ -8426,7 +8426,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/encoding"
         }
       ],
@@ -8452,7 +8452,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/encoding/node_modules/iconv-lite"
             }
           ]
@@ -8480,7 +8480,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/end-of-stream"
         }
       ]
@@ -8506,7 +8506,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/engine.io-parser"
         }
       ]
@@ -8532,7 +8532,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/engine.io"
         }
       ],
@@ -8558,7 +8558,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/engine.io/node_modules/debug"
             }
           ]
@@ -8584,7 +8584,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/engine.io/node_modules/ms"
             }
           ]
@@ -8612,7 +8612,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/env-paths"
         }
       ]
@@ -8638,7 +8638,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/err-code"
         }
       ]
@@ -8664,7 +8664,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/error-ex"
         }
       ]
@@ -8690,7 +8690,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/errorhandler"
         }
       ]
@@ -8716,7 +8716,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/es-abstract"
         }
       ]
@@ -8742,7 +8742,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/es-get-iterator"
         }
       ]
@@ -8768,7 +8768,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/es-to-primitive"
         }
       ]
@@ -8794,7 +8794,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/escape-html"
         }
       ]
@@ -8820,7 +8820,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/escape-string-regexp"
         }
       ]
@@ -8846,7 +8846,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/escodegen"
         }
       ]
@@ -8872,7 +8872,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/esprima"
         }
       ]
@@ -8898,7 +8898,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/estraverse"
         }
       ]
@@ -8924,7 +8924,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/esutils"
         }
       ]
@@ -8950,7 +8950,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/etag"
         }
       ]
@@ -8976,7 +8976,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/eventemitter2"
         }
       ]
@@ -9002,7 +9002,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/eventemitter3"
         }
       ]
@@ -9028,7 +9028,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/exif"
         }
       ]
@@ -9054,7 +9054,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/exit"
         }
       ]
@@ -9080,7 +9080,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/expand-brackets"
         }
       ],
@@ -9106,7 +9106,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/define-property"
             }
           ]
@@ -9132,7 +9132,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/extend-shallow"
             }
           ]
@@ -9158,7 +9158,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/is-accessor-descriptor"
             }
           ],
@@ -9184,7 +9184,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/expand-brackets/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
@@ -9212,7 +9212,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/is-data-descriptor"
             }
           ],
@@ -9238,7 +9238,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/expand-brackets/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
@@ -9266,7 +9266,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/is-descriptor"
             }
           ]
@@ -9292,7 +9292,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/is-extendable"
             }
           ]
@@ -9318,7 +9318,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets/node_modules/kind-of"
             }
           ]
@@ -9346,7 +9346,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/expand-template"
         }
       ]
@@ -9372,7 +9372,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/expand-tilde"
         }
       ]
@@ -9398,7 +9398,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-ipfilter"
         }
       ]
@@ -9424,7 +9424,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-jwt"
         }
       ],
@@ -9450,7 +9450,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/express-jwt/node_modules/jsonwebtoken"
             }
           ]
@@ -9476,7 +9476,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/express-jwt/node_modules/moment"
             }
           ]
@@ -9504,7 +9504,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-rate-limit"
         }
       ]
@@ -9530,7 +9530,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-robots-txt"
         }
       ]
@@ -9556,7 +9556,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-security.txt"
         }
       ]
@@ -9582,7 +9582,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express"
         }
       ],
@@ -9608,7 +9608,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/express/node_modules/cookie"
             }
           ]
@@ -9634,7 +9634,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/express/node_modules/safe-buffer"
             }
           ]
@@ -9662,7 +9662,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ext-list"
         }
       ]
@@ -9688,7 +9688,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ext-name"
         }
       ]
@@ -9714,7 +9714,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/extend-shallow"
         }
       ]
@@ -9740,7 +9740,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/extend"
         }
       ]
@@ -9766,7 +9766,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/extglob"
         }
       ],
@@ -9792,7 +9792,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/extglob/node_modules/define-property"
             }
           ]
@@ -9818,7 +9818,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/extglob/node_modules/extend-shallow"
             }
           ]
@@ -9844,7 +9844,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/extglob/node_modules/is-extendable"
             }
           ]
@@ -9872,7 +9872,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/extsprintf"
         }
       ]
@@ -9898,7 +9898,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fast-deep-equal"
         }
       ]
@@ -9924,7 +9924,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fast-json-stable-stringify"
         }
       ]
@@ -9950,7 +9950,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fast-levenshtein"
         }
       ]
@@ -9976,7 +9976,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fast.js"
         }
       ]
@@ -10002,7 +10002,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fd-slicer"
         }
       ]
@@ -10028,7 +10028,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/feature-policy"
         }
       ]
@@ -10054,7 +10054,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fecha"
         }
       ]
@@ -10080,7 +10080,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/file-js"
         }
       ],
@@ -10106,7 +10106,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/file-js/node_modules/brace-expansion"
             }
           ]
@@ -10132,7 +10132,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/file-js/node_modules/minimatch"
             }
           ]
@@ -10160,7 +10160,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/file-stream-rotator"
         }
       ]
@@ -10186,7 +10186,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/file-type"
         }
       ]
@@ -10212,7 +10212,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/file-uri-to-path"
         }
       ]
@@ -10238,7 +10238,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/filehound"
         }
       ]
@@ -10264,7 +10264,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/filename-reserved-regex"
         }
       ]
@@ -10290,7 +10290,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/filenamify"
         }
       ]
@@ -10316,7 +10316,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/filesniffer"
         }
       ]
@@ -10342,7 +10342,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fill-range"
         }
       ],
@@ -10368,7 +10368,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/fill-range/node_modules/extend-shallow"
             }
           ]
@@ -10394,7 +10394,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/fill-range/node_modules/is-extendable"
             }
           ]
@@ -10422,7 +10422,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/finale-rest"
         }
       ]
@@ -10448,7 +10448,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/finalhandler"
         }
       ]
@@ -10474,7 +10474,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/find-up"
         }
       ]
@@ -10500,7 +10500,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/findup-sync"
         }
       ]
@@ -10526,7 +10526,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fined"
         }
       ]
@@ -10552,7 +10552,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/flagged-respawn"
         }
       ]
@@ -10578,7 +10578,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fn.name"
         }
       ]
@@ -10604,7 +10604,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fontkit"
         }
       ]
@@ -10630,7 +10630,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/for-each"
         }
       ]
@@ -10656,7 +10656,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/for-in"
         }
       ]
@@ -10682,7 +10682,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/for-own"
         }
       ]
@@ -10708,7 +10708,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/foreachasync"
         }
       ]
@@ -10734,7 +10734,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/forever-agent"
         }
       ]
@@ -10760,7 +10760,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/form-data"
         }
       ]
@@ -10786,7 +10786,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/formatio"
         }
       ]
@@ -10812,7 +10812,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/forwarded"
         }
       ]
@@ -10838,7 +10838,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fragment-cache"
         }
       ]
@@ -10864,7 +10864,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fresh"
         }
       ]
@@ -10890,7 +10890,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/from2"
         }
       ]
@@ -10916,7 +10916,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fs-constants"
         }
       ]
@@ -10942,7 +10942,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fs-extra"
         }
       ]
@@ -10968,7 +10968,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fs-minipass"
         }
       ]
@@ -10994,7 +10994,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fs.realpath"
         }
       ]
@@ -11020,7 +11020,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fstream"
         }
       ],
@@ -11046,7 +11046,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/fstream/node_modules/mkdirp"
             }
           ]
@@ -11072,7 +11072,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/fstream/node_modules/rimraf"
             }
           ]
@@ -11100,7 +11100,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/function-bind"
         }
       ]
@@ -11126,7 +11126,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/function.prototype.name"
         }
       ]
@@ -11152,7 +11152,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/functions-have-names"
         }
       ]
@@ -11178,7 +11178,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fuzzball"
         }
       ]
@@ -11204,7 +11204,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/gauge"
         }
       ]
@@ -11230,7 +11230,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/geojson-utils"
         }
       ]
@@ -11256,7 +11256,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-caller-file"
         }
       ]
@@ -11282,7 +11282,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-intrinsic"
         }
       ]
@@ -11308,7 +11308,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-stream"
         }
       ]
@@ -11334,7 +11334,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-symbol-description"
         }
       ]
@@ -11360,7 +11360,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-value"
         }
       ]
@@ -11386,7 +11386,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/getobject"
         }
       ]
@@ -11412,7 +11412,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/getpass"
         }
       ]
@@ -11438,7 +11438,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/github-from-package"
         }
       ]
@@ -11464,7 +11464,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/glob-parent"
         }
       ],
@@ -11490,7 +11490,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/glob-parent/node_modules/is-glob"
             }
           ]
@@ -11518,7 +11518,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/glob"
         }
       ],
@@ -11544,7 +11544,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/glob/node_modules/brace-expansion"
             }
           ]
@@ -11570,7 +11570,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/glob/node_modules/minimatch"
             }
           ]
@@ -11598,7 +11598,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/global-modules"
         }
       ]
@@ -11624,7 +11624,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/global-prefix"
         }
       ],
@@ -11650,7 +11650,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/global-prefix/node_modules/which"
             }
           ]
@@ -11678,7 +11678,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/got"
         }
       ],
@@ -11704,7 +11704,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/got/node_modules/get-stream"
             }
           ]
@@ -11730,7 +11730,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/got/node_modules/pify"
             }
           ]
@@ -11758,7 +11758,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/graceful-fs"
         }
       ]
@@ -11784,7 +11784,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-cli"
         }
       ],
@@ -11810,7 +11810,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-cli/node_modules/nopt"
             }
           ]
@@ -11838,7 +11838,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-contrib-compress"
         }
       ],
@@ -11864,7 +11864,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-contrib-compress/node_modules/ansi-styles"
             }
           ]
@@ -11890,7 +11890,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-contrib-compress/node_modules/chalk"
             }
           ]
@@ -11916,7 +11916,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-contrib-compress/node_modules/supports-color"
             }
           ]
@@ -11944,7 +11944,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-known-options"
         }
       ]
@@ -11970,7 +11970,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-legacy-log-utils"
         }
       ],
@@ -11996,7 +11996,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils/node_modules/ansi-styles"
             }
           ]
@@ -12022,7 +12022,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils/node_modules/chalk"
             }
           ]
@@ -12048,7 +12048,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils/node_modules/color-convert"
             }
           ]
@@ -12074,7 +12074,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils/node_modules/color-name"
             }
           ]
@@ -12100,7 +12100,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils/node_modules/has-flag"
             }
           ]
@@ -12126,7 +12126,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils/node_modules/supports-color"
             }
           ]
@@ -12154,7 +12154,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-legacy-log"
         }
       ],
@@ -12180,7 +12180,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log/node_modules/colors"
             }
           ]
@@ -12208,7 +12208,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-legacy-util"
         }
       ],
@@ -12234,7 +12234,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-util/node_modules/async"
             }
           ]
@@ -12262,7 +12262,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-replace-json"
         }
       ]
@@ -12288,7 +12288,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt"
         }
       ],
@@ -12314,7 +12314,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt/node_modules/brace-expansion"
             }
           ]
@@ -12340,7 +12340,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt/node_modules/findup-sync"
             }
           ],
@@ -12366,7 +12366,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/grunt/node_modules/findup-sync/node_modules/glob"
                 }
               ]
@@ -12394,7 +12394,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt/node_modules/glob"
             }
           ]
@@ -12420,7 +12420,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt/node_modules/minimatch"
             }
           ]
@@ -12448,7 +12448,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/handlebars"
         }
       ],
@@ -12474,7 +12474,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/handlebars/node_modules/wordwrap"
             }
           ]
@@ -12502,7 +12502,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/har-schema"
         }
       ]
@@ -12528,7 +12528,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/har-validator"
         }
       ]
@@ -12554,7 +12554,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-ansi"
         }
       ]
@@ -12580,7 +12580,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-bigints"
         }
       ]
@@ -12606,7 +12606,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-flag"
         }
       ]
@@ -12632,7 +12632,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-property-descriptors"
         }
       ]
@@ -12658,7 +12658,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-symbol-support-x"
         }
       ]
@@ -12684,7 +12684,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-symbols"
         }
       ]
@@ -12710,7 +12710,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-to-string-tag-x"
         }
       ]
@@ -12736,7 +12736,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-tostringtag"
         }
       ]
@@ -12762,7 +12762,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-unicode"
         }
       ]
@@ -12788,7 +12788,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-value"
         }
       ]
@@ -12814,7 +12814,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-values"
         }
       ],
@@ -12840,7 +12840,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/has-values/node_modules/kind-of"
             }
           ]
@@ -12868,7 +12868,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has"
         }
       ]
@@ -12894,7 +12894,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hashids"
         }
       ]
@@ -12920,7 +12920,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hbs"
         }
       ]
@@ -12946,7 +12946,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/he"
         }
       ]
@@ -12972,7 +12972,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/heap"
         }
       ]
@@ -12998,7 +12998,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/helmet"
         }
       ]
@@ -13024,7 +13024,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hoister"
         }
       ]
@@ -13050,7 +13050,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/homedir-polyfill"
         }
       ]
@@ -13076,7 +13076,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hooker"
         }
       ]
@@ -13102,7 +13102,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hosted-git-info"
         }
       ]
@@ -13128,7 +13128,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/html-entities"
         }
       ]
@@ -13154,7 +13154,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/htmlparser2"
         }
       ],
@@ -13180,7 +13180,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/htmlparser2/node_modules/isarray"
             }
           ]
@@ -13206,7 +13206,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/htmlparser2/node_modules/readable-stream"
             }
           ]
@@ -13232,7 +13232,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/htmlparser2/node_modules/string_decoder"
             }
           ]
@@ -13260,7 +13260,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/http-cache-semantics"
         }
       ]
@@ -13286,7 +13286,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/http-errors"
         }
       ]
@@ -13312,7 +13312,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/http-proxy-agent"
         }
       ],
@@ -13338,7 +13338,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/http-proxy-agent/node_modules/debug"
             }
           ]
@@ -13364,7 +13364,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/http-proxy-agent/node_modules/ms"
             }
           ]
@@ -13392,7 +13392,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/http-signature"
         }
       ]
@@ -13418,7 +13418,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/https-proxy-agent"
         }
       ],
@@ -13444,7 +13444,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/https-proxy-agent/node_modules/debug"
             }
           ]
@@ -13470,7 +13470,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/https-proxy-agent/node_modules/ms"
             }
           ]
@@ -13498,7 +13498,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/humanize-ms"
         }
       ]
@@ -13524,7 +13524,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/i18n"
         }
       ]
@@ -13550,7 +13550,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/iconv-lite"
         }
       ]
@@ -13576,7 +13576,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ieee754"
         }
       ]
@@ -13602,7 +13602,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ignore-walk"
         }
       ],
@@ -13628,7 +13628,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/ignore-walk/node_modules/brace-expansion"
             }
           ]
@@ -13654,7 +13654,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/ignore-walk/node_modules/minimatch"
             }
           ]
@@ -13682,7 +13682,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/iltorb"
         }
       ]
@@ -13708,7 +13708,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/imurmurhash"
         }
       ]
@@ -13734,7 +13734,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/indent-string"
         }
       ]
@@ -13760,7 +13760,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/infer-owner"
         }
       ]
@@ -13786,7 +13786,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/inflection"
         }
       ]
@@ -13812,7 +13812,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/inflight"
         }
       ]
@@ -13838,7 +13838,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/inherits"
         }
       ]
@@ -13864,7 +13864,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ini"
         }
       ]
@@ -13890,7 +13890,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/internal-slot"
         }
       ]
@@ -13916,7 +13916,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/interpret"
         }
       ]
@@ -13942,7 +13942,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/into-stream"
         }
       ]
@@ -13968,7 +13968,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/invariant"
         }
       ]
@@ -13994,7 +13994,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ip"
         }
       ]
@@ -14020,7 +14020,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ip6"
         }
       ]
@@ -14046,7 +14046,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ipaddr.js"
         }
       ]
@@ -14072,7 +14072,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-absolute"
         }
       ]
@@ -14098,7 +14098,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-accessor-descriptor"
         }
       ]
@@ -14124,7 +14124,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-arguments"
         }
       ]
@@ -14150,7 +14150,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-arrayish"
         }
       ]
@@ -14176,7 +14176,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-bigint"
         }
       ]
@@ -14202,7 +14202,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-binary-path"
         }
       ]
@@ -14228,7 +14228,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-boolean-object"
         }
       ]
@@ -14254,7 +14254,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-buffer"
         }
       ]
@@ -14280,7 +14280,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-callable"
         }
       ]
@@ -14306,7 +14306,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-core-module"
         }
       ]
@@ -14332,7 +14332,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-data-descriptor"
         }
       ]
@@ -14358,7 +14358,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-date-object"
         }
       ]
@@ -14384,7 +14384,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-descriptor"
         }
       ]
@@ -14410,7 +14410,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-docker"
         }
       ]
@@ -14436,7 +14436,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-expression"
         }
       ]
@@ -14462,7 +14462,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-extendable"
         }
       ]
@@ -14488,7 +14488,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-extglob"
         }
       ]
@@ -14514,7 +14514,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-fullwidth-code-point"
         }
       ]
@@ -14540,7 +14540,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-generator-function"
         }
       ]
@@ -14566,7 +14566,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-glob"
         }
       ]
@@ -14592,7 +14592,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-heroku"
         }
       ]
@@ -14618,7 +14618,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-lambda"
         }
       ]
@@ -14644,7 +14644,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-map"
         }
       ]
@@ -14670,7 +14670,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-natural-number"
         }
       ]
@@ -14696,7 +14696,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-negative-zero"
         }
       ]
@@ -14722,7 +14722,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-number-like"
         }
       ]
@@ -14748,7 +14748,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-number-object"
         }
       ]
@@ -14774,7 +14774,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-number"
         }
       ],
@@ -14800,7 +14800,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/is-number/node_modules/kind-of"
             }
           ]
@@ -14828,7 +14828,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-object"
         }
       ]
@@ -14854,7 +14854,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-plain-obj"
         }
       ]
@@ -14880,7 +14880,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-plain-object"
         }
       ]
@@ -14906,7 +14906,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-promise"
         }
       ]
@@ -14932,7 +14932,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-regex"
         }
       ]
@@ -14958,7 +14958,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-relative"
         }
       ]
@@ -14984,7 +14984,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-retry-allowed"
         }
       ]
@@ -15010,7 +15010,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-set"
         }
       ]
@@ -15036,7 +15036,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-shared-array-buffer"
         }
       ]
@@ -15062,7 +15062,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-stream"
         }
       ]
@@ -15088,7 +15088,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-string"
         }
       ]
@@ -15114,7 +15114,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-symbol"
         }
       ]
@@ -15140,7 +15140,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-typed-array"
         }
       ]
@@ -15166,7 +15166,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-typedarray"
         }
       ]
@@ -15192,7 +15192,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-unc-path"
         }
       ]
@@ -15218,7 +15218,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-weakmap"
         }
       ]
@@ -15244,7 +15244,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-weakref"
         }
       ]
@@ -15270,7 +15270,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-weakset"
         }
       ]
@@ -15296,7 +15296,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-windows"
         }
       ]
@@ -15322,7 +15322,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isarray"
         }
       ]
@@ -15348,7 +15348,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isexe"
         }
       ]
@@ -15374,7 +15374,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isobject"
         }
       ]
@@ -15400,7 +15400,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isstream"
         }
       ]
@@ -15426,7 +15426,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isurl"
         }
       ]
@@ -15452,7 +15452,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/js-stringify"
         }
       ]
@@ -15478,7 +15478,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/js-tokens"
         }
       ]
@@ -15504,7 +15504,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/js-yaml"
         }
       ]
@@ -15530,7 +15530,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jsbn"
         }
       ]
@@ -15556,7 +15556,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-buffer"
         }
       ]
@@ -15582,7 +15582,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-parse-better-errors"
         }
       ]
@@ -15608,7 +15608,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-schema-traverse"
         }
       ]
@@ -15634,7 +15634,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-schema"
         }
       ]
@@ -15660,7 +15660,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-stringify-safe"
         }
       ]
@@ -15686,7 +15686,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json5"
         }
       ]
@@ -15712,7 +15712,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jsonfile"
         }
       ]
@@ -15738,7 +15738,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jsonwebtoken"
         }
       ]
@@ -15764,7 +15764,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jsprim"
         }
       ]
@@ -15790,7 +15790,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jssha"
         }
       ]
@@ -15816,7 +15816,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jstransformer"
         }
       ]
@@ -15842,7 +15842,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/juicy-chat-bot"
         }
       ]
@@ -15868,7 +15868,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jwa"
         }
       ]
@@ -15894,7 +15894,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jws"
         }
       ]
@@ -15920,7 +15920,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/keyv"
         }
       ]
@@ -15946,7 +15946,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/kind-of"
         }
       ]
@@ -15972,7 +15972,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/kuler"
         }
       ]
@@ -15998,7 +15998,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/kuromoji"
         }
       ]
@@ -16024,7 +16024,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lazystream"
         }
       ]
@@ -16050,7 +16050,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/levn"
         }
       ]
@@ -16076,7 +16076,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/libxmljs2"
         }
       ],
@@ -16102,7 +16102,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/libxmljs2/node_modules/nan"
             }
           ]
@@ -16130,7 +16130,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/liftup"
         }
       ],
@@ -16156,7 +16156,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/braces"
             }
           ]
@@ -16182,7 +16182,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/fill-range"
             }
           ]
@@ -16208,7 +16208,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/findup-sync"
             }
           ]
@@ -16234,7 +16234,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/is-glob"
             }
           ]
@@ -16260,7 +16260,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/is-number"
             }
           ]
@@ -16286,7 +16286,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/micromatch"
             }
           ]
@@ -16312,7 +16312,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup/node_modules/to-regex-range"
             }
           ]
@@ -16340,7 +16340,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/linebreak"
         }
       ],
@@ -16366,7 +16366,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/linebreak/node_modules/base64-js"
             }
           ]
@@ -16394,7 +16394,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/listenercount"
         }
       ]
@@ -16420,7 +16420,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/locate-path"
         }
       ]
@@ -16446,7 +16446,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lodash.camelcase"
         }
       ]
@@ -16472,7 +16472,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lodash.isfinite"
         }
       ]
@@ -16498,7 +16498,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lodash.set"
         }
       ]
@@ -16524,7 +16524,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lodash"
         }
       ]
@@ -16550,7 +16550,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/logform"
         }
       ],
@@ -16576,7 +16576,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/logform/node_modules/ms"
             }
           ]
@@ -16604,7 +16604,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lolex"
         }
       ]
@@ -16630,7 +16630,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/loose-envify"
         }
       ]
@@ -16656,7 +16656,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lowercase-keys"
         }
       ]
@@ -16682,7 +16682,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lru-cache"
         }
       ]
@@ -16708,7 +16708,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-dir"
         }
       ],
@@ -16734,7 +16734,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-dir/node_modules/semver"
             }
           ]
@@ -16762,7 +16762,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-error"
         }
       ]
@@ -16788,7 +16788,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-fetch-happen"
         }
       ],
@@ -16815,7 +16815,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen/node_modules/@tootallnate/once"
             }
           ]
@@ -16841,7 +16841,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen/node_modules/debug"
             }
           ]
@@ -16867,7 +16867,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen/node_modules/http-cache-semantics"
             }
           ]
@@ -16893,7 +16893,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen/node_modules/http-proxy-agent"
             }
           ]
@@ -16919,7 +16919,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen/node_modules/ms"
             }
           ]
@@ -16947,7 +16947,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-iterator"
         }
       ]
@@ -16973,7 +16973,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-plural"
         }
       ]
@@ -16999,7 +16999,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/map-cache"
         }
       ]
@@ -17025,7 +17025,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/map-visit"
         }
       ]
@@ -17051,7 +17051,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/marsdb"
         }
       ]
@@ -17077,7 +17077,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/math-interval-parser"
         }
       ]
@@ -17103,7 +17103,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/media-typer"
         }
       ]
@@ -17129,7 +17129,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/merge-descriptors"
         }
       ]
@@ -17155,7 +17155,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/messageformat-formatters"
         }
       ]
@@ -17181,7 +17181,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/messageformat-parser"
         }
       ]
@@ -17207,7 +17207,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/messageformat"
         }
       ],
@@ -17233,7 +17233,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/messageformat/node_modules/make-plural"
             }
           ]
@@ -17261,7 +17261,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/methods"
         }
       ]
@@ -17287,7 +17287,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/micromatch"
         }
       ]
@@ -17313,7 +17313,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mime-db"
         }
       ]
@@ -17339,7 +17339,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mime-types"
         }
       ]
@@ -17365,7 +17365,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mime"
         }
       ]
@@ -17391,7 +17391,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mimic-response"
         }
       ]
@@ -17417,7 +17417,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minimatch"
         }
       ]
@@ -17443,7 +17443,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minimist"
         }
       ]
@@ -17469,7 +17469,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-collect"
         }
       ]
@@ -17495,7 +17495,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-fetch"
         }
       ]
@@ -17521,7 +17521,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-flush"
         }
       ]
@@ -17547,7 +17547,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-pipeline"
         }
       ]
@@ -17573,7 +17573,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-sized"
         }
       ]
@@ -17599,7 +17599,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass"
         }
       ]
@@ -17625,7 +17625,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minizlib"
         }
       ]
@@ -17651,7 +17651,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mixin-deep"
         }
       ]
@@ -17677,7 +17677,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mkdirp-classic"
         }
       ]
@@ -17703,7 +17703,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mkdirp"
         }
       ]
@@ -17729,7 +17729,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/moment-timezone"
         }
       ]
@@ -17755,7 +17755,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/moment"
         }
       ]
@@ -17781,7 +17781,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/morgan"
         }
       ],
@@ -17807,7 +17807,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/morgan/node_modules/on-finished"
             }
           ]
@@ -17835,7 +17835,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mout"
         }
       ]
@@ -17861,7 +17861,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ms"
         }
       ]
@@ -17887,7 +17887,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/multer"
         }
       ],
@@ -17913,7 +17913,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/multer/node_modules/mkdirp"
             }
           ]
@@ -17941,7 +17941,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mustache"
         }
       ]
@@ -17967,7 +17967,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/nan"
         }
       ]
@@ -17993,7 +17993,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/nanomatch"
         }
       ]
@@ -18019,7 +18019,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/napi-build-utils"
         }
       ]
@@ -18045,7 +18045,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/needle"
         }
       ],
@@ -18071,7 +18071,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/needle/node_modules/debug"
             }
           ]
@@ -18097,7 +18097,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/needle/node_modules/ms"
             }
           ]
@@ -18125,7 +18125,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/negotiator"
         }
       ]
@@ -18151,7 +18151,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/neo-async"
         }
       ]
@@ -18177,7 +18177,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-abi"
         }
       ],
@@ -18203,7 +18203,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-abi/node_modules/semver"
             }
           ]
@@ -18231,7 +18231,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-addon-api"
         }
       ]
@@ -18257,7 +18257,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-fetch"
         }
       ]
@@ -18283,7 +18283,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-gyp"
         }
       ],
@@ -18309,7 +18309,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/ansi-regex"
             }
           ]
@@ -18335,7 +18335,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/are-we-there-yet"
             }
           ]
@@ -18361,7 +18361,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/gauge"
             }
           ]
@@ -18387,7 +18387,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -18413,7 +18413,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/nopt"
             }
           ]
@@ -18439,7 +18439,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/npmlog"
             }
           ]
@@ -18465,7 +18465,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/readable-stream"
             }
           ]
@@ -18491,7 +18491,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/string-width"
             }
           ]
@@ -18517,7 +18517,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp/node_modules/strip-ansi"
             }
           ]
@@ -18545,7 +18545,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-pre-gyp"
         }
       ],
@@ -18571,7 +18571,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/chownr"
             }
           ]
@@ -18597,7 +18597,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/fs-minipass"
             }
           ]
@@ -18623,7 +18623,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/minipass"
             }
           ]
@@ -18649,7 +18649,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/minizlib"
             }
           ]
@@ -18675,7 +18675,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/mkdirp"
             }
           ]
@@ -18701,7 +18701,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/nopt"
             }
           ]
@@ -18727,7 +18727,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/rimraf"
             }
           ]
@@ -18753,7 +18753,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/safe-buffer"
             }
           ]
@@ -18779,7 +18779,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/semver"
             }
           ]
@@ -18805,7 +18805,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/tar"
             }
           ]
@@ -18831,7 +18831,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp/node_modules/yallist"
             }
           ]
@@ -18859,7 +18859,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/noop-logger"
         }
       ]
@@ -18885,7 +18885,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/nopt"
         }
       ]
@@ -18911,7 +18911,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/normalize-package-data"
         }
       ],
@@ -18937,7 +18937,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/normalize-package-data/node_modules/semver"
             }
           ]
@@ -18965,7 +18965,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/normalize-path"
         }
       ]
@@ -18991,7 +18991,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/normalize-url"
         }
       ]
@@ -19017,7 +19017,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/notevil"
         }
       ],
@@ -19043,7 +19043,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/notevil/node_modules/esprima"
             }
           ]
@@ -19071,7 +19071,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/npm-bundled"
         }
       ]
@@ -19097,7 +19097,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/npm-normalize-package-bin"
         }
       ]
@@ -19123,7 +19123,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/npm-packlist"
         }
       ]
@@ -19149,7 +19149,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/npmlog"
         }
       ]
@@ -19175,7 +19175,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/number-is-nan"
         }
       ]
@@ -19201,7 +19201,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/oauth-sign"
         }
       ]
@@ -19227,7 +19227,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-assign"
         }
       ]
@@ -19253,7 +19253,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-copy"
         }
       ],
@@ -19279,7 +19279,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy/node_modules/define-property"
             }
           ]
@@ -19305,7 +19305,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy/node_modules/is-accessor-descriptor"
             }
           ]
@@ -19331,7 +19331,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy/node_modules/is-data-descriptor"
             }
           ]
@@ -19357,7 +19357,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy/node_modules/is-descriptor"
             }
           ],
@@ -19383,7 +19383,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/object-copy/node_modules/is-descriptor/node_modules/kind-of"
                 }
               ]
@@ -19411,7 +19411,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy/node_modules/kind-of"
             }
           ]
@@ -19439,7 +19439,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-inspect"
         }
       ]
@@ -19465,7 +19465,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-is"
         }
       ]
@@ -19491,7 +19491,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-keys"
         }
       ]
@@ -19517,7 +19517,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-visit"
         }
       ]
@@ -19543,7 +19543,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object.assign"
         }
       ]
@@ -19569,7 +19569,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object.defaults"
         }
       ]
@@ -19595,7 +19595,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object.map"
         }
       ]
@@ -19621,7 +19621,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object.pick"
         }
       ]
@@ -19647,7 +19647,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/on-finished"
         }
       ]
@@ -19673,7 +19673,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/on-headers"
         }
       ]
@@ -19699,7 +19699,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/once"
         }
       ]
@@ -19725,7 +19725,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/one-time"
         }
       ]
@@ -19751,7 +19751,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/opentype.js"
         }
       ]
@@ -19777,7 +19777,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/optionator"
         }
       ]
@@ -19803,7 +19803,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/os-homedir"
         }
       ]
@@ -19829,7 +19829,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/os-tmpdir"
         }
       ]
@@ -19855,7 +19855,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/osenv"
         }
       ]
@@ -19881,7 +19881,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/otplib"
         }
       ]
@@ -19907,7 +19907,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-cancelable"
         }
       ]
@@ -19933,7 +19933,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-event"
         }
       ]
@@ -19959,7 +19959,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-finally"
         }
       ]
@@ -19985,7 +19985,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-is-promise"
         }
       ]
@@ -20011,7 +20011,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-limit"
         }
       ]
@@ -20037,7 +20037,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-locate"
         }
       ]
@@ -20063,7 +20063,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-map"
         }
       ]
@@ -20089,7 +20089,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-timeout"
         }
       ]
@@ -20115,7 +20115,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-try"
         }
       ]
@@ -20141,7 +20141,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pako"
         }
       ]
@@ -20167,7 +20167,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/parse-filepath"
         }
       ]
@@ -20193,7 +20193,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/parse-json"
         }
       ]
@@ -20219,7 +20219,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/parse-passwd"
         }
       ]
@@ -20245,7 +20245,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/parseurl"
         }
       ]
@@ -20271,7 +20271,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pascalcase"
         }
       ]
@@ -20297,7 +20297,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-exists"
         }
       ]
@@ -20323,7 +20323,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-is-absolute"
         }
       ]
@@ -20349,7 +20349,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-parse"
         }
       ]
@@ -20375,7 +20375,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-root-regex"
         }
       ]
@@ -20401,7 +20401,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-root"
         }
       ]
@@ -20427,7 +20427,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-to-regexp"
         }
       ]
@@ -20453,7 +20453,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pdfkit"
         }
       ]
@@ -20479,7 +20479,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/peek-readable"
         }
       ]
@@ -20505,7 +20505,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pend"
         }
       ]
@@ -20531,7 +20531,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/performance-now"
         }
       ]
@@ -20557,7 +20557,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pg-connection-string"
         }
       ]
@@ -20583,7 +20583,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/picomatch"
         }
       ]
@@ -20609,7 +20609,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pify"
         }
       ]
@@ -20635,7 +20635,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pinkie-promise"
         }
       ]
@@ -20661,7 +20661,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pinkie"
         }
       ]
@@ -20687,7 +20687,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/png-js"
         }
       ]
@@ -20713,7 +20713,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/portscanner"
         }
       ]
@@ -20739,7 +20739,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/posix-character-classes"
         }
       ]
@@ -20765,7 +20765,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/prebuild-install"
         }
       ]
@@ -20791,7 +20791,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/prelude-ls"
         }
       ]
@@ -20817,7 +20817,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/prepend-http"
         }
       ]
@@ -20843,7 +20843,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pretty-bytes"
         }
       ]
@@ -20869,7 +20869,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/process-nextick-args"
         }
       ]
@@ -20895,7 +20895,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/prom-client"
         }
       ]
@@ -20921,7 +20921,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/promise-inflight"
         }
       ]
@@ -20947,7 +20947,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/promise-retry"
         }
       ],
@@ -20973,7 +20973,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/promise-retry/node_modules/err-code"
             }
           ]
@@ -20999,7 +20999,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/promise-retry/node_modules/retry"
             }
           ]
@@ -21027,7 +21027,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/promise"
         }
       ]
@@ -21053,7 +21053,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/proper-lockfile"
         }
       ]
@@ -21079,7 +21079,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/proxy-addr"
         }
       ]
@@ -21105,7 +21105,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/psl"
         }
       ]
@@ -21131,7 +21131,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-attrs"
         }
       ]
@@ -21157,7 +21157,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-code-gen"
         }
       ]
@@ -21183,7 +21183,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-error"
         }
       ]
@@ -21209,7 +21209,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-filters"
         }
       ]
@@ -21235,7 +21235,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-lexer"
         }
       ]
@@ -21261,7 +21261,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-linker"
         }
       ]
@@ -21287,7 +21287,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-load"
         }
       ]
@@ -21313,7 +21313,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-parser"
         }
       ]
@@ -21339,7 +21339,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-runtime"
         }
       ]
@@ -21365,7 +21365,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-strip-comments"
         }
       ]
@@ -21391,7 +21391,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-walk"
         }
       ]
@@ -21417,7 +21417,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug"
         }
       ]
@@ -21443,7 +21443,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pump"
         }
       ]
@@ -21469,7 +21469,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/punycode"
         }
       ]
@@ -21495,7 +21495,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/qs"
         }
       ]
@@ -21521,7 +21521,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/query-string"
         }
       ]
@@ -21547,7 +21547,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/range_check"
         }
       ]
@@ -21573,7 +21573,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/range-parser"
         }
       ]
@@ -21599,7 +21599,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/raw-body"
         }
       ]
@@ -21625,7 +21625,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/rc"
         }
       ]
@@ -21651,7 +21651,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/read-pkg"
         }
       ],
@@ -21677,7 +21677,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/read-pkg/node_modules/pify"
             }
           ]
@@ -21705,7 +21705,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/readable-stream"
         }
       ],
@@ -21731,7 +21731,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/readable-stream/node_modules/isarray"
             }
           ]
@@ -21759,7 +21759,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/readable-web-to-node-stream"
         }
       ],
@@ -21785,7 +21785,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/readable-web-to-node-stream/node_modules/readable-stream"
             }
           ]
@@ -21813,7 +21813,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/readdirp"
         }
       ]
@@ -21839,7 +21839,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/rechoir"
         }
       ]
@@ -21865,7 +21865,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/regex-not"
         }
       ]
@@ -21891,7 +21891,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/regexp.prototype.flags"
         }
       ]
@@ -21917,7 +21917,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/remove-trailing-separator"
         }
       ]
@@ -21943,7 +21943,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/repeat-element"
         }
       ]
@@ -21969,7 +21969,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/repeat-string"
         }
       ]
@@ -21995,7 +21995,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/replace"
         }
       ],
@@ -22021,7 +22021,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/ansi-regex"
             }
           ]
@@ -22047,7 +22047,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/ansi-styles"
             }
           ]
@@ -22073,7 +22073,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/brace-expansion"
             }
           ]
@@ -22099,7 +22099,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/cliui"
             }
           ]
@@ -22125,7 +22125,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/color-convert"
             }
           ]
@@ -22151,7 +22151,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/color-name"
             }
           ]
@@ -22177,7 +22177,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/find-up"
             }
           ]
@@ -22203,7 +22203,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -22229,7 +22229,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/locate-path"
             }
           ]
@@ -22255,7 +22255,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/minimatch"
             }
           ]
@@ -22281,7 +22281,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/p-locate"
             }
           ]
@@ -22307,7 +22307,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/path-exists"
             }
           ]
@@ -22333,7 +22333,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/string-width"
             }
           ]
@@ -22359,7 +22359,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/strip-ansi"
             }
           ]
@@ -22385,7 +22385,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/wrap-ansi"
             }
           ]
@@ -22411,7 +22411,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/yargs-parser"
             }
           ]
@@ -22437,7 +22437,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace/node_modules/yargs"
             }
           ]
@@ -22465,7 +22465,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/request"
         }
       ],
@@ -22491,7 +22491,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/request/node_modules/qs"
             }
           ]
@@ -22519,7 +22519,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/require-directory"
         }
       ]
@@ -22545,7 +22545,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/require-main-filename"
         }
       ]
@@ -22571,7 +22571,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/resolve-dir"
         }
       ]
@@ -22597,7 +22597,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/resolve-url"
         }
       ]
@@ -22623,7 +22623,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/resolve"
         }
       ]
@@ -22649,7 +22649,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/responselike"
         }
       ]
@@ -22675,7 +22675,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/restructure"
         }
       ]
@@ -22701,7 +22701,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ret"
         }
       ]
@@ -22727,7 +22727,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/retry-as-promised"
         }
       ]
@@ -22753,7 +22753,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/retry"
         }
       ]
@@ -22779,7 +22779,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/rimraf"
         }
       ]
@@ -22805,7 +22805,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/rxjs"
         }
       ],
@@ -22831,7 +22831,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/rxjs/node_modules/tslib"
             }
           ]
@@ -22859,7 +22859,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safe-buffer"
         }
       ]
@@ -22885,7 +22885,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safe-regex-test"
         }
       ]
@@ -22911,7 +22911,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safe-regex"
         }
       ]
@@ -22937,7 +22937,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safe-stable-stringify"
         }
       ]
@@ -22963,7 +22963,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safer-buffer"
         }
       ]
@@ -22989,7 +22989,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/samsam"
         }
       ]
@@ -23015,7 +23015,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sanitize-filename"
         }
       ]
@@ -23041,7 +23041,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sanitize-html"
         }
       ],
@@ -23067,7 +23067,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sanitize-html/node_modules/lodash"
             }
           ]
@@ -23095,7 +23095,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sax"
         }
       ]
@@ -23121,7 +23121,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/seek-bzip"
         }
       ]
@@ -23147,7 +23147,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/semver"
         }
       ]
@@ -23173,7 +23173,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/send"
         }
       ],
@@ -23199,7 +23199,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/send/node_modules/ms"
             }
           ]
@@ -23227,7 +23227,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sequelize-pool"
         }
       ]
@@ -23253,7 +23253,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sequelize"
         }
       ],
@@ -23279,7 +23279,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sequelize/node_modules/debug"
             }
           ]
@@ -23305,7 +23305,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sequelize/node_modules/ms"
             }
           ]
@@ -23331,7 +23331,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sequelize/node_modules/uuid"
             }
           ]
@@ -23359,7 +23359,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/serve-index"
         }
       ],
@@ -23385,7 +23385,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index/node_modules/depd"
             }
           ]
@@ -23411,7 +23411,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index/node_modules/http-errors"
             }
           ]
@@ -23437,7 +23437,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index/node_modules/inherits"
             }
           ]
@@ -23463,7 +23463,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index/node_modules/setprototypeof"
             }
           ]
@@ -23489,7 +23489,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index/node_modules/statuses"
             }
           ]
@@ -23517,7 +23517,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/serve-static"
         }
       ]
@@ -23543,7 +23543,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/set-blocking"
         }
       ]
@@ -23569,7 +23569,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/set-value"
         }
       ],
@@ -23595,7 +23595,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/set-value/node_modules/extend-shallow"
             }
           ]
@@ -23621,7 +23621,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/set-value/node_modules/is-extendable"
             }
           ]
@@ -23649,7 +23649,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/setimmediate"
         }
       ]
@@ -23675,7 +23675,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/setprototypeof"
         }
       ]
@@ -23701,7 +23701,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/side-channel"
         }
       ]
@@ -23727,7 +23727,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/signal-exit"
         }
       ]
@@ -23753,7 +23753,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/simple-concat"
         }
       ]
@@ -23779,7 +23779,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/simple-get"
         }
       ],
@@ -23805,7 +23805,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/simple-get/node_modules/decompress-response"
             }
           ]
@@ -23831,7 +23831,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/simple-get/node_modules/mimic-response"
             }
           ]
@@ -23859,7 +23859,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/simple-swizzle"
         }
       ],
@@ -23885,7 +23885,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/simple-swizzle/node_modules/is-arrayish"
             }
           ]
@@ -23913,7 +23913,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sinon"
         }
       ]
@@ -23939,7 +23939,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/smart-buffer"
         }
       ]
@@ -23965,7 +23965,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/snapdragon-node"
         }
       ],
@@ -23991,7 +23991,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon-node/node_modules/define-property"
             }
           ]
@@ -24019,7 +24019,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/snapdragon-util"
         }
       ],
@@ -24045,7 +24045,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon-util/node_modules/kind-of"
             }
           ]
@@ -24073,7 +24073,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/snapdragon"
         }
       ],
@@ -24099,7 +24099,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/define-property"
             }
           ]
@@ -24125,7 +24125,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/extend-shallow"
             }
           ]
@@ -24151,7 +24151,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/is-accessor-descriptor"
             }
           ],
@@ -24177,7 +24177,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/snapdragon/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
@@ -24205,7 +24205,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/is-data-descriptor"
             }
           ],
@@ -24231,7 +24231,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/snapdragon/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
@@ -24259,7 +24259,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/is-descriptor"
             }
           ]
@@ -24285,7 +24285,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/is-extendable"
             }
           ]
@@ -24311,7 +24311,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/kind-of"
             }
           ]
@@ -24337,7 +24337,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon/node_modules/source-map"
             }
           ]
@@ -24365,7 +24365,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socket.io-adapter"
         }
       ]
@@ -24391,7 +24391,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socket.io-parser"
         }
       ],
@@ -24417,7 +24417,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socket.io-parser/node_modules/debug"
             }
           ]
@@ -24443,7 +24443,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socket.io-parser/node_modules/ms"
             }
           ]
@@ -24471,7 +24471,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socket.io"
         }
       ],
@@ -24497,7 +24497,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socket.io/node_modules/debug"
             }
           ]
@@ -24523,7 +24523,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socket.io/node_modules/ms"
             }
           ]
@@ -24551,7 +24551,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socks-proxy-agent"
         }
       ],
@@ -24577,7 +24577,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socks-proxy-agent/node_modules/debug"
             }
           ]
@@ -24603,7 +24603,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socks-proxy-agent/node_modules/ms"
             }
           ]
@@ -24631,7 +24631,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socks"
         }
       ],
@@ -24657,7 +24657,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socks/node_modules/ip"
             }
           ]
@@ -24685,7 +24685,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sort-keys-length"
         }
       ],
@@ -24711,7 +24711,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sort-keys-length/node_modules/sort-keys"
             }
           ]
@@ -24739,7 +24739,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sort-keys"
         }
       ]
@@ -24765,7 +24765,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/source-map-resolve"
         }
       ]
@@ -24791,7 +24791,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/source-map-support"
         }
       ]
@@ -24817,7 +24817,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/source-map-url"
         }
       ]
@@ -24843,7 +24843,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/source-map"
         }
       ]
@@ -24869,7 +24869,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spawn-command"
         }
       ]
@@ -24895,7 +24895,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spdx-correct"
         }
       ]
@@ -24921,7 +24921,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spdx-exceptions"
         }
       ]
@@ -24947,7 +24947,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spdx-expression-parse"
         }
       ]
@@ -24973,7 +24973,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spdx-license-ids"
         }
       ]
@@ -24999,7 +24999,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/split-string"
         }
       ]
@@ -25025,7 +25025,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sprintf-js"
         }
       ]
@@ -25051,7 +25051,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sqlite3"
         }
       ]
@@ -25077,7 +25077,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sshpk"
         }
       ]
@@ -25103,7 +25103,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ssri"
         }
       ]
@@ -25129,7 +25129,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/stack-trace"
         }
       ]
@@ -25155,7 +25155,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/static-extend"
         }
       ],
@@ -25181,7 +25181,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend/node_modules/define-property"
             }
           ]
@@ -25207,7 +25207,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend/node_modules/is-accessor-descriptor"
             }
           ],
@@ -25233,7 +25233,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/static-extend/node_modules/is-accessor-descriptor/node_modules/kind-of"
                 }
               ]
@@ -25261,7 +25261,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend/node_modules/is-data-descriptor"
             }
           ],
@@ -25287,7 +25287,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/static-extend/node_modules/is-data-descriptor/node_modules/kind-of"
                 }
               ]
@@ -25315,7 +25315,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend/node_modules/is-descriptor"
             }
           ]
@@ -25341,7 +25341,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend/node_modules/kind-of"
             }
           ]
@@ -25369,7 +25369,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/statuses"
         }
       ]
@@ -25395,7 +25395,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/stream-buffers"
         }
       ]
@@ -25421,7 +25421,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/streamsearch"
         }
       ]
@@ -25447,7 +25447,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strict-uri-encode"
         }
       ]
@@ -25473,7 +25473,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string_decoder"
         }
       ]
@@ -25499,7 +25499,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string-width"
         }
       ]
@@ -25525,7 +25525,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string.fromcodepoint"
         }
       ]
@@ -25551,7 +25551,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string.prototype.codepointat"
         }
       ]
@@ -25577,7 +25577,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string.prototype.trimend"
         }
       ]
@@ -25603,7 +25603,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string.prototype.trimstart"
         }
       ]
@@ -25629,7 +25629,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-ansi"
         }
       ]
@@ -25655,7 +25655,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-bom"
         }
       ]
@@ -25681,7 +25681,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-dirs"
         }
       ]
@@ -25707,7 +25707,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-json-comments"
         }
       ]
@@ -25733,7 +25733,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-outer"
         }
       ]
@@ -25759,7 +25759,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strtok3"
         }
       ]
@@ -25785,7 +25785,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/supports-color"
         }
       ]
@@ -25811,7 +25811,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/supports-preserve-symlinks-flag"
         }
       ]
@@ -25837,7 +25837,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/svg-captcha"
         }
       ]
@@ -25863,7 +25863,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/swagger-ui-dist"
         }
       ]
@@ -25889,7 +25889,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/swagger-ui-express"
         }
       ]
@@ -25915,7 +25915,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tar-fs"
         }
       ],
@@ -25941,7 +25941,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/tar-fs/node_modules/bl"
             }
           ]
@@ -25967,7 +25967,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/tar-fs/node_modules/chownr"
             }
           ]
@@ -25993,7 +25993,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/tar-fs/node_modules/readable-stream"
             }
           ]
@@ -26019,7 +26019,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/tar-fs/node_modules/tar-stream"
             }
           ]
@@ -26047,7 +26047,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tar-stream"
         }
       ]
@@ -26073,7 +26073,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tar"
         }
       ]
@@ -26099,7 +26099,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tdigest"
         }
       ]
@@ -26125,7 +26125,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/text-hex"
         }
       ]
@@ -26151,7 +26151,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/thirty-two"
         }
       ]
@@ -26177,7 +26177,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/through"
         }
       ]
@@ -26203,7 +26203,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/timed-out"
         }
       ]
@@ -26229,7 +26229,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tiny-inflate"
         }
       ]
@@ -26255,7 +26255,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-buffer"
         }
       ]
@@ -26281,7 +26281,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-fast-properties"
         }
       ]
@@ -26307,7 +26307,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-object-path"
         }
       ],
@@ -26333,7 +26333,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/to-object-path/node_modules/kind-of"
             }
           ]
@@ -26361,7 +26361,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-regex-range"
         }
       ]
@@ -26387,7 +26387,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-regex"
         }
       ]
@@ -26413,7 +26413,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/toidentifier"
         }
       ]
@@ -26439,7 +26439,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/token-stream"
         }
       ]
@@ -26465,7 +26465,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/token-types"
         }
       ]
@@ -26491,7 +26491,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/toposort-class"
         }
       ]
@@ -26517,7 +26517,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tough-cookie"
         }
       ]
@@ -26543,7 +26543,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tr46"
         }
       ]
@@ -26569,7 +26569,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/traverse"
         }
       ]
@@ -26595,7 +26595,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tree-kill"
         }
       ]
@@ -26621,7 +26621,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/trim-repeated"
         }
       ]
@@ -26647,7 +26647,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/triple-beam"
         }
       ]
@@ -26673,7 +26673,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/truncate-utf8-bytes"
         }
       ]
@@ -26699,7 +26699,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ts-node-dev"
         }
       ],
@@ -26725,7 +26725,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/ts-node-dev/node_modules/rimraf"
             }
           ]
@@ -26753,7 +26753,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ts-node"
         }
       ]
@@ -26779,7 +26779,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tsconfig"
         }
       ]
@@ -26805,7 +26805,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tslib"
         }
       ]
@@ -26831,7 +26831,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tunnel-agent"
         }
       ]
@@ -26857,7 +26857,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tweetnacl"
         }
       ]
@@ -26883,7 +26883,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/type-check"
         }
       ]
@@ -26909,7 +26909,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/type-is"
         }
       ]
@@ -26935,7 +26935,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/typecast"
         }
       ]
@@ -26961,7 +26961,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/typedarray"
         }
       ]
@@ -26987,7 +26987,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/typescript"
         }
       ]
@@ -27013,7 +27013,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/uglify-js"
         }
       ]
@@ -27039,7 +27039,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unbox-primitive"
         }
       ]
@@ -27065,7 +27065,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unbzip2-stream"
         }
       ]
@@ -27091,7 +27091,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unc-path-regex"
         }
       ]
@@ -27117,7 +27117,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/underscore.string"
         }
       ]
@@ -27143,7 +27143,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unicode-properties"
         }
       ]
@@ -27169,7 +27169,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unicode-trie"
         }
       ]
@@ -27195,7 +27195,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/union-value"
         }
       ],
@@ -27221,7 +27221,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/union-value/node_modules/is-extendable"
             }
           ]
@@ -27249,7 +27249,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unique-filename"
         }
       ]
@@ -27275,7 +27275,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unique-slug"
         }
       ]
@@ -27301,7 +27301,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unit-compare"
         }
       ]
@@ -27327,7 +27327,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/universalify"
         }
       ]
@@ -27353,7 +27353,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unpipe"
         }
       ]
@@ -27379,7 +27379,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unset-value"
         }
       ],
@@ -27405,7 +27405,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/unset-value/node_modules/has-value"
             }
           ],
@@ -27431,7 +27431,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/unset-value/node_modules/has-value/node_modules/isobject"
                 }
               ]
@@ -27459,7 +27459,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/unset-value/node_modules/has-values"
             }
           ]
@@ -27485,7 +27485,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/unset-value/node_modules/isarray"
             }
           ]
@@ -27513,7 +27513,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/untildify"
         }
       ]
@@ -27539,7 +27539,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unzipper"
         }
       ],
@@ -27565,7 +27565,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/unzipper/node_modules/bluebird"
             }
           ]
@@ -27593,7 +27593,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/uri-js"
         }
       ]
@@ -27619,7 +27619,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/urix"
         }
       ]
@@ -27645,7 +27645,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/url-parse-lax"
         }
       ]
@@ -27671,7 +27671,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/url-to-options"
         }
       ]
@@ -27697,7 +27697,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/use"
         }
       ]
@@ -27723,7 +27723,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/utf8-byte-length"
         }
       ]
@@ -27749,7 +27749,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/util-deprecate"
         }
       ]
@@ -27775,7 +27775,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/util"
         }
       ]
@@ -27801,7 +27801,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/utils-merge"
         }
       ]
@@ -27827,7 +27827,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/uuid"
         }
       ]
@@ -27853,7 +27853,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/v8flags"
         }
       ]
@@ -27879,7 +27879,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/validate-npm-package-license"
         }
       ]
@@ -27905,7 +27905,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/validate"
         }
       ]
@@ -27931,7 +27931,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/validator"
         }
       ]
@@ -27957,7 +27957,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/vary"
         }
       ]
@@ -27983,7 +27983,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/verror"
         }
       ],
@@ -28009,7 +28009,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/verror/node_modules/core-util-is"
             }
           ]
@@ -28037,7 +28037,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/vm2"
         }
       ],
@@ -28063,7 +28063,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/vm2/node_modules/acorn"
             }
           ]
@@ -28091,7 +28091,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/void-elements"
         }
       ]
@@ -28117,7 +28117,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/walk"
         }
       ]
@@ -28143,7 +28143,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/walkdir"
         }
       ]
@@ -28169,7 +28169,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/webidl-conversions"
         }
       ]
@@ -28195,7 +28195,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/whatwg-url"
         }
       ]
@@ -28221,7 +28221,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-boxed-primitive"
         }
       ]
@@ -28247,7 +28247,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-collection"
         }
       ]
@@ -28273,7 +28273,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-module"
         }
       ]
@@ -28299,7 +28299,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-pm-runs"
         }
       ]
@@ -28325,7 +28325,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-typed-array"
         }
       ]
@@ -28351,7 +28351,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which"
         }
       ]
@@ -28377,7 +28377,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wide-align"
         }
       ]
@@ -28403,7 +28403,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/winston-transport"
         }
       ],
@@ -28429,7 +28429,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/winston-transport/node_modules/readable-stream"
             }
           ]
@@ -28457,7 +28457,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/winston"
         }
       ],
@@ -28483,7 +28483,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/winston/node_modules/async"
             }
           ]
@@ -28509,7 +28509,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/winston/node_modules/is-stream"
             }
           ]
@@ -28535,7 +28535,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/winston/node_modules/readable-stream"
             }
           ]
@@ -28563,7 +28563,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/with"
         }
       ]
@@ -28589,7 +28589,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wkx"
         }
       ]
@@ -28615,7 +28615,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/word-wrap"
         }
       ]
@@ -28641,7 +28641,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wordwrap"
         }
       ]
@@ -28667,7 +28667,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wrap-ansi"
         }
       ],
@@ -28693,7 +28693,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi/node_modules/ansi-regex"
             }
           ]
@@ -28719,7 +28719,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi/node_modules/emoji-regex"
             }
           ]
@@ -28745,7 +28745,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -28771,7 +28771,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi/node_modules/string-width"
             }
           ]
@@ -28797,7 +28797,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi/node_modules/strip-ansi"
             }
           ]
@@ -28825,7 +28825,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wrappy"
         }
       ]
@@ -28851,7 +28851,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ws"
         }
       ]
@@ -28877,7 +28877,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/xtend"
         }
       ]
@@ -28903,7 +28903,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/y18n"
         }
       ]
@@ -28929,7 +28929,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yallist"
         }
       ]
@@ -28955,7 +28955,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yaml-schema-validator"
         }
       ]
@@ -28981,7 +28981,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yargs-parser"
         }
       ]
@@ -29007,7 +29007,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yargs"
         }
       ],
@@ -29033,7 +29033,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs/node_modules/ansi-regex"
             }
           ]
@@ -29059,7 +29059,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs/node_modules/emoji-regex"
             }
           ]
@@ -29085,7 +29085,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs/node_modules/is-fullwidth-code-point"
             }
           ]
@@ -29111,7 +29111,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs/node_modules/string-width"
             }
           ]
@@ -29137,7 +29137,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs/node_modules/strip-ansi"
             }
           ]
@@ -29165,7 +29165,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yauzl"
         }
       ]
@@ -29191,7 +29191,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yn"
         }
       ]
@@ -29217,7 +29217,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/z85"
         }
       ]
@@ -29243,7 +29243,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/zip-stream"
         }
       ]
@@ -29269,7 +29269,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/zlibjs"
         }
       ]

--- a/tests/_data/sbom_demo-results/juice-shop_npm9_node18_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/juice-shop_npm9_node18_windows-latest.snap.json
@@ -62,6 +62,10 @@
       ],
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -88,6 +92,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@babel\\helper-string-parser"
+        }
       ]
     },
     {
@@ -108,6 +118,12 @@
           "url": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@babel\\helper-validator-identifier"
         }
       ]
     },
@@ -130,6 +146,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@babel\\parser"
+        }
       ]
     },
     {
@@ -150,6 +172,12 @@
           "url": "https://registry.npmjs.org/@babel/types/-/types-7.20.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@babel\\types"
         }
       ]
     },
@@ -172,6 +200,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@colors\\colors"
+        }
       ]
     },
     {
@@ -193,6 +227,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@dabh\\diagnostics"
+        }
       ]
     },
     {
@@ -213,6 +253,12 @@
           "url": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@gar\\promisify"
         }
       ]
     },
@@ -236,6 +282,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@mapbox\\node-pre-gyp"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -254,6 +306,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\ansi-regex"
             }
           ]
         },
@@ -275,6 +333,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\are-we-there-yet"
+            }
           ]
         },
         {
@@ -294,6 +358,12 @@
               "url": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\detect-libc"
             }
           ]
         },
@@ -315,6 +385,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\gauge"
+            }
           ]
         },
         {
@@ -334,6 +410,12 @@
               "url": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\is-fullwidth-code-point"
             }
           ]
         },
@@ -356,6 +438,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\make-dir"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -374,6 +462,12 @@
                   "url": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\make-dir\\node_modules\\semver"
                 }
               ]
             }
@@ -397,6 +491,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\nopt"
+            }
           ]
         },
         {
@@ -416,6 +516,12 @@
               "url": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\npmlog"
             }
           ]
         },
@@ -437,6 +543,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\readable-stream"
+            }
           ]
         },
         {
@@ -457,6 +569,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\string-width"
+            }
           ]
         },
         {
@@ -476,6 +594,12 @@
               "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\strip-ansi"
             }
           ]
         }
@@ -500,6 +624,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\core-loader"
+        }
       ]
     },
     {
@@ -520,6 +650,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/core/-/core-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\core"
         }
       ]
     },
@@ -542,6 +678,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\evaluator"
+        }
       ]
     },
     {
@@ -562,6 +704,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-all/-/lang-all-4.24.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-all"
         }
       ]
     },
@@ -584,6 +732,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-ar"
+        }
       ]
     },
     {
@@ -604,6 +758,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-bn/-/lang-bn-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-bn"
         }
       ]
     },
@@ -626,6 +786,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-ca"
+        }
       ]
     },
     {
@@ -646,6 +812,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-cs/-/lang-cs-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-cs"
         }
       ]
     },
@@ -668,6 +840,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-da"
+        }
       ]
     },
     {
@@ -688,6 +866,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-de/-/lang-de-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-de"
         }
       ]
     },
@@ -710,6 +894,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-el"
+        }
       ]
     },
     {
@@ -730,6 +920,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-en-min/-/lang-en-min-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-en-min"
         }
       ]
     },
@@ -752,6 +948,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-en"
+        }
       ]
     },
     {
@@ -772,6 +974,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-es/-/lang-es-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-es"
         }
       ]
     },
@@ -794,6 +1002,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-eu"
+        }
       ]
     },
     {
@@ -814,6 +1028,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-fa/-/lang-fa-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-fa"
         }
       ]
     },
@@ -836,6 +1056,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-fi"
+        }
       ]
     },
     {
@@ -856,6 +1082,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-fr/-/lang-fr-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-fr"
         }
       ]
     },
@@ -878,6 +1110,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-ga"
+        }
       ]
     },
     {
@@ -898,6 +1136,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-gl/-/lang-gl-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-gl"
         }
       ]
     },
@@ -920,6 +1164,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-hi"
+        }
       ]
     },
     {
@@ -940,6 +1190,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-hu/-/lang-hu-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-hu"
         }
       ]
     },
@@ -962,6 +1218,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-hy"
+        }
       ]
     },
     {
@@ -982,6 +1244,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-id/-/lang-id-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-id"
         }
       ]
     },
@@ -1004,6 +1272,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-it"
+        }
       ]
     },
     {
@@ -1024,6 +1298,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-ja/-/lang-ja-4.24.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-ja"
         }
       ]
     },
@@ -1046,6 +1326,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-ko"
+        }
       ]
     },
     {
@@ -1066,6 +1352,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-lt/-/lang-lt-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-lt"
         }
       ]
     },
@@ -1088,6 +1380,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-ms"
+        }
       ]
     },
     {
@@ -1108,6 +1406,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-ne/-/lang-ne-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-ne"
         }
       ]
     },
@@ -1130,6 +1434,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-nl"
+        }
       ]
     },
     {
@@ -1150,6 +1460,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-no/-/lang-no-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-no"
         }
       ]
     },
@@ -1172,6 +1488,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-pl"
+        }
       ]
     },
     {
@@ -1192,6 +1514,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-pt/-/lang-pt-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-pt"
         }
       ]
     },
@@ -1214,6 +1542,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-ro"
+        }
       ]
     },
     {
@@ -1234,6 +1568,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-ru/-/lang-ru-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-ru"
         }
       ]
     },
@@ -1256,6 +1596,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-sl"
+        }
       ]
     },
     {
@@ -1276,6 +1622,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-sr/-/lang-sr-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-sr"
         }
       ]
     },
@@ -1298,6 +1650,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-sv"
+        }
       ]
     },
     {
@@ -1318,6 +1676,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-ta/-/lang-ta-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-ta"
         }
       ]
     },
@@ -1340,6 +1704,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-th"
+        }
       ]
     },
     {
@@ -1360,6 +1730,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-tl/-/lang-tl-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-tl"
         }
       ]
     },
@@ -1382,6 +1758,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-tr"
+        }
       ]
     },
     {
@@ -1402,6 +1784,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/lang-uk/-/lang-uk-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-uk"
         }
       ]
     },
@@ -1424,6 +1812,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\lang-zh"
+        }
       ]
     },
     {
@@ -1444,6 +1838,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/language-min/-/language-min-4.22.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\language-min"
         }
       ]
     },
@@ -1466,6 +1866,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\language"
+        }
       ]
     },
     {
@@ -1486,6 +1892,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/ner/-/ner-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\ner"
         }
       ]
     },
@@ -1508,6 +1920,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\neural"
+        }
       ]
     },
     {
@@ -1528,6 +1946,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/nlg/-/nlg-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\nlg"
         }
       ]
     },
@@ -1550,6 +1974,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\nlp"
+        }
       ]
     },
     {
@@ -1570,6 +2000,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/nlu/-/nlu-4.23.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\nlu"
         }
       ]
     },
@@ -1592,6 +2028,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\request"
+        }
       ]
     },
     {
@@ -1612,6 +2054,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/sentiment/-/sentiment-4.23.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\sentiment"
         }
       ]
     },
@@ -1634,6 +2082,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\similarity"
+        }
       ]
     },
     {
@@ -1654,6 +2108,12 @@
           "url": "https://registry.npmjs.org/@nlpjs/slot/-/slot-4.22.17.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@nlpjs\\slot"
         }
       ]
     },
@@ -1676,6 +2136,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@npmcli\\fs"
+        }
       ]
     },
     {
@@ -1696,6 +2162,12 @@
           "url": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@npmcli\\move-file"
         }
       ]
     },
@@ -1718,6 +2190,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib\\core"
+        }
       ]
     },
     {
@@ -1738,6 +2216,12 @@
           "url": "https://registry.npmjs.org/@otplib/plugin-crypto/-/plugin-crypto-12.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib\\plugin-crypto"
         }
       ]
     },
@@ -1760,6 +2244,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib\\plugin-thirty-two"
+        }
       ]
     },
     {
@@ -1780,6 +2270,12 @@
           "url": "https://registry.npmjs.org/@otplib/preset-default/-/preset-default-12.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib\\preset-default"
         }
       ]
     },
@@ -1802,6 +2298,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@otplib\\preset-v11"
+        }
       ]
     },
     {
@@ -1822,6 +2324,12 @@
           "url": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@sindresorhus\\is"
         }
       ]
     },
@@ -1844,6 +2352,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@swc\\helpers"
+        }
       ]
     },
     {
@@ -1864,6 +2378,12 @@
           "url": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@tokenizer\\token"
         }
       ]
     },
@@ -1886,6 +2406,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@tootallnate\\once"
+        }
       ]
     },
     {
@@ -1906,6 +2432,12 @@
           "url": "https://registry.npmjs.org/@types/component-emitter/-/component-emitter-1.2.11.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types\\component-emitter"
         }
       ]
     },
@@ -1928,6 +2460,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types\\cookie"
+        }
       ]
     },
     {
@@ -1948,6 +2486,12 @@
           "url": "https://registry.npmjs.org/@types/cors/-/cors-2.8.12.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types\\cors"
         }
       ]
     },
@@ -1970,6 +2514,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types\\debug"
+        }
       ]
     },
     {
@@ -1990,6 +2540,12 @@
           "url": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types\\ms"
         }
       ]
     },
@@ -2012,6 +2568,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types\\node"
+        }
       ]
     },
     {
@@ -2032,6 +2594,12 @@
           "url": "https://registry.npmjs.org/@types/strip-bom/-/strip-bom-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types\\strip-bom"
         }
       ]
     },
@@ -2054,6 +2622,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types\\strip-json-comments"
+        }
       ]
     },
     {
@@ -2075,6 +2649,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/@types\\validator"
+        }
       ]
     },
     {
@@ -2094,6 +2674,12 @@
           "url": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/abbrev"
         }
       ]
     },
@@ -2115,6 +2701,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/accepts"
+        }
       ]
     },
     {
@@ -2135,6 +2727,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/acorn-walk"
+        }
       ]
     },
     {
@@ -2154,6 +2752,12 @@
           "url": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/acorn"
         }
       ]
     },
@@ -2176,6 +2780,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/agent-base"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -2194,6 +2804,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agent-base\\node_modules\\debug"
             }
           ]
         },
@@ -2214,6 +2830,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agent-base\\node_modules\\ms"
             }
           ]
         }
@@ -2238,6 +2860,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/agentkeepalive"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -2256,6 +2884,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agentkeepalive\\node_modules\\debug"
             }
           ]
         },
@@ -2277,6 +2911,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agentkeepalive\\node_modules\\depd"
+            }
           ]
         },
         {
@@ -2296,6 +2936,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/agentkeepalive\\node_modules\\ms"
             }
           ]
         }
@@ -2319,6 +2965,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/aggregate-error"
+        }
       ]
     },
     {
@@ -2338,6 +2990,12 @@
           "url": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ajv"
         }
       ]
     },
@@ -2359,6 +3017,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ansi-regex"
+        }
       ]
     },
     {
@@ -2378,6 +3042,12 @@
           "url": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ansi-styles"
         }
       ]
     },
@@ -2400,6 +3070,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/anymatch"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -2418,6 +3094,12 @@
               "url": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/anymatch\\node_modules\\normalize-path"
             }
           ]
         }
@@ -2441,6 +3123,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/append-field"
+        }
       ]
     },
     {
@@ -2460,6 +3148,12 @@
           "url": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/aproba"
         }
       ]
     },
@@ -2482,6 +3176,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/archive-type"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -2500,6 +3200,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-4.4.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/archive-type\\node_modules\\file-type"
             }
           ]
         }
@@ -2523,6 +3229,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/archiver-utils"
+        }
       ]
     },
     {
@@ -2542,6 +3254,12 @@
           "url": "https://registry.npmjs.org/archiver/-/archiver-1.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/archiver"
         }
       ]
     },
@@ -2563,6 +3281,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/are-we-there-yet"
+        }
       ]
     },
     {
@@ -2582,6 +3306,12 @@
           "url": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/arg"
         }
       ]
     },
@@ -2604,6 +3334,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/argparse"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -2622,6 +3358,12 @@
               "url": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/argparse\\node_modules\\sprintf-js"
             }
           ]
         }
@@ -2645,6 +3387,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/arr-diff"
+        }
       ]
     },
     {
@@ -2664,6 +3412,12 @@
           "url": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/arr-flatten"
         }
       ]
     },
@@ -2685,6 +3439,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/arr-union"
+        }
       ]
     },
     {
@@ -2704,6 +3464,12 @@
           "url": "https://registry.npmjs.org/array-each/-/array-each-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/array-each"
         }
       ]
     },
@@ -2725,6 +3491,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/array-flatten"
+        }
       ]
     },
     {
@@ -2744,6 +3516,12 @@
           "url": "https://registry.npmjs.org/array-slice/-/array-slice-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/array-slice"
         }
       ]
     },
@@ -2765,6 +3543,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/array-unique"
+        }
       ]
     },
     {
@@ -2784,6 +3568,12 @@
           "url": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/asap"
         }
       ]
     },
@@ -2805,6 +3595,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/asn1"
+        }
       ]
     },
     {
@@ -2824,6 +3620,12 @@
           "url": "https://registry.npmjs.org/assert-never/-/assert-never-1.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/assert-never"
         }
       ]
     },
@@ -2845,6 +3647,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/assert-plus"
+        }
       ]
     },
     {
@@ -2864,6 +3672,12 @@
           "url": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/assign-symbols"
         }
       ]
     },
@@ -2885,6 +3699,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/async"
+        }
       ]
     },
     {
@@ -2904,6 +3724,12 @@
           "url": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/asynckit"
         }
       ]
     },
@@ -2925,6 +3751,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/at-least-node"
+        }
       ]
     },
     {
@@ -2944,6 +3776,12 @@
           "url": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/atob"
         }
       ]
     },
@@ -2965,6 +3803,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/available-typed-arrays"
+        }
       ]
     },
     {
@@ -2984,6 +3828,12 @@
           "url": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/aws-sign2"
         }
       ]
     },
@@ -3005,6 +3855,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/aws4"
+        }
       ]
     },
     {
@@ -3025,6 +3881,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/babel-walk"
+        }
       ]
     },
     {
@@ -3044,6 +3906,12 @@
           "url": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/balanced-match"
         }
       ]
     },
@@ -3066,6 +3934,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -3084,6 +3958,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/base\\node_modules\\define-property"
             }
           ]
         }
@@ -3107,6 +3987,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base64-arraybuffer"
+        }
       ]
     },
     {
@@ -3126,6 +4012,12 @@
           "url": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base64-js"
         }
       ]
     },
@@ -3147,6 +4039,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base64id"
+        }
       ]
     },
     {
@@ -3166,6 +4064,12 @@
           "url": "https://registry.npmjs.org/base64url/-/base64url-0.0.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/base64url"
         }
       ]
     },
@@ -3187,6 +4091,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/basic-auth"
+        }
       ]
     },
     {
@@ -3206,6 +4116,12 @@
           "url": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/batch"
         }
       ]
     },
@@ -3227,6 +4143,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bcrypt-pbkdf"
+        }
       ]
     },
     {
@@ -3246,6 +4168,12 @@
           "url": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/big-integer"
         }
       ]
     },
@@ -3267,6 +4195,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/binary-extensions"
+        }
       ]
     },
     {
@@ -3286,6 +4220,12 @@
           "url": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/binary"
         }
       ]
     },
@@ -3307,6 +4247,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bindings"
+        }
       ]
     },
     {
@@ -3326,6 +4272,12 @@
           "url": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bintrees"
         }
       ]
     },
@@ -3347,6 +4299,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bl"
+        }
       ]
     },
     {
@@ -3367,6 +4325,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bluebird"
+        }
       ]
     },
     {
@@ -3386,6 +4350,12 @@
           "url": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/body-parser"
         }
       ]
     },
@@ -3408,6 +4378,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bower-config"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -3426,6 +4402,12 @@
               "url": "https://registry.npmjs.org/minimist/-/minimist-0.2.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/bower-config\\node_modules\\minimist"
             }
           ]
         }
@@ -3449,6 +4431,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/brace-expansion"
+        }
       ]
     },
     {
@@ -3470,6 +4458,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/braces"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -3488,6 +4482,12 @@
               "url": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/braces\\node_modules\\extend-shallow"
             }
           ]
         },
@@ -3508,6 +4508,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/braces\\node_modules\\is-extendable"
             }
           ]
         }
@@ -3531,6 +4537,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/brotli"
+        }
       ]
     },
     {
@@ -3550,6 +4562,12 @@
           "url": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-alloc-unsafe"
         }
       ]
     },
@@ -3571,6 +4589,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-alloc"
+        }
       ]
     },
     {
@@ -3590,6 +4614,12 @@
           "url": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-crc32"
         }
       ]
     },
@@ -3611,6 +4641,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-fill"
+        }
       ]
     },
     {
@@ -3630,6 +4666,12 @@
           "url": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-from"
         }
       ]
     },
@@ -3651,6 +4693,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer-indexof-polyfill"
+        }
       ]
     },
     {
@@ -3671,6 +4719,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffer"
+        }
       ]
     },
     {
@@ -3690,6 +4744,12 @@
           "url": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/buffers"
         }
       ]
     },
@@ -3712,6 +4772,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/busboy"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -3730,6 +4796,12 @@
               "url": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/busboy\\node_modules\\isarray"
             }
           ]
         },
@@ -3751,6 +4823,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/busboy\\node_modules\\readable-stream"
+            }
           ]
         },
         {
@@ -3770,6 +4848,12 @@
               "url": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/busboy\\node_modules\\string_decoder"
             }
           ]
         }
@@ -3793,6 +4877,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/byline"
+        }
       ]
     },
     {
@@ -3812,6 +4902,12 @@
           "url": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/bytes"
         }
       ]
     },
@@ -3833,6 +4929,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cacache"
+        }
       ]
     },
     {
@@ -3852,6 +4954,12 @@
           "url": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cache-base"
         }
       ]
     },
@@ -3874,6 +4982,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cacheable-request"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -3892,6 +5006,12 @@
               "url": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cacheable-request\\node_modules\\get-stream"
             }
           ]
         },
@@ -3912,6 +5032,12 @@
               "url": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cacheable-request\\node_modules\\lowercase-keys"
             }
           ]
         }
@@ -3935,6 +5061,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/call-bind"
+        }
       ]
     },
     {
@@ -3954,6 +5086,12 @@
           "url": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/camelcase"
         }
       ]
     },
@@ -3975,6 +5113,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/caseless"
+        }
       ]
     },
     {
@@ -3994,6 +5138,12 @@
           "url": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/chainsaw"
         }
       ]
     },
@@ -4015,6 +5165,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/chalk"
+        }
       ]
     },
     {
@@ -4034,6 +5190,12 @@
           "url": "https://registry.npmjs.org/character-parser/-/character-parser-2.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/character-parser"
         }
       ]
     },
@@ -4056,6 +5218,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/check-dependencies"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4074,6 +5242,12 @@
               "url": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/check-dependencies\\node_modules\\semver"
             }
           ]
         }
@@ -4097,6 +5271,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/check-types"
+        }
       ]
     },
     {
@@ -4118,6 +5298,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/chokidar"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4136,6 +5322,12 @@
               "url": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar\\node_modules\\braces"
             }
           ]
         },
@@ -4157,6 +5349,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar\\node_modules\\fill-range"
+            }
           ]
         },
         {
@@ -4176,6 +5374,12 @@
               "url": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar\\node_modules\\is-glob"
             }
           ]
         },
@@ -4197,6 +5401,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar\\node_modules\\is-number"
+            }
           ]
         },
         {
@@ -4217,6 +5427,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar\\node_modules\\normalize-path"
+            }
           ]
         },
         {
@@ -4236,6 +5452,12 @@
               "url": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/chokidar\\node_modules\\to-regex-range"
             }
           ]
         }
@@ -4259,6 +5481,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/chownr"
+        }
       ]
     },
     {
@@ -4278,6 +5506,12 @@
           "url": "https://registry.npmjs.org/clarinet/-/clarinet-0.12.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/clarinet"
         }
       ]
     },
@@ -4300,6 +5534,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/class-utils"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4318,6 +5558,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils\\node_modules\\define-property"
             }
           ]
         },
@@ -4340,6 +5586,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils\\node_modules\\is-accessor-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -4358,6 +5610,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/class-utils\\node_modules\\is-accessor-descriptor\\node_modules\\kind-of"
                 }
               ]
             }
@@ -4382,6 +5640,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils\\node_modules\\is-data-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -4400,6 +5664,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/class-utils\\node_modules\\is-data-descriptor\\node_modules\\kind-of"
                 }
               ]
             }
@@ -4423,6 +5693,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils\\node_modules\\is-descriptor"
+            }
           ]
         },
         {
@@ -4442,6 +5718,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/class-utils\\node_modules\\kind-of"
             }
           ]
         }
@@ -4465,6 +5747,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/clean-stack"
+        }
       ]
     },
     {
@@ -4486,6 +5774,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cliui"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4504,6 +5798,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui\\node_modules\\ansi-regex"
             }
           ]
         },
@@ -4525,6 +5825,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui\\node_modules\\emoji-regex"
+            }
           ]
         },
         {
@@ -4544,6 +5850,12 @@
               "url": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui\\node_modules\\is-fullwidth-code-point"
             }
           ]
         },
@@ -4565,6 +5877,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui\\node_modules\\string-width"
+            }
           ]
         },
         {
@@ -4584,6 +5902,12 @@
               "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/cliui\\node_modules\\strip-ansi"
             }
           ]
         }
@@ -4607,6 +5931,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/clone-response"
+        }
       ]
     },
     {
@@ -4626,6 +5956,12 @@
           "url": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/clone"
         }
       ]
     },
@@ -4647,6 +5983,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/code-point-at"
+        }
       ]
     },
     {
@@ -4666,6 +6008,12 @@
           "url": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/collection-visit"
         }
       ]
     },
@@ -4687,6 +6035,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color-convert"
+        }
       ]
     },
     {
@@ -4706,6 +6060,12 @@
           "url": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color-name"
         }
       ]
     },
@@ -4727,6 +6087,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color-string"
+        }
       ]
     },
     {
@@ -4746,6 +6112,12 @@
           "url": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color-support"
         }
       ]
     },
@@ -4767,6 +6139,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/color"
+        }
       ]
     },
     {
@@ -4786,6 +6164,12 @@
           "url": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/colors"
         }
       ]
     },
@@ -4807,6 +6191,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/colorspace"
+        }
       ]
     },
     {
@@ -4826,6 +6216,12 @@
           "url": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/combined-stream"
         }
       ]
     },
@@ -4847,6 +6243,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/commander"
+        }
       ]
     },
     {
@@ -4866,6 +6268,12 @@
           "url": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/component-emitter"
         }
       ]
     },
@@ -4887,6 +6295,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/component-type"
+        }
       ]
     },
     {
@@ -4907,6 +6321,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/compress-commons"
+        }
       ]
     },
     {
@@ -4926,6 +6346,12 @@
           "url": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/compressible"
         }
       ]
     },
@@ -4948,6 +6374,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/compression"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -4966,6 +6398,12 @@
               "url": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/compression\\node_modules\\bytes"
             }
           ]
         }
@@ -4989,6 +6427,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/concat-map"
+        }
       ]
     },
     {
@@ -5008,6 +6452,12 @@
           "url": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/concat-stream"
         }
       ]
     },
@@ -5030,6 +6480,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/concurrently"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5048,6 +6504,12 @@
               "url": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/concurrently\\node_modules\\supports-color"
             }
           ]
         }
@@ -5071,6 +6533,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/config"
+        }
       ]
     },
     {
@@ -5091,6 +6559,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/console-control-strings"
+        }
       ]
     },
     {
@@ -5110,6 +6584,12 @@
           "url": "https://registry.npmjs.org/constantinople/-/constantinople-4.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/constantinople"
         }
       ]
     },
@@ -5132,6 +6612,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/content-disposition"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5150,6 +6636,12 @@
               "url": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/content-disposition\\node_modules\\safe-buffer"
             }
           ]
         }
@@ -5173,6 +6665,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/content-type"
+        }
       ]
     },
     {
@@ -5192,6 +6690,12 @@
           "url": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cookie-parser"
         }
       ]
     },
@@ -5213,6 +6717,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cookie-signature"
+        }
       ]
     },
     {
@@ -5232,6 +6742,12 @@
           "url": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cookie"
         }
       ]
     },
@@ -5253,6 +6769,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/copy-descriptor"
+        }
       ]
     },
     {
@@ -5272,6 +6794,12 @@
           "url": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/core-util-is"
         }
       ]
     },
@@ -5293,6 +6821,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/cors"
+        }
       ]
     },
     {
@@ -5312,6 +6846,12 @@
           "url": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/crc"
         }
       ]
     },
@@ -5333,6 +6873,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/crc32-stream"
+        }
       ]
     },
     {
@@ -5352,6 +6898,12 @@
           "url": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/create-require"
         }
       ]
     },
@@ -5373,6 +6925,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/crypto-js"
+        }
       ]
     },
     {
@@ -5392,6 +6950,12 @@
           "url": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dashdash"
         }
       ]
     },
@@ -5413,6 +6977,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/date-fns"
+        }
       ]
     },
     {
@@ -5432,6 +7002,12 @@
           "url": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dateformat"
         }
       ]
     },
@@ -5453,6 +7029,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/debug"
+        }
       ]
     },
     {
@@ -5472,6 +7054,12 @@
           "url": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decamelize"
         }
       ]
     },
@@ -5493,6 +7081,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decode-uri-component"
+        }
       ]
     },
     {
@@ -5512,6 +7106,12 @@
           "url": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-response"
         }
       ]
     },
@@ -5534,6 +7134,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-tar"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5552,6 +7158,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-tar\\node_modules\\file-type"
             }
           ]
         }
@@ -5576,6 +7188,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-tarbz2"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5594,6 +7212,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-6.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-tarbz2\\node_modules\\file-type"
             }
           ]
         }
@@ -5618,6 +7242,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-targz"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5636,6 +7266,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-targz\\node_modules\\file-type"
             }
           ]
         }
@@ -5660,6 +7296,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress-unzip"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5678,6 +7320,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-unzip\\node_modules\\file-type"
             }
           ]
         },
@@ -5699,6 +7347,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-unzip\\node_modules\\get-stream"
+            }
           ]
         },
         {
@@ -5718,6 +7372,12 @@
               "url": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress-unzip\\node_modules\\pify"
             }
           ]
         }
@@ -5742,6 +7402,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/decompress"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -5762,6 +7428,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress\\node_modules\\make-dir"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -5780,6 +7452,12 @@
                   "url": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/decompress\\node_modules\\make-dir\\node_modules\\pify"
                 }
               ]
             }
@@ -5803,6 +7481,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/decompress\\node_modules\\pify"
+            }
           ]
         }
       ]
@@ -5825,6 +7509,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/deep-equal"
+        }
       ]
     },
     {
@@ -5844,6 +7534,12 @@
           "url": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/deep-extend"
         }
       ]
     },
@@ -5865,6 +7561,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/deep-is"
+        }
       ]
     },
     {
@@ -5884,6 +7586,12 @@
           "url": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/define-properties"
         }
       ]
     },
@@ -5905,6 +7613,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/define-property"
+        }
       ]
     },
     {
@@ -5924,6 +7638,12 @@
           "url": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/delayed-stream"
         }
       ]
     },
@@ -5945,6 +7665,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/delegates"
+        }
       ]
     },
     {
@@ -5964,6 +7690,12 @@
           "url": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/depd"
         }
       ]
     },
@@ -5985,6 +7717,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/destroy"
+        }
       ]
     },
     {
@@ -6004,6 +7742,12 @@
           "url": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/detect-file"
         }
       ]
     },
@@ -6025,6 +7769,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/detect-libc"
+        }
       ]
     },
     {
@@ -6044,6 +7794,12 @@
           "url": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dfa"
         }
       ]
     },
@@ -6066,6 +7822,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dicer"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -6084,6 +7846,12 @@
               "url": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/dicer\\node_modules\\isarray"
             }
           ]
         },
@@ -6105,6 +7873,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/dicer\\node_modules\\readable-stream"
+            }
           ]
         },
         {
@@ -6124,6 +7898,12 @@
               "url": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/dicer\\node_modules\\string_decoder"
             }
           ]
         }
@@ -6147,6 +7927,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/diff"
+        }
       ]
     },
     {
@@ -6166,6 +7952,12 @@
           "url": "https://registry.npmjs.org/doctypes/-/doctypes-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/doctypes"
         }
       ]
     },
@@ -6187,6 +7979,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/domelementtype"
+        }
       ]
     },
     {
@@ -6206,6 +8004,12 @@
           "url": "https://registry.npmjs.org/domhandler/-/domhandler-2.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/domhandler"
         }
       ]
     },
@@ -6227,6 +8031,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/domutils"
+        }
       ]
     },
     {
@@ -6246,6 +8056,12 @@
           "url": "https://registry.npmjs.org/dottie/-/dottie-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dottie"
         }
       ]
     },
@@ -6267,6 +8083,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/double-ended-queue"
+        }
       ]
     },
     {
@@ -6286,6 +8108,12 @@
           "url": "https://registry.npmjs.org/doublearray/-/doublearray-0.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/doublearray"
         }
       ]
     },
@@ -6308,6 +8136,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/download"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -6326,6 +8160,12 @@
               "url": "https://registry.npmjs.org/file-type/-/file-type-11.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/download\\node_modules\\file-type"
             }
           ]
         }
@@ -6349,6 +8189,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/duplexer2"
+        }
       ]
     },
     {
@@ -6368,6 +8214,12 @@
           "url": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/duplexer3"
         }
       ]
     },
@@ -6389,6 +8241,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/dynamic-dedupe"
+        }
       ]
     },
     {
@@ -6408,6 +8266,12 @@
           "url": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ecc-jsbn"
         }
       ]
     },
@@ -6429,6 +8293,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ee-first"
+        }
       ]
     },
     {
@@ -6448,6 +8318,12 @@
           "url": "https://registry.npmjs.org/eivindfjeldstad-dot/-/eivindfjeldstad-dot-0.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/eivindfjeldstad-dot"
         }
       ]
     },
@@ -6469,6 +8345,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/emoji-regex"
+        }
       ]
     },
     {
@@ -6489,6 +8371,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/enabled"
+        }
       ]
     },
     {
@@ -6508,6 +8396,12 @@
           "url": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/encodeurl"
         }
       ]
     },
@@ -6530,6 +8424,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/encoding"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -6548,6 +8448,12 @@
               "url": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/encoding\\node_modules\\iconv-lite"
             }
           ]
         }
@@ -6571,6 +8477,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/end-of-stream"
+        }
       ]
     },
     {
@@ -6590,6 +8502,12 @@
           "url": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-4.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/engine.io-parser"
         }
       ]
     },
@@ -6612,6 +8530,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/engine.io"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -6630,6 +8554,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/engine.io\\node_modules\\debug"
             }
           ]
         },
@@ -6650,6 +8580,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/engine.io\\node_modules\\ms"
             }
           ]
         }
@@ -6673,6 +8609,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/env-paths"
+        }
       ]
     },
     {
@@ -6692,6 +8634,12 @@
           "url": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/err-code"
         }
       ]
     },
@@ -6713,6 +8661,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/error-ex"
+        }
       ]
     },
     {
@@ -6732,6 +8686,12 @@
           "url": "https://registry.npmjs.org/errorhandler/-/errorhandler-1.5.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/errorhandler"
         }
       ]
     },
@@ -6753,6 +8713,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/es-abstract"
+        }
       ]
     },
     {
@@ -6772,6 +8738,12 @@
           "url": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/es-get-iterator"
         }
       ]
     },
@@ -6793,6 +8765,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/es-to-primitive"
+        }
       ]
     },
     {
@@ -6812,6 +8790,12 @@
           "url": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/escape-html"
         }
       ]
     },
@@ -6833,6 +8817,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/escape-string-regexp"
+        }
       ]
     },
     {
@@ -6852,6 +8842,12 @@
           "url": "https://registry.npmjs.org/escodegen/-/escodegen-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/escodegen"
         }
       ]
     },
@@ -6873,6 +8869,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/esprima"
+        }
       ]
     },
     {
@@ -6892,6 +8894,12 @@
           "url": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/estraverse"
         }
       ]
     },
@@ -6913,6 +8921,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/esutils"
+        }
       ]
     },
     {
@@ -6932,6 +8946,12 @@
           "url": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/etag"
         }
       ]
     },
@@ -6953,6 +8973,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/eventemitter2"
+        }
       ]
     },
     {
@@ -6972,6 +8998,12 @@
           "url": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/eventemitter3"
         }
       ]
     },
@@ -6993,6 +9025,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/exif"
+        }
       ]
     },
     {
@@ -7012,6 +9050,12 @@
           "url": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/exit"
         }
       ]
     },
@@ -7034,6 +9078,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/expand-brackets"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7052,6 +9102,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets\\node_modules\\define-property"
             }
           ]
         },
@@ -7072,6 +9128,12 @@
               "url": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets\\node_modules\\extend-shallow"
             }
           ]
         },
@@ -7094,6 +9156,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets\\node_modules\\is-accessor-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -7112,6 +9180,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/expand-brackets\\node_modules\\is-accessor-descriptor\\node_modules\\kind-of"
                 }
               ]
             }
@@ -7136,6 +9210,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets\\node_modules\\is-data-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -7154,6 +9234,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/expand-brackets\\node_modules\\is-data-descriptor\\node_modules\\kind-of"
                 }
               ]
             }
@@ -7177,6 +9263,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets\\node_modules\\is-descriptor"
+            }
           ]
         },
         {
@@ -7197,6 +9289,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets\\node_modules\\is-extendable"
+            }
           ]
         },
         {
@@ -7216,6 +9314,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/expand-brackets\\node_modules\\kind-of"
             }
           ]
         }
@@ -7239,6 +9343,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/expand-template"
+        }
       ]
     },
     {
@@ -7259,6 +9369,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/expand-tilde"
+        }
       ]
     },
     {
@@ -7278,6 +9394,12 @@
           "url": "https://registry.npmjs.org/express-ipfilter/-/express-ipfilter-1.3.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-ipfilter"
         }
       ]
     },
@@ -7300,6 +9422,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-jwt"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7318,6 +9446,12 @@
               "url": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-0.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/express-jwt\\node_modules\\jsonwebtoken"
             }
           ]
         },
@@ -7338,6 +9472,12 @@
               "url": "https://registry.npmjs.org/moment/-/moment-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/express-jwt\\node_modules\\moment"
             }
           ]
         }
@@ -7361,6 +9501,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-rate-limit"
+        }
       ]
     },
     {
@@ -7381,6 +9527,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-robots-txt"
+        }
       ]
     },
     {
@@ -7400,6 +9552,12 @@
           "url": "https://registry.npmjs.org/express-security.txt/-/express-security.txt-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express-security.txt"
         }
       ]
     },
@@ -7422,6 +9580,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/express"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7440,6 +9604,12 @@
               "url": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/express\\node_modules\\cookie"
             }
           ]
         },
@@ -7460,6 +9630,12 @@
               "url": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/express\\node_modules\\safe-buffer"
             }
           ]
         }
@@ -7483,6 +9659,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ext-list"
+        }
       ]
     },
     {
@@ -7502,6 +9684,12 @@
           "url": "https://registry.npmjs.org/ext-name/-/ext-name-5.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ext-name"
         }
       ]
     },
@@ -7523,6 +9711,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/extend-shallow"
+        }
       ]
     },
     {
@@ -7542,6 +9736,12 @@
           "url": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/extend"
         }
       ]
     },
@@ -7564,6 +9764,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/extglob"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7582,6 +9788,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/extglob\\node_modules\\define-property"
             }
           ]
         },
@@ -7603,6 +9815,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/extglob\\node_modules\\extend-shallow"
+            }
           ]
         },
         {
@@ -7622,6 +9840,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/extglob\\node_modules\\is-extendable"
             }
           ]
         }
@@ -7645,6 +9869,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/extsprintf"
+        }
       ]
     },
     {
@@ -7664,6 +9894,12 @@
           "url": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fast-deep-equal"
         }
       ]
     },
@@ -7685,6 +9921,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fast-json-stable-stringify"
+        }
       ]
     },
     {
@@ -7704,6 +9946,12 @@
           "url": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fast-levenshtein"
         }
       ]
     },
@@ -7725,6 +9973,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fast.js"
+        }
       ]
     },
     {
@@ -7744,6 +9998,12 @@
           "url": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fd-slicer"
         }
       ]
     },
@@ -7765,6 +10025,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/feature-policy"
+        }
       ]
     },
     {
@@ -7784,6 +10050,12 @@
           "url": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fecha"
         }
       ]
     },
@@ -7806,6 +10078,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/file-js"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -7824,6 +10102,12 @@
               "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/file-js\\node_modules\\brace-expansion"
             }
           ]
         },
@@ -7844,6 +10128,12 @@
               "url": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/file-js\\node_modules\\minimatch"
             }
           ]
         }
@@ -7867,6 +10157,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/file-stream-rotator"
+        }
       ]
     },
     {
@@ -7886,6 +10182,12 @@
           "url": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/file-type"
         }
       ]
     },
@@ -7907,6 +10209,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/file-uri-to-path"
+        }
       ]
     },
     {
@@ -7926,6 +10234,12 @@
           "url": "https://registry.npmjs.org/filehound/-/filehound-1.17.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/filehound"
         }
       ]
     },
@@ -7947,6 +10261,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/filename-reserved-regex"
+        }
       ]
     },
     {
@@ -7967,6 +10287,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/filenamify"
+        }
       ]
     },
     {
@@ -7986,6 +10312,12 @@
           "url": "https://registry.npmjs.org/filesniffer/-/filesniffer-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/filesniffer"
         }
       ]
     },
@@ -8008,6 +10340,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fill-range"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -8026,6 +10364,12 @@
               "url": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/fill-range\\node_modules\\extend-shallow"
             }
           ]
         },
@@ -8046,6 +10390,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/fill-range\\node_modules\\is-extendable"
             }
           ]
         }
@@ -8069,6 +10419,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/finale-rest"
+        }
       ]
     },
     {
@@ -8088,6 +10444,12 @@
           "url": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/finalhandler"
         }
       ]
     },
@@ -8109,6 +10471,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/find-up"
+        }
       ]
     },
     {
@@ -8128,6 +10496,12 @@
           "url": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/findup-sync"
         }
       ]
     },
@@ -8149,6 +10523,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fined"
+        }
       ]
     },
     {
@@ -8168,6 +10548,12 @@
           "url": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/flagged-respawn"
         }
       ]
     },
@@ -8189,6 +10575,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fn.name"
+        }
       ]
     },
     {
@@ -8208,6 +10600,12 @@
           "url": "https://registry.npmjs.org/fontkit/-/fontkit-1.9.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fontkit"
         }
       ]
     },
@@ -8229,6 +10627,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/for-each"
+        }
       ]
     },
     {
@@ -8248,6 +10652,12 @@
           "url": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/for-in"
         }
       ]
     },
@@ -8269,6 +10679,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/for-own"
+        }
       ]
     },
     {
@@ -8288,6 +10704,12 @@
           "url": "https://registry.npmjs.org/foreachasync/-/foreachasync-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/foreachasync"
         }
       ]
     },
@@ -8309,6 +10731,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/forever-agent"
+        }
       ]
     },
     {
@@ -8328,6 +10756,12 @@
           "url": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/form-data"
         }
       ]
     },
@@ -8349,6 +10783,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/formatio"
+        }
       ]
     },
     {
@@ -8368,6 +10808,12 @@
           "url": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/forwarded"
         }
       ]
     },
@@ -8389,6 +10835,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fragment-cache"
+        }
       ]
     },
     {
@@ -8408,6 +10860,12 @@
           "url": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fresh"
         }
       ]
     },
@@ -8429,6 +10887,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/from2"
+        }
       ]
     },
     {
@@ -8448,6 +10912,12 @@
           "url": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fs-constants"
         }
       ]
     },
@@ -8469,6 +10939,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fs-extra"
+        }
       ]
     },
     {
@@ -8489,6 +10965,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fs-minipass"
+        }
       ]
     },
     {
@@ -8508,6 +10990,12 @@
           "url": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fs.realpath"
         }
       ]
     },
@@ -8530,6 +11018,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fstream"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -8548,6 +11042,12 @@
               "url": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/fstream\\node_modules\\mkdirp"
             }
           ]
         },
@@ -8568,6 +11068,12 @@
               "url": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/fstream\\node_modules\\rimraf"
             }
           ]
         }
@@ -8591,6 +11097,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/function-bind"
+        }
       ]
     },
     {
@@ -8610,6 +11122,12 @@
           "url": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/function.prototype.name"
         }
       ]
     },
@@ -8631,6 +11149,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/functions-have-names"
+        }
       ]
     },
     {
@@ -8650,6 +11174,12 @@
           "url": "https://registry.npmjs.org/fuzzball/-/fuzzball-1.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/fuzzball"
         }
       ]
     },
@@ -8671,6 +11201,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/gauge"
+        }
       ]
     },
     {
@@ -8690,6 +11226,12 @@
           "url": "https://registry.npmjs.org/geojson-utils/-/geojson-utils-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/geojson-utils"
         }
       ]
     },
@@ -8711,6 +11253,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-caller-file"
+        }
       ]
     },
     {
@@ -8730,6 +11278,12 @@
           "url": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-intrinsic"
         }
       ]
     },
@@ -8751,6 +11305,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-stream"
+        }
       ]
     },
     {
@@ -8770,6 +11330,12 @@
           "url": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-symbol-description"
         }
       ]
     },
@@ -8791,6 +11357,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/get-value"
+        }
       ]
     },
     {
@@ -8810,6 +11382,12 @@
           "url": "https://registry.npmjs.org/getobject/-/getobject-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/getobject"
         }
       ]
     },
@@ -8831,6 +11409,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/getpass"
+        }
       ]
     },
     {
@@ -8850,6 +11434,12 @@
           "url": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/github-from-package"
         }
       ]
     },
@@ -8872,6 +11462,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/glob-parent"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -8890,6 +11486,12 @@
               "url": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/glob-parent\\node_modules\\is-glob"
             }
           ]
         }
@@ -8914,6 +11516,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/glob"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -8932,6 +11540,12 @@
               "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/glob\\node_modules\\brace-expansion"
             }
           ]
         },
@@ -8952,6 +11566,12 @@
               "url": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/glob\\node_modules\\minimatch"
             }
           ]
         }
@@ -8975,6 +11595,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/global-modules"
+        }
       ]
     },
     {
@@ -8996,6 +11622,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/global-prefix"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9014,6 +11646,12 @@
               "url": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/global-prefix\\node_modules\\which"
             }
           ]
         }
@@ -9038,6 +11676,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/got"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9056,6 +11700,12 @@
               "url": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/got\\node_modules\\get-stream"
             }
           ]
         },
@@ -9076,6 +11726,12 @@
               "url": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/got\\node_modules\\pify"
             }
           ]
         }
@@ -9099,6 +11755,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/graceful-fs"
+        }
       ]
     },
     {
@@ -9120,6 +11782,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-cli"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9138,6 +11806,12 @@
               "url": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-cli\\node_modules\\nopt"
             }
           ]
         }
@@ -9162,6 +11836,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-contrib-compress"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9180,6 +11860,12 @@
               "url": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-contrib-compress\\node_modules\\ansi-styles"
             }
           ]
         },
@@ -9201,6 +11887,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-contrib-compress\\node_modules\\chalk"
+            }
           ]
         },
         {
@@ -9220,6 +11912,12 @@
               "url": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-contrib-compress\\node_modules\\supports-color"
             }
           ]
         }
@@ -9243,6 +11941,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-known-options"
+        }
       ]
     },
     {
@@ -9264,6 +11968,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-legacy-log-utils"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9282,6 +11992,12 @@
               "url": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils\\node_modules\\ansi-styles"
             }
           ]
         },
@@ -9303,6 +12019,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils\\node_modules\\chalk"
+            }
           ]
         },
         {
@@ -9322,6 +12044,12 @@
               "url": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils\\node_modules\\color-convert"
             }
           ]
         },
@@ -9343,6 +12071,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils\\node_modules\\color-name"
+            }
           ]
         },
         {
@@ -9363,6 +12097,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils\\node_modules\\has-flag"
+            }
           ]
         },
         {
@@ -9382,6 +12122,12 @@
               "url": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log-utils\\node_modules\\supports-color"
             }
           ]
         }
@@ -9406,6 +12152,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-legacy-log"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9424,6 +12176,12 @@
               "url": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-log\\node_modules\\colors"
             }
           ]
         }
@@ -9448,6 +12206,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-legacy-util"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9466,6 +12230,12 @@
               "url": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt-legacy-util\\node_modules\\async"
             }
           ]
         }
@@ -9489,6 +12259,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt-replace-json"
+        }
       ]
     },
     {
@@ -9510,6 +12286,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/grunt"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9528,6 +12310,12 @@
               "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt\\node_modules\\brace-expansion"
             }
           ]
         },
@@ -9550,6 +12338,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt\\node_modules\\findup-sync"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -9568,6 +12362,12 @@
                   "url": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/grunt\\node_modules\\findup-sync\\node_modules\\glob"
                 }
               ]
             }
@@ -9591,6 +12391,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt\\node_modules\\glob"
+            }
           ]
         },
         {
@@ -9610,6 +12416,12 @@
               "url": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.8.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/grunt\\node_modules\\minimatch"
             }
           ]
         }
@@ -9634,6 +12446,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/handlebars"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9652,6 +12470,12 @@
               "url": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/handlebars\\node_modules\\wordwrap"
             }
           ]
         }
@@ -9675,6 +12499,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/har-schema"
+        }
       ]
     },
     {
@@ -9694,6 +12524,12 @@
           "url": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/har-validator"
         }
       ]
     },
@@ -9715,6 +12551,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-ansi"
+        }
       ]
     },
     {
@@ -9734,6 +12576,12 @@
           "url": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-bigints"
         }
       ]
     },
@@ -9755,6 +12603,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-flag"
+        }
       ]
     },
     {
@@ -9774,6 +12628,12 @@
           "url": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-property-descriptors"
         }
       ]
     },
@@ -9795,6 +12655,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-symbol-support-x"
+        }
       ]
     },
     {
@@ -9814,6 +12680,12 @@
           "url": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-symbols"
         }
       ]
     },
@@ -9835,6 +12707,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-to-string-tag-x"
+        }
       ]
     },
     {
@@ -9854,6 +12732,12 @@
           "url": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-tostringtag"
         }
       ]
     },
@@ -9875,6 +12759,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-unicode"
+        }
       ]
     },
     {
@@ -9894,6 +12784,12 @@
           "url": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-value"
         }
       ]
     },
@@ -9916,6 +12812,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has-values"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -9934,6 +12836,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/has-values\\node_modules\\kind-of"
             }
           ]
         }
@@ -9957,6 +12865,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/has"
+        }
       ]
     },
     {
@@ -9976,6 +12890,12 @@
           "url": "https://registry.npmjs.org/hashids/-/hashids-2.2.10.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hashids"
         }
       ]
     },
@@ -9997,6 +12917,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hbs"
+        }
       ]
     },
     {
@@ -10016,6 +12942,12 @@
           "url": "https://registry.npmjs.org/he/-/he-0.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/he"
         }
       ]
     },
@@ -10037,6 +12969,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/heap"
+        }
       ]
     },
     {
@@ -10056,6 +12994,12 @@
           "url": "https://registry.npmjs.org/helmet/-/helmet-4.6.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/helmet"
         }
       ]
     },
@@ -10077,6 +13021,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hoister"
+        }
       ]
     },
     {
@@ -10096,6 +13046,12 @@
           "url": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/homedir-polyfill"
         }
       ]
     },
@@ -10117,6 +13073,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hooker"
+        }
       ]
     },
     {
@@ -10137,6 +13099,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/hosted-git-info"
+        }
       ]
     },
     {
@@ -10156,6 +13124,12 @@
           "url": "https://registry.npmjs.org/html-entities/-/html-entities-1.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/html-entities"
         }
       ]
     },
@@ -10178,6 +13152,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/htmlparser2"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -10196,6 +13176,12 @@
               "url": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/htmlparser2\\node_modules\\isarray"
             }
           ]
         },
@@ -10217,6 +13203,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/htmlparser2\\node_modules\\readable-stream"
+            }
           ]
         },
         {
@@ -10236,6 +13228,12 @@
               "url": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/htmlparser2\\node_modules\\string_decoder"
             }
           ]
         }
@@ -10259,6 +13257,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/http-cache-semantics"
+        }
       ]
     },
     {
@@ -10278,6 +13282,12 @@
           "url": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/http-errors"
         }
       ]
     },
@@ -10300,6 +13310,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/http-proxy-agent"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -10318,6 +13334,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/http-proxy-agent\\node_modules\\debug"
             }
           ]
         },
@@ -10338,6 +13360,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/http-proxy-agent\\node_modules\\ms"
             }
           ]
         }
@@ -10361,6 +13389,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/http-signature"
+        }
       ]
     },
     {
@@ -10382,6 +13416,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/https-proxy-agent"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -10400,6 +13440,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/https-proxy-agent\\node_modules\\debug"
             }
           ]
         },
@@ -10420,6 +13466,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/https-proxy-agent\\node_modules\\ms"
             }
           ]
         }
@@ -10443,6 +13495,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/humanize-ms"
+        }
       ]
     },
     {
@@ -10462,6 +13520,12 @@
           "url": "https://registry.npmjs.org/i18n/-/i18n-0.11.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/i18n"
         }
       ]
     },
@@ -10483,6 +13547,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/iconv-lite"
+        }
       ]
     },
     {
@@ -10502,6 +13572,12 @@
           "url": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ieee754"
         }
       ]
     },
@@ -10524,6 +13600,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ignore-walk"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -10542,6 +13624,12 @@
               "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/ignore-walk\\node_modules\\brace-expansion"
             }
           ]
         },
@@ -10562,6 +13650,12 @@
               "url": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/ignore-walk\\node_modules\\minimatch"
             }
           ]
         }
@@ -10585,6 +13679,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/iltorb"
+        }
       ]
     },
     {
@@ -10604,6 +13704,12 @@
           "url": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/imurmurhash"
         }
       ]
     },
@@ -10625,6 +13731,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/indent-string"
+        }
       ]
     },
     {
@@ -10644,6 +13756,12 @@
           "url": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/infer-owner"
         }
       ]
     },
@@ -10665,6 +13783,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/inflection"
+        }
       ]
     },
     {
@@ -10684,6 +13808,12 @@
           "url": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/inflight"
         }
       ]
     },
@@ -10705,6 +13835,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/inherits"
+        }
       ]
     },
     {
@@ -10724,6 +13860,12 @@
           "url": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ini"
         }
       ]
     },
@@ -10745,6 +13887,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/internal-slot"
+        }
       ]
     },
     {
@@ -10764,6 +13912,12 @@
           "url": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/interpret"
         }
       ]
     },
@@ -10785,6 +13939,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/into-stream"
+        }
       ]
     },
     {
@@ -10804,6 +13964,12 @@
           "url": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/invariant"
         }
       ]
     },
@@ -10825,6 +13991,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ip"
+        }
       ]
     },
     {
@@ -10844,6 +14016,12 @@
           "url": "https://registry.npmjs.org/ip6/-/ip6-0.2.10.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ip6"
         }
       ]
     },
@@ -10865,6 +14043,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ipaddr.js"
+        }
       ]
     },
     {
@@ -10884,6 +14068,12 @@
           "url": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-absolute"
         }
       ]
     },
@@ -10905,6 +14095,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-accessor-descriptor"
+        }
       ]
     },
     {
@@ -10924,6 +14120,12 @@
           "url": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-arguments"
         }
       ]
     },
@@ -10945,6 +14147,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-arrayish"
+        }
       ]
     },
     {
@@ -10964,6 +14172,12 @@
           "url": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-bigint"
         }
       ]
     },
@@ -10985,6 +14199,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-binary-path"
+        }
       ]
     },
     {
@@ -11004,6 +14224,12 @@
           "url": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-boolean-object"
         }
       ]
     },
@@ -11025,6 +14251,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-buffer"
+        }
       ]
     },
     {
@@ -11044,6 +14276,12 @@
           "url": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-callable"
         }
       ]
     },
@@ -11065,6 +14303,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-core-module"
+        }
       ]
     },
     {
@@ -11084,6 +14328,12 @@
           "url": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-data-descriptor"
         }
       ]
     },
@@ -11105,6 +14355,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-date-object"
+        }
       ]
     },
     {
@@ -11124,6 +14380,12 @@
           "url": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-descriptor"
         }
       ]
     },
@@ -11145,6 +14407,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-docker"
+        }
       ]
     },
     {
@@ -11164,6 +14432,12 @@
           "url": "https://registry.npmjs.org/is-expression/-/is-expression-4.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-expression"
         }
       ]
     },
@@ -11185,6 +14459,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-extendable"
+        }
       ]
     },
     {
@@ -11204,6 +14484,12 @@
           "url": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-extglob"
         }
       ]
     },
@@ -11225,6 +14511,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-fullwidth-code-point"
+        }
       ]
     },
     {
@@ -11244,6 +14536,12 @@
           "url": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-generator-function"
         }
       ]
     },
@@ -11265,6 +14563,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-glob"
+        }
       ]
     },
     {
@@ -11284,6 +14588,12 @@
           "url": "https://registry.npmjs.org/is-heroku/-/is-heroku-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-heroku"
         }
       ]
     },
@@ -11305,6 +14615,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-lambda"
+        }
       ]
     },
     {
@@ -11324,6 +14640,12 @@
           "url": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-map"
         }
       ]
     },
@@ -11345,6 +14667,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-natural-number"
+        }
       ]
     },
     {
@@ -11364,6 +14692,12 @@
           "url": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-negative-zero"
         }
       ]
     },
@@ -11385,6 +14719,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-number-like"
+        }
       ]
     },
     {
@@ -11404,6 +14744,12 @@
           "url": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-number-object"
         }
       ]
     },
@@ -11426,6 +14772,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-number"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -11444,6 +14796,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/is-number\\node_modules\\kind-of"
             }
           ]
         }
@@ -11467,6 +14825,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-object"
+        }
       ]
     },
     {
@@ -11486,6 +14850,12 @@
           "url": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-plain-obj"
         }
       ]
     },
@@ -11507,6 +14877,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-plain-object"
+        }
       ]
     },
     {
@@ -11526,6 +14902,12 @@
           "url": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-promise"
         }
       ]
     },
@@ -11547,6 +14929,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-regex"
+        }
       ]
     },
     {
@@ -11566,6 +14954,12 @@
           "url": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-relative"
         }
       ]
     },
@@ -11587,6 +14981,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-retry-allowed"
+        }
       ]
     },
     {
@@ -11606,6 +15006,12 @@
           "url": "https://registry.npmjs.org/is-set/-/is-set-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-set"
         }
       ]
     },
@@ -11627,6 +15033,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-shared-array-buffer"
+        }
       ]
     },
     {
@@ -11646,6 +15058,12 @@
           "url": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-stream"
         }
       ]
     },
@@ -11667,6 +15085,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-string"
+        }
       ]
     },
     {
@@ -11686,6 +15110,12 @@
           "url": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-symbol"
         }
       ]
     },
@@ -11707,6 +15137,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-typed-array"
+        }
       ]
     },
     {
@@ -11726,6 +15162,12 @@
           "url": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-typedarray"
         }
       ]
     },
@@ -11747,6 +15189,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-unc-path"
+        }
       ]
     },
     {
@@ -11766,6 +15214,12 @@
           "url": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-weakmap"
         }
       ]
     },
@@ -11787,6 +15241,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-weakref"
+        }
       ]
     },
     {
@@ -11806,6 +15266,12 @@
           "url": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-weakset"
         }
       ]
     },
@@ -11827,6 +15293,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/is-windows"
+        }
       ]
     },
     {
@@ -11846,6 +15318,12 @@
           "url": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isarray"
         }
       ]
     },
@@ -11867,6 +15345,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isexe"
+        }
       ]
     },
     {
@@ -11886,6 +15370,12 @@
           "url": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isobject"
         }
       ]
     },
@@ -11907,6 +15397,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isstream"
+        }
       ]
     },
     {
@@ -11926,6 +15422,12 @@
           "url": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/isurl"
         }
       ]
     },
@@ -11947,6 +15449,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/js-stringify"
+        }
       ]
     },
     {
@@ -11966,6 +15474,12 @@
           "url": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/js-tokens"
         }
       ]
     },
@@ -11987,6 +15501,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/js-yaml"
+        }
       ]
     },
     {
@@ -12006,6 +15526,12 @@
           "url": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jsbn"
         }
       ]
     },
@@ -12027,6 +15553,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-buffer"
+        }
       ]
     },
     {
@@ -12046,6 +15578,12 @@
           "url": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-parse-better-errors"
         }
       ]
     },
@@ -12067,6 +15605,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-schema-traverse"
+        }
       ]
     },
     {
@@ -12086,6 +15630,12 @@
           "url": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-schema"
         }
       ]
     },
@@ -12107,6 +15657,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json-stringify-safe"
+        }
       ]
     },
     {
@@ -12126,6 +15682,12 @@
           "url": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/json5"
         }
       ]
     },
@@ -12147,6 +15709,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jsonfile"
+        }
       ]
     },
     {
@@ -12166,6 +15734,12 @@
           "url": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-0.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jsonwebtoken"
         }
       ]
     },
@@ -12187,6 +15761,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jsprim"
+        }
       ]
     },
     {
@@ -12206,6 +15786,12 @@
           "url": "https://registry.npmjs.org/jssha/-/jssha-3.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jssha"
         }
       ]
     },
@@ -12227,6 +15813,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jstransformer"
+        }
       ]
     },
     {
@@ -12246,6 +15838,12 @@
           "url": "https://registry.npmjs.org/juicy-chat-bot/-/juicy-chat-bot-0.6.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/juicy-chat-bot"
         }
       ]
     },
@@ -12267,6 +15865,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jwa"
+        }
       ]
     },
     {
@@ -12286,6 +15890,12 @@
           "url": "https://registry.npmjs.org/jws/-/jws-0.2.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/jws"
         }
       ]
     },
@@ -12307,6 +15917,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/keyv"
+        }
       ]
     },
     {
@@ -12326,6 +15942,12 @@
           "url": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/kind-of"
         }
       ]
     },
@@ -12347,6 +15969,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/kuler"
+        }
       ]
     },
     {
@@ -12366,6 +15994,12 @@
           "url": "https://registry.npmjs.org/kuromoji/-/kuromoji-0.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/kuromoji"
         }
       ]
     },
@@ -12387,6 +16021,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lazystream"
+        }
       ]
     },
     {
@@ -12406,6 +16046,12 @@
           "url": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/levn"
         }
       ]
     },
@@ -12428,6 +16074,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/libxmljs2"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12446,6 +16098,12 @@
               "url": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/libxmljs2\\node_modules\\nan"
             }
           ]
         }
@@ -12470,6 +16128,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/liftup"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12488,6 +16152,12 @@
               "url": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup\\node_modules\\braces"
             }
           ]
         },
@@ -12509,6 +16179,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup\\node_modules\\fill-range"
+            }
           ]
         },
         {
@@ -12528,6 +16204,12 @@
               "url": "https://registry.npmjs.org/findup-sync/-/findup-sync-4.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup\\node_modules\\findup-sync"
             }
           ]
         },
@@ -12549,6 +16231,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup\\node_modules\\is-glob"
+            }
           ]
         },
         {
@@ -12568,6 +16256,12 @@
               "url": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup\\node_modules\\is-number"
             }
           ]
         },
@@ -12589,6 +16283,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup\\node_modules\\micromatch"
+            }
           ]
         },
         {
@@ -12608,6 +16308,12 @@
               "url": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/liftup\\node_modules\\to-regex-range"
             }
           ]
         }
@@ -12632,6 +16338,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/linebreak"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12650,6 +16362,12 @@
               "url": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/linebreak\\node_modules\\base64-js"
             }
           ]
         }
@@ -12673,6 +16391,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/listenercount"
+        }
       ]
     },
     {
@@ -12692,6 +16416,12 @@
           "url": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/locate-path"
         }
       ]
     },
@@ -12713,6 +16443,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lodash.camelcase"
+        }
       ]
     },
     {
@@ -12732,6 +16468,12 @@
           "url": "https://registry.npmjs.org/lodash.isfinite/-/lodash.isfinite-3.3.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lodash.isfinite"
         }
       ]
     },
@@ -12753,6 +16495,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lodash.set"
+        }
       ]
     },
     {
@@ -12772,6 +16520,12 @@
           "url": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lodash"
         }
       ]
     },
@@ -12794,6 +16548,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/logform"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12812,6 +16572,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/logform\\node_modules\\ms"
             }
           ]
         }
@@ -12835,6 +16601,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lolex"
+        }
       ]
     },
     {
@@ -12854,6 +16626,12 @@
           "url": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/loose-envify"
         }
       ]
     },
@@ -12875,6 +16653,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lowercase-keys"
+        }
       ]
     },
     {
@@ -12894,6 +16678,12 @@
           "url": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/lru-cache"
         }
       ]
     },
@@ -12916,6 +16706,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-dir"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -12934,6 +16730,12 @@
               "url": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-dir\\node_modules\\semver"
             }
           ]
         }
@@ -12957,6 +16759,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-error"
+        }
       ]
     },
     {
@@ -12976,6 +16784,12 @@
           "url": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-9.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-fetch-happen"
         }
       ],
       "components": [
@@ -12998,6 +16812,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen\\node_modules\\@tootallnate\\once"
+            }
           ]
         },
         {
@@ -13017,6 +16837,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen\\node_modules\\debug"
             }
           ]
         },
@@ -13038,6 +16864,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen\\node_modules\\http-cache-semantics"
+            }
           ]
         },
         {
@@ -13058,6 +16890,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen\\node_modules\\http-proxy-agent"
+            }
           ]
         },
         {
@@ -13077,6 +16915,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/make-fetch-happen\\node_modules\\ms"
             }
           ]
         }
@@ -13100,6 +16944,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-iterator"
+        }
       ]
     },
     {
@@ -13119,6 +16969,12 @@
           "url": "https://registry.npmjs.org/make-plural/-/make-plural-6.2.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/make-plural"
         }
       ]
     },
@@ -13140,6 +16996,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/map-cache"
+        }
       ]
     },
     {
@@ -13159,6 +17021,12 @@
           "url": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/map-visit"
         }
       ]
     },
@@ -13180,6 +17048,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/marsdb"
+        }
       ]
     },
     {
@@ -13199,6 +17073,12 @@
           "url": "https://registry.npmjs.org/math-interval-parser/-/math-interval-parser-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/math-interval-parser"
         }
       ]
     },
@@ -13220,6 +17100,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/media-typer"
+        }
       ]
     },
     {
@@ -13239,6 +17125,12 @@
           "url": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/merge-descriptors"
         }
       ]
     },
@@ -13260,6 +17152,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/messageformat-formatters"
+        }
       ]
     },
     {
@@ -13279,6 +17177,12 @@
           "url": "https://registry.npmjs.org/messageformat-parser/-/messageformat-parser-4.1.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/messageformat-parser"
         }
       ]
     },
@@ -13301,6 +17205,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/messageformat"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -13319,6 +17229,12 @@
               "url": "https://registry.npmjs.org/make-plural/-/make-plural-4.3.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/messageformat\\node_modules\\make-plural"
             }
           ]
         }
@@ -13342,6 +17258,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/methods"
+        }
       ]
     },
     {
@@ -13361,6 +17283,12 @@
           "url": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/micromatch"
         }
       ]
     },
@@ -13382,6 +17310,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mime-db"
+        }
       ]
     },
     {
@@ -13401,6 +17335,12 @@
           "url": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mime-types"
         }
       ]
     },
@@ -13422,6 +17362,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mime"
+        }
       ]
     },
     {
@@ -13441,6 +17387,12 @@
           "url": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mimic-response"
         }
       ]
     },
@@ -13462,6 +17414,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minimatch"
+        }
       ]
     },
     {
@@ -13481,6 +17439,12 @@
           "url": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minimist"
         }
       ]
     },
@@ -13502,6 +17466,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-collect"
+        }
       ]
     },
     {
@@ -13521,6 +17491,12 @@
           "url": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-1.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-fetch"
         }
       ]
     },
@@ -13542,6 +17518,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-flush"
+        }
       ]
     },
     {
@@ -13561,6 +17543,12 @@
           "url": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-pipeline"
         }
       ]
     },
@@ -13582,6 +17570,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass-sized"
+        }
       ]
     },
     {
@@ -13601,6 +17595,12 @@
           "url": "https://registry.npmjs.org/minipass/-/minipass-3.3.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minipass"
         }
       ]
     },
@@ -13622,6 +17622,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/minizlib"
+        }
       ]
     },
     {
@@ -13641,6 +17647,12 @@
           "url": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mixin-deep"
         }
       ]
     },
@@ -13662,6 +17674,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mkdirp-classic"
+        }
       ]
     },
     {
@@ -13681,6 +17699,12 @@
           "url": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mkdirp"
         }
       ]
     },
@@ -13702,6 +17726,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/moment-timezone"
+        }
       ]
     },
     {
@@ -13721,6 +17751,12 @@
           "url": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/moment"
         }
       ]
     },
@@ -13743,6 +17779,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/morgan"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -13761,6 +17803,12 @@
               "url": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/morgan\\node_modules\\on-finished"
             }
           ]
         }
@@ -13784,6 +17832,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mout"
+        }
       ]
     },
     {
@@ -13803,6 +17857,12 @@
           "url": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ms"
         }
       ]
     },
@@ -13825,6 +17885,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/multer"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -13843,6 +17909,12 @@
               "url": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/multer\\node_modules\\mkdirp"
             }
           ]
         }
@@ -13866,6 +17938,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/mustache"
+        }
       ]
     },
     {
@@ -13885,6 +17963,12 @@
           "url": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/nan"
         }
       ]
     },
@@ -13906,6 +17990,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/nanomatch"
+        }
       ]
     },
     {
@@ -13925,6 +18015,12 @@
           "url": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/napi-build-utils"
         }
       ]
     },
@@ -13947,6 +18043,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/needle"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -13965,6 +18067,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/needle\\node_modules\\debug"
             }
           ]
         },
@@ -13985,6 +18093,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/needle\\node_modules\\ms"
             }
           ]
         }
@@ -14008,6 +18122,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/negotiator"
+        }
       ]
     },
     {
@@ -14027,6 +18147,12 @@
           "url": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/neo-async"
         }
       ]
     },
@@ -14049,6 +18175,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-abi"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14067,6 +18199,12 @@
               "url": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-abi\\node_modules\\semver"
             }
           ]
         }
@@ -14090,6 +18228,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-addon-api"
+        }
       ]
     },
     {
@@ -14109,6 +18253,12 @@
           "url": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-fetch"
         }
       ]
     },
@@ -14131,6 +18281,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-gyp"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14149,6 +18305,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp\\node_modules\\ansi-regex"
             }
           ]
         },
@@ -14170,6 +18332,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp\\node_modules\\are-we-there-yet"
+            }
           ]
         },
         {
@@ -14189,6 +18357,12 @@
               "url": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp\\node_modules\\gauge"
             }
           ]
         },
@@ -14210,6 +18384,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp\\node_modules\\is-fullwidth-code-point"
+            }
           ]
         },
         {
@@ -14229,6 +18409,12 @@
               "url": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp\\node_modules\\nopt"
             }
           ]
         },
@@ -14250,6 +18436,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp\\node_modules\\npmlog"
+            }
           ]
         },
         {
@@ -14269,6 +18461,12 @@
               "url": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp\\node_modules\\readable-stream"
             }
           ]
         },
@@ -14290,6 +18488,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp\\node_modules\\string-width"
+            }
           ]
         },
         {
@@ -14309,6 +18513,12 @@
               "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-gyp\\node_modules\\strip-ansi"
             }
           ]
         }
@@ -14333,6 +18543,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/node-pre-gyp"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14351,6 +18567,12 @@
               "url": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp\\node_modules\\chownr"
             }
           ]
         },
@@ -14372,6 +18594,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp\\node_modules\\fs-minipass"
+            }
           ]
         },
         {
@@ -14391,6 +18619,12 @@
               "url": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp\\node_modules\\minipass"
             }
           ]
         },
@@ -14412,6 +18646,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp\\node_modules\\minizlib"
+            }
           ]
         },
         {
@@ -14431,6 +18671,12 @@
               "url": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp\\node_modules\\mkdirp"
             }
           ]
         },
@@ -14452,6 +18698,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp\\node_modules\\nopt"
+            }
           ]
         },
         {
@@ -14471,6 +18723,12 @@
               "url": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp\\node_modules\\rimraf"
             }
           ]
         },
@@ -14492,6 +18750,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp\\node_modules\\safe-buffer"
+            }
           ]
         },
         {
@@ -14511,6 +18775,12 @@
               "url": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp\\node_modules\\semver"
             }
           ]
         },
@@ -14532,6 +18802,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp\\node_modules\\tar"
+            }
           ]
         },
         {
@@ -14551,6 +18827,12 @@
               "url": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/node-pre-gyp\\node_modules\\yallist"
             }
           ]
         }
@@ -14574,6 +18856,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/noop-logger"
+        }
       ]
     },
     {
@@ -14593,6 +18881,12 @@
           "url": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/nopt"
         }
       ]
     },
@@ -14615,6 +18909,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/normalize-package-data"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14633,6 +18933,12 @@
               "url": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/normalize-package-data\\node_modules\\semver"
             }
           ]
         }
@@ -14656,6 +18962,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/normalize-path"
+        }
       ]
     },
     {
@@ -14675,6 +18987,12 @@
           "url": "https://registry.npmjs.org/normalize-url/-/normalize-url-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/normalize-url"
         }
       ]
     },
@@ -14697,6 +19015,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/notevil"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14715,6 +19039,12 @@
               "url": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/notevil\\node_modules\\esprima"
             }
           ]
         }
@@ -14738,6 +19068,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/npm-bundled"
+        }
       ]
     },
     {
@@ -14757,6 +19093,12 @@
           "url": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/npm-normalize-package-bin"
         }
       ]
     },
@@ -14778,6 +19120,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/npm-packlist"
+        }
       ]
     },
     {
@@ -14797,6 +19145,12 @@
           "url": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/npmlog"
         }
       ]
     },
@@ -14818,6 +19172,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/number-is-nan"
+        }
       ]
     },
     {
@@ -14838,6 +19198,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/oauth-sign"
+        }
       ]
     },
     {
@@ -14857,6 +19223,12 @@
           "url": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-assign"
         }
       ]
     },
@@ -14879,6 +19251,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-copy"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -14897,6 +19275,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy\\node_modules\\define-property"
             }
           ]
         },
@@ -14918,6 +19302,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy\\node_modules\\is-accessor-descriptor"
+            }
           ]
         },
         {
@@ -14937,6 +19327,12 @@
               "url": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy\\node_modules\\is-data-descriptor"
             }
           ]
         },
@@ -14959,6 +19355,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy\\node_modules\\is-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -14977,6 +19379,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/object-copy\\node_modules\\is-descriptor\\node_modules\\kind-of"
                 }
               ]
             }
@@ -15000,6 +19408,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/object-copy\\node_modules\\kind-of"
+            }
           ]
         }
       ]
@@ -15022,6 +19436,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-inspect"
+        }
       ]
     },
     {
@@ -15041,6 +19461,12 @@
           "url": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-is"
         }
       ]
     },
@@ -15062,6 +19488,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-keys"
+        }
       ]
     },
     {
@@ -15081,6 +19513,12 @@
           "url": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object-visit"
         }
       ]
     },
@@ -15102,6 +19540,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object.assign"
+        }
       ]
     },
     {
@@ -15121,6 +19565,12 @@
           "url": "https://registry.npmjs.org/object.defaults/-/object.defaults-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object.defaults"
         }
       ]
     },
@@ -15142,6 +19592,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object.map"
+        }
       ]
     },
     {
@@ -15161,6 +19617,12 @@
           "url": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/object.pick"
         }
       ]
     },
@@ -15182,6 +19644,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/on-finished"
+        }
       ]
     },
     {
@@ -15201,6 +19669,12 @@
           "url": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/on-headers"
         }
       ]
     },
@@ -15222,6 +19696,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/once"
+        }
       ]
     },
     {
@@ -15241,6 +19721,12 @@
           "url": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/one-time"
         }
       ]
     },
@@ -15262,6 +19748,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/opentype.js"
+        }
       ]
     },
     {
@@ -15281,6 +19773,12 @@
           "url": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/optionator"
         }
       ]
     },
@@ -15302,6 +19800,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/os-homedir"
+        }
       ]
     },
     {
@@ -15321,6 +19825,12 @@
           "url": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/os-tmpdir"
         }
       ]
     },
@@ -15342,6 +19852,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/osenv"
+        }
       ]
     },
     {
@@ -15361,6 +19877,12 @@
           "url": "https://registry.npmjs.org/otplib/-/otplib-12.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/otplib"
         }
       ]
     },
@@ -15382,6 +19904,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-cancelable"
+        }
       ]
     },
     {
@@ -15401,6 +19929,12 @@
           "url": "https://registry.npmjs.org/p-event/-/p-event-2.3.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-event"
         }
       ]
     },
@@ -15422,6 +19956,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-finally"
+        }
       ]
     },
     {
@@ -15441,6 +19981,12 @@
           "url": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-is-promise"
         }
       ]
     },
@@ -15462,6 +20008,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-limit"
+        }
       ]
     },
     {
@@ -15481,6 +20033,12 @@
           "url": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-locate"
         }
       ]
     },
@@ -15502,6 +20060,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-map"
+        }
       ]
     },
     {
@@ -15521,6 +20085,12 @@
           "url": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-timeout"
         }
       ]
     },
@@ -15542,6 +20112,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/p-try"
+        }
       ]
     },
     {
@@ -15561,6 +20137,12 @@
           "url": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pako"
         }
       ]
     },
@@ -15582,6 +20164,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/parse-filepath"
+        }
       ]
     },
     {
@@ -15601,6 +20189,12 @@
           "url": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/parse-json"
         }
       ]
     },
@@ -15622,6 +20216,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/parse-passwd"
+        }
       ]
     },
     {
@@ -15641,6 +20241,12 @@
           "url": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/parseurl"
         }
       ]
     },
@@ -15662,6 +20268,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pascalcase"
+        }
       ]
     },
     {
@@ -15681,6 +20293,12 @@
           "url": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-exists"
         }
       ]
     },
@@ -15702,6 +20320,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-is-absolute"
+        }
       ]
     },
     {
@@ -15721,6 +20345,12 @@
           "url": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-parse"
         }
       ]
     },
@@ -15742,6 +20372,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-root-regex"
+        }
       ]
     },
     {
@@ -15761,6 +20397,12 @@
           "url": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-root"
         }
       ]
     },
@@ -15782,6 +20424,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/path-to-regexp"
+        }
       ]
     },
     {
@@ -15801,6 +20449,12 @@
           "url": "https://registry.npmjs.org/pdfkit/-/pdfkit-0.11.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pdfkit"
         }
       ]
     },
@@ -15822,6 +20476,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/peek-readable"
+        }
       ]
     },
     {
@@ -15841,6 +20501,12 @@
           "url": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pend"
         }
       ]
     },
@@ -15862,6 +20528,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/performance-now"
+        }
       ]
     },
     {
@@ -15881,6 +20553,12 @@
           "url": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.5.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pg-connection-string"
         }
       ]
     },
@@ -15902,6 +20580,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/picomatch"
+        }
       ]
     },
     {
@@ -15921,6 +20605,12 @@
           "url": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pify"
         }
       ]
     },
@@ -15942,6 +20632,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pinkie-promise"
+        }
       ]
     },
     {
@@ -15961,6 +20657,12 @@
           "url": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pinkie"
         }
       ]
     },
@@ -15982,6 +20684,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/png-js"
+        }
       ]
     },
     {
@@ -16001,6 +20709,12 @@
           "url": "https://registry.npmjs.org/portscanner/-/portscanner-2.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/portscanner"
         }
       ]
     },
@@ -16022,6 +20736,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/posix-character-classes"
+        }
       ]
     },
     {
@@ -16041,6 +20761,12 @@
           "url": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.3.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/prebuild-install"
         }
       ]
     },
@@ -16062,6 +20788,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/prelude-ls"
+        }
       ]
     },
     {
@@ -16081,6 +20813,12 @@
           "url": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/prepend-http"
         }
       ]
     },
@@ -16102,6 +20840,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pretty-bytes"
+        }
       ]
     },
     {
@@ -16121,6 +20865,12 @@
           "url": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/process-nextick-args"
         }
       ]
     },
@@ -16142,6 +20892,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/prom-client"
+        }
       ]
     },
     {
@@ -16161,6 +20917,12 @@
           "url": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/promise-inflight"
         }
       ]
     },
@@ -16183,6 +20945,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/promise-retry"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -16201,6 +20969,12 @@
               "url": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/promise-retry\\node_modules\\err-code"
             }
           ]
         },
@@ -16221,6 +20995,12 @@
               "url": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/promise-retry\\node_modules\\retry"
             }
           ]
         }
@@ -16244,6 +21024,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/promise"
+        }
       ]
     },
     {
@@ -16263,6 +21049,12 @@
           "url": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/proper-lockfile"
         }
       ]
     },
@@ -16284,6 +21076,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/proxy-addr"
+        }
       ]
     },
     {
@@ -16303,6 +21101,12 @@
           "url": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/psl"
         }
       ]
     },
@@ -16324,6 +21128,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-attrs"
+        }
       ]
     },
     {
@@ -16343,6 +21153,12 @@
           "url": "https://registry.npmjs.org/pug-code-gen/-/pug-code-gen-3.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-code-gen"
         }
       ]
     },
@@ -16364,6 +21180,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-error"
+        }
       ]
     },
     {
@@ -16383,6 +21205,12 @@
           "url": "https://registry.npmjs.org/pug-filters/-/pug-filters-4.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-filters"
         }
       ]
     },
@@ -16404,6 +21232,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-lexer"
+        }
       ]
     },
     {
@@ -16423,6 +21257,12 @@
           "url": "https://registry.npmjs.org/pug-linker/-/pug-linker-4.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-linker"
         }
       ]
     },
@@ -16444,6 +21284,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-load"
+        }
       ]
     },
     {
@@ -16463,6 +21309,12 @@
           "url": "https://registry.npmjs.org/pug-parser/-/pug-parser-6.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-parser"
         }
       ]
     },
@@ -16484,6 +21336,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-runtime"
+        }
       ]
     },
     {
@@ -16503,6 +21361,12 @@
           "url": "https://registry.npmjs.org/pug-strip-comments/-/pug-strip-comments-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-strip-comments"
         }
       ]
     },
@@ -16524,6 +21388,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug-walk"
+        }
       ]
     },
     {
@@ -16543,6 +21413,12 @@
           "url": "https://registry.npmjs.org/pug/-/pug-3.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pug"
         }
       ]
     },
@@ -16564,6 +21440,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/pump"
+        }
       ]
     },
     {
@@ -16583,6 +21465,12 @@
           "url": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/punycode"
         }
       ]
     },
@@ -16604,6 +21492,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/qs"
+        }
       ]
     },
     {
@@ -16623,6 +21517,12 @@
           "url": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/query-string"
         }
       ]
     },
@@ -16644,6 +21544,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/range_check"
+        }
       ]
     },
     {
@@ -16663,6 +21569,12 @@
           "url": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/range-parser"
         }
       ]
     },
@@ -16684,6 +21596,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/raw-body"
+        }
       ]
     },
     {
@@ -16703,6 +21621,12 @@
           "url": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/rc"
         }
       ]
     },
@@ -16725,6 +21649,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/read-pkg"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -16743,6 +21673,12 @@
               "url": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/read-pkg\\node_modules\\pify"
             }
           ]
         }
@@ -16767,6 +21703,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/readable-stream"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -16785,6 +21727,12 @@
               "url": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/readable-stream\\node_modules\\isarray"
             }
           ]
         }
@@ -16809,6 +21757,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/readable-web-to-node-stream"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -16827,6 +21781,12 @@
               "url": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/readable-web-to-node-stream\\node_modules\\readable-stream"
             }
           ]
         }
@@ -16850,6 +21810,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/readdirp"
+        }
       ]
     },
     {
@@ -16869,6 +21835,12 @@
           "url": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/rechoir"
         }
       ]
     },
@@ -16890,6 +21862,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/regex-not"
+        }
       ]
     },
     {
@@ -16909,6 +21887,12 @@
           "url": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/regexp.prototype.flags"
         }
       ]
     },
@@ -16930,6 +21914,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/remove-trailing-separator"
+        }
       ]
     },
     {
@@ -16950,6 +21940,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/repeat-element"
+        }
       ]
     },
     {
@@ -16969,6 +21965,12 @@
           "url": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/repeat-string"
         }
       ]
     },
@@ -16991,6 +21993,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/replace"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17009,6 +22017,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\ansi-regex"
             }
           ]
         },
@@ -17030,6 +22044,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\ansi-styles"
+            }
           ]
         },
         {
@@ -17049,6 +22069,12 @@
               "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\brace-expansion"
             }
           ]
         },
@@ -17070,6 +22096,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\cliui"
+            }
           ]
         },
         {
@@ -17089,6 +22121,12 @@
               "url": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\color-convert"
             }
           ]
         },
@@ -17110,6 +22148,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\color-name"
+            }
           ]
         },
         {
@@ -17129,6 +22173,12 @@
               "url": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\find-up"
             }
           ]
         },
@@ -17150,6 +22200,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\is-fullwidth-code-point"
+            }
           ]
         },
         {
@@ -17169,6 +22225,12 @@
               "url": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\locate-path"
             }
           ]
         },
@@ -17190,6 +22252,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\minimatch"
+            }
           ]
         },
         {
@@ -17209,6 +22277,12 @@
               "url": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\p-locate"
             }
           ]
         },
@@ -17230,6 +22304,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\path-exists"
+            }
           ]
         },
         {
@@ -17249,6 +22329,12 @@
               "url": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\string-width"
             }
           ]
         },
@@ -17270,6 +22356,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\strip-ansi"
+            }
           ]
         },
         {
@@ -17289,6 +22381,12 @@
               "url": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\wrap-ansi"
             }
           ]
         },
@@ -17310,6 +22408,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\yargs-parser"
+            }
           ]
         },
         {
@@ -17329,6 +22433,12 @@
               "url": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/replace\\node_modules\\yargs"
             }
           ]
         }
@@ -17353,6 +22463,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/request"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17371,6 +22487,12 @@
               "url": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/request\\node_modules\\qs"
             }
           ]
         }
@@ -17394,6 +22516,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/require-directory"
+        }
       ]
     },
     {
@@ -17413,6 +22541,12 @@
           "url": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/require-main-filename"
         }
       ]
     },
@@ -17434,6 +22568,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/resolve-dir"
+        }
       ]
     },
     {
@@ -17453,6 +22593,12 @@
           "url": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/resolve-url"
         }
       ]
     },
@@ -17474,6 +22620,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/resolve"
+        }
       ]
     },
     {
@@ -17493,6 +22645,12 @@
           "url": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/responselike"
         }
       ]
     },
@@ -17514,6 +22672,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/restructure"
+        }
       ]
     },
     {
@@ -17533,6 +22697,12 @@
           "url": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ret"
         }
       ]
     },
@@ -17554,6 +22724,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/retry-as-promised"
+        }
       ]
     },
     {
@@ -17574,6 +22750,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/retry"
+        }
       ]
     },
     {
@@ -17593,6 +22775,12 @@
           "url": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/rimraf"
         }
       ]
     },
@@ -17615,6 +22803,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/rxjs"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17633,6 +22827,12 @@
               "url": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/rxjs\\node_modules\\tslib"
             }
           ]
         }
@@ -17656,6 +22856,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safe-buffer"
+        }
       ]
     },
     {
@@ -17675,6 +22881,12 @@
           "url": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safe-regex-test"
         }
       ]
     },
@@ -17696,6 +22908,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safe-regex"
+        }
       ]
     },
     {
@@ -17715,6 +22933,12 @@
           "url": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safe-stable-stringify"
         }
       ]
     },
@@ -17736,6 +22960,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/safer-buffer"
+        }
       ]
     },
     {
@@ -17756,6 +22986,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/samsam"
+        }
       ]
     },
     {
@@ -17775,6 +23011,12 @@
           "url": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sanitize-filename"
         }
       ]
     },
@@ -17797,6 +23039,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sanitize-html"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17815,6 +23063,12 @@
               "url": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sanitize-html\\node_modules\\lodash"
             }
           ]
         }
@@ -17838,6 +23092,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sax"
+        }
       ]
     },
     {
@@ -17858,6 +23118,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/seek-bzip"
+        }
       ]
     },
     {
@@ -17877,6 +23143,12 @@
           "url": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/semver"
         }
       ]
     },
@@ -17899,6 +23171,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/send"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17917,6 +23195,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/send\\node_modules\\ms"
             }
           ]
         }
@@ -17940,6 +23224,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sequelize-pool"
+        }
       ]
     },
     {
@@ -17961,6 +23251,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sequelize"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -17979,6 +23275,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sequelize\\node_modules\\debug"
             }
           ]
         },
@@ -18000,6 +23302,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sequelize\\node_modules\\ms"
+            }
           ]
         },
         {
@@ -18019,6 +23327,12 @@
               "url": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sequelize\\node_modules\\uuid"
             }
           ]
         }
@@ -18043,6 +23357,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/serve-index"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18061,6 +23381,12 @@
               "url": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index\\node_modules\\depd"
             }
           ]
         },
@@ -18082,6 +23408,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index\\node_modules\\http-errors"
+            }
           ]
         },
         {
@@ -18101,6 +23433,12 @@
               "url": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index\\node_modules\\inherits"
             }
           ]
         },
@@ -18122,6 +23460,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index\\node_modules\\setprototypeof"
+            }
           ]
         },
         {
@@ -18141,6 +23485,12 @@
               "url": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/serve-index\\node_modules\\statuses"
             }
           ]
         }
@@ -18164,6 +23514,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/serve-static"
+        }
       ]
     },
     {
@@ -18183,6 +23539,12 @@
           "url": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/set-blocking"
         }
       ]
     },
@@ -18205,6 +23567,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/set-value"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18223,6 +23591,12 @@
               "url": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/set-value\\node_modules\\extend-shallow"
             }
           ]
         },
@@ -18243,6 +23617,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/set-value\\node_modules\\is-extendable"
             }
           ]
         }
@@ -18266,6 +23646,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/setimmediate"
+        }
       ]
     },
     {
@@ -18285,6 +23671,12 @@
           "url": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/setprototypeof"
         }
       ]
     },
@@ -18306,6 +23698,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/side-channel"
+        }
       ]
     },
     {
@@ -18326,6 +23724,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/signal-exit"
+        }
       ]
     },
     {
@@ -18345,6 +23749,12 @@
           "url": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/simple-concat"
         }
       ]
     },
@@ -18367,6 +23777,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/simple-get"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18385,6 +23801,12 @@
               "url": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/simple-get\\node_modules\\decompress-response"
             }
           ]
         },
@@ -18405,6 +23827,12 @@
               "url": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/simple-get\\node_modules\\mimic-response"
             }
           ]
         }
@@ -18429,6 +23857,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/simple-swizzle"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18447,6 +23881,12 @@
               "url": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/simple-swizzle\\node_modules\\is-arrayish"
             }
           ]
         }
@@ -18470,6 +23910,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sinon"
+        }
       ]
     },
     {
@@ -18489,6 +23935,12 @@
           "url": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/smart-buffer"
         }
       ]
     },
@@ -18511,6 +23963,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/snapdragon-node"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18529,6 +23987,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon-node\\node_modules\\define-property"
             }
           ]
         }
@@ -18553,6 +24017,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/snapdragon-util"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18571,6 +24041,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon-util\\node_modules\\kind-of"
             }
           ]
         }
@@ -18595,6 +24071,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/snapdragon"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18613,6 +24095,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon\\node_modules\\define-property"
             }
           ]
         },
@@ -18633,6 +24121,12 @@
               "url": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon\\node_modules\\extend-shallow"
             }
           ]
         },
@@ -18655,6 +24149,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon\\node_modules\\is-accessor-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -18673,6 +24173,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/snapdragon\\node_modules\\is-accessor-descriptor\\node_modules\\kind-of"
                 }
               ]
             }
@@ -18697,6 +24203,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon\\node_modules\\is-data-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -18715,6 +24227,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/snapdragon\\node_modules\\is-data-descriptor\\node_modules\\kind-of"
                 }
               ]
             }
@@ -18738,6 +24256,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon\\node_modules\\is-descriptor"
+            }
           ]
         },
         {
@@ -18757,6 +24281,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon\\node_modules\\is-extendable"
             }
           ]
         },
@@ -18778,6 +24308,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon\\node_modules\\kind-of"
+            }
           ]
         },
         {
@@ -18797,6 +24333,12 @@
               "url": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/snapdragon\\node_modules\\source-map"
             }
           ]
         }
@@ -18820,6 +24362,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socket.io-adapter"
+        }
       ]
     },
     {
@@ -18841,6 +24389,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socket.io-parser"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18859,6 +24413,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socket.io-parser\\node_modules\\debug"
             }
           ]
         },
@@ -18879,6 +24439,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socket.io-parser\\node_modules\\ms"
             }
           ]
         }
@@ -18903,6 +24469,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socket.io"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18921,6 +24493,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socket.io\\node_modules\\debug"
             }
           ]
         },
@@ -18941,6 +24519,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socket.io\\node_modules\\ms"
             }
           ]
         }
@@ -18965,6 +24549,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socks-proxy-agent"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -18983,6 +24573,12 @@
               "url": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socks-proxy-agent\\node_modules\\debug"
             }
           ]
         },
@@ -19003,6 +24599,12 @@
               "url": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socks-proxy-agent\\node_modules\\ms"
             }
           ]
         }
@@ -19027,6 +24629,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/socks"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -19045,6 +24653,12 @@
               "url": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/socks\\node_modules\\ip"
             }
           ]
         }
@@ -19069,6 +24683,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sort-keys-length"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -19087,6 +24707,12 @@
               "url": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/sort-keys-length\\node_modules\\sort-keys"
             }
           ]
         }
@@ -19110,6 +24736,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sort-keys"
+        }
       ]
     },
     {
@@ -19129,6 +24761,12 @@
           "url": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/source-map-resolve"
         }
       ]
     },
@@ -19150,6 +24788,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/source-map-support"
+        }
       ]
     },
     {
@@ -19169,6 +24813,12 @@
           "url": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/source-map-url"
         }
       ]
     },
@@ -19190,6 +24840,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/source-map"
+        }
       ]
     },
     {
@@ -19209,6 +24865,12 @@
           "url": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2-1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spawn-command"
         }
       ]
     },
@@ -19230,6 +24892,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spdx-correct"
+        }
       ]
     },
     {
@@ -19249,6 +24917,12 @@
           "url": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spdx-exceptions"
         }
       ]
     },
@@ -19270,6 +24944,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spdx-expression-parse"
+        }
       ]
     },
     {
@@ -19289,6 +24969,12 @@
           "url": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.12.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/spdx-license-ids"
         }
       ]
     },
@@ -19310,6 +24996,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/split-string"
+        }
       ]
     },
     {
@@ -19329,6 +25021,12 @@
           "url": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sprintf-js"
         }
       ]
     },
@@ -19350,6 +25048,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sqlite3"
+        }
       ]
     },
     {
@@ -19369,6 +25073,12 @@
           "url": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/sshpk"
         }
       ]
     },
@@ -19390,6 +25100,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ssri"
+        }
       ]
     },
     {
@@ -19409,6 +25125,12 @@
           "url": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/stack-trace"
         }
       ]
     },
@@ -19431,6 +25153,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/static-extend"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -19449,6 +25177,12 @@
               "url": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend\\node_modules\\define-property"
             }
           ]
         },
@@ -19471,6 +25205,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend\\node_modules\\is-accessor-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -19489,6 +25229,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/static-extend\\node_modules\\is-accessor-descriptor\\node_modules\\kind-of"
                 }
               ]
             }
@@ -19513,6 +25259,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend\\node_modules\\is-data-descriptor"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -19531,6 +25283,12 @@
                   "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/static-extend\\node_modules\\is-data-descriptor\\node_modules\\kind-of"
                 }
               ]
             }
@@ -19554,6 +25312,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend\\node_modules\\is-descriptor"
+            }
           ]
         },
         {
@@ -19573,6 +25337,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/static-extend\\node_modules\\kind-of"
             }
           ]
         }
@@ -19596,6 +25366,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/statuses"
+        }
       ]
     },
     {
@@ -19615,6 +25391,12 @@
           "url": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-2.2.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/stream-buffers"
         }
       ]
     },
@@ -19636,6 +25418,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/streamsearch"
+        }
       ]
     },
     {
@@ -19655,6 +25443,12 @@
           "url": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strict-uri-encode"
         }
       ]
     },
@@ -19676,6 +25470,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string_decoder"
+        }
       ]
     },
     {
@@ -19695,6 +25495,12 @@
           "url": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string-width"
         }
       ]
     },
@@ -19716,6 +25522,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string.fromcodepoint"
+        }
       ]
     },
     {
@@ -19735,6 +25547,12 @@
           "url": "https://registry.npmjs.org/string.prototype.codepointat/-/string.prototype.codepointat-0.2.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string.prototype.codepointat"
         }
       ]
     },
@@ -19756,6 +25574,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string.prototype.trimend"
+        }
       ]
     },
     {
@@ -19775,6 +25599,12 @@
           "url": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/string.prototype.trimstart"
         }
       ]
     },
@@ -19796,6 +25626,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-ansi"
+        }
       ]
     },
     {
@@ -19815,6 +25651,12 @@
           "url": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-bom"
         }
       ]
     },
@@ -19836,6 +25678,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-dirs"
+        }
       ]
     },
     {
@@ -19855,6 +25703,12 @@
           "url": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-json-comments"
         }
       ]
     },
@@ -19876,6 +25730,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strip-outer"
+        }
       ]
     },
     {
@@ -19895,6 +25755,12 @@
           "url": "https://registry.npmjs.org/strtok3/-/strtok3-6.3.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/strtok3"
         }
       ]
     },
@@ -19916,6 +25782,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/supports-color"
+        }
       ]
     },
     {
@@ -19935,6 +25807,12 @@
           "url": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/supports-preserve-symlinks-flag"
         }
       ]
     },
@@ -19956,6 +25834,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/svg-captcha"
+        }
       ]
     },
     {
@@ -19976,6 +25860,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/swagger-ui-dist"
+        }
       ]
     },
     {
@@ -19995,6 +25885,12 @@
           "url": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-4.5.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/swagger-ui-express"
         }
       ]
     },
@@ -20017,6 +25913,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tar-fs"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -20035,6 +25937,12 @@
               "url": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/tar-fs\\node_modules\\bl"
             }
           ]
         },
@@ -20056,6 +25964,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/tar-fs\\node_modules\\chownr"
+            }
           ]
         },
         {
@@ -20076,6 +25990,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/tar-fs\\node_modules\\readable-stream"
+            }
           ]
         },
         {
@@ -20095,6 +26015,12 @@
               "url": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/tar-fs\\node_modules\\tar-stream"
             }
           ]
         }
@@ -20118,6 +26044,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tar-stream"
+        }
       ]
     },
     {
@@ -20137,6 +26069,12 @@
           "url": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tar"
         }
       ]
     },
@@ -20158,6 +26096,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tdigest"
+        }
       ]
     },
     {
@@ -20177,6 +26121,12 @@
           "url": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/text-hex"
         }
       ]
     },
@@ -20198,6 +26148,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/thirty-two"
+        }
       ]
     },
     {
@@ -20217,6 +26173,12 @@
           "url": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/through"
         }
       ]
     },
@@ -20238,6 +26200,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/timed-out"
+        }
       ]
     },
     {
@@ -20257,6 +26225,12 @@
           "url": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tiny-inflate"
         }
       ]
     },
@@ -20278,6 +26252,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-buffer"
+        }
       ]
     },
     {
@@ -20297,6 +26277,12 @@
           "url": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-fast-properties"
         }
       ]
     },
@@ -20319,6 +26305,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-object-path"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -20337,6 +26329,12 @@
               "url": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/to-object-path\\node_modules\\kind-of"
             }
           ]
         }
@@ -20360,6 +26358,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-regex-range"
+        }
       ]
     },
     {
@@ -20379,6 +26383,12 @@
           "url": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/to-regex"
         }
       ]
     },
@@ -20400,6 +26410,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/toidentifier"
+        }
       ]
     },
     {
@@ -20419,6 +26435,12 @@
           "url": "https://registry.npmjs.org/token-stream/-/token-stream-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/token-stream"
         }
       ]
     },
@@ -20440,6 +26462,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/token-types"
+        }
       ]
     },
     {
@@ -20459,6 +26487,12 @@
           "url": "https://registry.npmjs.org/toposort-class/-/toposort-class-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/toposort-class"
         }
       ]
     },
@@ -20480,6 +26514,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tough-cookie"
+        }
       ]
     },
     {
@@ -20499,6 +26539,12 @@
           "url": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tr46"
         }
       ]
     },
@@ -20520,6 +26566,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/traverse"
+        }
       ]
     },
     {
@@ -20539,6 +26591,12 @@
           "url": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tree-kill"
         }
       ]
     },
@@ -20560,6 +26618,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/trim-repeated"
+        }
       ]
     },
     {
@@ -20580,6 +26644,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/triple-beam"
+        }
       ]
     },
     {
@@ -20599,6 +26669,12 @@
           "url": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/truncate-utf8-bytes"
         }
       ]
     },
@@ -20621,6 +26697,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ts-node-dev"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -20639,6 +26721,12 @@
               "url": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/ts-node-dev\\node_modules\\rimraf"
             }
           ]
         }
@@ -20662,6 +26750,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ts-node"
+        }
       ]
     },
     {
@@ -20681,6 +26775,12 @@
           "url": "https://registry.npmjs.org/tsconfig/-/tsconfig-7.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tsconfig"
         }
       ]
     },
@@ -20702,6 +26802,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tslib"
+        }
       ]
     },
     {
@@ -20721,6 +26827,12 @@
           "url": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tunnel-agent"
         }
       ]
     },
@@ -20742,6 +26854,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/tweetnacl"
+        }
       ]
     },
     {
@@ -20761,6 +26879,12 @@
           "url": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/type-check"
         }
       ]
     },
@@ -20782,6 +26906,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/type-is"
+        }
       ]
     },
     {
@@ -20801,6 +26931,12 @@
           "url": "https://registry.npmjs.org/typecast/-/typecast-0.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/typecast"
         }
       ]
     },
@@ -20822,6 +26958,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/typedarray"
+        }
       ]
     },
     {
@@ -20841,6 +26983,12 @@
           "url": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/typescript"
         }
       ]
     },
@@ -20862,6 +27010,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/uglify-js"
+        }
       ]
     },
     {
@@ -20881,6 +27035,12 @@
           "url": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unbox-primitive"
         }
       ]
     },
@@ -20902,6 +27062,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unbzip2-stream"
+        }
       ]
     },
     {
@@ -20921,6 +27087,12 @@
           "url": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unc-path-regex"
         }
       ]
     },
@@ -20942,6 +27114,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/underscore.string"
+        }
       ]
     },
     {
@@ -20962,6 +27140,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unicode-properties"
+        }
       ]
     },
     {
@@ -20981,6 +27165,12 @@
           "url": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unicode-trie"
         }
       ]
     },
@@ -21003,6 +27193,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/union-value"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21021,6 +27217,12 @@
               "url": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/union-value\\node_modules\\is-extendable"
             }
           ]
         }
@@ -21044,6 +27246,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unique-filename"
+        }
       ]
     },
     {
@@ -21063,6 +27271,12 @@
           "url": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unique-slug"
         }
       ]
     },
@@ -21084,6 +27298,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unit-compare"
+        }
       ]
     },
     {
@@ -21104,6 +27324,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/universalify"
+        }
       ]
     },
     {
@@ -21123,6 +27349,12 @@
           "url": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unpipe"
         }
       ]
     },
@@ -21145,6 +27377,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unset-value"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21165,6 +27403,12 @@
               "comment": "as detected from npm-ls property \"resolved\""
             }
           ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/unset-value\\node_modules\\has-value"
+            }
+          ],
           "components": [
             {
               "type": "library",
@@ -21183,6 +27427,12 @@
                   "url": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
                   "type": "distribution",
                   "comment": "as detected from npm-ls property \"resolved\""
+                }
+              ],
+              "properties": [
+                {
+                  "name": "cdx:npm:package:installPath",
+                  "value": "node_modules/unset-value\\node_modules\\has-value\\node_modules\\isobject"
                 }
               ]
             }
@@ -21206,6 +27456,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/unset-value\\node_modules\\has-values"
+            }
           ]
         },
         {
@@ -21225,6 +27481,12 @@
               "url": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/unset-value\\node_modules\\isarray"
             }
           ]
         }
@@ -21248,6 +27510,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/untildify"
+        }
       ]
     },
     {
@@ -21269,6 +27537,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/unzipper"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21287,6 +27561,12 @@
               "url": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/unzipper\\node_modules\\bluebird"
             }
           ]
         }
@@ -21310,6 +27590,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/uri-js"
+        }
       ]
     },
     {
@@ -21329,6 +27615,12 @@
           "url": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/urix"
         }
       ]
     },
@@ -21350,6 +27642,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/url-parse-lax"
+        }
       ]
     },
     {
@@ -21369,6 +27667,12 @@
           "url": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/url-to-options"
         }
       ]
     },
@@ -21390,6 +27694,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/use"
+        }
       ]
     },
     {
@@ -21409,6 +27719,12 @@
           "url": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/utf8-byte-length"
         }
       ]
     },
@@ -21430,6 +27746,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/util-deprecate"
+        }
       ]
     },
     {
@@ -21449,6 +27771,12 @@
           "url": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/util"
         }
       ]
     },
@@ -21470,6 +27798,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/utils-merge"
+        }
       ]
     },
     {
@@ -21489,6 +27823,12 @@
           "url": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/uuid"
         }
       ]
     },
@@ -21510,6 +27850,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/v8flags"
+        }
       ]
     },
     {
@@ -21529,6 +27875,12 @@
           "url": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/validate-npm-package-license"
         }
       ]
     },
@@ -21550,6 +27902,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/validate"
+        }
       ]
     },
     {
@@ -21570,6 +27928,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/validator"
+        }
       ]
     },
     {
@@ -21589,6 +27953,12 @@
           "url": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/vary"
         }
       ]
     },
@@ -21611,6 +27981,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/verror"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21629,6 +28005,12 @@
               "url": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/verror\\node_modules\\core-util-is"
             }
           ]
         }
@@ -21653,6 +28035,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/vm2"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21671,6 +28059,12 @@
               "url": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/vm2\\node_modules\\acorn"
             }
           ]
         }
@@ -21694,6 +28088,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/void-elements"
+        }
       ]
     },
     {
@@ -21713,6 +28113,12 @@
           "url": "https://registry.npmjs.org/walk/-/walk-2.3.15.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/walk"
         }
       ]
     },
@@ -21734,6 +28140,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/walkdir"
+        }
       ]
     },
     {
@@ -21753,6 +28165,12 @@
           "url": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/webidl-conversions"
         }
       ]
     },
@@ -21774,6 +28192,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/whatwg-url"
+        }
       ]
     },
     {
@@ -21793,6 +28217,12 @@
           "url": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-boxed-primitive"
         }
       ]
     },
@@ -21814,6 +28244,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-collection"
+        }
       ]
     },
     {
@@ -21833,6 +28269,12 @@
           "url": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-module"
         }
       ]
     },
@@ -21854,6 +28296,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-pm-runs"
+        }
       ]
     },
     {
@@ -21873,6 +28321,12 @@
           "url": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.8.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which-typed-array"
         }
       ]
     },
@@ -21894,6 +28348,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/which"
+        }
       ]
     },
     {
@@ -21913,6 +28373,12 @@
           "url": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wide-align"
         }
       ]
     },
@@ -21935,6 +28401,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/winston-transport"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21953,6 +28425,12 @@
               "url": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/winston-transport\\node_modules\\readable-stream"
             }
           ]
         }
@@ -21977,6 +28455,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/winston"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -21995,6 +28479,12 @@
               "url": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/winston\\node_modules\\async"
             }
           ]
         },
@@ -22016,6 +28506,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/winston\\node_modules\\is-stream"
+            }
           ]
         },
         {
@@ -22035,6 +28531,12 @@
               "url": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/winston\\node_modules\\readable-stream"
             }
           ]
         }
@@ -22058,6 +28560,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/with"
+        }
       ]
     },
     {
@@ -22077,6 +28585,12 @@
           "url": "https://registry.npmjs.org/wkx/-/wkx-0.5.0.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wkx"
         }
       ]
     },
@@ -22098,6 +28612,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/word-wrap"
+        }
       ]
     },
     {
@@ -22117,6 +28637,12 @@
           "url": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wordwrap"
         }
       ]
     },
@@ -22139,6 +28665,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wrap-ansi"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -22157,6 +28689,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi\\node_modules\\ansi-regex"
             }
           ]
         },
@@ -22178,6 +28716,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi\\node_modules\\emoji-regex"
+            }
           ]
         },
         {
@@ -22197,6 +28741,12 @@
               "url": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi\\node_modules\\is-fullwidth-code-point"
             }
           ]
         },
@@ -22218,6 +28768,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi\\node_modules\\string-width"
+            }
           ]
         },
         {
@@ -22237,6 +28793,12 @@
               "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/wrap-ansi\\node_modules\\strip-ansi"
             }
           ]
         }
@@ -22260,6 +28822,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/wrappy"
+        }
       ]
     },
     {
@@ -22279,6 +28847,12 @@
           "url": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/ws"
         }
       ]
     },
@@ -22300,6 +28874,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/xtend"
+        }
       ]
     },
     {
@@ -22319,6 +28899,12 @@
           "url": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/y18n"
         }
       ]
     },
@@ -22340,6 +28926,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yallist"
+        }
       ]
     },
     {
@@ -22360,6 +28952,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yaml-schema-validator"
+        }
       ]
     },
     {
@@ -22379,6 +28977,12 @@
           "url": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yargs-parser"
         }
       ]
     },
@@ -22401,6 +29005,12 @@
           "comment": "as detected from npm-ls property \"resolved\""
         }
       ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yargs"
+        }
+      ],
       "components": [
         {
           "type": "library",
@@ -22419,6 +29029,12 @@
               "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs\\node_modules\\ansi-regex"
             }
           ]
         },
@@ -22440,6 +29056,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs\\node_modules\\emoji-regex"
+            }
           ]
         },
         {
@@ -22459,6 +29081,12 @@
               "url": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs\\node_modules\\is-fullwidth-code-point"
             }
           ]
         },
@@ -22480,6 +29108,12 @@
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
             }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs\\node_modules\\string-width"
+            }
           ]
         },
         {
@@ -22499,6 +29133,12 @@
               "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
               "type": "distribution",
               "comment": "as detected from npm-ls property \"resolved\""
+            }
+          ],
+          "properties": [
+            {
+              "name": "cdx:npm:package:installPath",
+              "value": "node_modules/yargs\\node_modules\\strip-ansi"
             }
           ]
         }
@@ -22522,6 +29162,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yauzl"
+        }
       ]
     },
     {
@@ -22541,6 +29187,12 @@
           "url": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/yn"
         }
       ]
     },
@@ -22562,6 +29214,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/z85"
+        }
       ]
     },
     {
@@ -22582,6 +29240,12 @@
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/zip-stream"
+        }
       ]
     },
     {
@@ -22601,6 +29265,12 @@
           "url": "https://registry.npmjs.org/zlibjs/-/zlibjs-0.3.1.tgz",
           "type": "distribution",
           "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/zlibjs"
         }
       ]
     }

--- a/tests/_data/sbom_demo-results/juice-shop_npm9_node18_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/juice-shop_npm9_node18_windows-latest.snap.json
@@ -62,7 +62,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -95,7 +95,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@babel\\helper-string-parser"
         }
       ]
@@ -122,7 +122,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@babel\\helper-validator-identifier"
         }
       ]
@@ -149,7 +149,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@babel\\parser"
         }
       ]
@@ -176,7 +176,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@babel\\types"
         }
       ]
@@ -203,7 +203,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@colors\\colors"
         }
       ]
@@ -230,7 +230,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@dabh\\diagnostics"
         }
       ]
@@ -257,7 +257,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@gar\\promisify"
         }
       ]
@@ -284,7 +284,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@mapbox\\node-pre-gyp"
         }
       ],
@@ -310,7 +310,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\ansi-regex"
             }
           ]
@@ -336,7 +336,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\are-we-there-yet"
             }
           ]
@@ -362,7 +362,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\detect-libc"
             }
           ]
@@ -388,7 +388,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\gauge"
             }
           ]
@@ -414,7 +414,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\is-fullwidth-code-point"
             }
           ]
@@ -440,7 +440,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\make-dir"
             }
           ],
@@ -466,7 +466,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\make-dir\\node_modules\\semver"
                 }
               ]
@@ -494,7 +494,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\nopt"
             }
           ]
@@ -520,7 +520,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\npmlog"
             }
           ]
@@ -546,7 +546,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\readable-stream"
             }
           ]
@@ -572,7 +572,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\string-width"
             }
           ]
@@ -598,7 +598,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/@mapbox\\node-pre-gyp\\node_modules\\strip-ansi"
             }
           ]
@@ -627,7 +627,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\core-loader"
         }
       ]
@@ -654,7 +654,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\core"
         }
       ]
@@ -681,7 +681,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\evaluator"
         }
       ]
@@ -708,7 +708,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-all"
         }
       ]
@@ -735,7 +735,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-ar"
         }
       ]
@@ -762,7 +762,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-bn"
         }
       ]
@@ -789,7 +789,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-ca"
         }
       ]
@@ -816,7 +816,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-cs"
         }
       ]
@@ -843,7 +843,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-da"
         }
       ]
@@ -870,7 +870,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-de"
         }
       ]
@@ -897,7 +897,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-el"
         }
       ]
@@ -924,7 +924,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-en-min"
         }
       ]
@@ -951,7 +951,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-en"
         }
       ]
@@ -978,7 +978,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-es"
         }
       ]
@@ -1005,7 +1005,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-eu"
         }
       ]
@@ -1032,7 +1032,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-fa"
         }
       ]
@@ -1059,7 +1059,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-fi"
         }
       ]
@@ -1086,7 +1086,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-fr"
         }
       ]
@@ -1113,7 +1113,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-ga"
         }
       ]
@@ -1140,7 +1140,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-gl"
         }
       ]
@@ -1167,7 +1167,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-hi"
         }
       ]
@@ -1194,7 +1194,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-hu"
         }
       ]
@@ -1221,7 +1221,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-hy"
         }
       ]
@@ -1248,7 +1248,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-id"
         }
       ]
@@ -1275,7 +1275,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-it"
         }
       ]
@@ -1302,7 +1302,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-ja"
         }
       ]
@@ -1329,7 +1329,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-ko"
         }
       ]
@@ -1356,7 +1356,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-lt"
         }
       ]
@@ -1383,7 +1383,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-ms"
         }
       ]
@@ -1410,7 +1410,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-ne"
         }
       ]
@@ -1437,7 +1437,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-nl"
         }
       ]
@@ -1464,7 +1464,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-no"
         }
       ]
@@ -1491,7 +1491,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-pl"
         }
       ]
@@ -1518,7 +1518,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-pt"
         }
       ]
@@ -1545,7 +1545,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-ro"
         }
       ]
@@ -1572,7 +1572,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-ru"
         }
       ]
@@ -1599,7 +1599,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-sl"
         }
       ]
@@ -1626,7 +1626,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-sr"
         }
       ]
@@ -1653,7 +1653,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-sv"
         }
       ]
@@ -1680,7 +1680,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-ta"
         }
       ]
@@ -1707,7 +1707,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-th"
         }
       ]
@@ -1734,7 +1734,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-tl"
         }
       ]
@@ -1761,7 +1761,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-tr"
         }
       ]
@@ -1788,7 +1788,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-uk"
         }
       ]
@@ -1815,7 +1815,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\lang-zh"
         }
       ]
@@ -1842,7 +1842,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\language-min"
         }
       ]
@@ -1869,7 +1869,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\language"
         }
       ]
@@ -1896,7 +1896,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\ner"
         }
       ]
@@ -1923,7 +1923,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\neural"
         }
       ]
@@ -1950,7 +1950,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\nlg"
         }
       ]
@@ -1977,7 +1977,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\nlp"
         }
       ]
@@ -2004,7 +2004,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\nlu"
         }
       ]
@@ -2031,7 +2031,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\request"
         }
       ]
@@ -2058,7 +2058,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\sentiment"
         }
       ]
@@ -2085,7 +2085,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\similarity"
         }
       ]
@@ -2112,7 +2112,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@nlpjs\\slot"
         }
       ]
@@ -2139,7 +2139,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@npmcli\\fs"
         }
       ]
@@ -2166,7 +2166,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@npmcli\\move-file"
         }
       ]
@@ -2193,7 +2193,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib\\core"
         }
       ]
@@ -2220,7 +2220,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib\\plugin-crypto"
         }
       ]
@@ -2247,7 +2247,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib\\plugin-thirty-two"
         }
       ]
@@ -2274,7 +2274,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib\\preset-default"
         }
       ]
@@ -2301,7 +2301,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@otplib\\preset-v11"
         }
       ]
@@ -2328,7 +2328,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@sindresorhus\\is"
         }
       ]
@@ -2355,7 +2355,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@swc\\helpers"
         }
       ]
@@ -2382,7 +2382,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@tokenizer\\token"
         }
       ]
@@ -2409,7 +2409,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@tootallnate\\once"
         }
       ]
@@ -2436,7 +2436,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types\\component-emitter"
         }
       ]
@@ -2463,7 +2463,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types\\cookie"
         }
       ]
@@ -2490,7 +2490,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types\\cors"
         }
       ]
@@ -2517,7 +2517,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types\\debug"
         }
       ]
@@ -2544,7 +2544,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types\\ms"
         }
       ]
@@ -2571,7 +2571,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types\\node"
         }
       ]
@@ -2598,7 +2598,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types\\strip-bom"
         }
       ]
@@ -2625,7 +2625,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types\\strip-json-comments"
         }
       ]
@@ -2652,7 +2652,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/@types\\validator"
         }
       ]
@@ -2678,7 +2678,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/abbrev"
         }
       ]
@@ -2704,7 +2704,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/accepts"
         }
       ]
@@ -2730,7 +2730,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/acorn-walk"
         }
       ]
@@ -2756,7 +2756,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/acorn"
         }
       ]
@@ -2782,7 +2782,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/agent-base"
         }
       ],
@@ -2808,7 +2808,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agent-base\\node_modules\\debug"
             }
           ]
@@ -2834,7 +2834,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agent-base\\node_modules\\ms"
             }
           ]
@@ -2862,7 +2862,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/agentkeepalive"
         }
       ],
@@ -2888,7 +2888,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agentkeepalive\\node_modules\\debug"
             }
           ]
@@ -2914,7 +2914,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agentkeepalive\\node_modules\\depd"
             }
           ]
@@ -2940,7 +2940,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/agentkeepalive\\node_modules\\ms"
             }
           ]
@@ -2968,7 +2968,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/aggregate-error"
         }
       ]
@@ -2994,7 +2994,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ajv"
         }
       ]
@@ -3020,7 +3020,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ansi-regex"
         }
       ]
@@ -3046,7 +3046,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ansi-styles"
         }
       ]
@@ -3072,7 +3072,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/anymatch"
         }
       ],
@@ -3098,7 +3098,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/anymatch\\node_modules\\normalize-path"
             }
           ]
@@ -3126,7 +3126,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/append-field"
         }
       ]
@@ -3152,7 +3152,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/aproba"
         }
       ]
@@ -3178,7 +3178,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/archive-type"
         }
       ],
@@ -3204,7 +3204,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/archive-type\\node_modules\\file-type"
             }
           ]
@@ -3232,7 +3232,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/archiver-utils"
         }
       ]
@@ -3258,7 +3258,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/archiver"
         }
       ]
@@ -3284,7 +3284,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/are-we-there-yet"
         }
       ]
@@ -3310,7 +3310,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/arg"
         }
       ]
@@ -3336,7 +3336,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/argparse"
         }
       ],
@@ -3362,7 +3362,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/argparse\\node_modules\\sprintf-js"
             }
           ]
@@ -3390,7 +3390,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/arr-diff"
         }
       ]
@@ -3416,7 +3416,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/arr-flatten"
         }
       ]
@@ -3442,7 +3442,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/arr-union"
         }
       ]
@@ -3468,7 +3468,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/array-each"
         }
       ]
@@ -3494,7 +3494,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/array-flatten"
         }
       ]
@@ -3520,7 +3520,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/array-slice"
         }
       ]
@@ -3546,7 +3546,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/array-unique"
         }
       ]
@@ -3572,7 +3572,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/asap"
         }
       ]
@@ -3598,7 +3598,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/asn1"
         }
       ]
@@ -3624,7 +3624,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/assert-never"
         }
       ]
@@ -3650,7 +3650,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/assert-plus"
         }
       ]
@@ -3676,7 +3676,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/assign-symbols"
         }
       ]
@@ -3702,7 +3702,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/async"
         }
       ]
@@ -3728,7 +3728,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/asynckit"
         }
       ]
@@ -3754,7 +3754,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/at-least-node"
         }
       ]
@@ -3780,7 +3780,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/atob"
         }
       ]
@@ -3806,7 +3806,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/available-typed-arrays"
         }
       ]
@@ -3832,7 +3832,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/aws-sign2"
         }
       ]
@@ -3858,7 +3858,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/aws4"
         }
       ]
@@ -3884,7 +3884,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/babel-walk"
         }
       ]
@@ -3910,7 +3910,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/balanced-match"
         }
       ]
@@ -3936,7 +3936,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base"
         }
       ],
@@ -3962,7 +3962,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/base\\node_modules\\define-property"
             }
           ]
@@ -3990,7 +3990,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base64-arraybuffer"
         }
       ]
@@ -4016,7 +4016,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base64-js"
         }
       ]
@@ -4042,7 +4042,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base64id"
         }
       ]
@@ -4068,7 +4068,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/base64url"
         }
       ]
@@ -4094,7 +4094,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/basic-auth"
         }
       ]
@@ -4120,7 +4120,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/batch"
         }
       ]
@@ -4146,7 +4146,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bcrypt-pbkdf"
         }
       ]
@@ -4172,7 +4172,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/big-integer"
         }
       ]
@@ -4198,7 +4198,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/binary-extensions"
         }
       ]
@@ -4224,7 +4224,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/binary"
         }
       ]
@@ -4250,7 +4250,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bindings"
         }
       ]
@@ -4276,7 +4276,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bintrees"
         }
       ]
@@ -4302,7 +4302,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bl"
         }
       ]
@@ -4328,7 +4328,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bluebird"
         }
       ]
@@ -4354,7 +4354,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/body-parser"
         }
       ]
@@ -4380,7 +4380,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bower-config"
         }
       ],
@@ -4406,7 +4406,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/bower-config\\node_modules\\minimist"
             }
           ]
@@ -4434,7 +4434,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/brace-expansion"
         }
       ]
@@ -4460,7 +4460,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/braces"
         }
       ],
@@ -4486,7 +4486,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/braces\\node_modules\\extend-shallow"
             }
           ]
@@ -4512,7 +4512,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/braces\\node_modules\\is-extendable"
             }
           ]
@@ -4540,7 +4540,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/brotli"
         }
       ]
@@ -4566,7 +4566,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-alloc-unsafe"
         }
       ]
@@ -4592,7 +4592,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-alloc"
         }
       ]
@@ -4618,7 +4618,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-crc32"
         }
       ]
@@ -4644,7 +4644,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-fill"
         }
       ]
@@ -4670,7 +4670,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-from"
         }
       ]
@@ -4696,7 +4696,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer-indexof-polyfill"
         }
       ]
@@ -4722,7 +4722,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffer"
         }
       ]
@@ -4748,7 +4748,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/buffers"
         }
       ]
@@ -4774,7 +4774,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/busboy"
         }
       ],
@@ -4800,7 +4800,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/busboy\\node_modules\\isarray"
             }
           ]
@@ -4826,7 +4826,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/busboy\\node_modules\\readable-stream"
             }
           ]
@@ -4852,7 +4852,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/busboy\\node_modules\\string_decoder"
             }
           ]
@@ -4880,7 +4880,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/byline"
         }
       ]
@@ -4906,7 +4906,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/bytes"
         }
       ]
@@ -4932,7 +4932,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cacache"
         }
       ]
@@ -4958,7 +4958,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cache-base"
         }
       ]
@@ -4984,7 +4984,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cacheable-request"
         }
       ],
@@ -5010,7 +5010,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cacheable-request\\node_modules\\get-stream"
             }
           ]
@@ -5036,7 +5036,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cacheable-request\\node_modules\\lowercase-keys"
             }
           ]
@@ -5064,7 +5064,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/call-bind"
         }
       ]
@@ -5090,7 +5090,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/camelcase"
         }
       ]
@@ -5116,7 +5116,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/caseless"
         }
       ]
@@ -5142,7 +5142,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/chainsaw"
         }
       ]
@@ -5168,7 +5168,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/chalk"
         }
       ]
@@ -5194,7 +5194,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/character-parser"
         }
       ]
@@ -5220,7 +5220,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/check-dependencies"
         }
       ],
@@ -5246,7 +5246,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/check-dependencies\\node_modules\\semver"
             }
           ]
@@ -5274,7 +5274,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/check-types"
         }
       ]
@@ -5300,7 +5300,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/chokidar"
         }
       ],
@@ -5326,7 +5326,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar\\node_modules\\braces"
             }
           ]
@@ -5352,7 +5352,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar\\node_modules\\fill-range"
             }
           ]
@@ -5378,7 +5378,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar\\node_modules\\is-glob"
             }
           ]
@@ -5404,7 +5404,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar\\node_modules\\is-number"
             }
           ]
@@ -5430,7 +5430,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar\\node_modules\\normalize-path"
             }
           ]
@@ -5456,7 +5456,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/chokidar\\node_modules\\to-regex-range"
             }
           ]
@@ -5484,7 +5484,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/chownr"
         }
       ]
@@ -5510,7 +5510,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/clarinet"
         }
       ]
@@ -5536,7 +5536,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/class-utils"
         }
       ],
@@ -5562,7 +5562,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils\\node_modules\\define-property"
             }
           ]
@@ -5588,7 +5588,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils\\node_modules\\is-accessor-descriptor"
             }
           ],
@@ -5614,7 +5614,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/class-utils\\node_modules\\is-accessor-descriptor\\node_modules\\kind-of"
                 }
               ]
@@ -5642,7 +5642,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils\\node_modules\\is-data-descriptor"
             }
           ],
@@ -5668,7 +5668,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/class-utils\\node_modules\\is-data-descriptor\\node_modules\\kind-of"
                 }
               ]
@@ -5696,7 +5696,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils\\node_modules\\is-descriptor"
             }
           ]
@@ -5722,7 +5722,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/class-utils\\node_modules\\kind-of"
             }
           ]
@@ -5750,7 +5750,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/clean-stack"
         }
       ]
@@ -5776,7 +5776,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cliui"
         }
       ],
@@ -5802,7 +5802,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui\\node_modules\\ansi-regex"
             }
           ]
@@ -5828,7 +5828,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui\\node_modules\\emoji-regex"
             }
           ]
@@ -5854,7 +5854,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui\\node_modules\\is-fullwidth-code-point"
             }
           ]
@@ -5880,7 +5880,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui\\node_modules\\string-width"
             }
           ]
@@ -5906,7 +5906,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/cliui\\node_modules\\strip-ansi"
             }
           ]
@@ -5934,7 +5934,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/clone-response"
         }
       ]
@@ -5960,7 +5960,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/clone"
         }
       ]
@@ -5986,7 +5986,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/code-point-at"
         }
       ]
@@ -6012,7 +6012,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/collection-visit"
         }
       ]
@@ -6038,7 +6038,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color-convert"
         }
       ]
@@ -6064,7 +6064,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color-name"
         }
       ]
@@ -6090,7 +6090,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color-string"
         }
       ]
@@ -6116,7 +6116,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color-support"
         }
       ]
@@ -6142,7 +6142,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/color"
         }
       ]
@@ -6168,7 +6168,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/colors"
         }
       ]
@@ -6194,7 +6194,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/colorspace"
         }
       ]
@@ -6220,7 +6220,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/combined-stream"
         }
       ]
@@ -6246,7 +6246,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/commander"
         }
       ]
@@ -6272,7 +6272,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/component-emitter"
         }
       ]
@@ -6298,7 +6298,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/component-type"
         }
       ]
@@ -6324,7 +6324,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/compress-commons"
         }
       ]
@@ -6350,7 +6350,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/compressible"
         }
       ]
@@ -6376,7 +6376,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/compression"
         }
       ],
@@ -6402,7 +6402,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/compression\\node_modules\\bytes"
             }
           ]
@@ -6430,7 +6430,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/concat-map"
         }
       ]
@@ -6456,7 +6456,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/concat-stream"
         }
       ]
@@ -6482,7 +6482,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/concurrently"
         }
       ],
@@ -6508,7 +6508,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/concurrently\\node_modules\\supports-color"
             }
           ]
@@ -6536,7 +6536,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/config"
         }
       ]
@@ -6562,7 +6562,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/console-control-strings"
         }
       ]
@@ -6588,7 +6588,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/constantinople"
         }
       ]
@@ -6614,7 +6614,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/content-disposition"
         }
       ],
@@ -6640,7 +6640,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/content-disposition\\node_modules\\safe-buffer"
             }
           ]
@@ -6668,7 +6668,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/content-type"
         }
       ]
@@ -6694,7 +6694,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cookie-parser"
         }
       ]
@@ -6720,7 +6720,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cookie-signature"
         }
       ]
@@ -6746,7 +6746,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cookie"
         }
       ]
@@ -6772,7 +6772,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/copy-descriptor"
         }
       ]
@@ -6798,7 +6798,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/core-util-is"
         }
       ]
@@ -6824,7 +6824,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/cors"
         }
       ]
@@ -6850,7 +6850,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/crc"
         }
       ]
@@ -6876,7 +6876,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/crc32-stream"
         }
       ]
@@ -6902,7 +6902,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/create-require"
         }
       ]
@@ -6928,7 +6928,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/crypto-js"
         }
       ]
@@ -6954,7 +6954,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dashdash"
         }
       ]
@@ -6980,7 +6980,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/date-fns"
         }
       ]
@@ -7006,7 +7006,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dateformat"
         }
       ]
@@ -7032,7 +7032,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/debug"
         }
       ]
@@ -7058,7 +7058,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decamelize"
         }
       ]
@@ -7084,7 +7084,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decode-uri-component"
         }
       ]
@@ -7110,7 +7110,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-response"
         }
       ]
@@ -7136,7 +7136,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-tar"
         }
       ],
@@ -7162,7 +7162,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-tar\\node_modules\\file-type"
             }
           ]
@@ -7190,7 +7190,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-tarbz2"
         }
       ],
@@ -7216,7 +7216,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-tarbz2\\node_modules\\file-type"
             }
           ]
@@ -7244,7 +7244,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-targz"
         }
       ],
@@ -7270,7 +7270,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-targz\\node_modules\\file-type"
             }
           ]
@@ -7298,7 +7298,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress-unzip"
         }
       ],
@@ -7324,7 +7324,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-unzip\\node_modules\\file-type"
             }
           ]
@@ -7350,7 +7350,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-unzip\\node_modules\\get-stream"
             }
           ]
@@ -7376,7 +7376,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress-unzip\\node_modules\\pify"
             }
           ]
@@ -7404,7 +7404,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/decompress"
         }
       ],
@@ -7430,7 +7430,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress\\node_modules\\make-dir"
             }
           ],
@@ -7456,7 +7456,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/decompress\\node_modules\\make-dir\\node_modules\\pify"
                 }
               ]
@@ -7484,7 +7484,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/decompress\\node_modules\\pify"
             }
           ]
@@ -7512,7 +7512,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/deep-equal"
         }
       ]
@@ -7538,7 +7538,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/deep-extend"
         }
       ]
@@ -7564,7 +7564,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/deep-is"
         }
       ]
@@ -7590,7 +7590,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/define-properties"
         }
       ]
@@ -7616,7 +7616,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/define-property"
         }
       ]
@@ -7642,7 +7642,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/delayed-stream"
         }
       ]
@@ -7668,7 +7668,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/delegates"
         }
       ]
@@ -7694,7 +7694,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/depd"
         }
       ]
@@ -7720,7 +7720,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/destroy"
         }
       ]
@@ -7746,7 +7746,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/detect-file"
         }
       ]
@@ -7772,7 +7772,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/detect-libc"
         }
       ]
@@ -7798,7 +7798,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dfa"
         }
       ]
@@ -7824,7 +7824,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dicer"
         }
       ],
@@ -7850,7 +7850,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/dicer\\node_modules\\isarray"
             }
           ]
@@ -7876,7 +7876,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/dicer\\node_modules\\readable-stream"
             }
           ]
@@ -7902,7 +7902,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/dicer\\node_modules\\string_decoder"
             }
           ]
@@ -7930,7 +7930,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/diff"
         }
       ]
@@ -7956,7 +7956,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/doctypes"
         }
       ]
@@ -7982,7 +7982,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/domelementtype"
         }
       ]
@@ -8008,7 +8008,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/domhandler"
         }
       ]
@@ -8034,7 +8034,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/domutils"
         }
       ]
@@ -8060,7 +8060,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dottie"
         }
       ]
@@ -8086,7 +8086,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/double-ended-queue"
         }
       ]
@@ -8112,7 +8112,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/doublearray"
         }
       ]
@@ -8138,7 +8138,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/download"
         }
       ],
@@ -8164,7 +8164,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/download\\node_modules\\file-type"
             }
           ]
@@ -8192,7 +8192,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/duplexer2"
         }
       ]
@@ -8218,7 +8218,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/duplexer3"
         }
       ]
@@ -8244,7 +8244,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/dynamic-dedupe"
         }
       ]
@@ -8270,7 +8270,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ecc-jsbn"
         }
       ]
@@ -8296,7 +8296,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ee-first"
         }
       ]
@@ -8322,7 +8322,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/eivindfjeldstad-dot"
         }
       ]
@@ -8348,7 +8348,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/emoji-regex"
         }
       ]
@@ -8374,7 +8374,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/enabled"
         }
       ]
@@ -8400,7 +8400,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/encodeurl"
         }
       ]
@@ -8426,7 +8426,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/encoding"
         }
       ],
@@ -8452,7 +8452,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/encoding\\node_modules\\iconv-lite"
             }
           ]
@@ -8480,7 +8480,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/end-of-stream"
         }
       ]
@@ -8506,7 +8506,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/engine.io-parser"
         }
       ]
@@ -8532,7 +8532,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/engine.io"
         }
       ],
@@ -8558,7 +8558,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/engine.io\\node_modules\\debug"
             }
           ]
@@ -8584,7 +8584,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/engine.io\\node_modules\\ms"
             }
           ]
@@ -8612,7 +8612,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/env-paths"
         }
       ]
@@ -8638,7 +8638,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/err-code"
         }
       ]
@@ -8664,7 +8664,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/error-ex"
         }
       ]
@@ -8690,7 +8690,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/errorhandler"
         }
       ]
@@ -8716,7 +8716,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/es-abstract"
         }
       ]
@@ -8742,7 +8742,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/es-get-iterator"
         }
       ]
@@ -8768,7 +8768,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/es-to-primitive"
         }
       ]
@@ -8794,7 +8794,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/escape-html"
         }
       ]
@@ -8820,7 +8820,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/escape-string-regexp"
         }
       ]
@@ -8846,7 +8846,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/escodegen"
         }
       ]
@@ -8872,7 +8872,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/esprima"
         }
       ]
@@ -8898,7 +8898,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/estraverse"
         }
       ]
@@ -8924,7 +8924,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/esutils"
         }
       ]
@@ -8950,7 +8950,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/etag"
         }
       ]
@@ -8976,7 +8976,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/eventemitter2"
         }
       ]
@@ -9002,7 +9002,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/eventemitter3"
         }
       ]
@@ -9028,7 +9028,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/exif"
         }
       ]
@@ -9054,7 +9054,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/exit"
         }
       ]
@@ -9080,7 +9080,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/expand-brackets"
         }
       ],
@@ -9106,7 +9106,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets\\node_modules\\define-property"
             }
           ]
@@ -9132,7 +9132,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets\\node_modules\\extend-shallow"
             }
           ]
@@ -9158,7 +9158,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets\\node_modules\\is-accessor-descriptor"
             }
           ],
@@ -9184,7 +9184,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/expand-brackets\\node_modules\\is-accessor-descriptor\\node_modules\\kind-of"
                 }
               ]
@@ -9212,7 +9212,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets\\node_modules\\is-data-descriptor"
             }
           ],
@@ -9238,7 +9238,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/expand-brackets\\node_modules\\is-data-descriptor\\node_modules\\kind-of"
                 }
               ]
@@ -9266,7 +9266,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets\\node_modules\\is-descriptor"
             }
           ]
@@ -9292,7 +9292,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets\\node_modules\\is-extendable"
             }
           ]
@@ -9318,7 +9318,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/expand-brackets\\node_modules\\kind-of"
             }
           ]
@@ -9346,7 +9346,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/expand-template"
         }
       ]
@@ -9372,7 +9372,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/expand-tilde"
         }
       ]
@@ -9398,7 +9398,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-ipfilter"
         }
       ]
@@ -9424,7 +9424,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-jwt"
         }
       ],
@@ -9450,7 +9450,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/express-jwt\\node_modules\\jsonwebtoken"
             }
           ]
@@ -9476,7 +9476,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/express-jwt\\node_modules\\moment"
             }
           ]
@@ -9504,7 +9504,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-rate-limit"
         }
       ]
@@ -9530,7 +9530,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-robots-txt"
         }
       ]
@@ -9556,7 +9556,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express-security.txt"
         }
       ]
@@ -9582,7 +9582,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/express"
         }
       ],
@@ -9608,7 +9608,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/express\\node_modules\\cookie"
             }
           ]
@@ -9634,7 +9634,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/express\\node_modules\\safe-buffer"
             }
           ]
@@ -9662,7 +9662,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ext-list"
         }
       ]
@@ -9688,7 +9688,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ext-name"
         }
       ]
@@ -9714,7 +9714,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/extend-shallow"
         }
       ]
@@ -9740,7 +9740,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/extend"
         }
       ]
@@ -9766,7 +9766,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/extglob"
         }
       ],
@@ -9792,7 +9792,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/extglob\\node_modules\\define-property"
             }
           ]
@@ -9818,7 +9818,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/extglob\\node_modules\\extend-shallow"
             }
           ]
@@ -9844,7 +9844,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/extglob\\node_modules\\is-extendable"
             }
           ]
@@ -9872,7 +9872,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/extsprintf"
         }
       ]
@@ -9898,7 +9898,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fast-deep-equal"
         }
       ]
@@ -9924,7 +9924,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fast-json-stable-stringify"
         }
       ]
@@ -9950,7 +9950,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fast-levenshtein"
         }
       ]
@@ -9976,7 +9976,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fast.js"
         }
       ]
@@ -10002,7 +10002,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fd-slicer"
         }
       ]
@@ -10028,7 +10028,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/feature-policy"
         }
       ]
@@ -10054,7 +10054,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fecha"
         }
       ]
@@ -10080,7 +10080,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/file-js"
         }
       ],
@@ -10106,7 +10106,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/file-js\\node_modules\\brace-expansion"
             }
           ]
@@ -10132,7 +10132,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/file-js\\node_modules\\minimatch"
             }
           ]
@@ -10160,7 +10160,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/file-stream-rotator"
         }
       ]
@@ -10186,7 +10186,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/file-type"
         }
       ]
@@ -10212,7 +10212,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/file-uri-to-path"
         }
       ]
@@ -10238,7 +10238,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/filehound"
         }
       ]
@@ -10264,7 +10264,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/filename-reserved-regex"
         }
       ]
@@ -10290,7 +10290,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/filenamify"
         }
       ]
@@ -10316,7 +10316,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/filesniffer"
         }
       ]
@@ -10342,7 +10342,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fill-range"
         }
       ],
@@ -10368,7 +10368,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/fill-range\\node_modules\\extend-shallow"
             }
           ]
@@ -10394,7 +10394,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/fill-range\\node_modules\\is-extendable"
             }
           ]
@@ -10422,7 +10422,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/finale-rest"
         }
       ]
@@ -10448,7 +10448,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/finalhandler"
         }
       ]
@@ -10474,7 +10474,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/find-up"
         }
       ]
@@ -10500,7 +10500,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/findup-sync"
         }
       ]
@@ -10526,7 +10526,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fined"
         }
       ]
@@ -10552,7 +10552,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/flagged-respawn"
         }
       ]
@@ -10578,7 +10578,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fn.name"
         }
       ]
@@ -10604,7 +10604,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fontkit"
         }
       ]
@@ -10630,7 +10630,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/for-each"
         }
       ]
@@ -10656,7 +10656,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/for-in"
         }
       ]
@@ -10682,7 +10682,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/for-own"
         }
       ]
@@ -10708,7 +10708,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/foreachasync"
         }
       ]
@@ -10734,7 +10734,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/forever-agent"
         }
       ]
@@ -10760,7 +10760,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/form-data"
         }
       ]
@@ -10786,7 +10786,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/formatio"
         }
       ]
@@ -10812,7 +10812,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/forwarded"
         }
       ]
@@ -10838,7 +10838,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fragment-cache"
         }
       ]
@@ -10864,7 +10864,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fresh"
         }
       ]
@@ -10890,7 +10890,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/from2"
         }
       ]
@@ -10916,7 +10916,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fs-constants"
         }
       ]
@@ -10942,7 +10942,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fs-extra"
         }
       ]
@@ -10968,7 +10968,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fs-minipass"
         }
       ]
@@ -10994,7 +10994,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fs.realpath"
         }
       ]
@@ -11020,7 +11020,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fstream"
         }
       ],
@@ -11046,7 +11046,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/fstream\\node_modules\\mkdirp"
             }
           ]
@@ -11072,7 +11072,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/fstream\\node_modules\\rimraf"
             }
           ]
@@ -11100,7 +11100,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/function-bind"
         }
       ]
@@ -11126,7 +11126,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/function.prototype.name"
         }
       ]
@@ -11152,7 +11152,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/functions-have-names"
         }
       ]
@@ -11178,7 +11178,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/fuzzball"
         }
       ]
@@ -11204,7 +11204,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/gauge"
         }
       ]
@@ -11230,7 +11230,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/geojson-utils"
         }
       ]
@@ -11256,7 +11256,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-caller-file"
         }
       ]
@@ -11282,7 +11282,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-intrinsic"
         }
       ]
@@ -11308,7 +11308,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-stream"
         }
       ]
@@ -11334,7 +11334,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-symbol-description"
         }
       ]
@@ -11360,7 +11360,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/get-value"
         }
       ]
@@ -11386,7 +11386,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/getobject"
         }
       ]
@@ -11412,7 +11412,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/getpass"
         }
       ]
@@ -11438,7 +11438,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/github-from-package"
         }
       ]
@@ -11464,7 +11464,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/glob-parent"
         }
       ],
@@ -11490,7 +11490,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/glob-parent\\node_modules\\is-glob"
             }
           ]
@@ -11518,7 +11518,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/glob"
         }
       ],
@@ -11544,7 +11544,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/glob\\node_modules\\brace-expansion"
             }
           ]
@@ -11570,7 +11570,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/glob\\node_modules\\minimatch"
             }
           ]
@@ -11598,7 +11598,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/global-modules"
         }
       ]
@@ -11624,7 +11624,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/global-prefix"
         }
       ],
@@ -11650,7 +11650,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/global-prefix\\node_modules\\which"
             }
           ]
@@ -11678,7 +11678,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/got"
         }
       ],
@@ -11704,7 +11704,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/got\\node_modules\\get-stream"
             }
           ]
@@ -11730,7 +11730,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/got\\node_modules\\pify"
             }
           ]
@@ -11758,7 +11758,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/graceful-fs"
         }
       ]
@@ -11784,7 +11784,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-cli"
         }
       ],
@@ -11810,7 +11810,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-cli\\node_modules\\nopt"
             }
           ]
@@ -11838,7 +11838,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-contrib-compress"
         }
       ],
@@ -11864,7 +11864,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-contrib-compress\\node_modules\\ansi-styles"
             }
           ]
@@ -11890,7 +11890,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-contrib-compress\\node_modules\\chalk"
             }
           ]
@@ -11916,7 +11916,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-contrib-compress\\node_modules\\supports-color"
             }
           ]
@@ -11944,7 +11944,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-known-options"
         }
       ]
@@ -11970,7 +11970,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-legacy-log-utils"
         }
       ],
@@ -11996,7 +11996,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils\\node_modules\\ansi-styles"
             }
           ]
@@ -12022,7 +12022,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils\\node_modules\\chalk"
             }
           ]
@@ -12048,7 +12048,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils\\node_modules\\color-convert"
             }
           ]
@@ -12074,7 +12074,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils\\node_modules\\color-name"
             }
           ]
@@ -12100,7 +12100,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils\\node_modules\\has-flag"
             }
           ]
@@ -12126,7 +12126,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log-utils\\node_modules\\supports-color"
             }
           ]
@@ -12154,7 +12154,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-legacy-log"
         }
       ],
@@ -12180,7 +12180,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-log\\node_modules\\colors"
             }
           ]
@@ -12208,7 +12208,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-legacy-util"
         }
       ],
@@ -12234,7 +12234,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt-legacy-util\\node_modules\\async"
             }
           ]
@@ -12262,7 +12262,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt-replace-json"
         }
       ]
@@ -12288,7 +12288,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/grunt"
         }
       ],
@@ -12314,7 +12314,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt\\node_modules\\brace-expansion"
             }
           ]
@@ -12340,7 +12340,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt\\node_modules\\findup-sync"
             }
           ],
@@ -12366,7 +12366,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/grunt\\node_modules\\findup-sync\\node_modules\\glob"
                 }
               ]
@@ -12394,7 +12394,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt\\node_modules\\glob"
             }
           ]
@@ -12420,7 +12420,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/grunt\\node_modules\\minimatch"
             }
           ]
@@ -12448,7 +12448,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/handlebars"
         }
       ],
@@ -12474,7 +12474,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/handlebars\\node_modules\\wordwrap"
             }
           ]
@@ -12502,7 +12502,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/har-schema"
         }
       ]
@@ -12528,7 +12528,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/har-validator"
         }
       ]
@@ -12554,7 +12554,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-ansi"
         }
       ]
@@ -12580,7 +12580,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-bigints"
         }
       ]
@@ -12606,7 +12606,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-flag"
         }
       ]
@@ -12632,7 +12632,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-property-descriptors"
         }
       ]
@@ -12658,7 +12658,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-symbol-support-x"
         }
       ]
@@ -12684,7 +12684,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-symbols"
         }
       ]
@@ -12710,7 +12710,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-to-string-tag-x"
         }
       ]
@@ -12736,7 +12736,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-tostringtag"
         }
       ]
@@ -12762,7 +12762,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-unicode"
         }
       ]
@@ -12788,7 +12788,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-value"
         }
       ]
@@ -12814,7 +12814,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has-values"
         }
       ],
@@ -12840,7 +12840,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/has-values\\node_modules\\kind-of"
             }
           ]
@@ -12868,7 +12868,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/has"
         }
       ]
@@ -12894,7 +12894,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hashids"
         }
       ]
@@ -12920,7 +12920,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hbs"
         }
       ]
@@ -12946,7 +12946,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/he"
         }
       ]
@@ -12972,7 +12972,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/heap"
         }
       ]
@@ -12998,7 +12998,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/helmet"
         }
       ]
@@ -13024,7 +13024,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hoister"
         }
       ]
@@ -13050,7 +13050,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/homedir-polyfill"
         }
       ]
@@ -13076,7 +13076,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hooker"
         }
       ]
@@ -13102,7 +13102,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/hosted-git-info"
         }
       ]
@@ -13128,7 +13128,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/html-entities"
         }
       ]
@@ -13154,7 +13154,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/htmlparser2"
         }
       ],
@@ -13180,7 +13180,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/htmlparser2\\node_modules\\isarray"
             }
           ]
@@ -13206,7 +13206,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/htmlparser2\\node_modules\\readable-stream"
             }
           ]
@@ -13232,7 +13232,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/htmlparser2\\node_modules\\string_decoder"
             }
           ]
@@ -13260,7 +13260,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/http-cache-semantics"
         }
       ]
@@ -13286,7 +13286,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/http-errors"
         }
       ]
@@ -13312,7 +13312,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/http-proxy-agent"
         }
       ],
@@ -13338,7 +13338,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/http-proxy-agent\\node_modules\\debug"
             }
           ]
@@ -13364,7 +13364,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/http-proxy-agent\\node_modules\\ms"
             }
           ]
@@ -13392,7 +13392,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/http-signature"
         }
       ]
@@ -13418,7 +13418,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/https-proxy-agent"
         }
       ],
@@ -13444,7 +13444,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/https-proxy-agent\\node_modules\\debug"
             }
           ]
@@ -13470,7 +13470,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/https-proxy-agent\\node_modules\\ms"
             }
           ]
@@ -13498,7 +13498,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/humanize-ms"
         }
       ]
@@ -13524,7 +13524,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/i18n"
         }
       ]
@@ -13550,7 +13550,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/iconv-lite"
         }
       ]
@@ -13576,7 +13576,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ieee754"
         }
       ]
@@ -13602,7 +13602,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ignore-walk"
         }
       ],
@@ -13628,7 +13628,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/ignore-walk\\node_modules\\brace-expansion"
             }
           ]
@@ -13654,7 +13654,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/ignore-walk\\node_modules\\minimatch"
             }
           ]
@@ -13682,7 +13682,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/iltorb"
         }
       ]
@@ -13708,7 +13708,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/imurmurhash"
         }
       ]
@@ -13734,7 +13734,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/indent-string"
         }
       ]
@@ -13760,7 +13760,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/infer-owner"
         }
       ]
@@ -13786,7 +13786,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/inflection"
         }
       ]
@@ -13812,7 +13812,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/inflight"
         }
       ]
@@ -13838,7 +13838,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/inherits"
         }
       ]
@@ -13864,7 +13864,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ini"
         }
       ]
@@ -13890,7 +13890,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/internal-slot"
         }
       ]
@@ -13916,7 +13916,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/interpret"
         }
       ]
@@ -13942,7 +13942,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/into-stream"
         }
       ]
@@ -13968,7 +13968,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/invariant"
         }
       ]
@@ -13994,7 +13994,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ip"
         }
       ]
@@ -14020,7 +14020,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ip6"
         }
       ]
@@ -14046,7 +14046,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ipaddr.js"
         }
       ]
@@ -14072,7 +14072,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-absolute"
         }
       ]
@@ -14098,7 +14098,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-accessor-descriptor"
         }
       ]
@@ -14124,7 +14124,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-arguments"
         }
       ]
@@ -14150,7 +14150,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-arrayish"
         }
       ]
@@ -14176,7 +14176,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-bigint"
         }
       ]
@@ -14202,7 +14202,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-binary-path"
         }
       ]
@@ -14228,7 +14228,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-boolean-object"
         }
       ]
@@ -14254,7 +14254,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-buffer"
         }
       ]
@@ -14280,7 +14280,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-callable"
         }
       ]
@@ -14306,7 +14306,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-core-module"
         }
       ]
@@ -14332,7 +14332,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-data-descriptor"
         }
       ]
@@ -14358,7 +14358,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-date-object"
         }
       ]
@@ -14384,7 +14384,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-descriptor"
         }
       ]
@@ -14410,7 +14410,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-docker"
         }
       ]
@@ -14436,7 +14436,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-expression"
         }
       ]
@@ -14462,7 +14462,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-extendable"
         }
       ]
@@ -14488,7 +14488,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-extglob"
         }
       ]
@@ -14514,7 +14514,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-fullwidth-code-point"
         }
       ]
@@ -14540,7 +14540,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-generator-function"
         }
       ]
@@ -14566,7 +14566,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-glob"
         }
       ]
@@ -14592,7 +14592,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-heroku"
         }
       ]
@@ -14618,7 +14618,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-lambda"
         }
       ]
@@ -14644,7 +14644,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-map"
         }
       ]
@@ -14670,7 +14670,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-natural-number"
         }
       ]
@@ -14696,7 +14696,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-negative-zero"
         }
       ]
@@ -14722,7 +14722,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-number-like"
         }
       ]
@@ -14748,7 +14748,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-number-object"
         }
       ]
@@ -14774,7 +14774,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-number"
         }
       ],
@@ -14800,7 +14800,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/is-number\\node_modules\\kind-of"
             }
           ]
@@ -14828,7 +14828,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-object"
         }
       ]
@@ -14854,7 +14854,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-plain-obj"
         }
       ]
@@ -14880,7 +14880,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-plain-object"
         }
       ]
@@ -14906,7 +14906,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-promise"
         }
       ]
@@ -14932,7 +14932,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-regex"
         }
       ]
@@ -14958,7 +14958,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-relative"
         }
       ]
@@ -14984,7 +14984,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-retry-allowed"
         }
       ]
@@ -15010,7 +15010,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-set"
         }
       ]
@@ -15036,7 +15036,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-shared-array-buffer"
         }
       ]
@@ -15062,7 +15062,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-stream"
         }
       ]
@@ -15088,7 +15088,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-string"
         }
       ]
@@ -15114,7 +15114,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-symbol"
         }
       ]
@@ -15140,7 +15140,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-typed-array"
         }
       ]
@@ -15166,7 +15166,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-typedarray"
         }
       ]
@@ -15192,7 +15192,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-unc-path"
         }
       ]
@@ -15218,7 +15218,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-weakmap"
         }
       ]
@@ -15244,7 +15244,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-weakref"
         }
       ]
@@ -15270,7 +15270,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-weakset"
         }
       ]
@@ -15296,7 +15296,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/is-windows"
         }
       ]
@@ -15322,7 +15322,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isarray"
         }
       ]
@@ -15348,7 +15348,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isexe"
         }
       ]
@@ -15374,7 +15374,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isobject"
         }
       ]
@@ -15400,7 +15400,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isstream"
         }
       ]
@@ -15426,7 +15426,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/isurl"
         }
       ]
@@ -15452,7 +15452,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/js-stringify"
         }
       ]
@@ -15478,7 +15478,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/js-tokens"
         }
       ]
@@ -15504,7 +15504,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/js-yaml"
         }
       ]
@@ -15530,7 +15530,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jsbn"
         }
       ]
@@ -15556,7 +15556,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-buffer"
         }
       ]
@@ -15582,7 +15582,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-parse-better-errors"
         }
       ]
@@ -15608,7 +15608,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-schema-traverse"
         }
       ]
@@ -15634,7 +15634,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-schema"
         }
       ]
@@ -15660,7 +15660,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json-stringify-safe"
         }
       ]
@@ -15686,7 +15686,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/json5"
         }
       ]
@@ -15712,7 +15712,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jsonfile"
         }
       ]
@@ -15738,7 +15738,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jsonwebtoken"
         }
       ]
@@ -15764,7 +15764,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jsprim"
         }
       ]
@@ -15790,7 +15790,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jssha"
         }
       ]
@@ -15816,7 +15816,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jstransformer"
         }
       ]
@@ -15842,7 +15842,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/juicy-chat-bot"
         }
       ]
@@ -15868,7 +15868,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jwa"
         }
       ]
@@ -15894,7 +15894,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/jws"
         }
       ]
@@ -15920,7 +15920,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/keyv"
         }
       ]
@@ -15946,7 +15946,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/kind-of"
         }
       ]
@@ -15972,7 +15972,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/kuler"
         }
       ]
@@ -15998,7 +15998,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/kuromoji"
         }
       ]
@@ -16024,7 +16024,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lazystream"
         }
       ]
@@ -16050,7 +16050,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/levn"
         }
       ]
@@ -16076,7 +16076,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/libxmljs2"
         }
       ],
@@ -16102,7 +16102,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/libxmljs2\\node_modules\\nan"
             }
           ]
@@ -16130,7 +16130,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/liftup"
         }
       ],
@@ -16156,7 +16156,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup\\node_modules\\braces"
             }
           ]
@@ -16182,7 +16182,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup\\node_modules\\fill-range"
             }
           ]
@@ -16208,7 +16208,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup\\node_modules\\findup-sync"
             }
           ]
@@ -16234,7 +16234,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup\\node_modules\\is-glob"
             }
           ]
@@ -16260,7 +16260,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup\\node_modules\\is-number"
             }
           ]
@@ -16286,7 +16286,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup\\node_modules\\micromatch"
             }
           ]
@@ -16312,7 +16312,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/liftup\\node_modules\\to-regex-range"
             }
           ]
@@ -16340,7 +16340,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/linebreak"
         }
       ],
@@ -16366,7 +16366,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/linebreak\\node_modules\\base64-js"
             }
           ]
@@ -16394,7 +16394,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/listenercount"
         }
       ]
@@ -16420,7 +16420,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/locate-path"
         }
       ]
@@ -16446,7 +16446,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lodash.camelcase"
         }
       ]
@@ -16472,7 +16472,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lodash.isfinite"
         }
       ]
@@ -16498,7 +16498,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lodash.set"
         }
       ]
@@ -16524,7 +16524,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lodash"
         }
       ]
@@ -16550,7 +16550,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/logform"
         }
       ],
@@ -16576,7 +16576,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/logform\\node_modules\\ms"
             }
           ]
@@ -16604,7 +16604,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lolex"
         }
       ]
@@ -16630,7 +16630,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/loose-envify"
         }
       ]
@@ -16656,7 +16656,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lowercase-keys"
         }
       ]
@@ -16682,7 +16682,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/lru-cache"
         }
       ]
@@ -16708,7 +16708,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-dir"
         }
       ],
@@ -16734,7 +16734,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-dir\\node_modules\\semver"
             }
           ]
@@ -16762,7 +16762,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-error"
         }
       ]
@@ -16788,7 +16788,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-fetch-happen"
         }
       ],
@@ -16815,7 +16815,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen\\node_modules\\@tootallnate\\once"
             }
           ]
@@ -16841,7 +16841,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen\\node_modules\\debug"
             }
           ]
@@ -16867,7 +16867,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen\\node_modules\\http-cache-semantics"
             }
           ]
@@ -16893,7 +16893,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen\\node_modules\\http-proxy-agent"
             }
           ]
@@ -16919,7 +16919,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/make-fetch-happen\\node_modules\\ms"
             }
           ]
@@ -16947,7 +16947,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-iterator"
         }
       ]
@@ -16973,7 +16973,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/make-plural"
         }
       ]
@@ -16999,7 +16999,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/map-cache"
         }
       ]
@@ -17025,7 +17025,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/map-visit"
         }
       ]
@@ -17051,7 +17051,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/marsdb"
         }
       ]
@@ -17077,7 +17077,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/math-interval-parser"
         }
       ]
@@ -17103,7 +17103,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/media-typer"
         }
       ]
@@ -17129,7 +17129,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/merge-descriptors"
         }
       ]
@@ -17155,7 +17155,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/messageformat-formatters"
         }
       ]
@@ -17181,7 +17181,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/messageformat-parser"
         }
       ]
@@ -17207,7 +17207,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/messageformat"
         }
       ],
@@ -17233,7 +17233,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/messageformat\\node_modules\\make-plural"
             }
           ]
@@ -17261,7 +17261,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/methods"
         }
       ]
@@ -17287,7 +17287,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/micromatch"
         }
       ]
@@ -17313,7 +17313,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mime-db"
         }
       ]
@@ -17339,7 +17339,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mime-types"
         }
       ]
@@ -17365,7 +17365,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mime"
         }
       ]
@@ -17391,7 +17391,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mimic-response"
         }
       ]
@@ -17417,7 +17417,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minimatch"
         }
       ]
@@ -17443,7 +17443,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minimist"
         }
       ]
@@ -17469,7 +17469,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-collect"
         }
       ]
@@ -17495,7 +17495,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-fetch"
         }
       ]
@@ -17521,7 +17521,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-flush"
         }
       ]
@@ -17547,7 +17547,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-pipeline"
         }
       ]
@@ -17573,7 +17573,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass-sized"
         }
       ]
@@ -17599,7 +17599,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minipass"
         }
       ]
@@ -17625,7 +17625,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/minizlib"
         }
       ]
@@ -17651,7 +17651,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mixin-deep"
         }
       ]
@@ -17677,7 +17677,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mkdirp-classic"
         }
       ]
@@ -17703,7 +17703,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mkdirp"
         }
       ]
@@ -17729,7 +17729,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/moment-timezone"
         }
       ]
@@ -17755,7 +17755,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/moment"
         }
       ]
@@ -17781,7 +17781,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/morgan"
         }
       ],
@@ -17807,7 +17807,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/morgan\\node_modules\\on-finished"
             }
           ]
@@ -17835,7 +17835,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mout"
         }
       ]
@@ -17861,7 +17861,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ms"
         }
       ]
@@ -17887,7 +17887,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/multer"
         }
       ],
@@ -17913,7 +17913,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/multer\\node_modules\\mkdirp"
             }
           ]
@@ -17941,7 +17941,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/mustache"
         }
       ]
@@ -17967,7 +17967,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/nan"
         }
       ]
@@ -17993,7 +17993,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/nanomatch"
         }
       ]
@@ -18019,7 +18019,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/napi-build-utils"
         }
       ]
@@ -18045,7 +18045,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/needle"
         }
       ],
@@ -18071,7 +18071,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/needle\\node_modules\\debug"
             }
           ]
@@ -18097,7 +18097,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/needle\\node_modules\\ms"
             }
           ]
@@ -18125,7 +18125,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/negotiator"
         }
       ]
@@ -18151,7 +18151,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/neo-async"
         }
       ]
@@ -18177,7 +18177,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-abi"
         }
       ],
@@ -18203,7 +18203,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-abi\\node_modules\\semver"
             }
           ]
@@ -18231,7 +18231,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-addon-api"
         }
       ]
@@ -18257,7 +18257,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-fetch"
         }
       ]
@@ -18283,7 +18283,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-gyp"
         }
       ],
@@ -18309,7 +18309,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp\\node_modules\\ansi-regex"
             }
           ]
@@ -18335,7 +18335,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp\\node_modules\\are-we-there-yet"
             }
           ]
@@ -18361,7 +18361,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp\\node_modules\\gauge"
             }
           ]
@@ -18387,7 +18387,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp\\node_modules\\is-fullwidth-code-point"
             }
           ]
@@ -18413,7 +18413,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp\\node_modules\\nopt"
             }
           ]
@@ -18439,7 +18439,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp\\node_modules\\npmlog"
             }
           ]
@@ -18465,7 +18465,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp\\node_modules\\readable-stream"
             }
           ]
@@ -18491,7 +18491,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp\\node_modules\\string-width"
             }
           ]
@@ -18517,7 +18517,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-gyp\\node_modules\\strip-ansi"
             }
           ]
@@ -18545,7 +18545,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/node-pre-gyp"
         }
       ],
@@ -18571,7 +18571,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp\\node_modules\\chownr"
             }
           ]
@@ -18597,7 +18597,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp\\node_modules\\fs-minipass"
             }
           ]
@@ -18623,7 +18623,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp\\node_modules\\minipass"
             }
           ]
@@ -18649,7 +18649,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp\\node_modules\\minizlib"
             }
           ]
@@ -18675,7 +18675,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp\\node_modules\\mkdirp"
             }
           ]
@@ -18701,7 +18701,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp\\node_modules\\nopt"
             }
           ]
@@ -18727,7 +18727,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp\\node_modules\\rimraf"
             }
           ]
@@ -18753,7 +18753,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp\\node_modules\\safe-buffer"
             }
           ]
@@ -18779,7 +18779,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp\\node_modules\\semver"
             }
           ]
@@ -18805,7 +18805,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp\\node_modules\\tar"
             }
           ]
@@ -18831,7 +18831,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/node-pre-gyp\\node_modules\\yallist"
             }
           ]
@@ -18859,7 +18859,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/noop-logger"
         }
       ]
@@ -18885,7 +18885,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/nopt"
         }
       ]
@@ -18911,7 +18911,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/normalize-package-data"
         }
       ],
@@ -18937,7 +18937,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/normalize-package-data\\node_modules\\semver"
             }
           ]
@@ -18965,7 +18965,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/normalize-path"
         }
       ]
@@ -18991,7 +18991,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/normalize-url"
         }
       ]
@@ -19017,7 +19017,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/notevil"
         }
       ],
@@ -19043,7 +19043,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/notevil\\node_modules\\esprima"
             }
           ]
@@ -19071,7 +19071,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/npm-bundled"
         }
       ]
@@ -19097,7 +19097,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/npm-normalize-package-bin"
         }
       ]
@@ -19123,7 +19123,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/npm-packlist"
         }
       ]
@@ -19149,7 +19149,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/npmlog"
         }
       ]
@@ -19175,7 +19175,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/number-is-nan"
         }
       ]
@@ -19201,7 +19201,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/oauth-sign"
         }
       ]
@@ -19227,7 +19227,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-assign"
         }
       ]
@@ -19253,7 +19253,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-copy"
         }
       ],
@@ -19279,7 +19279,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy\\node_modules\\define-property"
             }
           ]
@@ -19305,7 +19305,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy\\node_modules\\is-accessor-descriptor"
             }
           ]
@@ -19331,7 +19331,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy\\node_modules\\is-data-descriptor"
             }
           ]
@@ -19357,7 +19357,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy\\node_modules\\is-descriptor"
             }
           ],
@@ -19383,7 +19383,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/object-copy\\node_modules\\is-descriptor\\node_modules\\kind-of"
                 }
               ]
@@ -19411,7 +19411,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/object-copy\\node_modules\\kind-of"
             }
           ]
@@ -19439,7 +19439,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-inspect"
         }
       ]
@@ -19465,7 +19465,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-is"
         }
       ]
@@ -19491,7 +19491,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-keys"
         }
       ]
@@ -19517,7 +19517,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object-visit"
         }
       ]
@@ -19543,7 +19543,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object.assign"
         }
       ]
@@ -19569,7 +19569,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object.defaults"
         }
       ]
@@ -19595,7 +19595,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object.map"
         }
       ]
@@ -19621,7 +19621,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/object.pick"
         }
       ]
@@ -19647,7 +19647,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/on-finished"
         }
       ]
@@ -19673,7 +19673,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/on-headers"
         }
       ]
@@ -19699,7 +19699,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/once"
         }
       ]
@@ -19725,7 +19725,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/one-time"
         }
       ]
@@ -19751,7 +19751,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/opentype.js"
         }
       ]
@@ -19777,7 +19777,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/optionator"
         }
       ]
@@ -19803,7 +19803,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/os-homedir"
         }
       ]
@@ -19829,7 +19829,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/os-tmpdir"
         }
       ]
@@ -19855,7 +19855,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/osenv"
         }
       ]
@@ -19881,7 +19881,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/otplib"
         }
       ]
@@ -19907,7 +19907,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-cancelable"
         }
       ]
@@ -19933,7 +19933,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-event"
         }
       ]
@@ -19959,7 +19959,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-finally"
         }
       ]
@@ -19985,7 +19985,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-is-promise"
         }
       ]
@@ -20011,7 +20011,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-limit"
         }
       ]
@@ -20037,7 +20037,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-locate"
         }
       ]
@@ -20063,7 +20063,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-map"
         }
       ]
@@ -20089,7 +20089,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-timeout"
         }
       ]
@@ -20115,7 +20115,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/p-try"
         }
       ]
@@ -20141,7 +20141,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pako"
         }
       ]
@@ -20167,7 +20167,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/parse-filepath"
         }
       ]
@@ -20193,7 +20193,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/parse-json"
         }
       ]
@@ -20219,7 +20219,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/parse-passwd"
         }
       ]
@@ -20245,7 +20245,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/parseurl"
         }
       ]
@@ -20271,7 +20271,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pascalcase"
         }
       ]
@@ -20297,7 +20297,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-exists"
         }
       ]
@@ -20323,7 +20323,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-is-absolute"
         }
       ]
@@ -20349,7 +20349,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-parse"
         }
       ]
@@ -20375,7 +20375,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-root-regex"
         }
       ]
@@ -20401,7 +20401,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-root"
         }
       ]
@@ -20427,7 +20427,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/path-to-regexp"
         }
       ]
@@ -20453,7 +20453,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pdfkit"
         }
       ]
@@ -20479,7 +20479,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/peek-readable"
         }
       ]
@@ -20505,7 +20505,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pend"
         }
       ]
@@ -20531,7 +20531,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/performance-now"
         }
       ]
@@ -20557,7 +20557,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pg-connection-string"
         }
       ]
@@ -20583,7 +20583,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/picomatch"
         }
       ]
@@ -20609,7 +20609,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pify"
         }
       ]
@@ -20635,7 +20635,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pinkie-promise"
         }
       ]
@@ -20661,7 +20661,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pinkie"
         }
       ]
@@ -20687,7 +20687,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/png-js"
         }
       ]
@@ -20713,7 +20713,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/portscanner"
         }
       ]
@@ -20739,7 +20739,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/posix-character-classes"
         }
       ]
@@ -20765,7 +20765,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/prebuild-install"
         }
       ]
@@ -20791,7 +20791,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/prelude-ls"
         }
       ]
@@ -20817,7 +20817,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/prepend-http"
         }
       ]
@@ -20843,7 +20843,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pretty-bytes"
         }
       ]
@@ -20869,7 +20869,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/process-nextick-args"
         }
       ]
@@ -20895,7 +20895,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/prom-client"
         }
       ]
@@ -20921,7 +20921,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/promise-inflight"
         }
       ]
@@ -20947,7 +20947,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/promise-retry"
         }
       ],
@@ -20973,7 +20973,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/promise-retry\\node_modules\\err-code"
             }
           ]
@@ -20999,7 +20999,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/promise-retry\\node_modules\\retry"
             }
           ]
@@ -21027,7 +21027,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/promise"
         }
       ]
@@ -21053,7 +21053,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/proper-lockfile"
         }
       ]
@@ -21079,7 +21079,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/proxy-addr"
         }
       ]
@@ -21105,7 +21105,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/psl"
         }
       ]
@@ -21131,7 +21131,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-attrs"
         }
       ]
@@ -21157,7 +21157,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-code-gen"
         }
       ]
@@ -21183,7 +21183,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-error"
         }
       ]
@@ -21209,7 +21209,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-filters"
         }
       ]
@@ -21235,7 +21235,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-lexer"
         }
       ]
@@ -21261,7 +21261,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-linker"
         }
       ]
@@ -21287,7 +21287,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-load"
         }
       ]
@@ -21313,7 +21313,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-parser"
         }
       ]
@@ -21339,7 +21339,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-runtime"
         }
       ]
@@ -21365,7 +21365,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-strip-comments"
         }
       ]
@@ -21391,7 +21391,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug-walk"
         }
       ]
@@ -21417,7 +21417,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pug"
         }
       ]
@@ -21443,7 +21443,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/pump"
         }
       ]
@@ -21469,7 +21469,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/punycode"
         }
       ]
@@ -21495,7 +21495,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/qs"
         }
       ]
@@ -21521,7 +21521,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/query-string"
         }
       ]
@@ -21547,7 +21547,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/range_check"
         }
       ]
@@ -21573,7 +21573,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/range-parser"
         }
       ]
@@ -21599,7 +21599,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/raw-body"
         }
       ]
@@ -21625,7 +21625,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/rc"
         }
       ]
@@ -21651,7 +21651,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/read-pkg"
         }
       ],
@@ -21677,7 +21677,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/read-pkg\\node_modules\\pify"
             }
           ]
@@ -21705,7 +21705,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/readable-stream"
         }
       ],
@@ -21731,7 +21731,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/readable-stream\\node_modules\\isarray"
             }
           ]
@@ -21759,7 +21759,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/readable-web-to-node-stream"
         }
       ],
@@ -21785,7 +21785,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/readable-web-to-node-stream\\node_modules\\readable-stream"
             }
           ]
@@ -21813,7 +21813,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/readdirp"
         }
       ]
@@ -21839,7 +21839,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/rechoir"
         }
       ]
@@ -21865,7 +21865,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/regex-not"
         }
       ]
@@ -21891,7 +21891,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/regexp.prototype.flags"
         }
       ]
@@ -21917,7 +21917,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/remove-trailing-separator"
         }
       ]
@@ -21943,7 +21943,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/repeat-element"
         }
       ]
@@ -21969,7 +21969,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/repeat-string"
         }
       ]
@@ -21995,7 +21995,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/replace"
         }
       ],
@@ -22021,7 +22021,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\ansi-regex"
             }
           ]
@@ -22047,7 +22047,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\ansi-styles"
             }
           ]
@@ -22073,7 +22073,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\brace-expansion"
             }
           ]
@@ -22099,7 +22099,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\cliui"
             }
           ]
@@ -22125,7 +22125,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\color-convert"
             }
           ]
@@ -22151,7 +22151,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\color-name"
             }
           ]
@@ -22177,7 +22177,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\find-up"
             }
           ]
@@ -22203,7 +22203,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\is-fullwidth-code-point"
             }
           ]
@@ -22229,7 +22229,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\locate-path"
             }
           ]
@@ -22255,7 +22255,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\minimatch"
             }
           ]
@@ -22281,7 +22281,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\p-locate"
             }
           ]
@@ -22307,7 +22307,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\path-exists"
             }
           ]
@@ -22333,7 +22333,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\string-width"
             }
           ]
@@ -22359,7 +22359,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\strip-ansi"
             }
           ]
@@ -22385,7 +22385,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\wrap-ansi"
             }
           ]
@@ -22411,7 +22411,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\yargs-parser"
             }
           ]
@@ -22437,7 +22437,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/replace\\node_modules\\yargs"
             }
           ]
@@ -22465,7 +22465,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/request"
         }
       ],
@@ -22491,7 +22491,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/request\\node_modules\\qs"
             }
           ]
@@ -22519,7 +22519,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/require-directory"
         }
       ]
@@ -22545,7 +22545,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/require-main-filename"
         }
       ]
@@ -22571,7 +22571,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/resolve-dir"
         }
       ]
@@ -22597,7 +22597,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/resolve-url"
         }
       ]
@@ -22623,7 +22623,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/resolve"
         }
       ]
@@ -22649,7 +22649,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/responselike"
         }
       ]
@@ -22675,7 +22675,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/restructure"
         }
       ]
@@ -22701,7 +22701,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ret"
         }
       ]
@@ -22727,7 +22727,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/retry-as-promised"
         }
       ]
@@ -22753,7 +22753,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/retry"
         }
       ]
@@ -22779,7 +22779,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/rimraf"
         }
       ]
@@ -22805,7 +22805,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/rxjs"
         }
       ],
@@ -22831,7 +22831,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/rxjs\\node_modules\\tslib"
             }
           ]
@@ -22859,7 +22859,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safe-buffer"
         }
       ]
@@ -22885,7 +22885,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safe-regex-test"
         }
       ]
@@ -22911,7 +22911,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safe-regex"
         }
       ]
@@ -22937,7 +22937,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safe-stable-stringify"
         }
       ]
@@ -22963,7 +22963,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/safer-buffer"
         }
       ]
@@ -22989,7 +22989,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/samsam"
         }
       ]
@@ -23015,7 +23015,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sanitize-filename"
         }
       ]
@@ -23041,7 +23041,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sanitize-html"
         }
       ],
@@ -23067,7 +23067,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sanitize-html\\node_modules\\lodash"
             }
           ]
@@ -23095,7 +23095,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sax"
         }
       ]
@@ -23121,7 +23121,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/seek-bzip"
         }
       ]
@@ -23147,7 +23147,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/semver"
         }
       ]
@@ -23173,7 +23173,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/send"
         }
       ],
@@ -23199,7 +23199,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/send\\node_modules\\ms"
             }
           ]
@@ -23227,7 +23227,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sequelize-pool"
         }
       ]
@@ -23253,7 +23253,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sequelize"
         }
       ],
@@ -23279,7 +23279,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sequelize\\node_modules\\debug"
             }
           ]
@@ -23305,7 +23305,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sequelize\\node_modules\\ms"
             }
           ]
@@ -23331,7 +23331,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sequelize\\node_modules\\uuid"
             }
           ]
@@ -23359,7 +23359,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/serve-index"
         }
       ],
@@ -23385,7 +23385,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index\\node_modules\\depd"
             }
           ]
@@ -23411,7 +23411,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index\\node_modules\\http-errors"
             }
           ]
@@ -23437,7 +23437,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index\\node_modules\\inherits"
             }
           ]
@@ -23463,7 +23463,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index\\node_modules\\setprototypeof"
             }
           ]
@@ -23489,7 +23489,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/serve-index\\node_modules\\statuses"
             }
           ]
@@ -23517,7 +23517,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/serve-static"
         }
       ]
@@ -23543,7 +23543,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/set-blocking"
         }
       ]
@@ -23569,7 +23569,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/set-value"
         }
       ],
@@ -23595,7 +23595,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/set-value\\node_modules\\extend-shallow"
             }
           ]
@@ -23621,7 +23621,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/set-value\\node_modules\\is-extendable"
             }
           ]
@@ -23649,7 +23649,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/setimmediate"
         }
       ]
@@ -23675,7 +23675,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/setprototypeof"
         }
       ]
@@ -23701,7 +23701,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/side-channel"
         }
       ]
@@ -23727,7 +23727,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/signal-exit"
         }
       ]
@@ -23753,7 +23753,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/simple-concat"
         }
       ]
@@ -23779,7 +23779,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/simple-get"
         }
       ],
@@ -23805,7 +23805,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/simple-get\\node_modules\\decompress-response"
             }
           ]
@@ -23831,7 +23831,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/simple-get\\node_modules\\mimic-response"
             }
           ]
@@ -23859,7 +23859,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/simple-swizzle"
         }
       ],
@@ -23885,7 +23885,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/simple-swizzle\\node_modules\\is-arrayish"
             }
           ]
@@ -23913,7 +23913,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sinon"
         }
       ]
@@ -23939,7 +23939,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/smart-buffer"
         }
       ]
@@ -23965,7 +23965,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/snapdragon-node"
         }
       ],
@@ -23991,7 +23991,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon-node\\node_modules\\define-property"
             }
           ]
@@ -24019,7 +24019,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/snapdragon-util"
         }
       ],
@@ -24045,7 +24045,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon-util\\node_modules\\kind-of"
             }
           ]
@@ -24073,7 +24073,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/snapdragon"
         }
       ],
@@ -24099,7 +24099,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon\\node_modules\\define-property"
             }
           ]
@@ -24125,7 +24125,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon\\node_modules\\extend-shallow"
             }
           ]
@@ -24151,7 +24151,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon\\node_modules\\is-accessor-descriptor"
             }
           ],
@@ -24177,7 +24177,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/snapdragon\\node_modules\\is-accessor-descriptor\\node_modules\\kind-of"
                 }
               ]
@@ -24205,7 +24205,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon\\node_modules\\is-data-descriptor"
             }
           ],
@@ -24231,7 +24231,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/snapdragon\\node_modules\\is-data-descriptor\\node_modules\\kind-of"
                 }
               ]
@@ -24259,7 +24259,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon\\node_modules\\is-descriptor"
             }
           ]
@@ -24285,7 +24285,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon\\node_modules\\is-extendable"
             }
           ]
@@ -24311,7 +24311,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon\\node_modules\\kind-of"
             }
           ]
@@ -24337,7 +24337,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/snapdragon\\node_modules\\source-map"
             }
           ]
@@ -24365,7 +24365,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socket.io-adapter"
         }
       ]
@@ -24391,7 +24391,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socket.io-parser"
         }
       ],
@@ -24417,7 +24417,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socket.io-parser\\node_modules\\debug"
             }
           ]
@@ -24443,7 +24443,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socket.io-parser\\node_modules\\ms"
             }
           ]
@@ -24471,7 +24471,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socket.io"
         }
       ],
@@ -24497,7 +24497,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socket.io\\node_modules\\debug"
             }
           ]
@@ -24523,7 +24523,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socket.io\\node_modules\\ms"
             }
           ]
@@ -24551,7 +24551,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socks-proxy-agent"
         }
       ],
@@ -24577,7 +24577,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socks-proxy-agent\\node_modules\\debug"
             }
           ]
@@ -24603,7 +24603,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socks-proxy-agent\\node_modules\\ms"
             }
           ]
@@ -24631,7 +24631,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/socks"
         }
       ],
@@ -24657,7 +24657,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/socks\\node_modules\\ip"
             }
           ]
@@ -24685,7 +24685,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sort-keys-length"
         }
       ],
@@ -24711,7 +24711,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/sort-keys-length\\node_modules\\sort-keys"
             }
           ]
@@ -24739,7 +24739,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sort-keys"
         }
       ]
@@ -24765,7 +24765,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/source-map-resolve"
         }
       ]
@@ -24791,7 +24791,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/source-map-support"
         }
       ]
@@ -24817,7 +24817,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/source-map-url"
         }
       ]
@@ -24843,7 +24843,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/source-map"
         }
       ]
@@ -24869,7 +24869,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spawn-command"
         }
       ]
@@ -24895,7 +24895,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spdx-correct"
         }
       ]
@@ -24921,7 +24921,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spdx-exceptions"
         }
       ]
@@ -24947,7 +24947,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spdx-expression-parse"
         }
       ]
@@ -24973,7 +24973,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/spdx-license-ids"
         }
       ]
@@ -24999,7 +24999,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/split-string"
         }
       ]
@@ -25025,7 +25025,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sprintf-js"
         }
       ]
@@ -25051,7 +25051,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sqlite3"
         }
       ]
@@ -25077,7 +25077,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/sshpk"
         }
       ]
@@ -25103,7 +25103,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ssri"
         }
       ]
@@ -25129,7 +25129,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/stack-trace"
         }
       ]
@@ -25155,7 +25155,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/static-extend"
         }
       ],
@@ -25181,7 +25181,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend\\node_modules\\define-property"
             }
           ]
@@ -25207,7 +25207,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend\\node_modules\\is-accessor-descriptor"
             }
           ],
@@ -25233,7 +25233,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/static-extend\\node_modules\\is-accessor-descriptor\\node_modules\\kind-of"
                 }
               ]
@@ -25261,7 +25261,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend\\node_modules\\is-data-descriptor"
             }
           ],
@@ -25287,7 +25287,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/static-extend\\node_modules\\is-data-descriptor\\node_modules\\kind-of"
                 }
               ]
@@ -25315,7 +25315,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend\\node_modules\\is-descriptor"
             }
           ]
@@ -25341,7 +25341,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/static-extend\\node_modules\\kind-of"
             }
           ]
@@ -25369,7 +25369,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/statuses"
         }
       ]
@@ -25395,7 +25395,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/stream-buffers"
         }
       ]
@@ -25421,7 +25421,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/streamsearch"
         }
       ]
@@ -25447,7 +25447,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strict-uri-encode"
         }
       ]
@@ -25473,7 +25473,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string_decoder"
         }
       ]
@@ -25499,7 +25499,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string-width"
         }
       ]
@@ -25525,7 +25525,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string.fromcodepoint"
         }
       ]
@@ -25551,7 +25551,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string.prototype.codepointat"
         }
       ]
@@ -25577,7 +25577,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string.prototype.trimend"
         }
       ]
@@ -25603,7 +25603,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/string.prototype.trimstart"
         }
       ]
@@ -25629,7 +25629,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-ansi"
         }
       ]
@@ -25655,7 +25655,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-bom"
         }
       ]
@@ -25681,7 +25681,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-dirs"
         }
       ]
@@ -25707,7 +25707,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-json-comments"
         }
       ]
@@ -25733,7 +25733,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strip-outer"
         }
       ]
@@ -25759,7 +25759,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/strtok3"
         }
       ]
@@ -25785,7 +25785,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/supports-color"
         }
       ]
@@ -25811,7 +25811,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/supports-preserve-symlinks-flag"
         }
       ]
@@ -25837,7 +25837,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/svg-captcha"
         }
       ]
@@ -25863,7 +25863,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/swagger-ui-dist"
         }
       ]
@@ -25889,7 +25889,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/swagger-ui-express"
         }
       ]
@@ -25915,7 +25915,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tar-fs"
         }
       ],
@@ -25941,7 +25941,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/tar-fs\\node_modules\\bl"
             }
           ]
@@ -25967,7 +25967,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/tar-fs\\node_modules\\chownr"
             }
           ]
@@ -25993,7 +25993,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/tar-fs\\node_modules\\readable-stream"
             }
           ]
@@ -26019,7 +26019,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/tar-fs\\node_modules\\tar-stream"
             }
           ]
@@ -26047,7 +26047,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tar-stream"
         }
       ]
@@ -26073,7 +26073,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tar"
         }
       ]
@@ -26099,7 +26099,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tdigest"
         }
       ]
@@ -26125,7 +26125,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/text-hex"
         }
       ]
@@ -26151,7 +26151,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/thirty-two"
         }
       ]
@@ -26177,7 +26177,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/through"
         }
       ]
@@ -26203,7 +26203,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/timed-out"
         }
       ]
@@ -26229,7 +26229,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tiny-inflate"
         }
       ]
@@ -26255,7 +26255,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-buffer"
         }
       ]
@@ -26281,7 +26281,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-fast-properties"
         }
       ]
@@ -26307,7 +26307,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-object-path"
         }
       ],
@@ -26333,7 +26333,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/to-object-path\\node_modules\\kind-of"
             }
           ]
@@ -26361,7 +26361,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-regex-range"
         }
       ]
@@ -26387,7 +26387,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/to-regex"
         }
       ]
@@ -26413,7 +26413,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/toidentifier"
         }
       ]
@@ -26439,7 +26439,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/token-stream"
         }
       ]
@@ -26465,7 +26465,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/token-types"
         }
       ]
@@ -26491,7 +26491,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/toposort-class"
         }
       ]
@@ -26517,7 +26517,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tough-cookie"
         }
       ]
@@ -26543,7 +26543,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tr46"
         }
       ]
@@ -26569,7 +26569,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/traverse"
         }
       ]
@@ -26595,7 +26595,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tree-kill"
         }
       ]
@@ -26621,7 +26621,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/trim-repeated"
         }
       ]
@@ -26647,7 +26647,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/triple-beam"
         }
       ]
@@ -26673,7 +26673,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/truncate-utf8-bytes"
         }
       ]
@@ -26699,7 +26699,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ts-node-dev"
         }
       ],
@@ -26725,7 +26725,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/ts-node-dev\\node_modules\\rimraf"
             }
           ]
@@ -26753,7 +26753,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ts-node"
         }
       ]
@@ -26779,7 +26779,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tsconfig"
         }
       ]
@@ -26805,7 +26805,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tslib"
         }
       ]
@@ -26831,7 +26831,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tunnel-agent"
         }
       ]
@@ -26857,7 +26857,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/tweetnacl"
         }
       ]
@@ -26883,7 +26883,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/type-check"
         }
       ]
@@ -26909,7 +26909,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/type-is"
         }
       ]
@@ -26935,7 +26935,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/typecast"
         }
       ]
@@ -26961,7 +26961,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/typedarray"
         }
       ]
@@ -26987,7 +26987,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/typescript"
         }
       ]
@@ -27013,7 +27013,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/uglify-js"
         }
       ]
@@ -27039,7 +27039,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unbox-primitive"
         }
       ]
@@ -27065,7 +27065,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unbzip2-stream"
         }
       ]
@@ -27091,7 +27091,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unc-path-regex"
         }
       ]
@@ -27117,7 +27117,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/underscore.string"
         }
       ]
@@ -27143,7 +27143,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unicode-properties"
         }
       ]
@@ -27169,7 +27169,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unicode-trie"
         }
       ]
@@ -27195,7 +27195,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/union-value"
         }
       ],
@@ -27221,7 +27221,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/union-value\\node_modules\\is-extendable"
             }
           ]
@@ -27249,7 +27249,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unique-filename"
         }
       ]
@@ -27275,7 +27275,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unique-slug"
         }
       ]
@@ -27301,7 +27301,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unit-compare"
         }
       ]
@@ -27327,7 +27327,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/universalify"
         }
       ]
@@ -27353,7 +27353,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unpipe"
         }
       ]
@@ -27379,7 +27379,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unset-value"
         }
       ],
@@ -27405,7 +27405,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/unset-value\\node_modules\\has-value"
             }
           ],
@@ -27431,7 +27431,7 @@
               ],
               "properties": [
                 {
-                  "name": "cdx:npm:package:installPath",
+                  "name": "cdx:npm:package:path",
                   "value": "node_modules/unset-value\\node_modules\\has-value\\node_modules\\isobject"
                 }
               ]
@@ -27459,7 +27459,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/unset-value\\node_modules\\has-values"
             }
           ]
@@ -27485,7 +27485,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/unset-value\\node_modules\\isarray"
             }
           ]
@@ -27513,7 +27513,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/untildify"
         }
       ]
@@ -27539,7 +27539,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/unzipper"
         }
       ],
@@ -27565,7 +27565,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/unzipper\\node_modules\\bluebird"
             }
           ]
@@ -27593,7 +27593,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/uri-js"
         }
       ]
@@ -27619,7 +27619,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/urix"
         }
       ]
@@ -27645,7 +27645,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/url-parse-lax"
         }
       ]
@@ -27671,7 +27671,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/url-to-options"
         }
       ]
@@ -27697,7 +27697,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/use"
         }
       ]
@@ -27723,7 +27723,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/utf8-byte-length"
         }
       ]
@@ -27749,7 +27749,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/util-deprecate"
         }
       ]
@@ -27775,7 +27775,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/util"
         }
       ]
@@ -27801,7 +27801,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/utils-merge"
         }
       ]
@@ -27827,7 +27827,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/uuid"
         }
       ]
@@ -27853,7 +27853,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/v8flags"
         }
       ]
@@ -27879,7 +27879,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/validate-npm-package-license"
         }
       ]
@@ -27905,7 +27905,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/validate"
         }
       ]
@@ -27931,7 +27931,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/validator"
         }
       ]
@@ -27957,7 +27957,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/vary"
         }
       ]
@@ -27983,7 +27983,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/verror"
         }
       ],
@@ -28009,7 +28009,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/verror\\node_modules\\core-util-is"
             }
           ]
@@ -28037,7 +28037,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/vm2"
         }
       ],
@@ -28063,7 +28063,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/vm2\\node_modules\\acorn"
             }
           ]
@@ -28091,7 +28091,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/void-elements"
         }
       ]
@@ -28117,7 +28117,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/walk"
         }
       ]
@@ -28143,7 +28143,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/walkdir"
         }
       ]
@@ -28169,7 +28169,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/webidl-conversions"
         }
       ]
@@ -28195,7 +28195,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/whatwg-url"
         }
       ]
@@ -28221,7 +28221,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-boxed-primitive"
         }
       ]
@@ -28247,7 +28247,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-collection"
         }
       ]
@@ -28273,7 +28273,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-module"
         }
       ]
@@ -28299,7 +28299,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-pm-runs"
         }
       ]
@@ -28325,7 +28325,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which-typed-array"
         }
       ]
@@ -28351,7 +28351,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/which"
         }
       ]
@@ -28377,7 +28377,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wide-align"
         }
       ]
@@ -28403,7 +28403,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/winston-transport"
         }
       ],
@@ -28429,7 +28429,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/winston-transport\\node_modules\\readable-stream"
             }
           ]
@@ -28457,7 +28457,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/winston"
         }
       ],
@@ -28483,7 +28483,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/winston\\node_modules\\async"
             }
           ]
@@ -28509,7 +28509,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/winston\\node_modules\\is-stream"
             }
           ]
@@ -28535,7 +28535,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/winston\\node_modules\\readable-stream"
             }
           ]
@@ -28563,7 +28563,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/with"
         }
       ]
@@ -28589,7 +28589,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wkx"
         }
       ]
@@ -28615,7 +28615,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/word-wrap"
         }
       ]
@@ -28641,7 +28641,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wordwrap"
         }
       ]
@@ -28667,7 +28667,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wrap-ansi"
         }
       ],
@@ -28693,7 +28693,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi\\node_modules\\ansi-regex"
             }
           ]
@@ -28719,7 +28719,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi\\node_modules\\emoji-regex"
             }
           ]
@@ -28745,7 +28745,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi\\node_modules\\is-fullwidth-code-point"
             }
           ]
@@ -28771,7 +28771,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi\\node_modules\\string-width"
             }
           ]
@@ -28797,7 +28797,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/wrap-ansi\\node_modules\\strip-ansi"
             }
           ]
@@ -28825,7 +28825,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/wrappy"
         }
       ]
@@ -28851,7 +28851,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/ws"
         }
       ]
@@ -28877,7 +28877,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/xtend"
         }
       ]
@@ -28903,7 +28903,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/y18n"
         }
       ]
@@ -28929,7 +28929,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yallist"
         }
       ]
@@ -28955,7 +28955,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yaml-schema-validator"
         }
       ]
@@ -28981,7 +28981,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yargs-parser"
         }
       ]
@@ -29007,7 +29007,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yargs"
         }
       ],
@@ -29033,7 +29033,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs\\node_modules\\ansi-regex"
             }
           ]
@@ -29059,7 +29059,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs\\node_modules\\emoji-regex"
             }
           ]
@@ -29085,7 +29085,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs\\node_modules\\is-fullwidth-code-point"
             }
           ]
@@ -29111,7 +29111,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs\\node_modules\\string-width"
             }
           ]
@@ -29137,7 +29137,7 @@
           ],
           "properties": [
             {
-              "name": "cdx:npm:package:installPath",
+              "name": "cdx:npm:package:path",
               "value": "node_modules/yargs\\node_modules\\strip-ansi"
             }
           ]
@@ -29165,7 +29165,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yauzl"
         }
       ]
@@ -29191,7 +29191,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/yn"
         }
       ]
@@ -29217,7 +29217,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/z85"
         }
       ]
@@ -29243,7 +29243,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/zip-stream"
         }
       ]
@@ -29269,7 +29269,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/zlibjs"
         }
       ]

--- a/tests/_data/sbom_demo-results/local-dependencies_npm6_node14_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-dependencies_npm6_node14_macos-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-local-deps@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -90,6 +94,10 @@
       ],
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-a"
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -110,6 +118,10 @@
       ],
       "purl": "pkg:npm/my-local-b-off@0.0.0",
       "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-b-off"
+        },
         {
           "name": "cdx:npm:package:private",
           "value": "true"

--- a/tests/_data/sbom_demo-results/local-dependencies_npm6_node14_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-dependencies_npm6_node14_macos-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-local-deps@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -94,7 +94,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-a"
         },
         {
@@ -119,7 +119,7 @@
       "purl": "pkg:npm/my-local-b-off@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-b-off"
         },
         {

--- a/tests/_data/sbom_demo-results/local-dependencies_npm6_node14_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-dependencies_npm6_node14_ubuntu-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-local-deps@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -90,6 +94,10 @@
       ],
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-a"
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -110,6 +118,10 @@
       ],
       "purl": "pkg:npm/my-local-b-off@0.0.0",
       "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-b-off"
+        },
         {
           "name": "cdx:npm:package:private",
           "value": "true"

--- a/tests/_data/sbom_demo-results/local-dependencies_npm6_node14_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-dependencies_npm6_node14_ubuntu-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-local-deps@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -94,7 +94,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-a"
         },
         {
@@ -119,7 +119,7 @@
       "purl": "pkg:npm/my-local-b-off@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-b-off"
         },
         {

--- a/tests/_data/sbom_demo-results/local-dependencies_npm6_node14_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-dependencies_npm6_node14_windows-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-local-deps@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -90,6 +94,10 @@
       ],
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-a"
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -110,6 +118,10 @@
       ],
       "purl": "pkg:npm/my-local-b-off@0.0.0",
       "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-b-off"
+        },
         {
           "name": "cdx:npm:package:private",
           "value": "true"

--- a/tests/_data/sbom_demo-results/local-dependencies_npm6_node14_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-dependencies_npm6_node14_windows-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-local-deps@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -94,7 +94,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-a"
         },
         {
@@ -119,7 +119,7 @@
       "purl": "pkg:npm/my-local-b-off@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-b-off"
         },
         {

--- a/tests/_data/sbom_demo-results/local-dependencies_npm6_node16_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-dependencies_npm6_node16_macos-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-local-deps@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -90,6 +94,10 @@
       ],
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-a"
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -110,6 +118,10 @@
       ],
       "purl": "pkg:npm/my-local-b-off@0.0.0",
       "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-b-off"
+        },
         {
           "name": "cdx:npm:package:private",
           "value": "true"

--- a/tests/_data/sbom_demo-results/local-dependencies_npm6_node16_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-dependencies_npm6_node16_macos-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-local-deps@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -94,7 +94,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-a"
         },
         {
@@ -119,7 +119,7 @@
       "purl": "pkg:npm/my-local-b-off@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-b-off"
         },
         {

--- a/tests/_data/sbom_demo-results/local-dependencies_npm6_node16_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-dependencies_npm6_node16_ubuntu-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-local-deps@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -90,6 +94,10 @@
       ],
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-a"
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -110,6 +118,10 @@
       ],
       "purl": "pkg:npm/my-local-b-off@0.0.0",
       "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-b-off"
+        },
         {
           "name": "cdx:npm:package:private",
           "value": "true"

--- a/tests/_data/sbom_demo-results/local-dependencies_npm6_node16_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-dependencies_npm6_node16_ubuntu-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-local-deps@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -94,7 +94,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-a"
         },
         {
@@ -119,7 +119,7 @@
       "purl": "pkg:npm/my-local-b-off@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-b-off"
         },
         {

--- a/tests/_data/sbom_demo-results/local-dependencies_npm6_node16_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-dependencies_npm6_node16_windows-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-local-deps@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -90,6 +94,10 @@
       ],
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-a"
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -110,6 +118,10 @@
       ],
       "purl": "pkg:npm/my-local-b-off@0.0.0",
       "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-b-off"
+        },
         {
           "name": "cdx:npm:package:private",
           "value": "true"

--- a/tests/_data/sbom_demo-results/local-dependencies_npm6_node16_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-dependencies_npm6_node16_windows-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-local-deps@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -94,7 +94,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-a"
         },
         {
@@ -119,7 +119,7 @@
       "purl": "pkg:npm/my-local-b-off@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-b-off"
         },
         {

--- a/tests/_data/sbom_demo-results/local-dependencies_npm6_node18_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-dependencies_npm6_node18_macos-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-local-deps@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -90,6 +94,10 @@
       ],
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-a"
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -110,6 +118,10 @@
       ],
       "purl": "pkg:npm/my-local-b-off@0.0.0",
       "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-b-off"
+        },
         {
           "name": "cdx:npm:package:private",
           "value": "true"

--- a/tests/_data/sbom_demo-results/local-dependencies_npm6_node18_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-dependencies_npm6_node18_macos-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-local-deps@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -94,7 +94,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-a"
         },
         {
@@ -119,7 +119,7 @@
       "purl": "pkg:npm/my-local-b-off@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-b-off"
         },
         {

--- a/tests/_data/sbom_demo-results/local-dependencies_npm6_node18_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-dependencies_npm6_node18_ubuntu-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-local-deps@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -90,6 +94,10 @@
       ],
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-a"
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -110,6 +118,10 @@
       ],
       "purl": "pkg:npm/my-local-b-off@0.0.0",
       "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-b-off"
+        },
         {
           "name": "cdx:npm:package:private",
           "value": "true"

--- a/tests/_data/sbom_demo-results/local-dependencies_npm6_node18_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-dependencies_npm6_node18_ubuntu-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-local-deps@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -94,7 +94,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-a"
         },
         {
@@ -119,7 +119,7 @@
       "purl": "pkg:npm/my-local-b-off@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-b-off"
         },
         {

--- a/tests/_data/sbom_demo-results/local-dependencies_npm6_node18_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-dependencies_npm6_node18_windows-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-local-deps@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -90,6 +94,10 @@
       ],
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-a"
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -110,6 +118,10 @@
       ],
       "purl": "pkg:npm/my-local-b-off@0.0.0",
       "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-b-off"
+        },
         {
           "name": "cdx:npm:package:private",
           "value": "true"

--- a/tests/_data/sbom_demo-results/local-dependencies_npm6_node18_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-dependencies_npm6_node18_windows-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-local-deps@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -94,7 +94,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-a"
         },
         {
@@ -119,7 +119,7 @@
       "purl": "pkg:npm/my-local-b-off@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-b-off"
         },
         {

--- a/tests/_data/sbom_demo-results/local-dependencies_npm7_node14_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-dependencies_npm7_node14_macos-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-local-deps@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -70,7 +70,7 @@
       "purl": "pkg:npm/my-local-a@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-a"
         }
       ]
@@ -90,7 +90,7 @@
       "purl": "pkg:npm/my-local-b@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-b-off"
         }
       ]
@@ -110,7 +110,7 @@
       "purl": "pkg:npm/my-noname@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-noname"
         }
       ]

--- a/tests/_data/sbom_demo-results/local-dependencies_npm7_node14_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-dependencies_npm7_node14_macos-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-local-deps@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -63,7 +67,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-a@0.0.0"
+      "purl": "pkg:npm/my-local-a@0.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-a"
+        }
+      ]
     },
     {
       "type": "library",
@@ -77,7 +87,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-b@0.0.0"
+      "purl": "pkg:npm/my-local-b@0.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-b-off"
+        }
+      ]
     },
     {
       "type": "library",
@@ -91,7 +107,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-noname@0.0.0"
+      "purl": "pkg:npm/my-noname@0.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-noname"
+        }
+      ]
     }
   ],
   "dependencies": [

--- a/tests/_data/sbom_demo-results/local-dependencies_npm7_node14_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-dependencies_npm7_node14_ubuntu-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-local-deps@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -70,7 +70,7 @@
       "purl": "pkg:npm/my-local-a@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-a"
         }
       ]
@@ -90,7 +90,7 @@
       "purl": "pkg:npm/my-local-b@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-b-off"
         }
       ]
@@ -110,7 +110,7 @@
       "purl": "pkg:npm/my-noname@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-noname"
         }
       ]

--- a/tests/_data/sbom_demo-results/local-dependencies_npm7_node14_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-dependencies_npm7_node14_ubuntu-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-local-deps@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -63,7 +67,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-a@0.0.0"
+      "purl": "pkg:npm/my-local-a@0.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-a"
+        }
+      ]
     },
     {
       "type": "library",
@@ -77,7 +87,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-b@0.0.0"
+      "purl": "pkg:npm/my-local-b@0.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-b-off"
+        }
+      ]
     },
     {
       "type": "library",
@@ -91,7 +107,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-noname@0.0.0"
+      "purl": "pkg:npm/my-noname@0.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-noname"
+        }
+      ]
     }
   ],
   "dependencies": [

--- a/tests/_data/sbom_demo-results/local-dependencies_npm7_node14_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-dependencies_npm7_node14_windows-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-local-deps@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -70,7 +70,7 @@
       "purl": "pkg:npm/my-local-a@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-a"
         }
       ]
@@ -90,7 +90,7 @@
       "purl": "pkg:npm/my-local-b@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-b-off"
         }
       ]
@@ -110,7 +110,7 @@
       "purl": "pkg:npm/my-noname@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-noname"
         }
       ]

--- a/tests/_data/sbom_demo-results/local-dependencies_npm7_node14_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-dependencies_npm7_node14_windows-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-local-deps@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -63,7 +67,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-a@0.0.0"
+      "purl": "pkg:npm/my-local-a@0.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-a"
+        }
+      ]
     },
     {
       "type": "library",
@@ -77,7 +87,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-b@0.0.0"
+      "purl": "pkg:npm/my-local-b@0.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-b-off"
+        }
+      ]
     },
     {
       "type": "library",
@@ -91,7 +107,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-noname@0.0.0"
+      "purl": "pkg:npm/my-noname@0.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-noname"
+        }
+      ]
     }
   ],
   "dependencies": [

--- a/tests/_data/sbom_demo-results/local-dependencies_npm7_node16_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-dependencies_npm7_node16_macos-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-local-deps@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -70,7 +70,7 @@
       "purl": "pkg:npm/my-local-a@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-a"
         }
       ]
@@ -90,7 +90,7 @@
       "purl": "pkg:npm/my-local-b@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-b-off"
         }
       ]
@@ -110,7 +110,7 @@
       "purl": "pkg:npm/my-noname@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-noname"
         }
       ]

--- a/tests/_data/sbom_demo-results/local-dependencies_npm7_node16_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-dependencies_npm7_node16_macos-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-local-deps@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -63,7 +67,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-a@0.0.0"
+      "purl": "pkg:npm/my-local-a@0.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-a"
+        }
+      ]
     },
     {
       "type": "library",
@@ -77,7 +87,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-b@0.0.0"
+      "purl": "pkg:npm/my-local-b@0.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-b-off"
+        }
+      ]
     },
     {
       "type": "library",
@@ -91,7 +107,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-noname@0.0.0"
+      "purl": "pkg:npm/my-noname@0.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-noname"
+        }
+      ]
     }
   ],
   "dependencies": [

--- a/tests/_data/sbom_demo-results/local-dependencies_npm7_node16_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-dependencies_npm7_node16_ubuntu-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-local-deps@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -70,7 +70,7 @@
       "purl": "pkg:npm/my-local-a@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-a"
         }
       ]
@@ -90,7 +90,7 @@
       "purl": "pkg:npm/my-local-b@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-b-off"
         }
       ]
@@ -110,7 +110,7 @@
       "purl": "pkg:npm/my-noname@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-noname"
         }
       ]

--- a/tests/_data/sbom_demo-results/local-dependencies_npm7_node16_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-dependencies_npm7_node16_ubuntu-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-local-deps@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -63,7 +67,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-a@0.0.0"
+      "purl": "pkg:npm/my-local-a@0.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-a"
+        }
+      ]
     },
     {
       "type": "library",
@@ -77,7 +87,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-b@0.0.0"
+      "purl": "pkg:npm/my-local-b@0.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-b-off"
+        }
+      ]
     },
     {
       "type": "library",
@@ -91,7 +107,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-noname@0.0.0"
+      "purl": "pkg:npm/my-noname@0.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-noname"
+        }
+      ]
     }
   ],
   "dependencies": [

--- a/tests/_data/sbom_demo-results/local-dependencies_npm7_node16_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-dependencies_npm7_node16_windows-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-local-deps@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -70,7 +70,7 @@
       "purl": "pkg:npm/my-local-a@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-a"
         }
       ]
@@ -90,7 +90,7 @@
       "purl": "pkg:npm/my-local-b@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-b-off"
         }
       ]
@@ -110,7 +110,7 @@
       "purl": "pkg:npm/my-noname@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-noname"
         }
       ]

--- a/tests/_data/sbom_demo-results/local-dependencies_npm7_node16_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-dependencies_npm7_node16_windows-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-local-deps@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -63,7 +67,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-a@0.0.0"
+      "purl": "pkg:npm/my-local-a@0.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-a"
+        }
+      ]
     },
     {
       "type": "library",
@@ -77,7 +87,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-b@0.0.0"
+      "purl": "pkg:npm/my-local-b@0.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-b-off"
+        }
+      ]
     },
     {
       "type": "library",
@@ -91,7 +107,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-noname@0.0.0"
+      "purl": "pkg:npm/my-noname@0.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-noname"
+        }
+      ]
     }
   ],
   "dependencies": [

--- a/tests/_data/sbom_demo-results/local-dependencies_npm7_node18_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-dependencies_npm7_node18_macos-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-local-deps@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -70,7 +70,7 @@
       "purl": "pkg:npm/my-local-a@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-a"
         }
       ]
@@ -90,7 +90,7 @@
       "purl": "pkg:npm/my-local-b@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-b-off"
         }
       ]
@@ -110,7 +110,7 @@
       "purl": "pkg:npm/my-noname@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-noname"
         }
       ]

--- a/tests/_data/sbom_demo-results/local-dependencies_npm7_node18_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-dependencies_npm7_node18_macos-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-local-deps@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -63,7 +67,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-a@0.0.0"
+      "purl": "pkg:npm/my-local-a@0.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-a"
+        }
+      ]
     },
     {
       "type": "library",
@@ -77,7 +87,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-b@0.0.0"
+      "purl": "pkg:npm/my-local-b@0.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-b-off"
+        }
+      ]
     },
     {
       "type": "library",
@@ -91,7 +107,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-noname@0.0.0"
+      "purl": "pkg:npm/my-noname@0.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-noname"
+        }
+      ]
     }
   ],
   "dependencies": [

--- a/tests/_data/sbom_demo-results/local-dependencies_npm7_node18_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-dependencies_npm7_node18_ubuntu-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-local-deps@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -70,7 +70,7 @@
       "purl": "pkg:npm/my-local-a@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-a"
         }
       ]
@@ -90,7 +90,7 @@
       "purl": "pkg:npm/my-local-b@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-b-off"
         }
       ]
@@ -110,7 +110,7 @@
       "purl": "pkg:npm/my-noname@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-noname"
         }
       ]

--- a/tests/_data/sbom_demo-results/local-dependencies_npm7_node18_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-dependencies_npm7_node18_ubuntu-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-local-deps@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -63,7 +67,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-a@0.0.0"
+      "purl": "pkg:npm/my-local-a@0.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-a"
+        }
+      ]
     },
     {
       "type": "library",
@@ -77,7 +87,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-b@0.0.0"
+      "purl": "pkg:npm/my-local-b@0.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-b-off"
+        }
+      ]
     },
     {
       "type": "library",
@@ -91,7 +107,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-noname@0.0.0"
+      "purl": "pkg:npm/my-noname@0.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-noname"
+        }
+      ]
     }
   ],
   "dependencies": [

--- a/tests/_data/sbom_demo-results/local-dependencies_npm7_node18_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-dependencies_npm7_node18_windows-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-local-deps@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -70,7 +70,7 @@
       "purl": "pkg:npm/my-local-a@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-a"
         }
       ]
@@ -90,7 +90,7 @@
       "purl": "pkg:npm/my-local-b@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-b-off"
         }
       ]
@@ -110,7 +110,7 @@
       "purl": "pkg:npm/my-noname@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-noname"
         }
       ]

--- a/tests/_data/sbom_demo-results/local-dependencies_npm7_node18_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-dependencies_npm7_node18_windows-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-local-deps@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -63,7 +67,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-a@0.0.0"
+      "purl": "pkg:npm/my-local-a@0.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-a"
+        }
+      ]
     },
     {
       "type": "library",
@@ -77,7 +87,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-b@0.0.0"
+      "purl": "pkg:npm/my-local-b@0.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-b-off"
+        }
+      ]
     },
     {
       "type": "library",
@@ -91,7 +107,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-noname@0.0.0"
+      "purl": "pkg:npm/my-noname@0.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-noname"
+        }
+      ]
     }
   ],
   "dependencies": [

--- a/tests/_data/sbom_demo-results/local-dependencies_npm8_node14_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-dependencies_npm8_node14_macos-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-local-deps@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -70,7 +70,7 @@
       "purl": "pkg:npm/my-local-a@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-a"
         }
       ]
@@ -90,7 +90,7 @@
       "purl": "pkg:npm/my-local-b@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-b-off"
         }
       ]
@@ -110,7 +110,7 @@
       "purl": "pkg:npm/my-noname@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-noname"
         }
       ]

--- a/tests/_data/sbom_demo-results/local-dependencies_npm8_node14_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-dependencies_npm8_node14_macos-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-local-deps@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -63,7 +67,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-a@0.0.0"
+      "purl": "pkg:npm/my-local-a@0.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-a"
+        }
+      ]
     },
     {
       "type": "library",
@@ -77,7 +87,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-b@0.0.0"
+      "purl": "pkg:npm/my-local-b@0.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-b-off"
+        }
+      ]
     },
     {
       "type": "library",
@@ -91,7 +107,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-noname@0.0.0"
+      "purl": "pkg:npm/my-noname@0.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-noname"
+        }
+      ]
     }
   ],
   "dependencies": [

--- a/tests/_data/sbom_demo-results/local-dependencies_npm8_node14_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-dependencies_npm8_node14_ubuntu-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-local-deps@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -70,7 +70,7 @@
       "purl": "pkg:npm/my-local-a@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-a"
         }
       ]
@@ -90,7 +90,7 @@
       "purl": "pkg:npm/my-local-b@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-b-off"
         }
       ]
@@ -110,7 +110,7 @@
       "purl": "pkg:npm/my-noname@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-noname"
         }
       ]

--- a/tests/_data/sbom_demo-results/local-dependencies_npm8_node14_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-dependencies_npm8_node14_ubuntu-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-local-deps@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -63,7 +67,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-a@0.0.0"
+      "purl": "pkg:npm/my-local-a@0.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-a"
+        }
+      ]
     },
     {
       "type": "library",
@@ -77,7 +87,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-b@0.0.0"
+      "purl": "pkg:npm/my-local-b@0.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-b-off"
+        }
+      ]
     },
     {
       "type": "library",
@@ -91,7 +107,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-noname@0.0.0"
+      "purl": "pkg:npm/my-noname@0.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-noname"
+        }
+      ]
     }
   ],
   "dependencies": [

--- a/tests/_data/sbom_demo-results/local-dependencies_npm8_node14_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-dependencies_npm8_node14_windows-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-local-deps@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -70,7 +70,7 @@
       "purl": "pkg:npm/my-local-a@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-a"
         }
       ]
@@ -90,7 +90,7 @@
       "purl": "pkg:npm/my-local-b@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-b-off"
         }
       ]
@@ -110,7 +110,7 @@
       "purl": "pkg:npm/my-noname@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-noname"
         }
       ]

--- a/tests/_data/sbom_demo-results/local-dependencies_npm8_node14_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-dependencies_npm8_node14_windows-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-local-deps@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -63,7 +67,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-a@0.0.0"
+      "purl": "pkg:npm/my-local-a@0.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-a"
+        }
+      ]
     },
     {
       "type": "library",
@@ -77,7 +87,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-b@0.0.0"
+      "purl": "pkg:npm/my-local-b@0.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-b-off"
+        }
+      ]
     },
     {
       "type": "library",
@@ -91,7 +107,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-noname@0.0.0"
+      "purl": "pkg:npm/my-noname@0.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-noname"
+        }
+      ]
     }
   ],
   "dependencies": [

--- a/tests/_data/sbom_demo-results/local-dependencies_npm8_node16_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-dependencies_npm8_node16_macos-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-local-deps@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -70,7 +70,7 @@
       "purl": "pkg:npm/my-local-a@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-a"
         }
       ]
@@ -90,7 +90,7 @@
       "purl": "pkg:npm/my-local-b@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-b-off"
         }
       ]
@@ -110,7 +110,7 @@
       "purl": "pkg:npm/my-noname@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-noname"
         }
       ]

--- a/tests/_data/sbom_demo-results/local-dependencies_npm8_node16_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-dependencies_npm8_node16_macos-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-local-deps@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -63,7 +67,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-a@0.0.0"
+      "purl": "pkg:npm/my-local-a@0.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-a"
+        }
+      ]
     },
     {
       "type": "library",
@@ -77,7 +87,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-b@0.0.0"
+      "purl": "pkg:npm/my-local-b@0.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-b-off"
+        }
+      ]
     },
     {
       "type": "library",
@@ -91,7 +107,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-noname@0.0.0"
+      "purl": "pkg:npm/my-noname@0.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-noname"
+        }
+      ]
     }
   ],
   "dependencies": [

--- a/tests/_data/sbom_demo-results/local-dependencies_npm8_node16_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-dependencies_npm8_node16_ubuntu-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-local-deps@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -70,7 +70,7 @@
       "purl": "pkg:npm/my-local-a@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-a"
         }
       ]
@@ -90,7 +90,7 @@
       "purl": "pkg:npm/my-local-b@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-b-off"
         }
       ]
@@ -110,7 +110,7 @@
       "purl": "pkg:npm/my-noname@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-noname"
         }
       ]

--- a/tests/_data/sbom_demo-results/local-dependencies_npm8_node16_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-dependencies_npm8_node16_ubuntu-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-local-deps@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -63,7 +67,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-a@0.0.0"
+      "purl": "pkg:npm/my-local-a@0.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-a"
+        }
+      ]
     },
     {
       "type": "library",
@@ -77,7 +87,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-b@0.0.0"
+      "purl": "pkg:npm/my-local-b@0.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-b-off"
+        }
+      ]
     },
     {
       "type": "library",
@@ -91,7 +107,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-noname@0.0.0"
+      "purl": "pkg:npm/my-noname@0.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-noname"
+        }
+      ]
     }
   ],
   "dependencies": [

--- a/tests/_data/sbom_demo-results/local-dependencies_npm8_node16_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-dependencies_npm8_node16_windows-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-local-deps@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -70,7 +70,7 @@
       "purl": "pkg:npm/my-local-a@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-a"
         }
       ]
@@ -90,7 +90,7 @@
       "purl": "pkg:npm/my-local-b@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-b-off"
         }
       ]
@@ -110,7 +110,7 @@
       "purl": "pkg:npm/my-noname@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-noname"
         }
       ]

--- a/tests/_data/sbom_demo-results/local-dependencies_npm8_node16_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-dependencies_npm8_node16_windows-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-local-deps@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -63,7 +67,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-a@0.0.0"
+      "purl": "pkg:npm/my-local-a@0.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-a"
+        }
+      ]
     },
     {
       "type": "library",
@@ -77,7 +87,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-b@0.0.0"
+      "purl": "pkg:npm/my-local-b@0.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-b-off"
+        }
+      ]
     },
     {
       "type": "library",
@@ -91,7 +107,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-noname@0.0.0"
+      "purl": "pkg:npm/my-noname@0.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-noname"
+        }
+      ]
     }
   ],
   "dependencies": [

--- a/tests/_data/sbom_demo-results/local-dependencies_npm8_node18_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-dependencies_npm8_node18_macos-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-local-deps@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -70,7 +70,7 @@
       "purl": "pkg:npm/my-local-a@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-a"
         }
       ]
@@ -90,7 +90,7 @@
       "purl": "pkg:npm/my-local-b@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-b-off"
         }
       ]
@@ -110,7 +110,7 @@
       "purl": "pkg:npm/my-noname@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-noname"
         }
       ]

--- a/tests/_data/sbom_demo-results/local-dependencies_npm8_node18_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-dependencies_npm8_node18_macos-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-local-deps@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -63,7 +67,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-a@0.0.0"
+      "purl": "pkg:npm/my-local-a@0.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-a"
+        }
+      ]
     },
     {
       "type": "library",
@@ -77,7 +87,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-b@0.0.0"
+      "purl": "pkg:npm/my-local-b@0.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-b-off"
+        }
+      ]
     },
     {
       "type": "library",
@@ -91,7 +107,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-noname@0.0.0"
+      "purl": "pkg:npm/my-noname@0.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-noname"
+        }
+      ]
     }
   ],
   "dependencies": [

--- a/tests/_data/sbom_demo-results/local-dependencies_npm8_node18_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-dependencies_npm8_node18_ubuntu-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-local-deps@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -70,7 +70,7 @@
       "purl": "pkg:npm/my-local-a@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-a"
         }
       ]
@@ -90,7 +90,7 @@
       "purl": "pkg:npm/my-local-b@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-b-off"
         }
       ]
@@ -110,7 +110,7 @@
       "purl": "pkg:npm/my-noname@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-noname"
         }
       ]

--- a/tests/_data/sbom_demo-results/local-dependencies_npm8_node18_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-dependencies_npm8_node18_ubuntu-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-local-deps@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -63,7 +67,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-a@0.0.0"
+      "purl": "pkg:npm/my-local-a@0.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-a"
+        }
+      ]
     },
     {
       "type": "library",
@@ -77,7 +87,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-b@0.0.0"
+      "purl": "pkg:npm/my-local-b@0.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-b-off"
+        }
+      ]
     },
     {
       "type": "library",
@@ -91,7 +107,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-noname@0.0.0"
+      "purl": "pkg:npm/my-noname@0.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-noname"
+        }
+      ]
     }
   ],
   "dependencies": [

--- a/tests/_data/sbom_demo-results/local-dependencies_npm8_node18_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-dependencies_npm8_node18_windows-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-local-deps@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -70,7 +70,7 @@
       "purl": "pkg:npm/my-local-a@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-a"
         }
       ]
@@ -90,7 +90,7 @@
       "purl": "pkg:npm/my-local-b@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-b-off"
         }
       ]
@@ -110,7 +110,7 @@
       "purl": "pkg:npm/my-noname@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-noname"
         }
       ]

--- a/tests/_data/sbom_demo-results/local-dependencies_npm8_node18_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-dependencies_npm8_node18_windows-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-local-deps@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -63,7 +67,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-a@0.0.0"
+      "purl": "pkg:npm/my-local-a@0.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-a"
+        }
+      ]
     },
     {
       "type": "library",
@@ -77,7 +87,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-b@0.0.0"
+      "purl": "pkg:npm/my-local-b@0.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-b-off"
+        }
+      ]
     },
     {
       "type": "library",
@@ -91,7 +107,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-noname@0.0.0"
+      "purl": "pkg:npm/my-noname@0.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-noname"
+        }
+      ]
     }
   ],
   "dependencies": [

--- a/tests/_data/sbom_demo-results/local-dependencies_npm9_node16_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-dependencies_npm9_node16_macos-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-local-deps@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -70,7 +70,7 @@
       "purl": "pkg:npm/my-local-a@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-a"
         }
       ]
@@ -90,7 +90,7 @@
       "purl": "pkg:npm/my-local-b@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-b-off"
         }
       ]
@@ -110,7 +110,7 @@
       "purl": "pkg:npm/my-noname@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-noname"
         }
       ]

--- a/tests/_data/sbom_demo-results/local-dependencies_npm9_node16_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-dependencies_npm9_node16_macos-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-local-deps@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -63,7 +67,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-a@0.0.0"
+      "purl": "pkg:npm/my-local-a@0.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-a"
+        }
+      ]
     },
     {
       "type": "library",
@@ -77,7 +87,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-b@0.0.0"
+      "purl": "pkg:npm/my-local-b@0.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-b-off"
+        }
+      ]
     },
     {
       "type": "library",
@@ -91,7 +107,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-noname@0.0.0"
+      "purl": "pkg:npm/my-noname@0.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-noname"
+        }
+      ]
     }
   ],
   "dependencies": [

--- a/tests/_data/sbom_demo-results/local-dependencies_npm9_node16_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-dependencies_npm9_node16_ubuntu-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-local-deps@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -70,7 +70,7 @@
       "purl": "pkg:npm/my-local-a@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-a"
         }
       ]
@@ -90,7 +90,7 @@
       "purl": "pkg:npm/my-local-b@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-b-off"
         }
       ]
@@ -110,7 +110,7 @@
       "purl": "pkg:npm/my-noname@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-noname"
         }
       ]

--- a/tests/_data/sbom_demo-results/local-dependencies_npm9_node16_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-dependencies_npm9_node16_ubuntu-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-local-deps@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -63,7 +67,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-a@0.0.0"
+      "purl": "pkg:npm/my-local-a@0.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-a"
+        }
+      ]
     },
     {
       "type": "library",
@@ -77,7 +87,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-b@0.0.0"
+      "purl": "pkg:npm/my-local-b@0.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-b-off"
+        }
+      ]
     },
     {
       "type": "library",
@@ -91,7 +107,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-noname@0.0.0"
+      "purl": "pkg:npm/my-noname@0.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-noname"
+        }
+      ]
     }
   ],
   "dependencies": [

--- a/tests/_data/sbom_demo-results/local-dependencies_npm9_node16_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-dependencies_npm9_node16_windows-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-local-deps@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -70,7 +70,7 @@
       "purl": "pkg:npm/my-local-a@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-a"
         }
       ]
@@ -90,7 +90,7 @@
       "purl": "pkg:npm/my-local-b@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-b-off"
         }
       ]
@@ -110,7 +110,7 @@
       "purl": "pkg:npm/my-noname@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-noname"
         }
       ]

--- a/tests/_data/sbom_demo-results/local-dependencies_npm9_node16_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-dependencies_npm9_node16_windows-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-local-deps@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -63,7 +67,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-a@0.0.0"
+      "purl": "pkg:npm/my-local-a@0.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-a"
+        }
+      ]
     },
     {
       "type": "library",
@@ -77,7 +87,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-b@0.0.0"
+      "purl": "pkg:npm/my-local-b@0.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-b-off"
+        }
+      ]
     },
     {
       "type": "library",
@@ -91,7 +107,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-noname@0.0.0"
+      "purl": "pkg:npm/my-noname@0.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-noname"
+        }
+      ]
     }
   ],
   "dependencies": [

--- a/tests/_data/sbom_demo-results/local-dependencies_npm9_node18_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-dependencies_npm9_node18_macos-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-local-deps@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -70,7 +70,7 @@
       "purl": "pkg:npm/my-local-a@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-a"
         }
       ]
@@ -90,7 +90,7 @@
       "purl": "pkg:npm/my-local-b@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-b-off"
         }
       ]
@@ -110,7 +110,7 @@
       "purl": "pkg:npm/my-noname@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-noname"
         }
       ]

--- a/tests/_data/sbom_demo-results/local-dependencies_npm9_node18_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-dependencies_npm9_node18_macos-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-local-deps@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -63,7 +67,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-a@0.0.0"
+      "purl": "pkg:npm/my-local-a@0.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-a"
+        }
+      ]
     },
     {
       "type": "library",
@@ -77,7 +87,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-b@0.0.0"
+      "purl": "pkg:npm/my-local-b@0.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-b-off"
+        }
+      ]
     },
     {
       "type": "library",
@@ -91,7 +107,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-noname@0.0.0"
+      "purl": "pkg:npm/my-noname@0.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-noname"
+        }
+      ]
     }
   ],
   "dependencies": [

--- a/tests/_data/sbom_demo-results/local-dependencies_npm9_node18_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-dependencies_npm9_node18_ubuntu-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-local-deps@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -70,7 +70,7 @@
       "purl": "pkg:npm/my-local-a@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-a"
         }
       ]
@@ -90,7 +90,7 @@
       "purl": "pkg:npm/my-local-b@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-b-off"
         }
       ]
@@ -110,7 +110,7 @@
       "purl": "pkg:npm/my-noname@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-noname"
         }
       ]

--- a/tests/_data/sbom_demo-results/local-dependencies_npm9_node18_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-dependencies_npm9_node18_ubuntu-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-local-deps@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -63,7 +67,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-a@0.0.0"
+      "purl": "pkg:npm/my-local-a@0.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-a"
+        }
+      ]
     },
     {
       "type": "library",
@@ -77,7 +87,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-b@0.0.0"
+      "purl": "pkg:npm/my-local-b@0.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-b-off"
+        }
+      ]
     },
     {
       "type": "library",
@@ -91,7 +107,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-noname@0.0.0"
+      "purl": "pkg:npm/my-noname@0.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-noname"
+        }
+      ]
     }
   ],
   "dependencies": [

--- a/tests/_data/sbom_demo-results/local-dependencies_npm9_node18_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-dependencies_npm9_node18_windows-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-local-deps@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -70,7 +70,7 @@
       "purl": "pkg:npm/my-local-a@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-a"
         }
       ]
@@ -90,7 +90,7 @@
       "purl": "pkg:npm/my-local-b@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-b-off"
         }
       ]
@@ -110,7 +110,7 @@
       "purl": "pkg:npm/my-noname@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-noname"
         }
       ]

--- a/tests/_data/sbom_demo-results/local-dependencies_npm9_node18_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-dependencies_npm9_node18_windows-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-local-deps@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -63,7 +67,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-a@0.0.0"
+      "purl": "pkg:npm/my-local-a@0.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-a"
+        }
+      ]
     },
     {
       "type": "library",
@@ -77,7 +87,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-b@0.0.0"
+      "purl": "pkg:npm/my-local-b@0.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-b-off"
+        }
+      ]
     },
     {
       "type": "library",
@@ -91,7 +107,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-noname@0.0.0"
+      "purl": "pkg:npm/my-noname@0.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-noname"
+        }
+      ]
     }
   ],
   "dependencies": [

--- a/tests/_data/sbom_demo-results/local-workspaces_npm6_node14_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-workspaces_npm6_node14_macos-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-workspaces@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -84,6 +88,10 @@
       ],
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-a"
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -104,6 +112,10 @@
       ],
       "purl": "pkg:npm/my-local-b-off@0.0.0",
       "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-b-off"
+        },
         {
           "name": "cdx:npm:package:private",
           "value": "true"

--- a/tests/_data/sbom_demo-results/local-workspaces_npm6_node14_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-workspaces_npm6_node14_macos-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-workspaces@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -88,7 +88,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-a"
         },
         {
@@ -113,7 +113,7 @@
       "purl": "pkg:npm/my-local-b-off@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-b-off"
         },
         {

--- a/tests/_data/sbom_demo-results/local-workspaces_npm6_node14_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-workspaces_npm6_node14_ubuntu-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-workspaces@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -84,6 +88,10 @@
       ],
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-a"
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -104,6 +112,10 @@
       ],
       "purl": "pkg:npm/my-local-b-off@0.0.0",
       "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-b-off"
+        },
         {
           "name": "cdx:npm:package:private",
           "value": "true"

--- a/tests/_data/sbom_demo-results/local-workspaces_npm6_node14_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-workspaces_npm6_node14_ubuntu-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-workspaces@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -88,7 +88,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-a"
         },
         {
@@ -113,7 +113,7 @@
       "purl": "pkg:npm/my-local-b-off@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-b-off"
         },
         {

--- a/tests/_data/sbom_demo-results/local-workspaces_npm6_node14_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-workspaces_npm6_node14_windows-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-workspaces@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -84,6 +88,10 @@
       ],
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-a"
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -104,6 +112,10 @@
       ],
       "purl": "pkg:npm/my-local-b-off@0.0.0",
       "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-b-off"
+        },
         {
           "name": "cdx:npm:package:private",
           "value": "true"

--- a/tests/_data/sbom_demo-results/local-workspaces_npm6_node14_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-workspaces_npm6_node14_windows-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-workspaces@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -88,7 +88,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-a"
         },
         {
@@ -113,7 +113,7 @@
       "purl": "pkg:npm/my-local-b-off@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-b-off"
         },
         {

--- a/tests/_data/sbom_demo-results/local-workspaces_npm6_node16_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-workspaces_npm6_node16_macos-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-workspaces@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -84,6 +88,10 @@
       ],
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-a"
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -104,6 +112,10 @@
       ],
       "purl": "pkg:npm/my-local-b-off@0.0.0",
       "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-b-off"
+        },
         {
           "name": "cdx:npm:package:private",
           "value": "true"

--- a/tests/_data/sbom_demo-results/local-workspaces_npm6_node16_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-workspaces_npm6_node16_macos-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-workspaces@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -88,7 +88,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-a"
         },
         {
@@ -113,7 +113,7 @@
       "purl": "pkg:npm/my-local-b-off@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-b-off"
         },
         {

--- a/tests/_data/sbom_demo-results/local-workspaces_npm6_node16_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-workspaces_npm6_node16_ubuntu-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-workspaces@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -84,6 +88,10 @@
       ],
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-a"
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -104,6 +112,10 @@
       ],
       "purl": "pkg:npm/my-local-b-off@0.0.0",
       "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-b-off"
+        },
         {
           "name": "cdx:npm:package:private",
           "value": "true"

--- a/tests/_data/sbom_demo-results/local-workspaces_npm6_node16_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-workspaces_npm6_node16_ubuntu-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-workspaces@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -88,7 +88,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-a"
         },
         {
@@ -113,7 +113,7 @@
       "purl": "pkg:npm/my-local-b-off@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-b-off"
         },
         {

--- a/tests/_data/sbom_demo-results/local-workspaces_npm6_node16_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-workspaces_npm6_node16_windows-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-workspaces@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -84,6 +88,10 @@
       ],
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-a"
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -104,6 +112,10 @@
       ],
       "purl": "pkg:npm/my-local-b-off@0.0.0",
       "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-b-off"
+        },
         {
           "name": "cdx:npm:package:private",
           "value": "true"

--- a/tests/_data/sbom_demo-results/local-workspaces_npm6_node16_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-workspaces_npm6_node16_windows-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-workspaces@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -88,7 +88,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-a"
         },
         {
@@ -113,7 +113,7 @@
       "purl": "pkg:npm/my-local-b-off@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-b-off"
         },
         {

--- a/tests/_data/sbom_demo-results/local-workspaces_npm6_node18_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-workspaces_npm6_node18_macos-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-workspaces@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -84,6 +88,10 @@
       ],
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-a"
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -104,6 +112,10 @@
       ],
       "purl": "pkg:npm/my-local-b-off@0.0.0",
       "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-b-off"
+        },
         {
           "name": "cdx:npm:package:private",
           "value": "true"

--- a/tests/_data/sbom_demo-results/local-workspaces_npm6_node18_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-workspaces_npm6_node18_macos-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-workspaces@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -88,7 +88,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-a"
         },
         {
@@ -113,7 +113,7 @@
       "purl": "pkg:npm/my-local-b-off@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-b-off"
         },
         {

--- a/tests/_data/sbom_demo-results/local-workspaces_npm6_node18_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-workspaces_npm6_node18_ubuntu-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-workspaces@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -84,6 +88,10 @@
       ],
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-a"
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -104,6 +112,10 @@
       ],
       "purl": "pkg:npm/my-local-b-off@0.0.0",
       "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-b-off"
+        },
         {
           "name": "cdx:npm:package:private",
           "value": "true"

--- a/tests/_data/sbom_demo-results/local-workspaces_npm6_node18_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-workspaces_npm6_node18_ubuntu-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-workspaces@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -88,7 +88,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-a"
         },
         {
@@ -113,7 +113,7 @@
       "purl": "pkg:npm/my-local-b-off@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-b-off"
         },
         {

--- a/tests/_data/sbom_demo-results/local-workspaces_npm6_node18_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-workspaces_npm6_node18_windows-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-workspaces@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -84,6 +88,10 @@
       ],
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-a"
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -104,6 +112,10 @@
       ],
       "purl": "pkg:npm/my-local-b-off@0.0.0",
       "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-b-off"
+        },
         {
           "name": "cdx:npm:package:private",
           "value": "true"

--- a/tests/_data/sbom_demo-results/local-workspaces_npm6_node18_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-workspaces_npm6_node18_windows-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-workspaces@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -88,7 +88,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-a"
         },
         {
@@ -113,7 +113,7 @@
       "purl": "pkg:npm/my-local-b-off@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-b-off"
         },
         {

--- a/tests/_data/sbom_demo-results/local-workspaces_npm7_node14_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-workspaces_npm7_node14_macos-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-workspaces@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -63,7 +67,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-a@0.1.0"
+      "purl": "pkg:npm/my-local-a@0.1.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-a"
+        }
+      ]
     },
     {
       "type": "library",
@@ -77,7 +87,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-b-off@0.0.0"
+      "purl": "pkg:npm/my-local-b-off@0.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-b-off"
+        }
+      ]
     },
     {
       "type": "library",
@@ -91,7 +107,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-c@0.23.42"
+      "purl": "pkg:npm/my-local-c@0.23.42",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-c"
+        }
+      ]
     }
   ],
   "dependencies": [

--- a/tests/_data/sbom_demo-results/local-workspaces_npm7_node14_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-workspaces_npm7_node14_macos-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-workspaces@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -70,7 +70,7 @@
       "purl": "pkg:npm/my-local-a@0.1.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-a"
         }
       ]
@@ -90,7 +90,7 @@
       "purl": "pkg:npm/my-local-b-off@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-b-off"
         }
       ]
@@ -110,7 +110,7 @@
       "purl": "pkg:npm/my-local-c@0.23.42",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-c"
         }
       ]

--- a/tests/_data/sbom_demo-results/local-workspaces_npm7_node14_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-workspaces_npm7_node14_ubuntu-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-workspaces@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -63,7 +67,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-a@0.1.0"
+      "purl": "pkg:npm/my-local-a@0.1.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-a"
+        }
+      ]
     },
     {
       "type": "library",
@@ -77,7 +87,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-b-off@0.0.0"
+      "purl": "pkg:npm/my-local-b-off@0.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-b-off"
+        }
+      ]
     },
     {
       "type": "library",
@@ -91,7 +107,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-c@0.23.42"
+      "purl": "pkg:npm/my-local-c@0.23.42",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-c"
+        }
+      ]
     }
   ],
   "dependencies": [

--- a/tests/_data/sbom_demo-results/local-workspaces_npm7_node14_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-workspaces_npm7_node14_ubuntu-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-workspaces@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -70,7 +70,7 @@
       "purl": "pkg:npm/my-local-a@0.1.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-a"
         }
       ]
@@ -90,7 +90,7 @@
       "purl": "pkg:npm/my-local-b-off@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-b-off"
         }
       ]
@@ -110,7 +110,7 @@
       "purl": "pkg:npm/my-local-c@0.23.42",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-c"
         }
       ]

--- a/tests/_data/sbom_demo-results/local-workspaces_npm7_node14_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-workspaces_npm7_node14_windows-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-workspaces@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -63,7 +67,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-a@0.1.0"
+      "purl": "pkg:npm/my-local-a@0.1.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-a"
+        }
+      ]
     },
     {
       "type": "library",
@@ -77,7 +87,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-b-off@0.0.0"
+      "purl": "pkg:npm/my-local-b-off@0.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-b-off"
+        }
+      ]
     },
     {
       "type": "library",
@@ -91,7 +107,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-c@0.23.42"
+      "purl": "pkg:npm/my-local-c@0.23.42",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-c"
+        }
+      ]
     }
   ],
   "dependencies": [

--- a/tests/_data/sbom_demo-results/local-workspaces_npm7_node14_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-workspaces_npm7_node14_windows-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-workspaces@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -70,7 +70,7 @@
       "purl": "pkg:npm/my-local-a@0.1.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-a"
         }
       ]
@@ -90,7 +90,7 @@
       "purl": "pkg:npm/my-local-b-off@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-b-off"
         }
       ]
@@ -110,7 +110,7 @@
       "purl": "pkg:npm/my-local-c@0.23.42",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-c"
         }
       ]

--- a/tests/_data/sbom_demo-results/local-workspaces_npm7_node16_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-workspaces_npm7_node16_macos-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-workspaces@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -63,7 +67,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-a@0.1.0"
+      "purl": "pkg:npm/my-local-a@0.1.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-a"
+        }
+      ]
     },
     {
       "type": "library",
@@ -77,7 +87,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-b-off@0.0.0"
+      "purl": "pkg:npm/my-local-b-off@0.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-b-off"
+        }
+      ]
     },
     {
       "type": "library",
@@ -91,7 +107,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-c@0.23.42"
+      "purl": "pkg:npm/my-local-c@0.23.42",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-c"
+        }
+      ]
     }
   ],
   "dependencies": [

--- a/tests/_data/sbom_demo-results/local-workspaces_npm7_node16_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-workspaces_npm7_node16_macos-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-workspaces@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -70,7 +70,7 @@
       "purl": "pkg:npm/my-local-a@0.1.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-a"
         }
       ]
@@ -90,7 +90,7 @@
       "purl": "pkg:npm/my-local-b-off@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-b-off"
         }
       ]
@@ -110,7 +110,7 @@
       "purl": "pkg:npm/my-local-c@0.23.42",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-c"
         }
       ]

--- a/tests/_data/sbom_demo-results/local-workspaces_npm7_node16_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-workspaces_npm7_node16_ubuntu-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-workspaces@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -63,7 +67,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-a@0.1.0"
+      "purl": "pkg:npm/my-local-a@0.1.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-a"
+        }
+      ]
     },
     {
       "type": "library",
@@ -77,7 +87,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-b-off@0.0.0"
+      "purl": "pkg:npm/my-local-b-off@0.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-b-off"
+        }
+      ]
     },
     {
       "type": "library",
@@ -91,7 +107,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-c@0.23.42"
+      "purl": "pkg:npm/my-local-c@0.23.42",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-c"
+        }
+      ]
     }
   ],
   "dependencies": [

--- a/tests/_data/sbom_demo-results/local-workspaces_npm7_node16_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-workspaces_npm7_node16_ubuntu-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-workspaces@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -70,7 +70,7 @@
       "purl": "pkg:npm/my-local-a@0.1.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-a"
         }
       ]
@@ -90,7 +90,7 @@
       "purl": "pkg:npm/my-local-b-off@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-b-off"
         }
       ]
@@ -110,7 +110,7 @@
       "purl": "pkg:npm/my-local-c@0.23.42",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-c"
         }
       ]

--- a/tests/_data/sbom_demo-results/local-workspaces_npm7_node16_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-workspaces_npm7_node16_windows-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-workspaces@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -63,7 +67,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-a@0.1.0"
+      "purl": "pkg:npm/my-local-a@0.1.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-a"
+        }
+      ]
     },
     {
       "type": "library",
@@ -77,7 +87,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-b-off@0.0.0"
+      "purl": "pkg:npm/my-local-b-off@0.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-b-off"
+        }
+      ]
     },
     {
       "type": "library",
@@ -91,7 +107,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-c@0.23.42"
+      "purl": "pkg:npm/my-local-c@0.23.42",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-c"
+        }
+      ]
     }
   ],
   "dependencies": [

--- a/tests/_data/sbom_demo-results/local-workspaces_npm7_node16_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-workspaces_npm7_node16_windows-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-workspaces@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -70,7 +70,7 @@
       "purl": "pkg:npm/my-local-a@0.1.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-a"
         }
       ]
@@ -90,7 +90,7 @@
       "purl": "pkg:npm/my-local-b-off@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-b-off"
         }
       ]
@@ -110,7 +110,7 @@
       "purl": "pkg:npm/my-local-c@0.23.42",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-c"
         }
       ]

--- a/tests/_data/sbom_demo-results/local-workspaces_npm7_node18_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-workspaces_npm7_node18_macos-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-workspaces@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -63,7 +67,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-a@0.1.0"
+      "purl": "pkg:npm/my-local-a@0.1.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-a"
+        }
+      ]
     },
     {
       "type": "library",
@@ -77,7 +87,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-b-off@0.0.0"
+      "purl": "pkg:npm/my-local-b-off@0.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-b-off"
+        }
+      ]
     },
     {
       "type": "library",
@@ -91,7 +107,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-c@0.23.42"
+      "purl": "pkg:npm/my-local-c@0.23.42",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-c"
+        }
+      ]
     }
   ],
   "dependencies": [

--- a/tests/_data/sbom_demo-results/local-workspaces_npm7_node18_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-workspaces_npm7_node18_macos-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-workspaces@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -70,7 +70,7 @@
       "purl": "pkg:npm/my-local-a@0.1.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-a"
         }
       ]
@@ -90,7 +90,7 @@
       "purl": "pkg:npm/my-local-b-off@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-b-off"
         }
       ]
@@ -110,7 +110,7 @@
       "purl": "pkg:npm/my-local-c@0.23.42",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-c"
         }
       ]

--- a/tests/_data/sbom_demo-results/local-workspaces_npm7_node18_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-workspaces_npm7_node18_ubuntu-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-workspaces@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -63,7 +67,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-a@0.1.0"
+      "purl": "pkg:npm/my-local-a@0.1.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-a"
+        }
+      ]
     },
     {
       "type": "library",
@@ -77,7 +87,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-b-off@0.0.0"
+      "purl": "pkg:npm/my-local-b-off@0.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-b-off"
+        }
+      ]
     },
     {
       "type": "library",
@@ -91,7 +107,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-c@0.23.42"
+      "purl": "pkg:npm/my-local-c@0.23.42",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-c"
+        }
+      ]
     }
   ],
   "dependencies": [

--- a/tests/_data/sbom_demo-results/local-workspaces_npm7_node18_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-workspaces_npm7_node18_ubuntu-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-workspaces@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -70,7 +70,7 @@
       "purl": "pkg:npm/my-local-a@0.1.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-a"
         }
       ]
@@ -90,7 +90,7 @@
       "purl": "pkg:npm/my-local-b-off@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-b-off"
         }
       ]
@@ -110,7 +110,7 @@
       "purl": "pkg:npm/my-local-c@0.23.42",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-c"
         }
       ]

--- a/tests/_data/sbom_demo-results/local-workspaces_npm7_node18_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-workspaces_npm7_node18_windows-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-workspaces@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -63,7 +67,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-a@0.1.0"
+      "purl": "pkg:npm/my-local-a@0.1.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-a"
+        }
+      ]
     },
     {
       "type": "library",
@@ -77,7 +87,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-b-off@0.0.0"
+      "purl": "pkg:npm/my-local-b-off@0.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-b-off"
+        }
+      ]
     },
     {
       "type": "library",
@@ -91,7 +107,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-c@0.23.42"
+      "purl": "pkg:npm/my-local-c@0.23.42",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-c"
+        }
+      ]
     }
   ],
   "dependencies": [

--- a/tests/_data/sbom_demo-results/local-workspaces_npm7_node18_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-workspaces_npm7_node18_windows-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-workspaces@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -70,7 +70,7 @@
       "purl": "pkg:npm/my-local-a@0.1.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-a"
         }
       ]
@@ -90,7 +90,7 @@
       "purl": "pkg:npm/my-local-b-off@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-b-off"
         }
       ]
@@ -110,7 +110,7 @@
       "purl": "pkg:npm/my-local-c@0.23.42",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-c"
         }
       ]

--- a/tests/_data/sbom_demo-results/local-workspaces_npm8_node14_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-workspaces_npm8_node14_macos-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-workspaces@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -63,7 +67,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-a@0.1.0"
+      "purl": "pkg:npm/my-local-a@0.1.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-a"
+        }
+      ]
     },
     {
       "type": "library",
@@ -77,7 +87,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-b-off@0.0.0"
+      "purl": "pkg:npm/my-local-b-off@0.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-b-off"
+        }
+      ]
     },
     {
       "type": "library",
@@ -91,7 +107,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-c@0.23.42"
+      "purl": "pkg:npm/my-local-c@0.23.42",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-c"
+        }
+      ]
     }
   ],
   "dependencies": [

--- a/tests/_data/sbom_demo-results/local-workspaces_npm8_node14_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-workspaces_npm8_node14_macos-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-workspaces@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -70,7 +70,7 @@
       "purl": "pkg:npm/my-local-a@0.1.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-a"
         }
       ]
@@ -90,7 +90,7 @@
       "purl": "pkg:npm/my-local-b-off@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-b-off"
         }
       ]
@@ -110,7 +110,7 @@
       "purl": "pkg:npm/my-local-c@0.23.42",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-c"
         }
       ]

--- a/tests/_data/sbom_demo-results/local-workspaces_npm8_node14_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-workspaces_npm8_node14_ubuntu-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-workspaces@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -63,7 +67,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-a@0.1.0"
+      "purl": "pkg:npm/my-local-a@0.1.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-a"
+        }
+      ]
     },
     {
       "type": "library",
@@ -77,7 +87,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-b-off@0.0.0"
+      "purl": "pkg:npm/my-local-b-off@0.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-b-off"
+        }
+      ]
     },
     {
       "type": "library",
@@ -91,7 +107,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-c@0.23.42"
+      "purl": "pkg:npm/my-local-c@0.23.42",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-c"
+        }
+      ]
     }
   ],
   "dependencies": [

--- a/tests/_data/sbom_demo-results/local-workspaces_npm8_node14_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-workspaces_npm8_node14_ubuntu-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-workspaces@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -70,7 +70,7 @@
       "purl": "pkg:npm/my-local-a@0.1.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-a"
         }
       ]
@@ -90,7 +90,7 @@
       "purl": "pkg:npm/my-local-b-off@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-b-off"
         }
       ]
@@ -110,7 +110,7 @@
       "purl": "pkg:npm/my-local-c@0.23.42",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-c"
         }
       ]

--- a/tests/_data/sbom_demo-results/local-workspaces_npm8_node14_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-workspaces_npm8_node14_windows-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-workspaces@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -63,7 +67,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-a@0.1.0"
+      "purl": "pkg:npm/my-local-a@0.1.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-a"
+        }
+      ]
     },
     {
       "type": "library",
@@ -77,7 +87,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-b-off@0.0.0"
+      "purl": "pkg:npm/my-local-b-off@0.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-b-off"
+        }
+      ]
     },
     {
       "type": "library",
@@ -91,7 +107,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-c@0.23.42"
+      "purl": "pkg:npm/my-local-c@0.23.42",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-c"
+        }
+      ]
     }
   ],
   "dependencies": [

--- a/tests/_data/sbom_demo-results/local-workspaces_npm8_node14_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-workspaces_npm8_node14_windows-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-workspaces@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -70,7 +70,7 @@
       "purl": "pkg:npm/my-local-a@0.1.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-a"
         }
       ]
@@ -90,7 +90,7 @@
       "purl": "pkg:npm/my-local-b-off@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-b-off"
         }
       ]
@@ -110,7 +110,7 @@
       "purl": "pkg:npm/my-local-c@0.23.42",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-c"
         }
       ]

--- a/tests/_data/sbom_demo-results/local-workspaces_npm8_node16_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-workspaces_npm8_node16_macos-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-workspaces@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -63,7 +67,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-a@0.1.0"
+      "purl": "pkg:npm/my-local-a@0.1.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-a"
+        }
+      ]
     },
     {
       "type": "library",
@@ -77,7 +87,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-b-off@0.0.0"
+      "purl": "pkg:npm/my-local-b-off@0.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-b-off"
+        }
+      ]
     },
     {
       "type": "library",
@@ -91,7 +107,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-c@0.23.42"
+      "purl": "pkg:npm/my-local-c@0.23.42",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-c"
+        }
+      ]
     }
   ],
   "dependencies": [

--- a/tests/_data/sbom_demo-results/local-workspaces_npm8_node16_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-workspaces_npm8_node16_macos-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-workspaces@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -70,7 +70,7 @@
       "purl": "pkg:npm/my-local-a@0.1.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-a"
         }
       ]
@@ -90,7 +90,7 @@
       "purl": "pkg:npm/my-local-b-off@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-b-off"
         }
       ]
@@ -110,7 +110,7 @@
       "purl": "pkg:npm/my-local-c@0.23.42",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-c"
         }
       ]

--- a/tests/_data/sbom_demo-results/local-workspaces_npm8_node16_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-workspaces_npm8_node16_ubuntu-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-workspaces@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -63,7 +67,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-a@0.1.0"
+      "purl": "pkg:npm/my-local-a@0.1.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-a"
+        }
+      ]
     },
     {
       "type": "library",
@@ -77,7 +87,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-b-off@0.0.0"
+      "purl": "pkg:npm/my-local-b-off@0.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-b-off"
+        }
+      ]
     },
     {
       "type": "library",
@@ -91,7 +107,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-c@0.23.42"
+      "purl": "pkg:npm/my-local-c@0.23.42",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-c"
+        }
+      ]
     }
   ],
   "dependencies": [

--- a/tests/_data/sbom_demo-results/local-workspaces_npm8_node16_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-workspaces_npm8_node16_ubuntu-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-workspaces@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -70,7 +70,7 @@
       "purl": "pkg:npm/my-local-a@0.1.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-a"
         }
       ]
@@ -90,7 +90,7 @@
       "purl": "pkg:npm/my-local-b-off@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-b-off"
         }
       ]
@@ -110,7 +110,7 @@
       "purl": "pkg:npm/my-local-c@0.23.42",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-c"
         }
       ]

--- a/tests/_data/sbom_demo-results/local-workspaces_npm8_node16_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-workspaces_npm8_node16_windows-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-workspaces@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -63,7 +67,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-a@0.1.0"
+      "purl": "pkg:npm/my-local-a@0.1.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-a"
+        }
+      ]
     },
     {
       "type": "library",
@@ -77,7 +87,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-b-off@0.0.0"
+      "purl": "pkg:npm/my-local-b-off@0.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-b-off"
+        }
+      ]
     },
     {
       "type": "library",
@@ -91,7 +107,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-c@0.23.42"
+      "purl": "pkg:npm/my-local-c@0.23.42",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-c"
+        }
+      ]
     }
   ],
   "dependencies": [

--- a/tests/_data/sbom_demo-results/local-workspaces_npm8_node16_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-workspaces_npm8_node16_windows-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-workspaces@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -70,7 +70,7 @@
       "purl": "pkg:npm/my-local-a@0.1.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-a"
         }
       ]
@@ -90,7 +90,7 @@
       "purl": "pkg:npm/my-local-b-off@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-b-off"
         }
       ]
@@ -110,7 +110,7 @@
       "purl": "pkg:npm/my-local-c@0.23.42",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-c"
         }
       ]

--- a/tests/_data/sbom_demo-results/local-workspaces_npm8_node18_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-workspaces_npm8_node18_macos-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-workspaces@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -63,7 +67,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-a@0.1.0"
+      "purl": "pkg:npm/my-local-a@0.1.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-a"
+        }
+      ]
     },
     {
       "type": "library",
@@ -77,7 +87,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-b-off@0.0.0"
+      "purl": "pkg:npm/my-local-b-off@0.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-b-off"
+        }
+      ]
     },
     {
       "type": "library",
@@ -91,7 +107,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-c@0.23.42"
+      "purl": "pkg:npm/my-local-c@0.23.42",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-c"
+        }
+      ]
     }
   ],
   "dependencies": [

--- a/tests/_data/sbom_demo-results/local-workspaces_npm8_node18_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-workspaces_npm8_node18_macos-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-workspaces@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -70,7 +70,7 @@
       "purl": "pkg:npm/my-local-a@0.1.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-a"
         }
       ]
@@ -90,7 +90,7 @@
       "purl": "pkg:npm/my-local-b-off@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-b-off"
         }
       ]
@@ -110,7 +110,7 @@
       "purl": "pkg:npm/my-local-c@0.23.42",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-c"
         }
       ]

--- a/tests/_data/sbom_demo-results/local-workspaces_npm8_node18_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-workspaces_npm8_node18_ubuntu-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-workspaces@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -63,7 +67,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-a@0.1.0"
+      "purl": "pkg:npm/my-local-a@0.1.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-a"
+        }
+      ]
     },
     {
       "type": "library",
@@ -77,7 +87,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-b-off@0.0.0"
+      "purl": "pkg:npm/my-local-b-off@0.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-b-off"
+        }
+      ]
     },
     {
       "type": "library",
@@ -91,7 +107,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-c@0.23.42"
+      "purl": "pkg:npm/my-local-c@0.23.42",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-c"
+        }
+      ]
     }
   ],
   "dependencies": [

--- a/tests/_data/sbom_demo-results/local-workspaces_npm8_node18_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-workspaces_npm8_node18_ubuntu-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-workspaces@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -70,7 +70,7 @@
       "purl": "pkg:npm/my-local-a@0.1.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-a"
         }
       ]
@@ -90,7 +90,7 @@
       "purl": "pkg:npm/my-local-b-off@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-b-off"
         }
       ]
@@ -110,7 +110,7 @@
       "purl": "pkg:npm/my-local-c@0.23.42",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-c"
         }
       ]

--- a/tests/_data/sbom_demo-results/local-workspaces_npm8_node18_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-workspaces_npm8_node18_windows-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-workspaces@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -63,7 +67,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-a@0.1.0"
+      "purl": "pkg:npm/my-local-a@0.1.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-a"
+        }
+      ]
     },
     {
       "type": "library",
@@ -77,7 +87,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-b-off@0.0.0"
+      "purl": "pkg:npm/my-local-b-off@0.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-b-off"
+        }
+      ]
     },
     {
       "type": "library",
@@ -91,7 +107,13 @@
           }
         }
       ],
-      "purl": "pkg:npm/my-local-c@0.23.42"
+      "purl": "pkg:npm/my-local-c@0.23.42",
+      "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-c"
+        }
+      ]
     }
   ],
   "dependencies": [

--- a/tests/_data/sbom_demo-results/local-workspaces_npm8_node18_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-workspaces_npm8_node18_windows-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-workspaces@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -70,7 +70,7 @@
       "purl": "pkg:npm/my-local-a@0.1.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-a"
         }
       ]
@@ -90,7 +90,7 @@
       "purl": "pkg:npm/my-local-b-off@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-b-off"
         }
       ]
@@ -110,7 +110,7 @@
       "purl": "pkg:npm/my-local-c@0.23.42",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-c"
         }
       ]

--- a/tests/_data/sbom_demo-results/local-workspaces_npm9_node16_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-workspaces_npm9_node16_macos-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-workspaces@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -78,7 +78,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-a"
         },
         {
@@ -103,7 +103,7 @@
       "purl": "pkg:npm/my-local-b-off@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-b-off"
         },
         {
@@ -135,7 +135,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-c"
         },
         {

--- a/tests/_data/sbom_demo-results/local-workspaces_npm9_node16_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-workspaces_npm9_node16_macos-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-workspaces@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -74,6 +78,10 @@
       ],
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-a"
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -94,6 +102,10 @@
       ],
       "purl": "pkg:npm/my-local-b-off@0.0.0",
       "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-b-off"
+        },
         {
           "name": "cdx:npm:package:private",
           "value": "true"
@@ -122,6 +134,10 @@
         }
       ],
       "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-c"
+        },
         {
           "name": "cdx:npm:package:private",
           "value": "true"

--- a/tests/_data/sbom_demo-results/local-workspaces_npm9_node16_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-workspaces_npm9_node16_ubuntu-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-workspaces@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -78,7 +78,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-a"
         },
         {
@@ -103,7 +103,7 @@
       "purl": "pkg:npm/my-local-b-off@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-b-off"
         },
         {
@@ -135,7 +135,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-c"
         },
         {

--- a/tests/_data/sbom_demo-results/local-workspaces_npm9_node16_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-workspaces_npm9_node16_ubuntu-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-workspaces@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -74,6 +78,10 @@
       ],
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-a"
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -94,6 +102,10 @@
       ],
       "purl": "pkg:npm/my-local-b-off@0.0.0",
       "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-b-off"
+        },
         {
           "name": "cdx:npm:package:private",
           "value": "true"
@@ -122,6 +134,10 @@
         }
       ],
       "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-c"
+        },
         {
           "name": "cdx:npm:package:private",
           "value": "true"

--- a/tests/_data/sbom_demo-results/local-workspaces_npm9_node16_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-workspaces_npm9_node16_windows-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-workspaces@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -78,7 +78,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-a"
         },
         {
@@ -103,7 +103,7 @@
       "purl": "pkg:npm/my-local-b-off@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-b-off"
         },
         {
@@ -135,7 +135,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-c"
         },
         {

--- a/tests/_data/sbom_demo-results/local-workspaces_npm9_node16_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-workspaces_npm9_node16_windows-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-workspaces@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -74,6 +78,10 @@
       ],
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-a"
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -94,6 +102,10 @@
       ],
       "purl": "pkg:npm/my-local-b-off@0.0.0",
       "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-b-off"
+        },
         {
           "name": "cdx:npm:package:private",
           "value": "true"
@@ -122,6 +134,10 @@
         }
       ],
       "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-c"
+        },
         {
           "name": "cdx:npm:package:private",
           "value": "true"

--- a/tests/_data/sbom_demo-results/local-workspaces_npm9_node18_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-workspaces_npm9_node18_macos-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-workspaces@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -78,7 +78,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-a"
         },
         {
@@ -103,7 +103,7 @@
       "purl": "pkg:npm/my-local-b-off@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-b-off"
         },
         {
@@ -135,7 +135,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-c"
         },
         {

--- a/tests/_data/sbom_demo-results/local-workspaces_npm9_node18_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-workspaces_npm9_node18_macos-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-workspaces@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -74,6 +78,10 @@
       ],
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-a"
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -94,6 +102,10 @@
       ],
       "purl": "pkg:npm/my-local-b-off@0.0.0",
       "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-b-off"
+        },
         {
           "name": "cdx:npm:package:private",
           "value": "true"
@@ -122,6 +134,10 @@
         }
       ],
       "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-c"
+        },
         {
           "name": "cdx:npm:package:private",
           "value": "true"

--- a/tests/_data/sbom_demo-results/local-workspaces_npm9_node18_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-workspaces_npm9_node18_ubuntu-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-workspaces@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -78,7 +78,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-a"
         },
         {
@@ -103,7 +103,7 @@
       "purl": "pkg:npm/my-local-b-off@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-b-off"
         },
         {
@@ -135,7 +135,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-c"
         },
         {

--- a/tests/_data/sbom_demo-results/local-workspaces_npm9_node18_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-workspaces_npm9_node18_ubuntu-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-workspaces@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -74,6 +78,10 @@
       ],
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-a"
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -94,6 +102,10 @@
       ],
       "purl": "pkg:npm/my-local-b-off@0.0.0",
       "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-b-off"
+        },
         {
           "name": "cdx:npm:package:private",
           "value": "true"
@@ -122,6 +134,10 @@
         }
       ],
       "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-c"
+        },
         {
           "name": "cdx:npm:package:private",
           "value": "true"

--- a/tests/_data/sbom_demo-results/local-workspaces_npm9_node18_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-workspaces_npm9_node18_windows-latest.snap.json
@@ -44,7 +44,7 @@
       "purl": "pkg:npm/demo-workspaces@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": ""
         },
         {
@@ -78,7 +78,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-a"
         },
         {
@@ -103,7 +103,7 @@
       "purl": "pkg:npm/my-local-b-off@0.0.0",
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-b-off"
         },
         {
@@ -135,7 +135,7 @@
       ],
       "properties": [
         {
-          "name": "cdx:npm:package:installPath",
+          "name": "cdx:npm:package:path",
           "value": "node_modules/my-local-c"
         },
         {

--- a/tests/_data/sbom_demo-results/local-workspaces_npm9_node18_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/local-workspaces_npm9_node18_windows-latest.snap.json
@@ -44,6 +44,10 @@
       "purl": "pkg:npm/demo-workspaces@0.0.0",
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": ""
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -74,6 +78,10 @@
       ],
       "properties": [
         {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-a"
+        },
+        {
           "name": "cdx:npm:package:private",
           "value": "true"
         }
@@ -94,6 +102,10 @@
       ],
       "purl": "pkg:npm/my-local-b-off@0.0.0",
       "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-b-off"
+        },
         {
           "name": "cdx:npm:package:private",
           "value": "true"
@@ -122,6 +134,10 @@
         }
       ],
       "properties": [
+        {
+          "name": "cdx:npm:package:installPath",
+          "value": "node_modules/my-local-c"
+        },
         {
           "name": "cdx:npm:package:private",
           "value": "true"


### PR DESCRIPTION
a draft for #305 
not final, yet. the actual property taxonomy registration process is not complete!!1

- [x] demo implementation with `cdx:npm:package:installPath` <-- NON-FINAL
- [x] link to registered taxonomy in code and docs -- 0dddd498b282b78c10c91f87583fdcd6a7805920 
- [x] final implementation based on actual registered taxonomy/namings
- [x] update demo results
- [x] update examples
- [x] add docs/HISTORY entry 
- [x] have property taken to the standards: see https://github.com/CycloneDX/cyclonedx-property-taxonomy/pull/35 